### PR TITLE
issue 61346 route can be added and disposed in the same frame

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -213,7 +213,11 @@ abstract class Route<T> {
     // focused child can only be attached to navigator after initState which
     // will be guarded by the asynchronous gap.
     TickerFuture.complete().then<void>((void _) {
-      navigator.focusScopeNode.requestFocus();
+      // The route can be disposed before the ticker future completes. This can
+      // happen when the navigator is under a TabView that does a warping. The
+      // navigator will be null in this case, and we have to do a null-safe
+      // operation.
+      navigator?.focusScopeNode?.requestFocus();
     });
   }
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -516,17 +516,9 @@ void main() {
       ),
     );
 
-    dynamic error;
-
-    try {
-      controller.index = 2;
-      await tester.pumpAndSettle();
-    } catch (e){
-      error = e;
-    }
-
-    expect(error, isNull);
-
+    // This test should finish without crashing.
+    controller.index = 2;
+    await tester.pumpAndSettle();
   });
 
   testWidgets('replaceNamed replaces', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -489,6 +489,46 @@ void main() {
     expect(observations[2].previous, '/A');
   });
 
+  testWidgets('Route didAdd and dispose in same frame work', (WidgetTester tester) async {
+    // Regression Test for https://github.com/flutter/flutter/issues/61346.
+    Widget buildNavigator() {
+      return Navigator(
+        pages: <Page<void>>[
+          MaterialPage<void>(
+            builder: (BuildContext context) => const Placeholder(),
+          )
+        ],
+        onPopPage: (Route<dynamic> route, dynamic result) => false,
+      );
+    }
+    final TabController controller = TabController(length: 3, vsync: tester);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TabBarView(
+          controller: controller,
+          children: <Widget>[
+            buildNavigator(),
+            buildNavigator(),
+            buildNavigator(),
+          ],
+        )
+      ),
+    );
+
+    dynamic error;
+
+    try {
+      controller.index = 2;
+      await tester.pumpAndSettle();
+    } catch (e){
+      error = e;
+    }
+
+    expect(error, isNull);
+
+  });
+
   testWidgets('replaceNamed replaces', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/' : (BuildContext context) => OnTapPage(id: '/', onTap: () { Navigator.pushReplacementNamed(context, '/A'); }),


### PR DESCRIPTION
## Description

The route may be added and disposed in the same frame and it throws error in such cases. This pr fixes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61346

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
