### PR TITLE
Prevent material switch from recreating its render object when it becomes disabled

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -250,6 +250,7 @@ class Switch extends StatefulWidget {
 
 class _SwitchState extends State<Switch> with TickerProviderStateMixin {
   Map<Type, Action<Intent>> _actionMap;
+  final GlobalKey materialRenderSwitchKey = GlobalKey();
 
   @override
   void initState() {
@@ -343,6 +344,10 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
       child: Builder(
         builder: (BuildContext context) {
           return _SwitchRenderObjectWidget(
+            // FocusableActionDetector changes the shape of the tree when the
+            // value of `enabled` changes. Use a GlobalKey to force it to reuse
+            // the existing _RenderSwitch.
+            key: materialRenderSwitchKey,
             dragStartBehavior: widget.dragStartBehavior,
             value: widget.value,
             activeColor: activeThumbColor,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -250,7 +250,6 @@ class Switch extends StatefulWidget {
 
 class _SwitchState extends State<Switch> with TickerProviderStateMixin {
   Map<Type, Action<Intent>> _actionMap;
-  final GlobalKey materialRenderSwitchKey = GlobalKey();
 
   @override
   void initState() {
@@ -344,10 +343,6 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
       child: Builder(
         builder: (BuildContext context) {
           return _SwitchRenderObjectWidget(
-            // FocusableActionDetector changes the shape of the tree when the
-            // value of `enabled` changes. Use a GlobalKey to force it to reuse
-            // the existing _RenderSwitch.
-            key: materialRenderSwitchKey,
             dragStartBehavior: widget.dragStartBehavior,
             value: widget.value,
             activeColor: activeThumbColor,

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1080,25 +1080,30 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
 
   @override
   Widget build(BuildContext context) {
-    Widget child = MouseRegion(
-      onEnter: _handleMouseEnter,
-      onExit: _handleMouseExit,
-      cursor: widget.mouseCursor,
-      child: Focus(
-        focusNode: widget.focusNode,
-        autofocus: widget.autofocus,
-        canRequestFocus: _canRequestFocus,
-        onFocusChange: _handleFocusChange,
-        child: widget.child,
+    final Map<Type, Action<Intent>> actions = widget.enabled && widget.actions != null
+      ? widget.actions
+      : const <Type, Action<Intent>>{};
+    final Map<LogicalKeySet, Intent> shortcuts = widget.enabled && widget.shortcuts != null
+      ? widget.shortcuts
+      : const <LogicalKeySet, Intent>{};
+
+    return Actions(actions:  actions,
+      child: Shortcuts(
+        shortcuts: shortcuts,
+        child: MouseRegion(
+          onEnter: _handleMouseEnter,
+          onExit: _handleMouseExit,
+          cursor: widget.mouseCursor,
+          child: Focus(
+            focusNode: widget.focusNode,
+            autofocus: widget.autofocus,
+            canRequestFocus: _canRequestFocus,
+            onFocusChange: _handleFocusChange,
+            child: widget.child,
+          ),
+        ),
       ),
     );
-    if (widget.enabled && widget.actions != null && widget.actions.isNotEmpty) {
-      child = Actions(actions: widget.actions, child: child);
-    }
-    if (widget.enabled && widget.shortcuts != null && widget.shortcuts.isNotEmpty) {
-      child = Shortcuts(shortcuts: widget.shortcuts, child: child);
-    }
-    return child;
   }
 }
 

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -70,7 +70,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isEnabled: true,
@@ -85,7 +85,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -101,6 +101,15 @@ void main() {
       ),
     ));
 
+    expect(tester.getSemantics(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_CheckboxRenderObjectWidget')), matchesSemantics(
+      hasCheckedState: true,
+      hasEnabledState: true,
+      // isFocusable is delayed by 1 frame.
+      isFocusable: true,
+    ));
+
+    await tester.pump();
+    // isFocusable should be false now after the 1 frame delay.
     expect(tester.getSemantics(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_CheckboxRenderObjectWidget')), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -237,7 +237,24 @@ void main() {
     expect(semantics, hasSemantics(TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 2,
+          id: 1,
+          flags: <SemanticsFlag>[
+            SemanticsFlag.hasCheckedState,
+            SemanticsFlag.hasEnabledState,
+            SemanticsFlag.isInMutuallyExclusiveGroup,
+            SemanticsFlag.isFocusable,  // This flag is delayed by 1 frame.
+          ],
+        ),
+      ],
+    ), ignoreRect: true, ignoreTransform: true));
+
+    await tester.pump();
+
+    // Now the isFocusable should be gone.
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
           flags: <SemanticsFlag>[
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
@@ -258,7 +275,7 @@ void main() {
     expect(semantics, hasSemantics(TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 2,
+          id: 1,
           flags: <SemanticsFlag>[
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.isChecked,

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1402,7 +1402,11 @@ void main() {
                       children: <TestSemantics>[
                         TestSemantics(
                           id: 4,
-                          flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.hasEnabledState,
+                            // isFocusable is delayed by 1 frame.
+                            SemanticsFlag.isFocusable,
+                          ],
                           value: '50%',
                           increasedValue: '55%',
                           decreasedValue: '45%',
@@ -1420,6 +1424,47 @@ void main() {
         ignoreTransform: true,
       ),
     );
+
+    await tester.pump();
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 4,
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.hasEnabledState,
+                          ],
+                          value: '50%',
+                          increasedValue: '55%',
+                          decreasedValue: '45%',
+                          textDirection: TextDirection.ltr,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
     semantics.dispose();
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android,  TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }));
 


### PR DESCRIPTION
## Description

`FocusableActionDetector` changes the shape of the tree so `_SwitchRenderObjectWidget` needs a `GlobalKey` to get reused. Preferred this `GlobalKey` solution over changing the implementation of `FocusableActionDetector`, because that latter would change the semantics of many other widgets.

## Related Issues

fixes https://github.com/flutter/flutter/issues/61247

## Tests

I added the following tests:

Material switch should not recreate its render object when disabled

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
