### PR TITLE
Make ThemeData.shadowColor the default shadowColor in TextButton et al.

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -14,7 +14,6 @@ import 'package:flutter/widgets.dart';
 import 'button_style.dart';
 import 'button_style_button.dart';
 import 'color_scheme.dart';
-import 'colors.dart';
 import 'constants.dart';
 import 'elevated_button_theme.dart';
 import 'material_state.dart';
@@ -220,7 +219,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// * `overlayColor`
   ///   * hovered - Theme.colorScheme.onPrimary(0.08)
   ///   * focused or pressed - Theme.colorScheme.onPrimary(0.24)
-  /// * `shadowColor` - Colors.black
+  /// * `shadowColor` - Theme.shadowColor
   /// * `elevation`
   ///   * disabled - 0
   ///   * hovered or focused - 2
@@ -264,7 +263,7 @@ class ElevatedButton extends ButtonStyleButton {
       primary: colorScheme.primary,
       onPrimary: colorScheme.onPrimary,
       onSurface: colorScheme.onSurface,
-      shadowColor: Colors.black,
+      shadowColor: theme.shadowColor,
       elevation: 2,
       textStyle: theme.textTheme.button,
       padding: scaledPadding,

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -202,7 +202,7 @@ class OutlinedButton extends ButtonStyleButton {
   /// * `overlayColor`
   ///   * hovered - Theme.colorScheme.primary(0.04)
   ///   * focused or pressed - Theme.colorScheme.primary(0.12)
-  /// * `shadowColor` - Colors.black
+  /// * `shadowColor` - Theme.shadowColor
   /// * `elevation` - 0
   /// * `padding`
   ///   * `textScaleFactor <= 1` - horizontal(16)
@@ -235,7 +235,7 @@ class OutlinedButton extends ButtonStyleButton {
       primary: colorScheme.primary,
       onSurface: colorScheme.onSurface,
       backgroundColor: Colors.transparent,
-      shadowColor: Colors.black,
+      shadowColor: theme.shadowColor,
       elevation: 0,
       textStyle: theme.textTheme.button,
       padding: scaledPadding,

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -211,7 +211,7 @@ class TextButton extends ButtonStyleButton {
   /// * `overlayColor`
   ///   * hovered - Theme.colorScheme.primary(0.04)
   ///   * focused or pressed - Theme.colorScheme.primary(0.12)
-  /// * `shadowColor` - Colors.black
+  /// * `shadowColor` - Theme.shadowColor
   /// * `elevation` - 0
   /// * `padding`
   ///   * `textScaleFactor <= 1` - all(8)
@@ -251,7 +251,7 @@ class TextButton extends ButtonStyleButton {
       primary: colorScheme.primary,
       onSurface: colorScheme.onSurface,
       backgroundColor: Colors.transparent,
-      shadowColor: Colors.black,
+      shadowColor: theme.shadowColor,
       elevation: 0,
       textStyle: theme.textTheme.button,
       padding: scaledPadding,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -764,19 +764,15 @@ class ThemeData with Diagnosticable {
   /// The default color of [MaterialType.canvas] [Material].
   final Color canvasColor;
 
-  /// The color that [Material] widget uses to draw elevation shadows.
+  /// The color that the [Material] widget uses to draw elevation shadows.
   ///
   /// Defaults to fully opaque black.
   ///
   /// Shadows can be difficult to see in a dark theme, so the elevation of a
-  /// surface should be portrayed with an "overlay" in addition to the shadow.
+  /// surface should be rendered with an "overlay" in addition to the shadow.
   /// As the elevation of the component increases, the overlay increases in
-  /// opacity.
-  ///
-  /// See also:
-  ///
-  ///  * [applyElevationOverlayColor], which turns elevation overlay on or off
-  /// for dark themes.
+  /// opacity. The [applyElevationOverlayColor] property turns the elevation
+  /// overlay on or off for dark themes.
   final Color shadowColor;
 
   /// The foreground color for widgets (knobs, text, overscroll edge effect, etc).

--- a/packages/flutter/test/material/elevated_button_theme_test.dart
+++ b/packages/flutter/test/material/elevated_button_theme_test.dart
@@ -179,4 +179,58 @@ void main() {
       checkButton(tester);
     });
   });
+
+  testWidgets('Theme shadowColor', (WidgetTester tester) async {
+    const ColorScheme colorScheme = ColorScheme.light();
+    const Color shadowColor = Color(0xff000001);
+
+    Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
+      return MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme).copyWith(
+          shadowColor: overallShadowColor,
+        ),
+        home: Scaffold(
+          body: Center(
+            child: ElevatedButtonTheme(
+              data: ElevatedButtonThemeData(
+                style: ElevatedButton.styleFrom(
+                  shadowColor: themeShadowColor,
+                ),
+              ),
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      shadowColor: shadowColor,
+                    ),
+                    onPressed: () { },
+                    child: const Text('button'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder buttonMaterialFinder = find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(Material),
+    );
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+  });
 }

--- a/packages/flutter/test/material/elevated_button_theme_test.dart
+++ b/packages/flutter/test/material/elevated_button_theme_test.dart
@@ -183,6 +183,7 @@ void main() {
   testWidgets('Theme shadowColor', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     const Color shadowColor = Color(0xff000001);
+    const Color overiddenColor = Color(0xff000002);
 
     Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
       return MaterialApp(
@@ -219,8 +220,13 @@ void main() {
       matching: find.byType(Material),
     );
 
-    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpWidget(buildFrame());
     Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, Colors.black); //default
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
@@ -229,6 +235,16 @@ void main() {
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: overiddenColor, themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: overiddenColor, shadowColor: shadowColor));
     await tester.pumpAndSettle(); // theme animation
     material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -35,7 +35,7 @@ void main() {
     expect(material.borderRadius, null);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shadowColor, Colors.black);
     expect(material.shape, RoundedRectangleBorder(
       side: BorderSide(width: 1, color: colorScheme.onSurface.withOpacity(0.12)),
       borderRadius: BorderRadius.circular(4.0),
@@ -184,6 +184,7 @@ void main() {
   testWidgets('Theme shadowColor', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     const Color shadowColor = Color(0xff000001);
+    const Color overiddenColor = Color(0xff000002);
 
     Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
       return MaterialApp(
@@ -220,8 +221,13 @@ void main() {
       matching: find.byType(Material),
     );
 
-    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpWidget(buildFrame());
     Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, Colors.black); //default
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
@@ -230,6 +236,16 @@ void main() {
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: overiddenColor, themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: overiddenColor, shadowColor: shadowColor));
     await tester.pumpAndSettle(); // theme animation
     material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -180,4 +180,58 @@ void main() {
       checkButton(tester);
     });
   });
+
+  testWidgets('Theme shadowColor', (WidgetTester tester) async {
+    const ColorScheme colorScheme = ColorScheme.light();
+    const Color shadowColor = Color(0xff000001);
+
+    Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
+      return MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme).copyWith(
+          shadowColor: overallShadowColor,
+        ),
+        home: Scaffold(
+          body: Center(
+            child: OutlinedButtonTheme(
+              data: OutlinedButtonThemeData(
+                style: OutlinedButton.styleFrom(
+                  shadowColor: themeShadowColor,
+                ),
+              ),
+              child: Builder(
+                builder: (BuildContext context) {
+                  return OutlinedButton(
+                    style: OutlinedButton.styleFrom(
+                      shadowColor: shadowColor,
+                    ),
+                    onPressed: () { },
+                    child: const Text('button'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder buttonMaterialFinder = find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.byType(Material),
+    );
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+  });
 }

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -181,6 +181,7 @@ void main() {
   testWidgets('Theme shadowColor', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     const Color shadowColor = Color(0xff000001);
+    const Color overiddenColor = Color(0xff000002);
 
     Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
       return MaterialApp(
@@ -217,8 +218,13 @@ void main() {
       matching: find.byType(Material),
     );
 
-    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpWidget(buildFrame());
     Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, Colors.black); //default
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
@@ -227,6 +233,16 @@ void main() {
     expect(material.shadowColor, shadowColor);
 
     await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: overiddenColor, themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: overiddenColor, shadowColor: shadowColor));
     await tester.pumpAndSettle(); // theme animation
     material = tester.widget<Material>(buttonMaterialFinder);
     expect(material.shadowColor, shadowColor);

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -177,4 +177,58 @@ void main() {
       checkButton(tester);
     });
   });
+
+  testWidgets('Theme shadowColor', (WidgetTester tester) async {
+    const ColorScheme colorScheme = ColorScheme.light();
+    const Color shadowColor = Color(0xff000001);
+
+    Widget buildFrame({ Color overallShadowColor, Color themeShadowColor, Color shadowColor }) {
+      return MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme).copyWith(
+          shadowColor: overallShadowColor,
+        ),
+        home: Scaffold(
+          body: Center(
+            child: TextButtonTheme(
+              data: TextButtonThemeData(
+                style: TextButton.styleFrom(
+                  shadowColor: themeShadowColor,
+                ),
+              ),
+              child: Builder(
+                builder: (BuildContext context) {
+                  return TextButton(
+                    style: TextButton.styleFrom(
+                      shadowColor: shadowColor,
+                    ),
+                    onPressed: () { },
+                    child: const Text('button'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Finder buttonMaterialFinder = find.descendant(
+      of: find.byType(TextButton),
+      matching: find.byType(Material),
+    );
+
+    await tester.pumpWidget(buildFrame(overallShadowColor: shadowColor));
+    Material material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(themeShadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+
+    await tester.pumpWidget(buildFrame(shadowColor: shadowColor));
+    await tester.pumpAndSettle(); // theme animation
+    material = tester.widget<Material>(buttonMaterialFinder);
+    expect(material.shadowColor, shadowColor);
+  });
 }


### PR DESCRIPTION
Updated the default value shadowColor in TextButton, ElevatedButton, OutlinedButton to be `Theme.of(context).shadowColor`, per https://github.com/flutter/flutter/pull/60337.