### PR TITLE
Add per thumb Range Slider semantics

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1523,6 +1523,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   // Create the semantics configuration for a single value.
   SemanticsConfiguration _createSemanticsConfiguration(
       double value,
+      double increasedValue,
+      double decreasedValue,
       String label,
       VoidCallback increaseAction,
       VoidCallback decreaseAction,
@@ -1537,12 +1539,12 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     config.label = label ?? '';
     if (semanticFormatterCallback != null) {
       config.value = semanticFormatterCallback(_state._lerp(value));
-      config.increasedValue = semanticFormatterCallback(_state._lerp((value + _semanticActionUnit).clamp(0.0, 1.0) as double));
-      config.decreasedValue = semanticFormatterCallback(_state._lerp((value - _semanticActionUnit).clamp(0.0, 1.0) as double));
+      config.increasedValue = semanticFormatterCallback(_state._lerp(increasedValue));
+      config.decreasedValue = semanticFormatterCallback(_state._lerp(decreasedValue));
     } else {
       config.value = '${(value * 100).round()}%';
-      config.increasedValue = '${((value + _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
-      config.decreasedValue = '${((value - _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
+      config.increasedValue = '${(increasedValue * 100).round()}%';
+      config.decreasedValue = '${(decreasedValue * 100).round()}%';
     }
 
     return config;
@@ -1557,16 +1559,20 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     assert(children.isEmpty);
 
     final SemanticsConfiguration startSemanticsConfiguration = _createSemanticsConfiguration(
-        values.start,
-        labels?.start,
-        _increaseStartAction,
-        _decreaseStartAction,
+      values.start,
+      _increasedStartValue,
+      _decreasedStartValue,
+      labels?.start,
+      _increaseStartAction,
+      _decreaseStartAction,
     );
     final SemanticsConfiguration endSemanticsConfiguration = _createSemanticsConfiguration(
-        values.end,
-        labels?.end,
-        _increaseEndAction,
-        _decreaseEndAction,
+      values.end,
+      _increasedEndValue,
+      _decreasedEndValue,
+      labels?.end,
+      _increaseEndAction,
+      _decreaseEndAction,
     );
 
     // Split the semantics node area between the start and end nodes.
@@ -1611,34 +1617,44 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   void _increaseStartAction() {
     if (isEnabled) {
-      onChanged(RangeValues(math.min(_increaseValue(values.start), values.end - _minThumbSeparationValue), values.end));
+        onChanged(RangeValues(_increasedStartValue, values.end));
     }
   }
 
   void _decreaseStartAction() {
     if (isEnabled) {
-      onChanged(RangeValues(_decreaseValue(values.start), values.end));
+      onChanged(RangeValues(_decreasedStartValue, values.end));
     }
   }
 
   void _increaseEndAction() {
     if (isEnabled) {
-      onChanged(RangeValues(values.start, _increaseValue(values.end)));
+      onChanged(RangeValues(values.start, _increasedEndValue));
     }
   }
 
   void _decreaseEndAction() {
     if (isEnabled) {
-      onChanged(RangeValues(values.start, math.max(_decreaseValue(values.end), values.start + _minThumbSeparationValue)));
+      onChanged(RangeValues(values.start, _decreasedEndValue));
     }
   }
 
-  double _increaseValue(double value) {
-    return (value + _semanticActionUnit).clamp(0.0, 1.0) as double;
+  double get _increasedStartValue {
+    final double increasedStartValue = values.start + _semanticActionUnit;
+    return increasedStartValue <= values.end - _minThumbSeparationValue ? increasedStartValue : values.start;
   }
 
-  double _decreaseValue(double value) {
-    return (value - _semanticActionUnit).clamp(0.0, 1.0) as double;
+  double get _decreasedStartValue {
+    return (values.start - _semanticActionUnit).clamp(0.0, 1.0) as double;
+  }
+
+  double get _increasedEndValue {
+    return (values.end + _semanticActionUnit).clamp(0.0, 1.0) as double;
+  }
+
+  double get _decreasedEndValue {
+    final double decreasedEndValue = values.end - _semanticActionUnit;
+    return decreasedEndValue >= values.start + _minThumbSeparationValue ? decreasedEndValue : values.end;
   }
 }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1640,7 +1640,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   }
 
   double get _increasedStartValue {
-    final double increasedStartValue = values.start + _semanticActionUnit;
+    // Due to floating-point operations, this value can actually be greater than
+    // expected (e.g. 0.4 + 0.2 = 0.600000000001), so we limit to 2 decimal points.
+    final double increasedStartValue = double.parse((values.start + _semanticActionUnit).toStringAsFixed(2));
     return increasedStartValue <= values.end - _minThumbSeparationValue ? increasedStartValue : values.start;
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1554,6 +1554,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       SemanticsConfiguration config,
       Iterable<SemanticsNode> children,
   ) {
+    assert(children.isEmpty);
+
     final SemanticsConfiguration startSemanticsConfiguration = _createSemanticsConfiguration(
         values.start,
         labels?.start,

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1568,8 +1568,18 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     );
 
     // Split the semantics node area between the start and end nodes.
-    _startSemanticsNode.rect = Rect.fromPoints(node.rect.topLeft, node.rect.bottomCenter);
-    _endSemanticsNode.rect = Rect.fromPoints(node.rect.topCenter, node.rect.bottomRight);
+    final Rect leftRect = Rect.fromPoints(node.rect.topLeft, node.rect.bottomCenter);
+    final Rect rightRect = Rect.fromPoints(node.rect.topCenter, node.rect.bottomRight);
+    switch (textDirection) {
+      case TextDirection.ltr:
+        _startSemanticsNode.rect = leftRect;
+        _endSemanticsNode.rect = rightRect;
+        break;
+      case TextDirection.rtl:
+        _startSemanticsNode.rect = rightRect;
+        _endSemanticsNode.rect = leftRect;
+        break;
+    }
 
     _startSemanticsNode.updateWith(config: startSemanticsConfiguration);
     _endSemanticsNode.updateWith(config: endSemanticsConfiguration);

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -858,7 +858,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   bool get isDiscrete => divisions != null && divisions > 0;
 
-  double get minThumbSeparationValue => isDiscrete ? 0 : sliderTheme.minThumbSeparation / _trackRect.width;
+  double get _minThumbSeparationValue => isDiscrete ? 0 : sliderTheme.minThumbSeparation / _trackRect.width;
 
   RangeValues get values => _values;
   RangeValues _values;
@@ -1192,9 +1192,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       final double currentDragValue = _discretize(dragValue);
 
       if (_lastThumbSelection == Thumb.start) {
-        _newValues = RangeValues(math.min(currentDragValue, currentValues.end - minThumbSeparationValue), currentValues.end);
+        _newValues = RangeValues(math.min(currentDragValue, currentValues.end - _minThumbSeparationValue), currentValues.end);
       } else if (_lastThumbSelection == Thumb.end) {
-        _newValues = RangeValues(currentValues.start, math.max(currentDragValue, currentValues.start + minThumbSeparationValue));
+        _newValues = RangeValues(currentValues.start, math.max(currentDragValue, currentValues.start + _minThumbSeparationValue));
       }
       onChanged(_newValues);
     }
@@ -1592,7 +1592,6 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-
     config.isSemanticBoundary = true;
   }
 
@@ -1600,7 +1599,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   void _increaseStartAction() {
     if (isEnabled) {
-      onChanged(RangeValues(math.min(_increaseValue(values.start), values.end - minThumbSeparationValue), values.end));
+      onChanged(RangeValues(math.min(_increaseValue(values.start), values.end - _minThumbSeparationValue), values.end));
     }
   }
 
@@ -1618,7 +1617,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   void _decreaseEndAction() {
     if (isEnabled) {
-      onChanged(RangeValues(values.start, math.max(_decreaseValue(values.end), values.start + minThumbSeparationValue)));
+      onChanged(RangeValues(values.start, math.max(_decreaseValue(values.end), values.start + _minThumbSeparationValue)));
     }
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1593,7 +1593,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
 
-    config.isSemanticBoundary = isEnabled;
+    config.isSemanticBoundary = true;
   }
 
   double get _semanticActionUnit => divisions != null ? 1.0 / divisions : _adjustmentUnit;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -28,13 +28,6 @@ import 'theme.dart';
 // int _duelCommandment = 1;
 // void setState(VoidCallback fn) { }
 
-/// A callback that formats a numeric value from a [Slider] widget.
-///
-/// See also:
-///
-///  * [Slider.semanticFormatterCallback], which shows an example use case.
-typedef SemanticFormatterCallback = String Function(double value);
-
 /// [Slider] uses this callback to paint the value indicator on the overlay.
 ///
 /// Since the value indicator is painted on the Overlay; this method paints the

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -3307,12 +3307,13 @@ class _PaddleSliderValueIndicatorPathPainter {
   }
 }
 
-/// A callback that formats the numeric values from a [RangeSlider] widget.
+/// A callback that formats a numeric value from a [Slider] or [RangerSlider] widget.
 ///
 /// See also:
 ///
+///  * [Slider.semanticFormatterCallback], which shows an example use case.
 ///  * [RangeSlider.semanticFormatterCallback], which shows an example use case.
-typedef RangeSemanticFormatterCallback = String Function(RangeValues values);
+typedef SemanticFormatterCallback = String Function(double value);
 
 /// Decides which thumbs (if any) should be selected.
 ///

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
-import '../widgets/semantics_tester.dart';
 
 void main() {
   testWidgets('Range Slider can move when tapped (continuous LTR)', (WidgetTester tester) async {

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1744,8 +1744,6 @@ void main() {
   });
 
   testWidgets('Range Slider Semantics', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-
     await tester.pumpWidget(
         MaterialApp(
           home: Theme(
@@ -1769,56 +1767,35 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-
+    
     expect(
-      semantics,
-      hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics(
-              id: 3,
-              textDirection: TextDirection.ltr,
-              children: <TestSemantics>[
-                TestSemantics(
-                  id: 4,
-                  children: <TestSemantics>[
-                    TestSemantics(
-                      id: 5,
-                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                      children: <TestSemantics>[
-                        TestSemantics(
-                          id: 6,
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 1,
-                              flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
-                              actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
-                              value: '10%',
-                              increasedValue: '15%',
-                              decreasedValue: '5%',
-                              textDirection: TextDirection.ltr,
-                            ),
-                            TestSemantics(
-                              id: 2,
-                              flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
-                              actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
-                              value: '100%',
-                              increasedValue: '100%',
-                              decreasedValue: '95%',
-                              textDirection: TextDirection.ltr,
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ],
-        ),
-        ignoreRect: true,
-        ignoreTransform: true,
+      tester.getSemantics(find.byType(RangeSlider)),
+      matchesSemantics(
+        scopesRoute: true,
+        children:<Matcher>[
+          matchesSemantics(
+            children:  <Matcher>[
+              matchesSemantics(
+                isEnabled: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '10%',
+                increasedValue: '15%',
+                decreasedValue: '5%',
+              ),
+              matchesSemantics(
+                isEnabled: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '100%',
+                increasedValue: '100%',
+                decreasedValue: '95%',
+              ),
+            ],
+          ),
+        ],
       ),
     );
   });

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1767,7 +1767,7 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    
+
     expect(
       tester.getSemantics(find.byType(RangeSlider)),
       matchesSemantics(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1753,7 +1753,7 @@ void main() {
                 data: MediaQueryData.fromWindow(window),
                 child: Material(
                   child: RangeSlider(
-                    values: const RangeValues(10.0, 100.0),
+                    values: const RangeValues(10.0, 12.0),
                     min: 0.0,
                     max: 100.0,
                     onChanged: (RangeValues v) { },
@@ -1780,7 +1780,7 @@ void main() {
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
                 value: '10%',
-                increasedValue: '15%',
+                increasedValue: '10%',
                 decreasedValue: '5%',
               ),
               matchesSemantics(
@@ -1788,9 +1788,9 @@ void main() {
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
-                value: '100%',
-                increasedValue: '100%',
-                decreasedValue: '95%',
+                value: '12%',
+                increasedValue: '17%',
+                decreasedValue: '12%',
               ),
             ],
           ),

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
+import '../widgets/semantics_tester.dart';
 
 void main() {
   testWidgets('Range Slider can move when tapped (continuous LTR)', (WidgetTester tester) async {
@@ -1739,6 +1740,86 @@ void main() {
           ..circle()
           ..circle(color: sliderTheme.overlappingShapeStrokeColor)
           ..circle()
+    );
+  });
+
+  testWidgets('Range Slider Semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+        MaterialApp(
+          home: Theme(
+            data: ThemeData.light(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: MediaQuery(
+                data: MediaQueryData.fromWindow(window),
+                child: Material(
+                  child: RangeSlider(
+                    values: const RangeValues(10.0, 100.0),
+                    min: 0.0,
+                    max: 100.0,
+                    onChanged: (RangeValues v) { },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        )
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 3,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 4,
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 5,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 6,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 1,
+                              flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
+                              actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                              value: '10%',
+                              increasedValue: '15%',
+                              decreasedValue: '5%',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 2,
+                              flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled],
+                              actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                              value: '100%',
+                              increasedValue: '100%',
+                              decreasedValue: '95%',
+                              textDirection: TextDirection.ltr,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
     );
   });
 


### PR DESCRIPTION
## Description

Each `RangeSlider` thumb now has its own `SemanticNode`, each controllable like an individual slider, and which respects gesture rules like `minThumbSeparation` and inability to pass the other.

The `semanticFormatterCallback` passed to `RangeSlider` now formats both values individually instead of together (e.g. '10$' and '25$' instead of '15$').

In action: https://i.imgur.com/0ZEfYyF.mp4

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60715
#39510 

## Tests

A test to validate the a RangeSlider's semantics tree 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
