### PR TITLE
Update the golden image comparator to handle read-only image ByteData views

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -210,7 +210,9 @@ Future<ComparisonResult> compareLists(List<int> test, List<int> master) async {
   final ByteData invertedMasterRgba = _invert(masterImageRgba);
   final ByteData invertedTestRgba = _invert(testImageRgba);
 
-  final ByteData maskedDiffRgba = await testImage.toByteData();
+  final Uint8List testImageBytes = (await testImage.toByteData()).buffer.asUint8List();
+  final ByteData maskedDiffRgba = ByteData(testImageBytes.length);
+  maskedDiffRgba.buffer.asUint8List().setRange(0, testImageBytes.length, testImageBytes);
   final ByteData isolatedDiffRgba = ByteData(width * height * 4);
 
   for (int x = 0; x < width; x++) {


### PR DESCRIPTION
The engine is now wrapping image byte data in an UnmodifiableByteDataView
(see https://github.com/flutter/engine/pull/19504).  The golden image
comparator must make a copy before modifying the buffer.