### PR TITLE
Show correct errors when plugins yaml forgot the 'flutter.plugins.pla…

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -213,6 +213,14 @@ class Plugin {
       return <String>[errorMessage];
     }
 
+    if (!usesOldPluginFormat && !usesNewPluginFormat) {
+      const String errorMessage =
+          'Cannot find the `flutter.plugin.platforms` key in the `pubspec.yaml` file. '
+          'An instruction to format the `pubspec.yaml` can be found here: '
+          'https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms';
+      return <String>[errorMessage];
+    }
+
     if (usesNewPluginFormat) {
       if (yaml['platforms'] != null && yaml['platforms'] is! YamlMap) {
         const String errorMessage = 'flutter.plugin.platforms should be a map with the platform name as the key';
@@ -264,18 +272,6 @@ class Plugin {
 
   static List<String> _validateLegacyYaml(YamlMap yaml) {
     final List<String> errors = <String>[];
-
-      if (yaml[AndroidPlugin.kConfigKey] != null ||
-        yaml[IOSPlugin.kConfigKey] != null ||
-        yaml[LinuxPlugin.kConfigKey] != null ||
-        yaml[MacOSPlugin.kConfigKey] != null ||
-        yaml[WindowsPlugin.kConfigKey] != null) {
-      const String errorMessage =
-          'The flutter.plugin.platforms key should be added,'
-          'when specifying a plugin supported platforms\n'
-          'See: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin';
-      return <String>[errorMessage];
-    }
 
     if (yaml['androidPackage'] != null && yaml['androidPackage'] is! String) {
       errors.add('The "androidPackage" must either be null or a string.');

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -264,6 +264,19 @@ class Plugin {
 
   static List<String> _validateLegacyYaml(YamlMap yaml) {
     final List<String> errors = <String>[];
+
+      if (yaml[AndroidPlugin.kConfigKey] != null ||
+        yaml[IOSPlugin.kConfigKey] != null ||
+        yaml[LinuxPlugin.kConfigKey] != null ||
+        yaml[MacOSPlugin.kConfigKey] != null ||
+        yaml[WindowsPlugin.kConfigKey] != null) {
+      const String errorMessage =
+          'The flutter.plugin.platforms key should be added,'
+          'when specifying a plugin supported platforms\n'
+          'See: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin';
+      return <String>[errorMessage];
+    }
+
     if (yaml['androidPackage'] != null && yaml['androidPackage'] is! String) {
       errors.add('The "androidPackage" must either be null or a string.');
     }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -964,7 +964,7 @@ flutter:
       contains('flutter.plugin.platforms should be a map with the platform name as the key'));
   });
 
-    testWithoutContext('FlutterManifest validates missing flutter.plugin.platforms key', () {
+    testWithoutContext('FlutterManifest validates plugin format not support.', () {
     const String manifest = '''
 name: test
 flutter:
@@ -983,8 +983,7 @@ flutter:
 
     expect(flutterManifest, null);
     expect(logger.errorText,
-      contains('The flutter.plugin.platforms key should be added,'
-      'when specifying a plugin supported platforms'));
+      contains('Cannot find the `flutter.plugin.platforms` key in the `pubspec.yaml` file. '));
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -963,6 +963,29 @@ flutter:
     expect(logger.errorText,
       contains('flutter.plugin.platforms should be a map with the platform name as the key'));
   });
+
+    testWithoutContext('FlutterManifest validates missing flutter.plugin.platforms key', () {
+    const String manifest = '''
+name: test
+flutter:
+  plugin:
+    android:
+      package: com.example
+      pluginClass: SomeClass
+    ios:
+      pluginClass: SomeClass
+''';
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains('The flutter.plugin.platforms key should be added,'
+      'when specifying a plugin supported platforms'));
+  });
 }
 
 Matcher matchesManifest({


### PR DESCRIPTION
## Description

If a plugin is migrating from old plugin format to new plugin format (The multi-platform format) and forgot to add the key `flutter.plugin.platforms` at `pubspec.yaml` like below

```yaml
flutter:
  plugin:
    android:
      package: packageName
      pluginClass: className
```

and users upgrade the plugin, they will not receive any error but the build will pass as before.

BUT the plugin's platform side registrar already missing, because the `flutter_tool` can't found the correct platform type for it to generate it.

I was meet this problem recently, so create this MR to avoid this problem again.

> https://pub.dev/packages/flutter_growingio_track  version: 2.6.5  is a real case 

This is my first time to contribute to flutter,  if has any issues of this MR, please let me know.

## Related Issues

Fixes #61337

## Tests

I added the following tests:
```dart
    testWithoutContext('FlutterManifest validates missing flutter.plugin.platforms key', () {
    const String manifest = '''
name: test
flutter:
  plugin:
    android:
      package: com.example
      pluginClass: SomeClass
    ios:
      pluginClass: SomeClass
''';
    final BufferLogger logger = BufferLogger.test();
    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
      manifest,
      logger: logger,
    );

    expect(flutterManifest, null);
    expect(logger.errorText,
      contains('The flutter.plugin.platforms key should be added,'
      'when specifying a plugin supported platforms'));
  });
}
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
