### PR TITLE
[flutter_tools] cleanups to web runner functionality

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -633,8 +633,8 @@ class _ResidentWebRunner extends ResidentWebRunner {
         if (hasWebPlugins)
           "import '$generatedImport';",
         '',
-        'typedef _UnaryFunction = Function(List<String> args);',
-        'typedef _NullaryFunction = Function();',
+        'typedef _UnaryFunction = dynamic Function(List<String> args);',
+        'typedef _NullaryFunction = dynamic Function();',
         'Future<void> main() async {',
         if (hasWebPlugins)
           '  registerPlugins(webPluginRegistry);',

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -189,7 +189,9 @@ abstract class ResidentWebRunner extends ResidentRunner {
     globals.printStatus('');
     globals.printStatus(message);
     const String quitMessage = 'To quit, press "q".';
-    globals.printStatus('For a more detailed help message, press "h". $quitMessage');
+    if (device.device is! WebServerDevice) {
+      globals.printStatus('For a more detailed help message, press "h". $quitMessage');
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -625,6 +625,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
         '// Flutter web bootstrap script for $importedEntrypoint.',
         '',
         "import 'dart:ui' as ui;",
+        "import 'dart:async';",
         '',
         "import '$importedEntrypoint' as entrypoint;",
         if (hasWebPlugins)
@@ -632,11 +633,16 @@ class _ResidentWebRunner extends ResidentWebRunner {
         if (hasWebPlugins)
           "import '$generatedImport';",
         '',
+        'typedef _UnaryFunction = Function(List<String> args);',
+        'typedef _NullaryFunction = Function();',
         'Future<void> main() async {',
         if (hasWebPlugins)
           '  registerPlugins(webPluginRegistry);',
         '  await ui.webOnlyInitializePlatform();',
-        '  entrypoint.main();',
+        '  if (entrypoint.main is _UnaryFunction) {',
+        '    return (entrypoint.main as _UnaryFunction)(<String>[]);',
+        '  }',
+        '  return (entrypoint.main as _NullaryFunction)();',
         '}',
         '',
       ].join('\n');

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -91,6 +91,7 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
             operatingSystemUtils: globals.os,
             platform:  globals.platform,
             processManager: globals.processManager,
+            logger: globals.logger,
           ),
           platform: globals.platform,
         ),

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -88,7 +88,6 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
           chromiumLauncher: ChromiumLauncher(
             browserFinder: findChromeExecutable,
             fileSystem: globals.fs,
-            logger: globals.logger,
             operatingSystemUtils: globals.os,
             platform:  globals.platform,
             processManager: globals.processManager,

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -667,7 +667,7 @@ class BrowserManager {
   /// Loads [_BrowserEnvironment].
   Future<_BrowserEnvironment> _loadBrowserEnvironment() async {
     return _BrowserEnvironment(
-        this, null, null, _onRestartController.stream);
+        this, null, await _browser.debuggerUri, _onRestartController.stream);
   }
 
   /// Tells the browser to load a test suite from the URL [url].

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -628,7 +628,6 @@ class BrowserManager {
       browserFinder: findChromeExecutable,
       fileSystem: globals.fs,
       operatingSystemUtils: globals.os,
-      logger: globals.logger,
       platform: globals.platform,
       processManager: globals.processManager,
     );
@@ -668,7 +667,7 @@ class BrowserManager {
   /// Loads [_BrowserEnvironment].
   Future<_BrowserEnvironment> _loadBrowserEnvironment() async {
     return _BrowserEnvironment(
-        this, null, _browser.remoteDebuggerUri, _onRestartController.stream);
+        this, null, null, _onRestartController.stream);
   }
 
   /// Tells the browser to load a test suite from the URL [url].

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -666,16 +666,8 @@ class BrowserManager {
 
   /// Loads [_BrowserEnvironment].
   Future<_BrowserEnvironment> _loadBrowserEnvironment() async {
-    final Uri debugUri = await _browser.debuggerUri;
-    final Uri uri =  Uri(
-      scheme: 'http',
-      host: debugUri.host,
-      port: debugUri.port,
-      path: '/devtools/inspector',
-      query: 'ws=${debugUri.host}:${debugUri.port}${debugUri.path}',
-    );
     return _BrowserEnvironment(
-        this, null, uri, _onRestartController.stream);
+        this, null, _browser.chromeConnection.url, _onRestartController.stream);
   }
 
   /// Tells the browser to load a test suite from the URL [url].

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -630,6 +630,7 @@ class BrowserManager {
       operatingSystemUtils: globals.os,
       platform: globals.platform,
       processManager: globals.processManager,
+      logger: globals.logger,
     );
     final Chromium chrome =
       await chromiumLauncher.launch(url.toString(), headless: headless);

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -666,8 +666,16 @@ class BrowserManager {
 
   /// Loads [_BrowserEnvironment].
   Future<_BrowserEnvironment> _loadBrowserEnvironment() async {
+    final Uri debugUri = await _browser.debuggerUri;
+    final Uri uri =  Uri(
+      scheme: 'http',
+      host: debugUri.host,
+      port: debugUri.port,
+      path: '/devtools/inspector',
+      query: 'ws=${debugUri.host}:${debugUri.port}${debugUri.path}',
+    );
     return _BrowserEnvironment(
-        this, null, await _browser.debuggerUri, _onRestartController.stream);
+        this, null, uri, _onRestartController.stream);
   }
 
   /// Tells the browser to load a test suite from the URL [url].

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -66,19 +66,19 @@ define("main_module.bootstrap", ["$entrypoint", "dart_sdk"], function(app, dart_
   window.\$dartLoader.rootDirectories = [];
   if (window.\$requireLoader) {
     window.\$requireLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
-    if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {
-      window.\$dartStackTraceUtility.ready = true;
-      let dart = dart_sdk.dart;
-      window.\$dartStackTraceUtility.setSourceMapProvider(function(url) {
-        var baseUrl = window.location.protocol + '//' + window.location.host;
-        url = url.replace(baseUrl + '/', '');
-        if (url == 'dart_sdk.js') {
-          return dart.getSourceMap('dart_sdk');
-        }
-        url = url.replace(".lib.js", "");
-        return dart.getSourceMap(url);
-      });
-    }
+  }
+  if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {
+    window.\$dartStackTraceUtility.ready = true;
+    let dart = dart_sdk.dart;
+    window.\$dartStackTraceUtility.setSourceMapProvider(function(url) {
+      var baseUrl = window.location.protocol + '//' + window.location.host;
+      url = url.replace(baseUrl + '/', '');
+      if (url == 'dart_sdk.js') {
+        return dart.getSourceMap('dart_sdk');
+      }
+      url = url.replace(".lib.js", "");
+      return dart.getSourceMap(url);
+    });
   }
 });
 ''';

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -316,6 +316,6 @@ class Chromium {
   Future<Uri> get debuggerUri async {
     final ChromeTab tab = (await chromeConnection.getTabs())
       .firstWhere((ChromeTab tab) => !tab.isBackgroundPage && !tab.isChromeExtension);
-    return Uri.parse(tab.webSocketDebuggerUrl);
+    return Uri.parse(tab.devtoolsFrontendUrl);
   }
 }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -11,11 +11,8 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
-import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
-import '../convert.dart';
-import '../globals.dart' as globals;
 
 /// An environment variable used to override the location of Google Chrome.
 const String kChromeEnvironment = 'CHROME_EXECUTABLE';
@@ -105,13 +102,11 @@ class ChromiumLauncher {
     @required Platform platform,
     @required ProcessManager processManager,
     @required OperatingSystemUtils operatingSystemUtils,
-    @required Logger logger,
     @required BrowserFinder browserFinder,
   }) : _fileSystem = fileSystem,
        _platform = platform,
        _processManager = processManager,
        _operatingSystemUtils = operatingSystemUtils,
-       _logger = logger,
        _browserFinder = browserFinder,
        _fileSystemUtils = FileSystemUtils(
          fileSystem: fileSystem,
@@ -122,7 +117,6 @@ class ChromiumLauncher {
   final Platform _platform;
   final ProcessManager _processManager;
   final OperatingSystemUtils _operatingSystemUtils;
-  Logger _logger;
   final BrowserFinder _browserFinder;
   final FileSystemUtils _fileSystemUtils;
 
@@ -163,7 +157,6 @@ class ChromiumLauncher {
     bool skipCheck = false,
     Directory cacheDir,
   }) async {
-    _logger ??= globals.logger;
     if (_currentCompleter.isCompleted) {
       throwToolExit('Only one instance of chrome can be started.');
     }
@@ -213,32 +206,11 @@ class ChromiumLauncher {
         _cacheUserSessionInformation(userDataDir, cacheDir);
       }));
     }
-
-    process.stdout
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen((String line) {
-        _logger.printTrace('[CHROME]: $line');
-      });
-
-    // Wait until the DevTools are listening before trying to connect.
-    await process.stderr
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .map((String line) {
-        _logger.printTrace('[CHROME]:$line');
-        return line;
-      })
-      .firstWhere((String line) => line.startsWith('DevTools listening'), orElse: () {
-        return 'Failed to spawn stderr';
-      });
-    final Uri remoteDebuggerUri = await _getRemoteDebuggerUrl(Uri.parse('http://localhost:$port'));
     return _connect(Chromium._(
       port,
       ChromeConnection('localhost', port),
       url: url,
       process: process,
-      remoteDebuggerUri: remoteDebuggerUri,
       chromiumLauncher: this,
     ), skipCheck);
   }
@@ -311,28 +283,6 @@ class ChromiumLauncher {
   }
 
   Future<Chromium> get connectedInstance => _currentCompleter.future;
-
-  /// Returns the full URL of the Chrome remote debugger for the main page.
-  ///
-  /// This takes the [base] remote debugger URL (which points to a browser-wide
-  /// page) and uses its JSON API to find the resolved URL for debugging the host
-  /// page.
-  Future<Uri> _getRemoteDebuggerUrl(Uri base) async {
-    try {
-      final HttpClient client = HttpClient();
-      final HttpClientRequest request = await client.getUrl(base.resolve('/json/list'));
-      final HttpClientResponse response = await request.close();
-      final List<dynamic> jsonObject = await json.fuse(utf8).decoder.bind(response).single as List<dynamic>;
-      if (jsonObject == null || jsonObject.isEmpty) {
-        return base;
-      }
-      return base.resolve(jsonObject.first['devtoolsFrontendUrl'] as String);
-    } on Exception {
-      // If we fail to talk to the remote debugger protocol, give up and return
-      // the raw URL rather than crashing.
-      return base;
-    }
-  }
 }
 
 /// A class for managing an instance of a Chromium browser.
@@ -342,7 +292,6 @@ class Chromium {
     this.chromeConnection, {
     this.url,
     Process process,
-    this.remoteDebuggerUri,
     @required ChromiumLauncher chromiumLauncher,
   })  : _process = process,
         _chromiumLauncher = chromiumLauncher;
@@ -351,7 +300,6 @@ class Chromium {
   final int debugPort;
   final Process _process;
   final ChromeConnection chromeConnection;
-  final Uri remoteDebuggerUri;
   final ChromiumLauncher _chromiumLauncher;
 
   Future<int> get onExit => _process.exitCode;

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -312,10 +312,4 @@ class Chromium {
     _process?.kill();
     await _process?.exitCode;
   }
-
-  Future<Uri> get debuggerUri async {
-    final ChromeTab tab = (await chromeConnection.getTabs())
-      .firstWhere((ChromeTab tab) => !tab.isBackgroundPage && !tab.isChromeExtension);
-    return Uri.parse(tab.devtoolsFrontendUrl);
-  }
 }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -312,4 +312,10 @@ class Chromium {
     _process?.kill();
     await _process?.exitCode;
   }
+
+  Future<Uri> get debuggerUri async {
+    final ChromeTab tab = (await chromeConnection.getTabs())
+      .firstWhere((ChromeTab tab) => !tab.isBackgroundPage && !tab.isChromeExtension);
+    return Uri.parse(tab.webSocketDebuggerUrl);
+  }
 }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -308,6 +308,7 @@ class WebDevices extends PollingDeviceDiscovery {
         platform: platform,
         processManager: processManager,
         operatingSystemUtils: operatingSystemUtils,
+        logger: logger,
       ),
     );
     if (platform.isWindows) {
@@ -318,6 +319,7 @@ class WebDevices extends PollingDeviceDiscovery {
           platform: platform,
           processManager: processManager,
           operatingSystemUtils: operatingSystemUtils,
+          logger: logger,
         ),
         processManager: processManager,
         logger: logger,

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -305,7 +305,6 @@ class WebDevices extends PollingDeviceDiscovery {
       chromiumLauncher: ChromiumLauncher(
         browserFinder: findChromeExecutable,
         fileSystem: fileSystem,
-        logger: logger,
         platform: platform,
         processManager: processManager,
         operatingSystemUtils: operatingSystemUtils,
@@ -316,7 +315,6 @@ class WebDevices extends PollingDeviceDiscovery {
         chromiumLauncher: ChromiumLauncher(
           browserFinder: findEdgeExecutable,
           fileSystem: fileSystem,
-          logger: logger,
           platform: platform,
           processManager: processManager,
           operatingSystemUtils: operatingSystemUtils,
@@ -450,6 +448,10 @@ class WebServerDevice extends Device {
     } else {
       _logger.printStatus('$mainPath is being served at $url', emphasis: true);
     }
+    _logger.printStatus(
+      'The web-server device does not support debugging. Consider using '
+      'the Chrome or Edge devices for an improved development workflow.'
+    );
     _logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': false});
     return LaunchResult.succeeded(observatoryUri: url != null ? Uri.parse(url): null);
   }

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -158,7 +158,7 @@ void main() {
       .childFile('preferences');
     preferencesFile
       ..createSync(recursive: true)
-      ..writeAsStringSync('example');
+      ..writeAsStringSync('"exit_type":"Crashed"');
 
     final Directory localStorageContentsDirectory = dataDir
         .childDirectory('Default')
@@ -182,18 +182,8 @@ void main() {
       cacheDir: dataDir,
     );
 
-    // validate preferences
-    final File tempFile = fileSystem
-      .directory('.tmp_rand0/flutter_tools_chrome_device.rand0')
-      .childDirectory('Default')
-      .childFile('preferences');
-
-    expect(tempFile.existsSync(), true);
-    expect(tempFile.readAsStringSync(), 'example');
-
-    // write crash to file:
-    tempFile.writeAsStringSync('"exit_type":"Crashed"');
     exitCompleter.complete();
+    await Future<void>.delayed(const Duration(microseconds: 1));
 
     // writes non-crash back to dart_tool
     expect(preferencesFile.readAsStringSync(), '"exit_type":"Normal"');

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
@@ -35,10 +34,8 @@ void main() {
   Platform platform;
   FakeProcessManager processManager;
   OperatingSystemUtils operatingSystemUtils;
-  Logger logger;
 
   setUp(() {
-    logger = BufferLogger.test();
     operatingSystemUtils = MockOperatingSystemUtils();
     when(operatingSystemUtils.findFreePort())
         .thenAnswer((Invocation invocation) async {
@@ -54,7 +51,6 @@ void main() {
       platform: platform,
       processManager: processManager,
       operatingSystemUtils: operatingSystemUtils,
-      logger: logger,
       browserFinder: findChromeExecutable,
     );
   });

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
@@ -52,6 +53,7 @@ void main() {
       processManager: processManager,
       operatingSystemUtils: operatingSystemUtils,
       browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
     );
   });
 

--- a/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
@@ -34,6 +35,7 @@ void main() {
       processManager: processManager,
       operatingSystemUtils: null,
       browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
     );
     webValidator = webValidator = ChromeValidator(
       platform: platform,

--- a/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
@@ -34,7 +33,6 @@ void main() {
       platform: platform,
       processManager: processManager,
       operatingSystemUtils: null,
-      logger: BufferLogger.test(),
       browserFinder: findChromeExecutable,
     );
     webValidator = webValidator = ChromeValidator(

--- a/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
@@ -52,3 +52,46 @@ class BasicProject extends Project {
   Uri get topLevelFunctionBreakpointUri => mainDart;
   int get topLevelFunctionBreakpointLine => lineContaining(main, '// TOP LEVEL BREAKPOINT');
 }
+
+class BasicProjectWithUnaryMain extends Project {
+
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ">=2.0.0-dev.68.0 <3.0.0"
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'''
+  import 'dart:async';
+
+  import 'package:flutter/material.dart';
+
+  Future<void> main(List<String> args) async {
+    while (true) {
+      runApp(new MyApp());
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+  }
+
+  class MyApp extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      topLevelFunction();
+      return new MaterialApp( // BUILD BREAKPOINT
+        title: 'Flutter Demo',
+        home: new Container(),
+      );
+    }
+  }
+
+  topLevelFunction() {
+    print("topLevelFunction"); // TOP LEVEL BREAKPOINT
+  }
+  ''';
+}

--- a/packages/flutter_tools/test/integration.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_run_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import '../src/common.dart';
+import 'test_data/basic_project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  final BasicProjectWithUnaryMain project = BasicProjectWithUnaryMain();
+  FlutterRunTestDriver flutter;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+    await project.setUpIn(tempDir);
+    flutter = FlutterRunTestDriver(tempDir);
+  });
+
+  tearDown(() async {
+    await flutter.stop();
+    tryToDelete(tempDir);
+  });
+
+  test('flutter run works on web devices with a unary main function', () async {
+    await flutter.run(chrome: true);
+  }, skip: 'Web tests cannot currently run on cirrus');
+}

--- a/packages/flutter_tools/test/integration.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_run_test.dart
@@ -27,5 +27,5 @@ void main() {
 
   test('flutter run works on web devices with a unary main function', () async {
     await flutter.run(chrome: true);
-  });
+  }, skip: 'Web CI skipped');
 }

--- a/packages/flutter_tools/test/integration.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_run_test.dart
@@ -27,5 +27,5 @@ void main() {
 
   test('flutter run works on web devices with a unary main function', () async {
     await flutter.run(chrome: true);
-  }, skip: 'Web tests cannot currently run on cirrus');
+  });
 }


### PR DESCRIPTION
## Description

Implement some cleanups to web functionality that had been lingering for a while.

1. Skip unnecessary parsing of chrome URI, this was only needed for package:test debugging which we're not going to support.
2. Ensure stack traces are initialized in web server
3. Disclaimer on web server that it does not support debugging and remove help message.
4. Fix generated entrypoint to check for `main(List<String> args)`

Fixes https://github.com/flutter/flutter/issues/59643
Fixes https://github.com/flutter/flutter/issues/55084
Fixes https://github.com/flutter/flutter/issues/60417
