### PR TITLE
Migrate Android views e2e to the new embedding

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
@@ -25,5 +25,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -9,6 +9,8 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
 
 import java.util.HashMap;
 
@@ -29,6 +31,18 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     // This is null when not waiting for the Android permission request;
     private MethodChannel.Result permissionResult;
 
+    private View getFlutterView() {
+        // TODO(egarciad): Set an unique ID in FlutterView, so it's easier to look it up.
+        ViewGroup root = (ViewGroup)findViewById(android.R.id.content);
+        return ((ViewGroup)root.getChildAt(0)).getChildAt(0);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mFlutterViewTouchPipe = new TouchPipe(mMethodChannel, getFlutterView());
+    }
+
     @Override
     public void configureFlutterEngine(FlutterEngine flutterEngine) {
         DartExecutor executor = flutterEngine.getDartExecutor();
@@ -38,7 +52,6 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
             .registerViewFactory("simple_view", new SimpleViewFactory(executor));
         mMethodChannel = new MethodChannel(executor, "android_views_integration");
         mMethodChannel.setMethodCallHandler(this);
-        mFlutterViewTouchPipe = new TouchPipe(mMethodChannel, findViewById(android.R.id.content));
     }
 
     @Override
@@ -70,7 +83,7 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     @SuppressWarnings("unchecked")
     public void synthesizeEvent(MethodCall methodCall, MethodChannel.Result result) {
         MotionEvent event = MotionEventCodec.decode((HashMap<String, Object>) methodCall.arguments());
-        findViewById(android.R.id.content).dispatchTouchEvent(event);
+        getFlutterView().dispatchTouchEvent(event);
         result.success(null);
     }
 

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -12,7 +12,9 @@ import android.view.MotionEvent;
 
 import java.util.HashMap;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.GeneratedPluginRegistrant;
@@ -28,15 +30,15 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     private MethodChannel.Result permissionResult;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        GeneratedPluginRegistrant.registerWith(this);
-        getFlutterView().getPluginRegistry()
-                .registrarFor("io.flutter.integration.platform_views").platformViewRegistry()
-                .registerViewFactory("simple_view", new SimpleViewFactory(getFlutterView()));
-        mMethodChannel = new MethodChannel(this.getFlutterView(), "android_views_integration");
+    public void configureFlutterEngine(FlutterEngine flutterEngine) {
+        DartExecutor executor = flutterEngine.getDartExecutor();
+        flutterEngine
+            .getPlatformViewsController()
+            .getRegistry()
+            .registerViewFactory("simple_view", new SimpleViewFactory(executor));
+        mMethodChannel = new MethodChannel(executor, "android_views_integration");
         mMethodChannel.setMethodCallHandler(this);
-        mFlutterViewTouchPipe = new TouchPipe(mMethodChannel, getFlutterView());
+        mFlutterViewTouchPipe = new TouchPipe(mMethodChannel, findViewById(android.R.id.content));
     }
 
     @Override
@@ -68,7 +70,7 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     @SuppressWarnings("unchecked")
     public void synthesizeEvent(MethodCall methodCall, MethodChannel.Result result) {
         MotionEvent event = MotionEventCodec.decode((HashMap<String, Object>) methodCall.arguments());
-        getFlutterView().dispatchTouchEvent(event);
+        findViewById(android.R.id.content).dispatchTouchEvent(event);
         result.success(null);
     }
 

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -20,19 +20,21 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 
 public class SimplePlatformView implements PlatformView, MethodChannel.MethodCallHandler {
-    private final View view;
+    private final TextView view;
     private final MethodChannel methodChannel;
     private final io.flutter.integration.platformviews.TouchPipe touchPipe;
 
     SimplePlatformView(Context context, MethodChannel methodChannel) {
         this.methodChannel = methodChannel;
-        view = new View(context) {
+        view = new TextView(context) {
             @Override
             public boolean onTouchEvent(MotionEvent event) {
                 return true;
             }
         };
+        view.setTextSize(72);
         view.setBackgroundColor(0xff0000ff);
+        view.setText("Hello from Android view");
         this.methodChannel.setMethodCallHandler(this);
         touchPipe = new io.flutter.integration.platformviews.TouchPipe(this.methodChannel, view);
     }

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimpleViewFactory.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimpleViewFactory.java
@@ -6,22 +6,22 @@ package io.flutter.integration.platformviews;
 
 import android.content.Context;
 
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
 
 public class SimpleViewFactory extends PlatformViewFactory {
-    final BinaryMessenger messenger;
+    final DartExecutor executor;
 
-    public SimpleViewFactory(BinaryMessenger messenger) {
+    public SimpleViewFactory(DartExecutor executor) {
         super(null);
-        this.messenger = messenger;
+        this.executor = executor;
     }
 
     @Override
     public PlatformView create(Context context, int id, Object params) {
-        MethodChannel methodChannel = new MethodChannel(messenger, "simple_view/" + id);
+        MethodChannel methodChannel = new MethodChannel(executor, "simple_view/" + id);
         return new SimplePlatformView(context, methodChannel);
     }
 }

--- a/dev/integration_tests/android_views/lib/motion_event_diff.dart
+++ b/dev/integration_tests/android_views/lib/motion_event_diff.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 
 // Android MotionEvent actions for which a pointer index is encoded in the
 // unmasked action code.

--- a/dev/integration_tests/android_views/lib/motion_event_diff.dart
+++ b/dev/integration_tests/android_views/lib/motion_event_diff.dart
@@ -14,7 +14,7 @@ const List<int> kPointerActions = <int>[
   6, // POINTER_UP
 ];
 
-const double kDoubleErrorMargin = precisionErrorTolerance;
+const double kDoubleErrorMargin = 1e-4;
 
 String diffMotionEvents(
   Map<String, dynamic> originalEvent,


### PR DESCRIPTION
## Description

 The reason why https://github.com/flutter/flutter/issues/61169 didn't get detected by the e2e test is because it's using the old v1 embedding.  The test is failing after migrating it to v2.

## Related Issues

https://github.com/flutter/flutter/issues/61169

## Tests

I added the following tests: this is a test


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
