### PR TITLE
Use CloseButton on AppBar in PopupRoute

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -503,7 +503,8 @@ class _AppBarState extends State<AppBar> {
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
     final bool canPop = parentRoute?.canPop ?? false;
-    final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
+    final bool useCloseButton = parentRoute is PopupRoute<dynamic> ||
+        parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
     final double toolbarHeight = widget.toolbarHeight ?? kToolbarHeight;
 

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -537,7 +537,7 @@ void main() {
   });
 
   group('close button', () {
-    Future<void> expectCloseIcon(WidgetTester tester, PageRoute<void> routeBuilder(), String type) async {
+    Future<void> expectCloseIcon(WidgetTester tester, ModalRoute<void> routeBuilder(), String type) async {
       const IconData expectedIcon = Icons.close;
       await tester.pumpWidget(
         MaterialApp(
@@ -582,6 +582,14 @@ void main() {
       );
     }
 
+    PopupRoute<void> customPopupRouteBuilder() {
+      return _CustomPopupRoute<void>(
+        builder: (BuildContext context) {
+          return Scaffold(appBar: AppBar(), body: const Text('Page 2'));
+        },
+      );
+    }
+
     testWidgets('Close button shows correctly', (WidgetTester tester) async {
       await expectCloseIcon(tester, materialRouteBuilder, 'materialRouteBuilder');
     }, variant: TargetPlatformVariant.all());
@@ -592,6 +600,10 @@ void main() {
 
     testWidgets('Close button shows correctly with custom page route', (WidgetTester tester) async {
       await expectCloseIcon(tester, customPageRouteBuilder, 'customPageRouteBuilder');
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets('Close button shows correctly with custom PopupRoute', (WidgetTester tester) async {
+      await expectCloseIcon(tester, customPopupRouteBuilder, 'customPopupRouteBuilder');
     }, variant: TargetPlatformVariant.all());
   });
 
@@ -2116,5 +2128,32 @@ class _CustomPageRoute<T> extends PageRoute<T> {
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return child;
+  }
+}
+
+class _CustomPopupRoute<T> extends PopupRoute<T> {
+  _CustomPopupRoute({
+    @required this.builder,
+    RouteSettings settings = const RouteSettings(),
+  }) : assert(builder != null),
+       super(settings: settings);
+
+  final WidgetBuilder builder;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 200);
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Color get barrierColor => null;
+
+  @override
+  String get barrierLabel => null;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return builder(context);
   }
 }

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -100,7 +100,7 @@ void main() {
       ),
     );
 
-    expect(find.byTooltip('Back'), findsNothing);
+    expect(find.byTooltip('Close'), findsNothing);
     expect(find.text('Sample Page'), findsNothing);
 
     await tester.tap(find.text('X'));
@@ -110,7 +110,7 @@ void main() {
     expect(find.text('Sample Page'), findsOneWidget);
 
     willPopValue = false;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(find.byTooltip('Close'));
     await tester.pump();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -123,7 +123,7 @@ void main() {
     expect(find.text('Sample Page'), findsOneWidget);
 
     willPopValue = true;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(find.byTooltip('Close'));
     await tester.pump();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));


### PR DESCRIPTION
## Description

From #61255:
In a `PopupRoute` like used by `showModalBottomSheet`, the `AppBar` currently shows a `BackButton` rather than `CloseButton`.

An `AppBar` within a `PopupRoute` should likely display a `CloseButton` because it's displayed over top of another page and `BackButton` doesn't make much sense.

Current:
<img width="398" alt="Screen Shot 2020-07-10 at 4 37 33 PM" src="https://user-images.githubusercontent.com/6323077/87200984-b2ac3000-c2cb-11ea-9de4-cc62aae3020c.png">

Proposed:
<img width="392" alt="Screen Shot 2020-07-10 at 4 37 05 PM" src="https://user-images.githubusercontent.com/6323077/87200985-b2ac3000-c2cb-11ea-9ac4-928acafe42ae.png">

## Related Issues

Fixes #61255.

## Tests

I added the following tests:
`Close button shows correctly with custom PopupRoute` to `scaffold_test.dart` since it contained the related checks for `PageRoute`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [X] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

The existing test failed because it checked for the `'Back'` tooltip on a `showDialog`.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
