### PR TITLE
[flutter_tools] Increase minimum supported iOS version to 9.0 in iOS create templates

### DIFF
--- a/packages/flutter_tools/templates/app/ios.tmpl/Flutter/AppFrameworkInfo.plist
+++ b/packages/flutter_tools/templates/app/ios.tmpl/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Increased the minimum supported iOS version because Xcode 14 drops support for iOS 8 in templates folder.

## Related Issues

Fixes #60035

## Tests

I added the following tests:

No Tests added

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Yes, removes support for iOS 8.
