### PR TITLE
Case insensitive check flavor names against Xcode schemes

### DIFF
--- a/dev/integration_tests/flavors/ios/Runner.xcodeproj/xcshareddata/xcschemes/free.xcscheme
+++ b/dev/integration_tests/flavors/ios/Runner.xcodeproj/xcshareddata/xcschemes/free.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,33 +14,24 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
-               BuildableName = "Paid App.app"
-               BlueprintName = "Paid App"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Free App.app"
+               BlueprintName = "Free App"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug Paid"
+      buildConfiguration = "Debug Free"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Free App.app"
-            BlueprintName = "Free App"
-            ReferencedContainer = "container:Runner.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug Paid"
+      buildConfiguration = "Debug Free"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -53,34 +44,35 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
-            BuildableName = "Paid App.app"
-            BlueprintName = "Paid App"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Free App.app"
+            BlueprintName = "Free App"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release Paid"
+      buildConfiguration = "Release Free"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
-            BuildableName = "Paid App.app"
-            BlueprintName = "Paid App"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Free App.app"
+            BlueprintName = "Free App"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug Paid">
+      buildConfiguration = "Debug Free">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release Paid"
+      buildConfiguration = "Release Free"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/dev/integration_tests/flavors/ios/Runner.xcodeproj/xcshareddata/xcschemes/paid.xcscheme
+++ b/dev/integration_tests/flavors/ios/Runner.xcodeproj/xcshareddata/xcschemes/paid.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,33 +14,24 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-               BuildableName = "Free App.app"
-               BlueprintName = "Free App"
+               BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
+               BuildableName = "Paid App.app"
+               BlueprintName = "Paid App"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug Free"
+      buildConfiguration = "Debug Paid"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Free App.app"
-            BlueprintName = "Free App"
-            ReferencedContainer = "container:Runner.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug Free"
+      buildConfiguration = "Debug Paid"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -53,35 +44,34 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Free App.app"
-            BlueprintName = "Free App"
+            BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
+            BuildableName = "Paid App.app"
+            BlueprintName = "Paid App"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release Free"
+      buildConfiguration = "Release Paid"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Free App.app"
-            BlueprintName = "Free App"
+            BlueprintIdentifier = "F723D22E2464E1C10004F0E0"
+            BuildableName = "Paid App.app"
+            BlueprintName = "Paid App"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug Free">
+      buildConfiguration = "Debug Paid">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release Free"
+      buildConfiguration = "Release Paid"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -119,18 +119,10 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   await removeFinderExtendedAttributes(app.project.hostAppRoot, processUtils, globals.logger);
 
-  final XcodeProjectInfo projectInfo = await globals.xcodeProjectInterpreter.getInfo(app.project.hostAppRoot.path);
+  final XcodeProjectInfo projectInfo = await app.project.projectInfo();
   final String scheme = projectInfo.schemeFor(buildInfo);
   if (scheme == null) {
-    globals.printError('');
-    if (projectInfo.definesCustomSchemes) {
-      globals.printError('The Xcode project defines schemes: ${projectInfo.schemes.join(', ')}');
-      globals.printError('You must specify a --flavor option to select one of them.');
-    } else {
-      globals.printError('The Xcode project does not define custom schemes.');
-      globals.printError('You cannot use the --flavor option.');
-    }
-    return XcodeBuildResult(success: false);
+    projectInfo.reportFlavorNotFoundAndExit();
   }
   final String configuration = projectInfo.buildConfigurationFor(buildInfo, scheme);
   if (configuration == null) {

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -61,7 +61,7 @@ Future<void> buildMacOS({
   );
   final String scheme = projectInfo.schemeFor(buildInfo);
   if (scheme == null) {
-    throwToolExit('Unable to find expected scheme in Xcode project.');
+    projectInfo.reportFlavorNotFoundAndExit();
   }
   final String configuration = projectInfo.buildConfigurationFor(buildInfo, scheme);
   if (configuration == null) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -26,6 +27,7 @@ class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter
       <String>['Runner'],
       <String>['Debug', 'Profile', 'Release'],
       <String>['Runner'],
+      BufferLogger.test(),
     );
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/commands/clean.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -140,6 +141,6 @@ class MockXcode extends Mock implements Xcode {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {
   @override
   Future<XcodeProjectInfo> getInfo(String projectPath, {String projectFilename}) async {
-    return XcodeProjectInfo(null, null, <String>['Runner']);
+    return XcodeProjectInfo(null, null, <String>['Runner'], BufferLogger.test());
   }
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -87,6 +87,7 @@ void main() {
             <String>['Runner'],
             <String>['Debug', 'Release'],
             <String>['Runner'],
+            logger,
           ));
         }
       );

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -414,6 +414,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
       <String>['Runner'],
       <String>['Debug', 'Release'],
       <String>['Runner'],
+      BufferLogger.test(),
     );
   }
 }


### PR DESCRIPTION
## Description

Check `--flavor` parameter against Xcode schemes case insensitively.  Exit earlier if the scheme names don't match.
Remove dead "make editable" code while we're here.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59029.

## Tests

- Updated flavor integration test to have different cased flavor/scheme names.
- project_tests
- xcodeproj_tests

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*