### PR TITLE
Document the addition of LRM and RLM characters

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -620,6 +620,16 @@ class EditableText extends StatefulWidget {
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
+  /// When text from an LTR language is entered into an RTL field, or RTL text
+  /// is entered into an LTR field,
+  /// [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) or
+  /// [RLM](https://en.wikipedia.org/wiki/Right-to-left_mark) characters will be
+  /// inserted alongside whitespace characters, respectively. For example, LRM
+  /// characters will be inserted when an English keyboard is used to enter text
+  /// that includes spaces into an app with a Hebrew locale with RTL
+  /// directionality. These characters will affect the length of the string and
+  /// may need to be parsed out when doing things like string comparison.
+  ///
   /// Defaults to the ambient [Directionality], if any.
   ///
   /// See also:

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -624,11 +624,11 @@ class EditableText extends StatefulWidget {
   /// is entered into an LTR field,
   /// [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) or
   /// [RLM](https://en.wikipedia.org/wiki/Right-to-left_mark) characters will be
-  /// inserted alongside whitespace characters, respectively. For example, LRM
-  /// characters will be inserted when an English keyboard is used to enter text
-  /// that includes spaces into an app with a Hebrew locale with RTL
-  /// directionality. These characters will affect the length of the string and
-  /// may need to be parsed out when doing things like string comparison.
+  /// inserted alongside whitespace characters, respectively. For example, an
+  /// LRM character will be inserted when an English keyboard is used to enter a
+  /// space into a TextField with a Hebrew locale and RTL directionality. These
+  /// characters will affect the length of the string and may need to be parsed
+  /// out when doing things like string comparison.
   ///
   /// Defaults to the ambient [Directionality], if any.
   ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -623,9 +623,11 @@ class EditableText extends StatefulWidget {
   /// When LTR text is entered into an RTL field, or RTL text is entered into an
   /// LTR field, [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) or
   /// [RLM](https://en.wikipedia.org/wiki/Right-to-left_mark) characters will be
-  /// inserted alongside whitespace characters, respectively. These characters
-  /// will affect the length of the string and may need to be parsed out when
-  /// doing things like string comparison with other text.
+  /// inserted alongside whitespace characters, respectively. This is to
+  /// eliminate ambiguous directionality in whitespace and ensure proper caret
+  /// placement. These characters will affect the length of the string and may
+  /// need to be parsed out when doing things like string comparison with other
+  /// text.
   ///
   /// Defaults to the ambient [Directionality], if any.
   ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -620,15 +620,12 @@ class EditableText extends StatefulWidget {
   /// context, the English phrase will be on the right and the Hebrew phrase on
   /// its left.
   ///
-  /// When text from an LTR language is entered into an RTL field, or RTL text
-  /// is entered into an LTR field,
-  /// [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) or
+  /// When LTR text is entered into an RTL field, or RTL text is entered into an
+  /// LTR field, [LRM](https://en.wikipedia.org/wiki/Left-to-right_mark) or
   /// [RLM](https://en.wikipedia.org/wiki/Right-to-left_mark) characters will be
-  /// inserted alongside whitespace characters, respectively. For example, an
-  /// LRM character will be inserted when an English keyboard is used to enter a
-  /// space into a TextField with a Hebrew locale and RTL directionality. These
-  /// characters will affect the length of the string and may need to be parsed
-  /// out when doing things like string comparison.
+  /// inserted alongside whitespace characters, respectively. These characters
+  /// will affect the length of the string and may need to be parsed out when
+  /// doing things like string comparison with other text.
   ///
   /// Defaults to the ambient [Directionality], if any.
   ///


### PR DESCRIPTION
## Description

Some confusion arose around Flutter's implicit insertion of LRM and RLM characters into TextField text in https://github.com/flutter/flutter/issues/56514.  This PR adds some information in the docs about when this happens and what to do about it.

## Related Issues

Closes https://github.com/flutter/flutter/issues/56514

## Tests

None, docs only change.

## Breaking Change

None.