### PR TITLE
Remove the default shortcut mapping for GameButtonB.

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -854,7 +854,6 @@ class WidgetsApp extends StatefulWidget {
 
     // Dismissal
     LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
-    LogicalKeySet(LogicalKeyboardKey.gameButtonB): const ActivateIntent(),
 
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),


### PR DESCRIPTION
## Description

The default shortcut map has `LogicalKeyboardKey.gameButtonB` mapped to `DismissIntent` (actually there is a typo such that it is currently `ActiveIntent`, so it is doubly broken). However, on Android devices that use the B button on a controller, this causes the back navigation to trigger twice as the system already triggers the Android back button to the B button.

We could special case this for Android, but given that we don't really know the context in which apps would like to dismiss dialogs from a game controller, we should just remove this mapping altogether. Apps can then hook up whatever key they want for dismissal in their own shortcut map.

## Related Issues

Fixes: #61369

## Tests

I added the following tests:

This removed a shortcut that wasn't actually being tested in the first place.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
