### PR TITLE
Fix Border.symmetric: phase 1

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -331,15 +331,28 @@ class Border extends BoxBorder {
   /// Creates a border with symmetrical vertical and horizontal sides.
   ///
   /// All arguments default to [BorderSide.none] and must not be null.
+  ///
+  /// Currently, the `vertical` argument will apply to the top and bottom
+  /// borders, and the `horizontal` argument will apply to the left and right
+  /// borders. This is not consistent with the use of "vertical" and
+  /// "horizontal" elsewhere in the framework, so the
+  /// `invertMeaningOfVerticalAndHorizontal` argument exists to facilitate
+  /// the transition of this constructor to using the correct semantics of
+  /// these arguments. Callers are encouraged to pass false to that argument
+  /// to get the correct semantics. In a future change, the default value of
+  /// the argument will be changed to false, followed by the removal of the
+  /// argument altogether.
   const Border.symmetric({
     BorderSide vertical = BorderSide.none,
     BorderSide horizontal = BorderSide.none,
+    bool invertMeaningOfVerticalAndHorizontal = true,
   }) : assert(vertical != null),
        assert(horizontal != null),
-       left = horizontal,
-       top = vertical,
-       right = horizontal,
-       bottom = vertical;
+       assert(invertMeaningOfVerticalAndHorizontal != null),
+       left = invertMeaningOfVerticalAndHorizontal ? horizontal : vertical,
+       top = invertMeaningOfVerticalAndHorizontal ? vertical : horizontal,
+       right = invertMeaningOfVerticalAndHorizontal ? horizontal : vertical,
+       bottom = invertMeaningOfVerticalAndHorizontal ? vertical : horizontal;
 
   /// A uniform border with all sides the same color and width.
   ///

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -35,6 +35,15 @@ void main() {
     expect(border.top, same(side1));
     expect(border.right, same(side2));
     expect(border.bottom, same(side1));
+    const Border border2 = Border.symmetric(
+      vertical: side1,
+      horizontal: side2,
+      invertMeaningOfVerticalAndHorizontal: false,
+    );
+    expect(border2.left, same(side1));
+    expect(border2.top, same(side2));
+    expect(border2.right, same(side1));
+    expect(border2.bottom, same(side2));
   });
 
   test('Border.merge', () {


### PR DESCRIPTION
## Description

This adds a `invertMeaningOfVerticalAndHorizontal` argument to the
Border.symmetric constructor, which will allow us to fix the semantics
of the `vertical` and `horizontal` arguments in a soft-breaking way.

## Related Issues

https://github.com/flutter/flutter/issues/61470

## Tests

I added the following tests:

* A test that when the argument is overridden, you get the correct behavior in the constructor.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
