### PR TITLE
Account for MotionEvent instance mutations

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -52,6 +52,7 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
             .registerViewFactory("simple_view", new SimpleViewFactory(executor));
         mMethodChannel = new MethodChannel(executor, "android_views_integration");
         mMethodChannel.setMethodCallHandler(this);
+        GeneratedPluginRegistrant.registerWith(flutterEngine);
     }
 
     @Override

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -16,7 +17,6 @@ class WindowManagerIntegrationsPage extends PageWidget {
 
   @override
   Widget build(BuildContext context) => WindowManagerBody();
-
 }
 
 class WindowManagerBody extends StatefulWidget {
@@ -133,15 +133,17 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
     }
   }
 
-
   Future<void> onTapWindowPressed() async {
     await Future<void>.delayed(const Duration(seconds: 1));
-    for (final AndroidMotionEvent event in _tapSequence) {
-      await SystemChannels.platform_views.invokeMethod<dynamic>(
-        'touch',
-        _motionEventasList(event, id),
-      );
-    }
+
+    // Dispatch a tap event on the child view inside the platform view.
+    //
+    // Android mutates `MotionEvent` instances, so in this case *do not* dispatch
+    // new instances as it won't cover the `MotionEventTracker` class in the embedding
+    // which tracks events.
+    //
+    // See the issue this prevents: https://github.com/flutter/flutter/issues/61169
+    await Process.run('input', const <String>['tap', '250', '550']);
   }
 
   void onPlatformViewCreated(int id) {
@@ -186,75 +188,4 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       event.motionEventId,
     ];
   }
-
-  static final List<AndroidMotionEvent> _tapSequence = <AndroidMotionEvent> [
-    AndroidMotionEvent(
-      downTime: 723657071,
-      pointerCount: 1,
-      pointerCoords:  <AndroidPointerCoords> [
-        const AndroidPointerCoords(
-          orientation: 0.0,
-          touchMajor: 5.0,
-          size: 0.019607843831181526,
-          x: 180.0,
-          y: 200.0,
-          touchMinor: 5.0,
-          pressure: 1.0,
-          toolMajor: 5.0,
-          toolMinor: 5.0,
-        ),
-      ],
-      yPrecision: 1.0,
-      buttonState: 0,
-      flags: 0,
-      source: 4098,
-      deviceId: 4,
-      metaState: 0,
-      pointerProperties:  <AndroidPointerProperties> [
-        const AndroidPointerProperties(
-          id: 0,
-          toolType: 1,
-        ),
-      ],
-      edgeFlags: 0,
-      eventTime: 723657071,
-      action: 0,
-      xPrecision: 1.0,
-      motionEventId: 1,
-    ),
-    AndroidMotionEvent(
-      downTime: 723657071,
-      eventTime: 723657137,
-      action: 1,
-      pointerCount: 1,
-      pointerProperties: <AndroidPointerProperties> [
-        const AndroidPointerProperties(
-          id:  0,
-          toolType: 1,
-        ),
-      ],
-      pointerCoords: <AndroidPointerCoords> [
-        const AndroidPointerCoords(
-          orientation: 0.0,
-          touchMajor: 5.0,
-          size: 0.019607843831181526,
-          x: 180.0,
-          y: 200.0,
-          touchMinor: 5.0,
-          pressure: 1.0,
-          toolMajor: 5.0,
-          toolMinor: 5.0,
-        )
-      ],
-      metaState: 0,
-      buttonState: 0,
-      xPrecision: 1.0,
-      yPrecision: 1.0,
-      deviceId: 4,
-      edgeFlags: 0,
-      source: 4098,
-      flags: 0,
-      motionEventId: 2,
-    ),
-  ];
 }

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -153,39 +153,4 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
     });
   }
 
-
-  static List<double> _pointerCoordsAsList(AndroidPointerCoords coords) {
-    return <double>[
-      coords.orientation,
-      coords.pressure,
-      coords.size,
-      coords.toolMajor,
-      coords.toolMinor,
-      coords.touchMajor,
-      coords.touchMinor,
-      coords.x,
-      coords.y,
-    ];
-  }
-
-  static List<dynamic> _motionEventasList(AndroidMotionEvent event, int viewId) {
-    return <dynamic>[
-      viewId,
-      event.downTime,
-      event.eventTime,
-      event.action,
-      event.pointerCount,
-      event.pointerProperties.map<List<int>>((AndroidPointerProperties p) => <int> [p.id, p.toolType]).toList(),
-      event.pointerCoords.map<List<double>>((AndroidPointerCoords p) => _pointerCoordsAsList(p)).toList(),
-      event.metaState,
-      event.buttonState,
-      event.xPrecision,
-      event.yPrecision,
-      event.deviceId,
-      event.edgeFlags,
-      event.source,
-      event.flags,
-      event.motionEventId,
-    ];
-  }
 }

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -58,7 +58,10 @@ Future<void> main() async {
       await driver.tap(addWindow);
       final SerializableFinder tapWindow = find.byValueKey('TapWindow');
       await driver.tap(tapWindow);
-      final String windowClickCount = await driver.getText(find.byValueKey('WindowClickCount'));
+      final String windowClickCount = await driver.getText(
+        find.byValueKey('WindowClickCount'),
+        timeout: const Duration(seconds: 5),
+      );
       expect(windowClickCount, 'Click count: 1');
     });
   });


### PR DESCRIPTION
## Description

Android mutates a single `MotionEvent` instance. However, the test dispatches unique instances, which caused https://github.com/flutter/flutter/issues/61169

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
