### PR TITLE
[flutter_tools] abstract logger construction (why can't I hold all these loggers)

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -134,29 +134,19 @@ Future<void> main(List<String> args) async {
        WebRunnerFactory: () => DwdsWebRunnerFactory(),
        // The mustache dependency is different in google3
        TemplateRenderer: () => const MustacheTemplateRenderer(),
-       if (daemon)
-        Logger: () => NotifyingLogger(
+       Logger: () {
+        final LoggerFactory loggerFactory = LoggerFactory(
+          outputPreferences: globals.outputPreferences,
+          terminal: globals.terminal,
+          stdio: globals.stdio,
+          timeoutConfiguration: timeoutConfiguration,
+        );
+        return loggerFactory.createLogger(
+          daemon: daemon,
+          machine: runMachine,
           verbose: verbose,
-          parent: VerboseLogger(StdoutLogger(
-            timeoutConfiguration: timeoutConfiguration,
-            stdio: globals.stdio,
-            terminal: globals.terminal,
-            outputPreferences: globals.outputPreferences,
-          ),
-        ))
-       else if (verbose && !muteCommandLogging)
-        Logger: () => VerboseLogger(StdoutLogger(
-          timeoutConfiguration: timeoutConfiguration,
-          stdio: globals.stdio,
-          terminal: globals.terminal,
-          outputPreferences: globals.outputPreferences,
-        ))
-      else if (runMachine)
-        Logger: () => AppRunLogger(parent: StdoutLogger(
-          timeoutConfiguration: timeoutConfiguration,
-          stdio: globals.stdio,
-          terminal: globals.terminal,
-          outputPreferences: globals.outputPreferences,
-        ))
+          windows: globals.platform.isWindows,
+        );
+       }
      });
 }

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -4,13 +4,17 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import 'runner.dart' as runner;
 import 'src/base/context.dart';
+import 'src/base/io.dart';
 import 'src/base/logger.dart';
 import 'src/base/template.dart';
 // The build_runner code generation is provided here to make it easier to
 // avoid introducing the dependency into google3. Not all build* packages
 // are synced internally.
+import 'src/base/terminal.dart';
 import 'src/build_runner/build_runner.dart';
 import 'src/build_runner/mustache_template.dart';
 import 'src/build_runner/resident_web_runner.dart';
@@ -150,4 +154,65 @@ Future<void> main(List<String> args) async {
         );
        }
      });
+}
+
+
+/// An abstraction for instantiation of the correct logger type.
+///
+/// Our logger class hierarchy and runtime requirements are overly complicated.
+class LoggerFactory {
+  LoggerFactory({
+    @required Terminal terminal,
+    @required Stdio stdio,
+    @required OutputPreferences outputPreferences,
+    @required TimeoutConfiguration timeoutConfiguration,
+    StopwatchFactory stopwatchFactory = const StopwatchFactory(),
+  }) : _terminal = terminal,
+       _stdio = stdio,
+       _timeoutConfiguration = timeoutConfiguration,
+       _stopwatchFactory = stopwatchFactory,
+       _outputPreferences = outputPreferences;
+
+  final Terminal _terminal;
+  final Stdio _stdio;
+  final TimeoutConfiguration _timeoutConfiguration;
+  final StopwatchFactory _stopwatchFactory;
+  final OutputPreferences _outputPreferences;
+
+  /// Create the appropriate logger for the current platform and configuration.
+  Logger createLogger({
+    @required bool verbose,
+    @required bool machine,
+    @required bool daemon,
+    @required bool windows,
+  }) {
+    Logger logger;
+    if (windows) {
+      logger = WindowsStdoutLogger(
+        terminal: _terminal,
+        stdio: _stdio,
+        outputPreferences: _outputPreferences,
+        timeoutConfiguration: _timeoutConfiguration,
+        stopwatchFactory: _stopwatchFactory,
+      );
+    } else {
+      logger = StdoutLogger(
+        terminal: _terminal,
+        stdio: _stdio,
+        outputPreferences: _outputPreferences,
+        timeoutConfiguration: _timeoutConfiguration,
+        stopwatchFactory: _stopwatchFactory
+      );
+    }
+    if (verbose) {
+      logger = VerboseLogger(logger, stopwatchFactory: _stopwatchFactory);
+    }
+    if (daemon) {
+      return NotifyingLogger(verbose: verbose, parent: logger);
+    }
+    if (machine) {
+      return AppRunLogger(parent: logger);
+    }
+    return logger;
+  }
 }

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -149,7 +149,7 @@ Future<void> main(List<String> args) async {
         return loggerFactory.createLogger(
           daemon: daemon,
           machine: runMachine,
-          verbose: verbose,
+          verbose: verbose && !muteCommandLogging,
           windows: globals.platform.isWindows,
         );
        }

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../base/context.dart';
-import '../commands/daemon.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import 'io.dart';
@@ -49,66 +48,6 @@ class TimeoutConfiguration {
 }
 
 typedef VoidCallback = void Function();
-
-/// An abstraction for instantiation of the correct logger type.
-///
-/// Our logger class hierarchy and runtime requirements are overly complicated.
-class LoggerFactory {
-  LoggerFactory({
-    @required Terminal terminal,
-    @required Stdio stdio,
-    @required OutputPreferences outputPreferences,
-    @required TimeoutConfiguration timeoutConfiguration,
-    StopwatchFactory stopwatchFactory = const StopwatchFactory(),
-  }) : _terminal = terminal,
-       _stdio = stdio,
-       _timeoutConfiguration = timeoutConfiguration,
-       _stopwatchFactory = stopwatchFactory,
-       _outputPreferences = outputPreferences;
-
-  final Terminal _terminal;
-  final Stdio _stdio;
-  final TimeoutConfiguration _timeoutConfiguration;
-  final StopwatchFactory _stopwatchFactory;
-  final OutputPreferences _outputPreferences;
-
-  /// Create the appropriate logger for the current platform and configuration.
-  Logger createLogger({
-    @required bool verbose,
-    @required bool machine,
-    @required bool daemon,
-    @required bool windows,
-  }) {
-    Logger logger;
-    if (windows) {
-      logger = WindowsStdoutLogger(
-        terminal: _terminal,
-        stdio: _stdio,
-        outputPreferences: _outputPreferences,
-        timeoutConfiguration: _timeoutConfiguration,
-        stopwatchFactory: _stopwatchFactory,
-      );
-    } else {
-      logger = StdoutLogger(
-        terminal: _terminal,
-        stdio: _stdio,
-        outputPreferences: _outputPreferences,
-        timeoutConfiguration: _timeoutConfiguration,
-        stopwatchFactory: _stopwatchFactory
-      );
-    }
-    if (verbose) {
-      logger = VerboseLogger(logger, stopwatchFactory: _stopwatchFactory);
-    }
-    if (daemon) {
-      return NotifyingLogger(verbose: verbose, parent: logger);
-    }
-    if (machine) {
-      return AppRunLogger(parent: logger);
-    }
-    return logger;
-  }
-}
 
 abstract class Logger {
   bool get isVerbose => false;

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -96,9 +96,9 @@ class LoggerFactory {
         timeoutConfiguration: _timeoutConfiguration,
         stopwatchFactory: _stopwatchFactory
       );
-      if (verbose) {
-        logger = VerboseLogger(logger, stopwatchFactory: _stopwatchFactory);
-      }
+    }
+    if (verbose) {
+      logger = VerboseLogger(logger, stopwatchFactory: _stopwatchFactory);
     }
     if (daemon) {
       return NotifyingLogger(verbose: verbose, parent: logger);

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:mockito/mockito.dart';
 import 'package:quiver/testing/async.dart';
 
@@ -24,6 +25,46 @@ final String resetColor = RegExp.escape(AnsiTerminal.resetColor);
 class MockStdout extends Mock implements Stdout {}
 
 void main() {
+  testWithoutContext('correct logger instance is created', () {
+    final LoggerFactory loggerFactory = LoggerFactory(
+      terminal: Terminal.test(),
+      stdio: mocks.MockStdio(),
+      outputPreferences: OutputPreferences.test(),
+      timeoutConfiguration: const TimeoutConfiguration(),
+    );
+
+    expect(loggerFactory.createLogger(
+      verbose: false,
+      machine: false,
+      daemon: false,
+      windows: false,
+    ), isA<StdoutLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: false,
+      machine: false,
+      daemon: false,
+      windows: true,
+    ), isA<WindowsStdoutLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: true,
+      machine: false,
+      daemon: false,
+      windows: false,
+    ), isA<VerboseLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: false,
+      machine: false,
+      daemon: true,
+      windows: false,
+    ), isA<NotifyingLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: false,
+      machine: true,
+      daemon: false,
+      windows: false,
+    ), isA<AppRunLogger>());
+  });
+
   group('AppContext', () {
     FakeStopwatch fakeStopWatch;
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -49,6 +49,12 @@ void main() {
       verbose: true,
       machine: false,
       daemon: false,
+      windows: true,
+    ), isA<VerboseLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: true,
+      machine: false,
+      daemon: false,
       windows: false,
     ), isA<VerboseLogger>());
     expect(loggerFactory.createLogger(

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert' show jsonEncode;
 
+import 'package:flutter_tools/executable.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';


### PR DESCRIPTION
## Description

We have too many loggers, and the logger construction rules are too complicated to be untested. Capture these in a LoggerFactory and test that construction is correct.