### PR TITLE
Make RenderObject.paint() protected

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -16,6 +16,7 @@ import 'package:flutter/services.dart';
 
 import 'box.dart';
 import 'debug.dart';
+import 'layer.dart';
 import 'mouse_tracking.dart';
 import 'object.dart';
 import 'view.dart';
@@ -137,6 +138,22 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
         },
       );
     }
+  }
+
+  /// Creates a fresh [PaintingContext] into which [RenderObject]s may paint.
+  ///
+  /// The `layer` argument specifies the compositing layer into which draw
+  /// operations will be recorded.
+  ///
+  /// The `paintBounds` argument specifies an estimate of the bounds within
+  /// which the painting context's [canvas] will record painting commands.
+  /// This can be useful for debugging.
+  ///
+  /// See also:
+  ///
+  ///  * [PaintingContext.createChildContext]
+  PaintingContext createPaintingContext({ContainerLayer layer, Rect paintBounds}) {
+    return PaintingContext(layer, paintBounds);
   }
 
   /// Creates a [RenderView] object to be the root of the

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -531,6 +531,7 @@ class PictureLayer extends Layer {
 
   @override
   void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
+    assert(picture != null);
     builder.addPicture(layerOffset, picture, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -133,7 +133,10 @@ class PaintingContext extends ClipContext {
       child._layer.debugCreator = child.debugCreator ?? child.runtimeType;
       return true;
     }());
-    childContext ??= PaintingContext(child._layer, child.paintBounds);
+    childContext ??= RendererBinding.instance.createPaintingContext(
+      layer: child._layer,
+      paintBounds: child.paintBounds,
+    );
     child._paintWithContext(childContext, Offset.zero);
 
     // Double-check that the paint method did not replace the layer (the first
@@ -272,9 +275,16 @@ class PaintingContext extends ClipContext {
     assert(!_isRecording);
     _currentLayer = PictureLayer(estimatedBounds);
     _recorder = ui.PictureRecorder();
-    _canvas = Canvas(_recorder);
+    _canvas = createCanvas(_recorder);
     _containerLayer.append(_currentLayer);
   }
+
+  /// Creates a canvas for recording graphical operations into the
+  /// given picture recorder.
+  ///
+  /// This is used to create [canvas].
+  @protected
+  Canvas createCanvas(ui.PictureRecorder recorder) => Canvas(recorder);
 
   /// Stop recording to a canvas if recording has started.
   ///
@@ -2304,6 +2314,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// given context), the current canvas held by the context might change
   /// because draw operations before and after painting children might need to
   /// be recorded on separate compositing layers.
+  @protected
   void paint(PaintingContext context, Offset offset) { }
 
   /// Applies the transform that would be applied when painting the given child

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -136,7 +136,7 @@ void main() {
     );
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) => editable.paint(LegacyTestRecordingPaintingContext(canvas), Offset.zero),
       paints..clipRect(rect: const Rect.fromLTRB(0.0, 0.0, 1000.0, 10.0)),
     );
   });
@@ -657,7 +657,7 @@ void main() {
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
 
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) => editable.paint(LegacyTestRecordingPaintingContext(canvas), Offset.zero),
       paints..rect(color: promptRectColor),
     );
 
@@ -668,7 +668,7 @@ void main() {
 
     expect(editable.promptRectColor, promptRectColor);
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) => editable.paint(LegacyTestRecordingPaintingContext(canvas), Offset.zero),
       isNot(paints..rect(color: promptRectColor)),
     );
   });

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -527,7 +527,7 @@ abstract class _TestRecordingCanvasMatcher extends Matcher {
   @override
   bool matches(Object object, Map<dynamic, dynamic> matchState) {
     final TestRecordingCanvas canvas = TestRecordingCanvas();
-    final TestRecordingPaintingContext context = TestRecordingPaintingContext(canvas);
+    final LegacyTestRecordingPaintingContext context = LegacyTestRecordingPaintingContext(canvas);
     final StringBuffer description = StringBuffer();
     String prefixMessage = 'unexpectedly failed.';
     bool result = false;
@@ -632,7 +632,7 @@ class _TestRecordingCanvasPaintsAssertionMatcher extends Matcher {
   @override
   bool matches(Object object, Map<dynamic, dynamic> matchState) {
     final TestRecordingCanvas canvas = TestRecordingCanvas();
-    final TestRecordingPaintingContext context = TestRecordingPaintingContext(canvas);
+    final LegacyTestRecordingPaintingContext context = LegacyTestRecordingPaintingContext(canvas);
     final StringBuffer description = StringBuffer();
     String prefixMessage = 'unexpectedly failed.';
     bool result = false;

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -4,6 +4,9 @@
 
 // @dart = 2.8
 
+import 'dart:typed_data';
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/src/rendering/layer.dart';
@@ -92,10 +95,256 @@ class TestRecordingCanvas implements Canvas {
   }
 }
 
+class MultiplexingCanvas extends Canvas {
+  MultiplexingCanvas(PictureRecorder recorder, this.observer) : super(recorder);
+
+  final Canvas observer;
+
+  @override
+  void clipPath(Path path, {bool doAntiAlias = true}) {
+    super.clipPath(path, doAntiAlias: doAntiAlias);
+    observer.clipPath(path, doAntiAlias: doAntiAlias);
+  }
+
+  @override
+  void clipRRect(RRect rrect, {bool doAntiAlias = true}) {
+    super.clipRRect(rrect, doAntiAlias: doAntiAlias);
+    observer.clipRRect(rrect, doAntiAlias: doAntiAlias);
+  }
+
+  @override
+  void clipRect(Rect rect, {ClipOp clipOp = ClipOp.intersect, bool doAntiAlias = true}) {
+    super.clipRect(rect, clipOp: clipOp, doAntiAlias: doAntiAlias);
+    observer.clipRect(rect, clipOp: clipOp, doAntiAlias: doAntiAlias);
+  }
+
+  @override
+  void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
+    super.drawArc(rect, startAngle, sweepAngle, useCenter, paint);
+    observer.drawArc(rect, startAngle, sweepAngle, useCenter, paint);
+  }
+
+  @override
+  void drawAtlas(Image atlas, List<RSTransform> transforms, List<Rect> rects, List<Color> colors, BlendMode blendMode, Rect cullRect, Paint paint) {
+    super.drawAtlas(atlas, transforms, rects, colors, blendMode, cullRect, paint);
+    observer.drawAtlas(atlas, transforms, rects, colors, blendMode, cullRect, paint);
+  }
+
+  @override
+  void drawCircle(Offset c, double radius, Paint paint) {
+    super.drawCircle(c, radius, paint);
+    observer.drawCircle(c, radius, paint);
+  }
+
+  @override
+  void drawColor(Color color, BlendMode blendMode) {
+    super.drawColor(color, blendMode);
+    observer.drawColor(color, blendMode);
+  }
+
+  @override
+  void drawDRRect(RRect outer, RRect inner, Paint paint) {
+    super.drawDRRect(outer, inner, paint);
+    observer.drawDRRect(outer, inner, paint);
+  }
+
+  @override
+  void drawImage(Image image, Offset offset, Paint paint) {
+    super.drawImage(image, offset, paint);
+    observer.drawImage(image, offset, paint);
+  }
+
+  @override
+  void drawImageNine(Image image, Rect center, Rect dst, Paint paint) {
+    super.drawImageNine(image, center, dst, paint);
+    observer.drawImageNine(image, center, dst, paint);
+  }
+
+  @override
+  void drawImageRect(Image image, Rect src, Rect dst, Paint paint) {
+    super.drawImageRect(image, src, dst, paint);
+    observer.drawImageRect(image, src, dst, paint);
+  }
+
+  @override
+  void drawLine(Offset p1, Offset p2, Paint paint) {
+    super.drawLine(p1, p2, paint);
+    observer.drawLine(p1, p2, paint);
+  }
+
+  @override
+  void drawOval(Rect rect, Paint paint) {
+    super.drawOval(rect, paint);
+    observer.drawOval(rect, paint);
+  }
+
+  @override
+  void drawPaint(Paint paint) {
+    super.drawPaint(paint);
+    observer.drawPaint(paint);
+  }
+
+  @override
+  void drawParagraph(Paragraph paragraph, Offset offset) {
+    super.drawParagraph(paragraph, offset);
+    observer.drawParagraph(paragraph, offset);
+  }
+
+  @override
+  void drawPath(Path path, Paint paint) {
+    super.drawPath(path, paint);
+    observer.drawPath(path, paint);
+  }
+
+  @override
+  void drawPicture(Picture picture) {
+    super.drawPicture(picture);
+    observer.drawPicture(picture);
+  }
+
+  @override
+  void drawPoints(PointMode pointMode, List<Offset> points, Paint paint) {
+    super.drawPoints(pointMode, points, paint);
+    observer.drawPoints(pointMode, points, paint);
+  }
+
+  @override
+  void drawRRect(RRect rrect, Paint paint) {
+    super.drawRRect(rrect, paint);
+    observer.drawRRect(rrect, paint);
+  }
+
+  @override
+  void drawRawAtlas(Image atlas, Float32List rstTransforms, Float32List rects, Int32List colors, BlendMode blendMode, Rect cullRect, Paint paint) {
+    super.drawRawAtlas(atlas, rstTransforms, rects, colors, blendMode, cullRect, paint);
+    observer.drawRawAtlas(atlas, rstTransforms, rects, colors, blendMode, cullRect, paint);
+  }
+
+  @override
+  void drawRawPoints(PointMode pointMode, Float32List points, Paint paint) {
+    super.drawRawPoints(pointMode, points, paint);
+    observer.drawRawPoints(pointMode, points, paint);
+  }
+
+  @override
+  void drawRect(Rect rect, Paint paint) {
+    super.drawRect(rect, paint);
+    observer.drawRect(rect, paint);
+  }
+
+  @override
+  void drawShadow(Path path, Color color, double elevation, bool transparentOccluder) {
+    super.drawShadow(path, color, elevation, transparentOccluder);
+    observer.drawShadow(path, color, elevation, transparentOccluder);
+  }
+
+  @override
+  void drawVertices(Vertices vertices, BlendMode blendMode, Paint paint) {
+    super.drawVertices(vertices, blendMode, paint);
+    observer.drawVertices(vertices, blendMode, paint);
+  }
+
+  @override
+  int getSaveCount() {
+    final int saveCount = super.getSaveCount();
+    observer.getSaveCount();
+    return saveCount;
+  }
+
+  @override
+  void restore() {
+    super.restore();
+    observer.restore();
+  }
+
+  @override
+  void rotate(double radians) {
+    super.rotate(radians);
+    observer.rotate(radians);
+  }
+
+  @override
+  void save() {
+    super.save();
+    observer.save();
+  }
+
+  @override
+  void saveLayer(Rect bounds, Paint paint) {
+    super.saveLayer(bounds, paint);
+    observer.saveLayer(bounds, paint);
+  }
+
+  @override
+  void scale(double sx, [double sy]) {
+    super.scale(sx, sy);
+    observer.scale(sx, sy);
+  }
+
+  @override
+  void skew(double sx, double sy) {
+    super.skew(sx, sy);
+    observer.skew(sx, sy);
+  }
+
+  @override
+  void transform(Float64List matrix4) {
+    super.transform(matrix4);
+    observer.transform(matrix4);
+  }
+
+  @override
+  void translate(double dx, double dy) {
+    super.translate(dx, dy);
+    observer.translate(dx, dy);
+  }
+}
+
 /// A [PaintingContext] for tests that use [TestRecordingCanvas].
-class TestRecordingPaintingContext extends ClipContext implements PaintingContext {
+///
+/// This can be set as the painting context to be used by the Flutter framework
+/// by setting the value of the [createPaintingContext] test variable, like so:
+///
+/// ```dart
+/// testWidgets('...', (WidgetTester tester) async {
+///   final TestRecordingCanvas canvas = TestRecordingCanvas();
+///   createPaintingContext = ({ContainerLayer layer, Rect paintBounds}) {
+///     return TestRecordingPaintingContext(layer, paintBounds, canvas);
+///   };
+///
+///   // Run your test body, inspecting the properties of `canvas`
+///
+///   createPaintingContext = null;
+/// });
+/// ```
+class TestRecordingPaintingContext<T extends TestRecordingCanvas> extends PaintingContext {
   /// Creates a [PaintingContext] for tests that use [TestRecordingCanvas].
-  TestRecordingPaintingContext(this.canvas);
+  TestRecordingPaintingContext(
+    ContainerLayer containerLayer,
+    Rect estimatedBounds,
+    T canvas,
+  ) : _canvas = canvas,
+      super(containerLayer, estimatedBounds);
+
+  final T _canvas;
+
+  @override
+  Canvas createCanvas(PictureRecorder recorder) {
+    return MultiplexingCanvas(recorder, _canvas);
+  }
+
+  @override
+  PaintingContext createChildContext(ContainerLayer childLayer, Rect bounds) {
+    return TestRecordingPaintingContext<T>(childLayer, bounds, _canvas);
+  }
+}
+
+/// A [PaintingContext] for tests that use [TestRecordingCanvas].
+///
+/// Callers should prefer the more modern [TestRecordingPaintingContext].
+class LegacyTestRecordingPaintingContext extends ClipContext implements PaintingContext {
+  /// Creates a [PaintingContext] for tests that use [TestRecordingCanvas].
+  LegacyTestRecordingPaintingContext(this.canvas);
 
   @override
   final Canvas canvas;

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -62,6 +62,7 @@ export 'src/stack_manipulation.dart';
 export 'src/test_async_utils.dart';
 export 'src/test_compat.dart';
 export 'src/test_exception_reporter.dart';
+export 'src/test_painting.dart';
 export 'src/test_pointer.dart';
 export 'src/test_text_input.dart';
 export 'src/test_vsync.dart';

--- a/packages/flutter_test/lib/src/test_painting.dart
+++ b/packages/flutter_test/lib/src/test_painting.dart
@@ -1,0 +1,25 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+
+/// Function for creating instances of [PaintingContext].
+///
+/// Used by [TestWidgetsFlutterBinding.createPaintingContext]
+typedef PaintingContextFactory = PaintingContext Function({
+  ContainerLayer layer,
+  Rect paintBounds,
+});
+
+/// A function that will be used to create fresh [PaintingContext]s into
+/// which [RenderObject]s may paint.
+///
+/// This allows tests a hook into the creation of [PaintingContext]s, thus
+/// allowing them to inspect painting operations that are issued during their
+/// tests.
+///
+/// Tests that set this value are required to unset it by the end of their test
+/// so as to not interfere with other tests. Failure to do so will cause the
+/// test to fail.
+PaintingContextFactory createPaintingContext;


### PR DESCRIPTION
## Description

`RenderObject.paint()` is not intended to be called by anyone other than the parent render object (and even then not directly).  This updates the method to use the `@protected` annotation to ward other would-be callers off of it.

## Related Issues

https://github.com/flutter/flutter/issues/40038 (this PR doesn't make any headway on that issue, but it's related)

## Tests

n/a

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
