### PR TITLE
implement handlePointerEventRecord for LiveWidgetController

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -718,8 +719,80 @@ class LiveWidgetController extends WidgetController {
 
   @override
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records) {
-    // TODO(CareF): This will be implemented after we decide what should be the
-    // correct pumping strategy.
-    throw UnimplementedError;
+    assert(records != null);
+    assert(records.isNotEmpty);
+    return TestAsyncUtils.guard<List<Duration>>(() async {
+      // hitTestHistory is an equivalence of _hitTests in [GestureBinding]
+      final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
+      final List<Duration> handleTimeStampDiff = <Duration>[];
+      DateTime startTime;
+      for (final PointerEventRecord record in records) {
+        final DateTime now = clock.now();
+        startTime ??= now;
+        // So that the first event is promised to receive a zero timeDiff
+        final Duration timeDiff = record.timeDelay - now.difference(startTime);
+        if (timeDiff.isNegative) {
+          // Flush all past events
+          handleTimeStampDiff.add(timeDiff);
+          for (final PointerEvent event in record.events) {
+            _handlePointerEvent(event, hitTestHistory);
+          }
+        } else {
+          await Future<void>.delayed(timeDiff);
+          handleTimeStampDiff.add(
+            record.timeDelay - clock.now().difference(startTime),
+          );
+          for (final PointerEvent event in record.events) {
+            _handlePointerEvent(event, hitTestHistory);
+          }
+        }
+      }
+      // This makes sure that a gesture is completed, with no more pointers
+      // active.
+      assert(hitTestHistory.isEmpty);
+      return handleTimeStampDiff;
+    });
+  }
+
+  // This is a parallel implementation of [GestureBinding._handlePointerEvent]
+  // to make compatible with test bindings.
+  void _handlePointerEvent(
+    PointerEvent event,
+    Map<int, HitTestResult> _hitTests
+  ) {
+    HitTestResult hitTestResult;
+    if (event is PointerDownEvent || event is PointerSignalEvent) {
+      assert(!_hitTests.containsKey(event.pointer));
+      hitTestResult = HitTestResult();
+      binding.hitTest(hitTestResult, event.position);
+      if (event is PointerDownEvent) {
+        _hitTests[event.pointer] = hitTestResult;
+      }
+      assert(() {
+        if (debugPrintHitTestResults)
+          debugPrint('$event: $hitTestResult');
+        return true;
+      }());
+    } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+      hitTestResult = _hitTests.remove(event.pointer);
+    } else if (event.down) {
+      // Because events that occur with the pointer down (like
+      // PointerMoveEvents) should be dispatched to the same place that their
+      // initial PointerDownEvent was, we want to re-use the path we found when
+      // the pointer went down, rather than do hit detection each time we get
+      // such an event.
+      hitTestResult = _hitTests[event.pointer];
+    }
+    assert(() {
+      if (debugPrintMouseHoverEvents && event is PointerHoverEvent)
+        debugPrint('$event');
+      return true;
+    }());
+    if (hitTestResult != null ||
+        event is PointerHoverEvent ||
+        event is PointerAddedEvent ||
+        event is PointerRemovedEvent) {
+      binding.dispatchEvent(event, hitTestResult);
+    }
   }
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -736,7 +736,7 @@ class LiveWidgetController extends WidgetController {
           // This happens when something (e.g. GC) takes a long time during the
           // processing of the events.
           // Flush all past events
-          handleTimeStampDiff.add(timeDiff);
+          handleTimeStampDiff.add(-timeDiff);
           for (final PointerEvent event in record.events) {
             _handlePointerEvent(event, hitTestHistory);
           }
@@ -746,7 +746,7 @@ class LiveWidgetController extends WidgetController {
             // Recalculating the time diff for getting exact time when the event
             // packet is sent. For a perfect Future.delayed like the one in a
             // fake async this new diff should be zero.
-            record.timeDelay - clock.now().difference(startTime),
+            clock.now().difference(startTime) - record.timeDelay,
           );
           for (final PointerEvent event in record.events) {
             _handlePointerEvent(event, hitTestHistory);

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -71,7 +71,6 @@ Future<void> main() async {
     for (final Duration diff in timeDiffs) {
       // Allow some freedom of time delay in real world.
       assert(diff.inMilliseconds > -1);
-      assert(diff.inMilliseconds < 50);
     }
 
     const String b = '$kSecondaryMouseButton';

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
-  test('Input events on LiveWidgetController', () async {
+  test('Input event array on LiveWidgetController', () async {
     final List<String> logs = <String>[];
     runApp(
       MaterialApp(
@@ -70,7 +70,7 @@ Future<void> main() async {
     expect(timeDiffs.length, records.length);
     for (final Duration diff in timeDiffs) {
       // Allow some freedom of time delay in real world.
-      assert(diff.inMicroseconds < 1000);
+      assert(diff.inMicroseconds.abs() < 1000);
     }
 
     const String b = '$kSecondaryMouseButton';

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -70,7 +70,8 @@ Future<void> main() async {
     expect(timeDiffs.length, records.length);
     for (final Duration diff in timeDiffs) {
       // Allow some freedom of time delay in real world.
-      assert(diff.inMicroseconds.abs() < 1000);
+      assert(diff.inMilliseconds > -1);
+      assert(diff.inMilliseconds < 50);
     }
 
     const String b = '$kSecondaryMouseButton';

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  final List<String> logs = <String>[];
+  runApp(
+    MaterialApp(
+      home: Listener(
+        onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
+        onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
+        onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
+        child: const Text('test'),
+      ),
+    ),
+  );
+  await SchedulerBinding.instance.endOfFrame;
+  final WidgetController controller =
+      LiveWidgetController(WidgetsBinding.instance);
+
+  final Offset location = controller.getCenter(find.text('test'));
+  final List<PointerEventRecord> records = <PointerEventRecord>[
+    PointerEventRecord(Duration.zero, <PointerEvent>[
+      // Typically PointerAddedEvent is not used in testers, but for records
+      // captured on a device it is usually what start a gesture.
+      PointerAddedEvent(
+        timeStamp: Duration.zero,
+        position: location,
+      ),
+      PointerDownEvent(
+        timeStamp: Duration.zero,
+        position: location,
+        buttons: kSecondaryMouseButton,
+        pointer: 1,
+      ),
+    ]),
+    ...<PointerEventRecord>[
+      for (Duration t = const Duration(milliseconds: 5);
+          t < const Duration(milliseconds: 80);
+          t += const Duration(milliseconds: 16))
+        PointerEventRecord(t, <PointerEvent>[
+          PointerMoveEvent(
+            timeStamp: t - const Duration(milliseconds: 1),
+            position: location,
+            buttons: kSecondaryMouseButton,
+            pointer: 1,
+          )
+        ])
+    ],
+    PointerEventRecord(const Duration(milliseconds: 80), <PointerEvent>[
+      PointerUpEvent(
+        timeStamp: const Duration(milliseconds: 79),
+        position: location,
+        buttons: kSecondaryMouseButton,
+        pointer: 1,
+      )
+    ])
+  ];
+  final List<Duration> timeDiffs =
+      await controller.handlePointerEventRecord(records);
+
+  test('Input events on LiveWidgetController', () async {
+    expect(timeDiffs.length, records.length);
+    for (final Duration diff in timeDiffs) {
+      // Allow some freedom of time delay in real world.
+      assert(diff.inMicroseconds < 1000);
+    }
+
+    const String b = '$kSecondaryMouseButton';
+    expect(logs.first, 'down $b');
+    for (int i = 1; i < logs.length - 1; i++) {
+      expect(logs[i], 'move $b');
+    }
+    expect(logs.last, 'up $b');
+  });
+}

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -10,63 +10,63 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
-  final List<String> logs = <String>[];
-  runApp(
-    MaterialApp(
-      home: Listener(
-        onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
-        onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
-        onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
-        child: const Text('test'),
-      ),
-    ),
-  );
-  await SchedulerBinding.instance.endOfFrame;
-  final WidgetController controller =
-      LiveWidgetController(WidgetsBinding.instance);
-
-  final Offset location = controller.getCenter(find.text('test'));
-  final List<PointerEventRecord> records = <PointerEventRecord>[
-    PointerEventRecord(Duration.zero, <PointerEvent>[
-      // Typically PointerAddedEvent is not used in testers, but for records
-      // captured on a device it is usually what start a gesture.
-      PointerAddedEvent(
-        timeStamp: Duration.zero,
-        position: location,
-      ),
-      PointerDownEvent(
-        timeStamp: Duration.zero,
-        position: location,
-        buttons: kSecondaryMouseButton,
-        pointer: 1,
-      ),
-    ]),
-    ...<PointerEventRecord>[
-      for (Duration t = const Duration(milliseconds: 5);
-          t < const Duration(milliseconds: 80);
-          t += const Duration(milliseconds: 16))
-        PointerEventRecord(t, <PointerEvent>[
-          PointerMoveEvent(
-            timeStamp: t - const Duration(milliseconds: 1),
-            position: location,
-            buttons: kSecondaryMouseButton,
-            pointer: 1,
-          )
-        ])
-    ],
-    PointerEventRecord(const Duration(milliseconds: 80), <PointerEvent>[
-      PointerUpEvent(
-        timeStamp: const Duration(milliseconds: 79),
-        position: location,
-        buttons: kSecondaryMouseButton,
-        pointer: 1,
-      )
-    ])
-  ];
-  final List<Duration> timeDiffs =
-      await controller.handlePointerEventRecord(records);
-
   test('Input events on LiveWidgetController', () async {
+    final List<String> logs = <String>[];
+    runApp(
+      MaterialApp(
+        home: Listener(
+          onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
+          onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
+          onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
+          child: const Text('test'),
+        ),
+      ),
+    );
+    await SchedulerBinding.instance.endOfFrame;
+    final WidgetController controller =
+        LiveWidgetController(WidgetsBinding.instance);
+
+    final Offset location = controller.getCenter(find.text('test'));
+    final List<PointerEventRecord> records = <PointerEventRecord>[
+      PointerEventRecord(Duration.zero, <PointerEvent>[
+        // Typically PointerAddedEvent is not used in testers, but for records
+        // captured on a device it is usually what start a gesture.
+        PointerAddedEvent(
+          timeStamp: Duration.zero,
+          position: location,
+        ),
+        PointerDownEvent(
+          timeStamp: Duration.zero,
+          position: location,
+          buttons: kSecondaryMouseButton,
+          pointer: 1,
+        ),
+      ]),
+      ...<PointerEventRecord>[
+        for (Duration t = const Duration(milliseconds: 5);
+            t < const Duration(milliseconds: 80);
+            t += const Duration(milliseconds: 16))
+          PointerEventRecord(t, <PointerEvent>[
+            PointerMoveEvent(
+              timeStamp: t - const Duration(milliseconds: 1),
+              position: location,
+              buttons: kSecondaryMouseButton,
+              pointer: 1,
+            )
+          ])
+      ],
+      PointerEventRecord(const Duration(milliseconds: 80), <PointerEvent>[
+        PointerUpEvent(
+          timeStamp: const Duration(milliseconds: 79),
+          position: location,
+          buttons: kSecondaryMouseButton,
+          pointer: 1,
+        )
+      ])
+    ];
+    final List<Duration> timeDiffs =
+        await controller.handlePointerEventRecord(records);
+
     expect(timeDiffs.length, records.length);
     for (final Duration diff in timeDiffs) {
       // Allow some freedom of time delay in real world.


### PR DESCRIPTION
## Description

This is a follow up of #60796

The way we are using this `LiveWidgetController` in the repo are:
1. `dev/benchmarks/complex_layout/test_memory/scroll_perf.dart` is using `fling` which already is pumping regardless. 
2. `dev/integration_tests/flutter_gallery/test/live_smoketest.dart` and `dev/integration_tests/flutter_gallery/test_memory/image_cache_memory.dart` don't pump at all
3. `packages/flutter_driver/lib/src/extension/extension.dart` is used in `flutter_driver` and don't have pump. 

From these use cases I believe 1 is just not taking much consideration about pumping while 2 and 3 already suggest not to pump. 

## Related Issues

Resolves #61263

## Tests

I added the following tests:

`packages/flutter_test/test/live_widget_controller_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
