### PR TITLE
Add spaces between sentences in create --platforms help text

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -522,10 +522,10 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
 
   void _addPlatformsOptions() {
     argParser.addMultiOption('platforms',
-      help: 'the platforms supported by this project.'
-        'This argument only works when the --template is set to app or plugin.'
-        'Platform folders (e.g. android/) will be generated in the target project.'
-        'When adding platforms to a plugin project, the pubspec.yaml will be updated with the requested platform.'
+      help: 'The platforms supported by this project. '
+        'This argument only works when the --template is set to app or plugin. '
+        'Platform folders (e.g. android/) will be generated in the target project. '
+        'When adding platforms to a plugin project, the pubspec.yaml will be updated with the requested platform. '
         'Adding desktop platforms requires the corresponding desktop config setting to be enabled.',
       defaultsTo: _kAvailablePlatforms,
       allowed: _kAvailablePlatforms);


### PR DESCRIPTION
## Description
Add missing spaces between help text. Sentence case first sentence.
```
    --platforms                the platforms supported by this project.This argument only works when the --template is set to app or plugin.Platform folders (e.g. android/) will be generated in the target project.When adding platforms to a plugin project, the
                               pubspec.yaml will be updated with the requested platform.Adding desktop platforms requires the corresponding desktop config setting to be enabled.
```
to
```
    --platforms                The platforms supported by this project. This argument only works when the --template is set to app or plugin. Platform folders (e.g. android/) will be generated in the target project. When adding platforms to a plugin project,
                               the pubspec.yaml will be updated with the requested platform. Adding desktop platforms requires the corresponding desktop config setting to be enabled.
```

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*