### PR TITLE
Add the ability to ignore lines from coverage depending on comments

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -66,7 +66,11 @@ class CoverageCollector extends TestWatcher {
     assert(data != null);
 
     _logMessage('($observatoryUri): collected coverage data; merging...');
-    _addHitmap(await coverage.createHitmap(data['coverage'] as List<Map<String, dynamic>>));
+    _addHitmap(await coverage.createHitmap(
+      data['coverage'] as List<Map<String, dynamic>>,
+      packagesPath: globalPackagesPath,
+      checkIgnoredLines: true,
+    ));
     _logMessage('($observatoryUri): done merging coverage data into global coverage map.');
   }
 
@@ -98,7 +102,11 @@ class CoverageCollector extends TestWatcher {
     assert(data != null);
 
     _logMessage('pid $pid ($observatoryUri): collected coverage data; merging...');
-    _addHitmap(await coverage.createHitmap(data['coverage'] as List<Map<String, dynamic>>));
+    _addHitmap(await coverage.createHitmap(
+      data['coverage'] as List<Map<String, dynamic>>,
+      packagesPath: globalPackagesPath,
+      checkIgnoredLines: true,
+    ));
     _logMessage('pid $pid ($observatoryUri): done merging coverage data into global coverage map.');
   }
 


### PR DESCRIPTION
## Description

https://github.com/dart-lang/coverage - 0.14.0 added the ability to be able to ignore coverage depending on comments (https://github.com/dart-lang/coverage/pull/302).


// coverage:ignore-line to ignore one line.
// coverage:ignore-start and // coverage:ignore-end to ignore range of lines inclusive.
// coverage:ignore-file to ignore the whole file.

## Related Issues

This was landed on https://github.com/flutter/flutter/pull/58656 then reverted in https://github.com/flutter/flutter/pull/59813 because coverage packages wasn't rolled into google3, now it is rolled into google3

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
