### PR TITLE
This fixes an error in the form field example

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -82,9 +82,8 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 ///     child: Center(
 ///       child: Shortcuts(
 ///         shortcuts: <LogicalKeySet, Intent>{
-///           // Pressing enter on the field will now move to the next field.
-///           LogicalKeySet(LogicalKeyboardKey.enter):
-///               NextFocusIntent(),
+///           // Pressing space in the field will now move to the next field.
+///           LogicalKeySet(LogicalKeyboardKey.space): const NextFocusIntent(),
 ///         },
 ///         child: FocusTraversalGroup(
 ///           child: Form(
@@ -97,7 +96,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 ///                 return Padding(
 ///                   padding: const EdgeInsets.all(8.0),
 ///                   child: ConstrainedBox(
-///                     constraints: BoxConstraints.tight(Size(200, 50)),
+///                     constraints: BoxConstraints.tight(const Size(200, 50)),
 ///                     child: TextFormField(
 ///                       onSaved: (String value) {
 ///                         print('Value for field $index saved as "$value"');


### PR DESCRIPTION
## Description

This fixes an error in the form field example, by switching to using `space` instead of `enter` as the example for moving to the next field, since the text field on web un-focuses automatically when enter is pressed, causing the `Shortcuts` widget to not see the keypress.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/61078

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.