### PR TITLE
Ignore .idea/* files in the analysis bot.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1155,6 +1155,8 @@ Iterable<File> _allFiles(String workingDirectory, String extension, { @required 
         continue;
       if (path.basename(entity.path) == '.dart_tool')
         continue;
+      if (path.basename(entity.path) == '.idea')
+        continue;
       if (path.basename(entity.path) == 'build')
         continue;
       pending.addAll(entity.listSync());


### PR DESCRIPTION
## Description

If a developer is using IntelliJ IDEA with a flutter tree, it is hard to run the bot's analysis against their tree as the bot will try to analyze a bunch of files in the .idea project directory. This PR just adds an ignore clause to prevent the analyzer from looking at these files.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
