### PR TITLE
Filter profiling events by names not category

### DIFF
--- a/packages/flutter_driver/lib/src/driver/profiling_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/profiling_summarizer.dart
@@ -5,8 +5,15 @@
 import 'percentile_utils.dart';
 import 'timeline.dart';
 
-/// The catrgory shared by all profiling related timeline events.
-const String kProfilingCategory = 'flutter::profiling';
+/// Profiling related timeline events.
+///
+/// We do not use a profiling category for these as all the dart timeline events
+/// have the same profiling category "embedder".
+const Set<String> kProfilingEvents = <String>{
+  _kCpuProfile,
+  _kGpuProfile,
+  _kMemoryProfile,
+};
 
 // These field names need to be in-sync with:
 // https://github.com/flutter/engine/blob/master/shell/profiling/sampling_profiler.cc
@@ -26,12 +33,12 @@ enum ProfileType {
   Memory,
 }
 
-/// Summarizes [TimelineEvents]s corresponding to [kProfilingCategory] category.
+/// Summarizes [TimelineEvents]s corresponding to [kProfilingEvents] category.
 ///
 /// A sample event (some fields have been omitted for brewity):
 /// ```
 ///     {
-///      "category": "flutter::profiling",
+///      "category": "embedder",
 ///      "name": "CpuUsage",
 ///      "ts": 121120,
 ///      "args": {
@@ -51,7 +58,7 @@ class ProfilingSummarizer {
     final Map<ProfileType, List<TimelineEvent>> eventsByType =
         <ProfileType, List<TimelineEvent>>{};
     for (final TimelineEvent event in profilingEvents) {
-      assert(event.category == kProfilingCategory);
+      assert(kProfilingEvents.contains(event.name));
       final ProfileType type = _getProfileType(event.name);
       eventsByType[type] ??= <TimelineEvent>[];
       eventsByType[type].add(event);

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -229,9 +229,9 @@ class TimelineSummary {
       .toList();
   }
 
-  List<TimelineEvent> _extractCategorizedEvents(String category) {
+  List<TimelineEvent> _extractEventsWithNames(Set<String> names) {
     return _timeline.events
-      .where((TimelineEvent event) => event.category == category)
+      .where((TimelineEvent event) => names.contains(event.name))
       .toList();
   }
 
@@ -319,7 +319,7 @@ class TimelineSummary {
 
   List<Duration> _extractGpuRasterizerDrawDurations() => _extractBeginEndEvents(kRasterizeFrameEventName);
 
-  ProfilingSummarizer _profilingSummarizer() => ProfilingSummarizer.fromEvents(_extractCategorizedEvents(kProfilingCategory));
+  ProfilingSummarizer _profilingSummarizer() => ProfilingSummarizer.fromEvents(_extractEventsWithNames(kProfilingEvents));
 
   List<Duration> _extractFrameDurations() => _extractBeginEndEvents(kBuildFrameEventName);
 }

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -65,7 +65,7 @@ void main() {
     };
 
     Map<String, dynamic> cpuUsage(int timeStamp, double cpuUsage) => <String, dynamic>{
-      'cat': 'flutter::profiling',
+      'cat': 'embedder',
       'name': 'CpuUsage',
       'ts': timeStamp,
       'args': <String, String>{
@@ -74,7 +74,7 @@ void main() {
     };
 
     Map<String, dynamic> memoryUsage(int timeStamp, double dirty, double shared) => <String, dynamic>{
-      'cat': 'flutter::profiling',
+      'cat': 'embedder',
       'name': 'MemoryUsage',
       'ts': timeStamp,
       'args': <String, String>{


### PR DESCRIPTION
Category isn't preserved by timeline events as `Dart_TimelineEvent`
specifies the category as `embedder`.

Fixes: https://github.com/flutter/flutter/issues/60008