### PR TITLE
fix(cupertino-nav-bar): use transparent backgroundColor on largeTitle

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -790,7 +790,7 @@ class _LargeTitleNavigationBarSliverDelegate
 
     final Widget navBar = _wrapWithBackground(
       border: border,
-      backgroundColor: CupertinoDynamicColor.resolve(backgroundColor, context)!,
+      backgroundColor: showLargeTitle ? const Color(0x00000000) : CupertinoDynamicColor.resolve(backgroundColor, context)!,
       brightness: brightness,
       child: DefaultTextStyle(
         style: CupertinoTheme.of(context).textTheme.textStyle,

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -871,6 +871,24 @@ void main() {
     expect(bottom.color, const Color(0xFFAABBCC));
   });
 
+  testWidgets('Default background is transparent when showing large title', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CustomScrollView(
+            slivers: <Widget>[
+              CupertinoSliverNavigationBar(
+                largeTitle: Text('Large Title'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CupertinoSliverNavigationBar), paints..rect(color: const Color(0x00000000)));
+  });
+
   testWidgets(
     'Standard title golden',
     (WidgetTester tester) async {


### PR DESCRIPTION
## Description

As described in the #60411, Apple's iOS apps typically don't shade the background until it's in the collapsed state.
To have an all-around solution to match any sort of background on the underlying content, I used `Colors.transparent`.

Collapsed:
![IMG_0532](https://user-images.githubusercontent.com/6323077/86013395-19d50500-b9ed-11ea-9273-6184e216ae01.jpg)

Expanded:
![IMG_0531](https://user-images.githubusercontent.com/6323077/86013397-1a6d9b80-b9ed-11ea-9acd-5ee0a696330c.jpg)

Potentially this could also allow a customizable `largeBackgroundColor` with a default of `CupertinoTheme.of(context).scaffoldBackgroundColor`, but I figured `Colors.transparent` would be easiest for a drop-in fix with minimal impact on existing apps.

```dart
final largeBackgroundColor = CupertinoDynamicColor.resolve(widget.largeBackgroundColor, context)
    ?? CupertinoTheme.of(context).scaffoldBackgroundColor;
...
    final Widget navBar = _wrapWithBackground(
      border: border,
      backgroundColor: showLargeTitle
          ? CupertinoDynamicColor.resolve(largeBackgroundColor, context)
          : CupertinoDynamicColor.resolve(backgroundColor, context),
...
```

## Related Issues

Fixes #60411.

## Tests

I added the following tests:

None yet. Starting this PR to get better discussion about the best path forward for this change.
If a `largeBackgroundColor` field is desired, then obviously different tests are needed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

The `Large title golden` test failed, as this has an impact on the `backgroundColor`.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
