### PR TITLE
change approach of initialization "_highlightMode" field

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1490,14 +1490,25 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   ///
   /// If [highlightMode] returns [FocusHighlightMode.traditional], then widgets should
   /// draw their focus highlight whenever they are focused.
-  // Don't want to set _highlightMode here, since it's possible for the target
-  // platform to change (especially in tests).
-  FocusHighlightMode get highlightMode => _highlightMode ?? _defaultModeForPlatform;
-  FocusHighlightMode _highlightMode;
+  FocusHighlightMode get highlightMode => _highlightMode;
+  FocusHighlightMode _highlightMode = _defaultModeForPlatform;
 
   // If set, indicates if the last interaction detected was touch or not.
   // If null, no interactions have occurred yet.
   bool _lastInteractionWasTouch;
+
+  /// Updates initial value of highlight mode.
+  ///
+  /// It necessary when platform is changed during testing
+  /// (Since working with FocusManager is carried out using singleton pattern).
+  @visibleForTesting
+  void updateHighlightModeByPlatform() {
+    final FocusHighlightMode newMode = _defaultModeForPlatform;
+    if (_highlightMode != newMode) {
+      _highlightMode = newMode;
+      _notifyHighlightModeListeners();
+    }
+  }
 
   // Update function to be called whenever the state relating to highlightMode
   // changes.
@@ -1525,12 +1536,9 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
         newMode = FocusHighlightMode.traditional;
         break;
     }
-    // We can't just compare newMode with _highlightMode here, since
-    // _highlightMode could be null, so we want to compare with the return value
-    // for the getter, since that's what clients will be looking at.
-    final FocusHighlightMode oldMode = highlightMode;
-    _highlightMode = newMode;
-    if (highlightMode != oldMode) {
+
+    if (_highlightMode != newMode) {
+      _highlightMode = newMode;
       _notifyHighlightModeListeners();
     }
   }

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -915,6 +915,8 @@ void main() {
       expect(receivedAnEvent, isEmpty);
     });
     testWidgets('Initial highlight mode guesses correctly.', (WidgetTester tester) async {
+      FocusManager.instance.updateHighlightModeByPlatform();
+
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.automatic;
       switch (defaultTargetPlatform) {
         case TargetPlatform.fuchsia:
@@ -930,6 +932,8 @@ void main() {
       }
     }, variant: TargetPlatformVariant.all());
     testWidgets('Mouse events change initial focus highlight mode on mobile.', (WidgetTester tester) async {
+      FocusManager.instance.updateHighlightModeByPlatform();
+
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
       RendererBinding.instance.initMouseTracker(); // Clear out the mouse state.
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 0);
@@ -938,6 +942,8 @@ void main() {
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
     }, variant: TargetPlatformVariant.mobile());
     testWidgets('Mouse events change initial focus highlight mode on desktop.', (WidgetTester tester) async {
+      FocusManager.instance.updateHighlightModeByPlatform();
+
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
       RendererBinding.instance.initMouseTracker(); // Clear out the mouse state.
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 0);
@@ -946,10 +952,14 @@ void main() {
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
     }, variant: TargetPlatformVariant.desktop());
     testWidgets('Keyboard events change initial focus highlight mode.', (WidgetTester tester) async {
+      FocusManager.instance.updateHighlightModeByPlatform();
+
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
     }, variant: TargetPlatformVariant.all());
     testWidgets('Events change focus highlight mode.', (WidgetTester tester) async {
+      FocusManager.instance.updateHighlightModeByPlatform();
+
       await setupWidget(tester);
       int callCount = 0;
       FocusHighlightMode lastMode;


### PR DESCRIPTION
## Description

The cause of problem:

This is how Flutter tries to guess the OS for a device in **_platform_web.dart**. :
![image](https://user-images.githubusercontent.com/17338801/86946117-1e7b8500-c174-11ea-8edf-419a6a3a6626.png)

Here we see that it will be either an _Apple_ device or it will be guessed as _Android_.
That is why **highlightMode** is “**touch**” at the time the web-application starts.
When the mouse moves in an application window, **FocusManager** captures this moment via its listener.
After that, FocusManger checks kind of pointerEvent (kind is "mouse"). **FocusManager*** checkS if value of **highlightMode** and **new highlightMode by pointerEvent** are different.
And if you look on peacture:
![image](https://user-images.githubusercontent.com/17338801/86946518-aeb9ca00-c174-11ea-819e-b45f65117974.png)

 you will see that value of highlightMode is already "traditional" like new highlightMode (becouse mouse is connected at the moment). This means that the current value and the previous one are equals. But listeners of FocusManager waren't notified.

I think that current approach of initializing **highlightMode** is not correct. 
The point of the approach is that when the platform changes, the field **highlightMode** will also change. 
But if developer sets **highlightStrategy = touch**, and then return it to **automatic*, changing of platform will not affect the field any more.
I think it is impossible that the application can change the platform at runtime.
Therefore, in the new implementation, I did not add this functionality (but i added support for testing initialization of **highlightMode*).

P.S.
Perhaps this is not the best way to solve the problem, but I think that with this PR it will be easier to understand the cause of the error.

## Related Issues
#58130

## Tests
I didn't add new tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.