### PR TITLE
Prefer tear offs to lambdas in test expects

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -47,7 +47,7 @@ void main() {
           'wobble': 'womble',
         },
       );
-      expect(() => fingerprinter.buildFingerprint(), throwsA(anything));
+      expect(fingerprinter.buildFingerprint, throwsA(anything));
     }, overrides: contextOverrides);
 
     testUsingContext('creates fingerprint with specified properties and files', () {

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -482,8 +482,8 @@ void main() {
             expect(lines[1], equals(''));
 
             // Verify that stopping or canceling multiple times throws.
-            expect(() { ansiStatus.cancel(); }, throwsAssertionError);
-            expect(() { ansiStatus.stop(); }, throwsAssertionError);
+            expect(ansiStatus.cancel, throwsAssertionError);
+            expect(ansiStatus.stop, throwsAssertionError);
             done = true;
           });
           expect(done, isTrue);

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -122,7 +122,7 @@ void main() {
 
     await fileCache.diffFileList(<File>[file]);
 
-    expect(() => fileCache.persist(), returnsNormally);
+    expect(fileCache.persist, returnsNormally);
   });
 
   testWithoutContext('FileStore handles hashing missing files', () async {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -48,7 +48,7 @@ void main() {
     });
 
     test('should throw when locking is not acquired', () {
-      expect(() => Cache.checkLockAcquired(), throwsStateError);
+      expect(Cache.checkLockAcquired, throwsStateError);
     });
 
     test('should not throw when locking is disabled', () {
@@ -547,7 +547,7 @@ void main() {
     final MockCache mockCache = MockCache();
     final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
     when(mockCache.includeAllPlatforms).thenReturn(false);
-    expect(() => artifacts.getBinaryDirs(), throwsToolExit(message: 'Unsupported operating system: ${globals.platform.operatingSystem}'));
+    expect(artifacts.getBinaryDirs, throwsToolExit(message: 'Unsupported operating system: ${globals.platform.operatingSystem}'));
   }, overrides: <Type, Generator> {
     Platform: () => FakePlatform(operatingSystem: 'fuchsia'),
   });

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -164,7 +164,7 @@ keep this 2
           mockUsage,
         );
 
-        expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
+        expect(iosProjectMigration.migrate, throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
       });
 
@@ -182,7 +182,7 @@ keep this 2
           mockXcode,
           mockUsage,
         );
-        expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
+        expect(iosProjectMigration.migrate, throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
       });
 
@@ -198,7 +198,7 @@ keep this 2
           mockXcode,
           mockUsage,
         );
-        expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
+        expect(iosProjectMigration.migrate, throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
       });
 
@@ -235,7 +235,7 @@ keep this 2
           mockXcode,
           mockUsage,
         );
-        expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
+        expect(iosProjectMigration.migrate, throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
       });
 
@@ -253,7 +253,7 @@ keep this 2
           mockXcode,
           mockUsage,
         );
-        expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
+        expect(iosProjectMigration.migrate, throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
       });
     });

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -474,7 +474,7 @@ Information about project "Runner":
     );
 
     expect(
-      () => defaultInfo.reportFlavorNotFoundAndExit(),
+      defaultInfo.reportFlavorNotFoundAndExit,
       throwsToolExit(
         message: 'The Xcode project does not define custom schemes. You cannot use the --flavor option.'
       ),
@@ -490,7 +490,7 @@ Information about project "Runner":
     );
 
     expect(
-     () => info.reportFlavorNotFoundAndExit(),
+      info.reportFlavorNotFoundAndExit,
       throwsToolExit(
         message: 'You must specify a --flavor option to select one of the available schemes.'
       ),

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -135,7 +135,7 @@ void main() {
       );
 
       final MDnsObservatoryDiscovery portDiscovery = MDnsObservatoryDiscovery(mdnsClient: client);
-      expect(() => portDiscovery.query(), throwsToolExit());
+      expect(portDiscovery.query, throwsToolExit());
     });
 
     testUsingContext('Multiple ports available, with appId', () async {

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -24,7 +24,7 @@ void main() {
       flutterUsage: usage,
     );
 
-    expect(() => doctorResultEvent.send(), returnsNormally);
+    expect(doctorResultEvent.send, returnsNormally);
 
     verify(usage.sendEvent('doctor-result', any, label: anyNamed('label'))).called(3);
   });
@@ -46,7 +46,7 @@ void main() {
       flutterUsage: usage,
     );
 
-    expect(() => doctorResultEvent.send(), returnsNormally);
+    expect(doctorResultEvent.send, returnsNormally);
 
     verify(usage.sendEvent('doctor-result', any, label: anyNamed('label'))).called(1);
   });

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -875,7 +875,7 @@ void main() {
   testUsingContext('ResidentRunner does support CanvasKit', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
 
-    expect(() => residentRunner.toggleCanvaskit(),
+    expect(residentRunner.toggleCanvaskit,
       throwsA(isA<Exception>()));
   }));
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1560,7 +1560,7 @@ void main() {
     when(mockWebDevFS.connect(any))
       .thenThrow(const WebSocketException());
 
-    await expectLater(() => residentWebRunner.run(), throwsToolExit());
+    await expectLater(residentWebRunner.run, throwsToolExit());
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1577,7 +1577,7 @@ void main() {
     when(mockWebDevFS.connect(any))
       .thenThrow(AppConnectionException(''));
 
-    await expectLater(() => residentWebRunner.run(), throwsToolExit());
+    await expectLater(residentWebRunner.run, throwsToolExit());
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1594,7 +1594,7 @@ void main() {
     when(mockWebDevFS.connect(any))
       .thenThrow(ChromeDebugException(<String, dynamic>{}));
 
-    await expectLater(() => residentWebRunner.run(), throwsToolExit());
+    await expectLater(residentWebRunner.run, throwsToolExit());
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1609,7 +1609,7 @@ void main() {
     _setupMocks();
     when(mockWebDevFS.connect(any)).thenThrow(Exception());
 
-    await expectLater(() => residentWebRunner.run(), throwsException);
+    await expectLater(residentWebRunner.run, throwsException);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1628,7 +1628,7 @@ void main() {
 
     when(mockWebDevFS.connect(any)).thenThrow(StateError(''));
 
-    await expectLater(() => residentWebRunner.run(), throwsStateError);
+    await expectLater(residentWebRunner.run, throwsStateError);
     verify(mockStatus.stop()).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

[DON’T create a lambda when a tear-off will do.](https://dart.dev/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do)

## Related Issues

https://github.com/flutter/flutter/pull/61140#discussion_r452545732
