### PR TITLE
[flutter_tools] allow unmuting of command logging

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -58,13 +58,14 @@ import 'src/web/web_runner.dart';
 ///
 /// This function is intended to be used from the `flutter` command line tool.
 Future<void> main(List<String> args) async {
-  final bool verbose = args.contains('-v') || args.contains('--verbose');
+  final bool veryVerbose = args.contains('-vv');
+  final bool verbose = args.contains('-v') || args.contains('--verbose') || veryVerbose;
 
   final bool doctor = (args.isNotEmpty && args.first == 'doctor') ||
       (args.length == 2 && verbose && args.last == 'doctor');
   final bool help = args.contains('-h') || args.contains('--help') ||
       (args.isNotEmpty && args.first == 'help') || (args.length == 1 && verbose);
-  final bool muteCommandLogging = help || doctor;
+  final bool muteCommandLogging = (help || doctor) && !veryVerbose;
   final bool verboseHelp = help && verbose;
   final bool daemon = args.contains('daemon');
   final bool runMachine = (args.contains('--machine') && args.contains('run')) ||

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -41,6 +41,18 @@ void main() {
     expect(result.stdout, isNot(contains('exiting with code 0')));
   });
 
+  test('flutter doctor -vv super verbose', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await const LocalProcessManager().run(<String>[
+      flutterBin,
+      'doctor',
+      '-vv',
+    ]);
+
+    // Check for message only printed in verbose mode.
+    expect(result.stdout, contains('Running shutdown hooks'));
+  });
+
   test('flutter run --machine uses AppRunLogger', () async {
     final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await const LocalProcessManager().run(<String>[


### PR DESCRIPTION
## Description

Running flutter doctor -v prints out extra details instead of running in verbose mode. Allow disabling this with -vv so it can be debugged.