### PR TITLE
Fixing patch for coming breaking change in HttpClientRequest

### DIFF
--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -228,8 +228,13 @@ class _MockHttpRequest extends HttpClientRequest {
     return Future<HttpClientResponse>.value(_MockHttpResponse());
   }
 
+  // TODO(zichangguo): Uncomment following line when abort() breaking change
+  // lands in g3.
+  // @override
+  // void abort([Object exception, StackTrace stackTrace]) {}
+
   @override
-  void abort([Object exception, StackTrace stackTrace]) {}
+  void noSuchMethod(Invocation invocation) {}
 
   @override
   HttpConnectionInfo get connectionInfo => null;

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -229,6 +229,9 @@ class _MockHttpRequest extends HttpClientRequest {
   }
 
   @override
+  void abort([Object exception, StackTrace stackTrace]) {}
+
+  @override
   HttpConnectionInfo get connectionInfo => null;
 
   @override

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -228,13 +228,10 @@ class _MockHttpRequest extends HttpClientRequest {
     return Future<HttpClientResponse>.value(_MockHttpResponse());
   }
 
-  // TODO(zichangguo): Uncomment following line when abort() breaking change
-  // lands in g3.
-  // @override
-  // void abort([Object exception, StackTrace stackTrace]) {}
-
+  // TODO(zichangguo): remove the ignore after the change in dart:io lands.
   @override
-  void noSuchMethod(Invocation invocation) {}
+  // ignore: override_on_non_overriding_member
+  void abort([Object exception, StackTrace stackTrace]) {}
 
   @override
   HttpConnectionInfo get connectionInfo => null;

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -377,6 +377,9 @@ class FakeHttpClientRequest implements HttpClientRequest {
 
   @override
   void writeln([Object obj = '']) {}
+
+  @override
+  void abort([Object exception, StackTrace stackTrace]) {}
 }
 
 class FakeHttpClientResponse implements HttpClientResponse {

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -378,8 +378,13 @@ class FakeHttpClientRequest implements HttpClientRequest {
   @override
   void writeln([Object obj = '']) {}
 
+  // TODO(zichangguo): Uncomment following line when abort() breaking change
+  // lands in g3.
+  // @override
+  // void abort([Object exception, StackTrace stackTrace]) {}
+
   @override
-  void abort([Object exception, StackTrace stackTrace]) {}
+  void noSuchMethod(Invocation invocation) {}
 }
 
 class FakeHttpClientResponse implements HttpClientResponse {

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -378,13 +378,10 @@ class FakeHttpClientRequest implements HttpClientRequest {
   @override
   void writeln([Object obj = '']) {}
 
-  // TODO(zichangguo): Uncomment following line when abort() breaking change
-  // lands in g3.
-  // @override
-  // void abort([Object exception, StackTrace stackTrace]) {}
-
+  // TODO(zichangguo): remove the ignore after the change in dart:io lands.
   @override
-  void noSuchMethod(Invocation invocation) {}
+  // ignore: override_on_non_overriding_member
+  void abort([Object exception, StackTrace stackTrace]) {}
 }
 
 class FakeHttpClientResponse implements HttpClientResponse {


### PR DESCRIPTION
[The breaking change](https://dart-review.googlesource.com/c/sdk/+/147339) will be landed in dart-sdk. This patch will update the test accordingly and stop the breakage.