### PR TITLE
remove LICENSE/NOTICES work around

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -103,14 +103,7 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     // TODO(ianh): Remove this complexity once these bugs are fixed.
     final Completer<String> rawLicenses = Completer<String>();
     scheduleTask(() async {
-      // TODO(jonahwilliams): temporary catch to allow migrating LICENSE to NOTICES.
-      // Once both the tool and google3 use notices this can be removed after PR:
-      // https://github.com/flutter/flutter/pull/57871
-      try {
-        rawLicenses.complete(await rootBundle.loadString('NOTICES', cache: false));
-      } on FlutterError {
-        rawLicenses.complete(await rootBundle.loadString('LICENSE', cache: false));
-      }
+      rawLicenses.complete(await rootBundle.loadString('NOTICES', cache: false));
     }, Priority.animation);
     await rawLicenses.future;
     final Completer<List<LicenseEntry>> parsedLicenses = Completer<List<LicenseEntry>>();

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -46,10 +46,7 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
   BinaryMessenger createBinaryMessenger() {
     return super.createBinaryMessenger()
       ..setMockMessageHandler('flutter/assets', (ByteData message) async {
-        // Temporarily check for both LICENSE and NOTICES
-        // Once both the tool and google3 use notices this can be removed after PR:
-        // https://github.com/flutter/flutter/pull/57871
-        if (const StringCodec().decodeMessage(message) == 'LICENSE' || const StringCodec().decodeMessage(message) == 'NOTICES') {
+        if (const StringCodec().decodeMessage(message) == 'NOTICES') {
           return const StringCodec().encodeMessage(licenses);
         }
         return null;


### PR DESCRIPTION
## Description

Now that google3 has been updated, remove the LICENSE loading fallback. This was done in cl/320506032

https://github.com/flutter/flutter/issues/16723