### PR TITLE
Improve error reporting for RenderObject visitChildren errors

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2232,6 +2232,38 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       return;
     assert(() {
       if (_needsCompositingBitsUpdate) {
+        final RenderObject parent = this.parent as RenderObject;
+        if (parent is RenderObject) {
+          bool isChildOfParent = false;
+          parent.visitChildren((RenderObject child) {
+            assert(!isChildOfParent);
+            if (child == this) {
+              isChildOfParent = true;
+            }
+          });
+          if (!isChildOfParent) {
+            throw FlutterError.fromParts(<DiagnosticsNode>[
+              ErrorSummary(
+                "A RenderObject was not visited by the parent's visitChildren "
+                'during paint.',
+              ),
+              parent.describeForError(
+                'The parent was',
+              ),
+              describeForError(
+                'The child that was not visited was'
+              ),
+              ErrorDescription(
+                'A RenderObject with children must implement visitChildren and '
+                'call the visitor exactly once for each child, it also should not '
+                'paint children that were removed with dropChild.'
+              ),
+              ErrorHint(
+                'This usually indicates an error in the Flutter framework itself.'
+              ),
+            ]);
+          }
+        }
         throw FlutterError.fromParts(<DiagnosticsNode>[
           ErrorSummary(
             'Tried to paint a RenderObject before its compositing bits were '

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2232,16 +2232,15 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       return;
     assert(() {
       if (_needsCompositingBitsUpdate) {
-        final RenderObject parent = this.parent as RenderObject;
         if (parent is RenderObject) {
-          bool isChildOfParent = false;
+          final RenderObject parent = this.parent as RenderObject;
+          bool visitedByParent = false;
           parent.visitChildren((RenderObject child) {
-            assert(!isChildOfParent);
             if (child == this) {
-              isChildOfParent = true;
+              visitedByParent = true;
             }
           });
-          if (!isChildOfParent) {
+          if (!visitedByParent) {
             throw FlutterError.fromParts(<DiagnosticsNode>[
               ErrorSummary(
                 "A RenderObject was not visited by the parent's visitChildren "
@@ -2255,7 +2254,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
               ),
               ErrorDescription(
                 'A RenderObject with children must implement visitChildren and '
-                'call the visitor exactly once for each child, it also should not '
+                'call the visitor exactly once for each child; it also should not '
                 'paint children that were removed with dropChild.'
               ),
               ErrorHint(


### PR DESCRIPTION
## Description

Currently, if a RenderObject does not visit a child in its `visitChildren` method, you are presented with a confusing error related to compositing bits. This PR fixes that by displaying a different error message when `visitChildren` was the probable root cause.

## Related Issues

Fixes #60746

## Tests

Added a minimal test to reproduce the compositing bits exception

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*