### PR TITLE
[FIX] For CupertinoAlertDialog allows empty actions

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -128,13 +128,12 @@ class CupertinoAlertDialog extends StatelessWidget {
     Key key,
     this.title,
     this.content,
-    this.actions = const <Widget>[],
+    this.actions,
     this.scrollController,
     this.actionScrollController,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
-  }) : assert(actions != null),
-       super(key: key);
+  }) : super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.
@@ -206,16 +205,47 @@ class CupertinoAlertDialog extends StatelessWidget {
     );
   }
 
-  Widget _buildActions() {
+  /// Create a default [CupertinoDialogAction] with OK Text
+  /// NOTE :: OK text should be kept in localization for different lang
+  List<Widget> _defaultActions(BuildContext context){
+    return <Widget>[
+      CupertinoDialogAction(
+          child: const Text('OK'),
+          onPressed: () => Navigator.pop(context),
+        )
+    ];
+  }
+
+  /// Create a default [_CupertinoAlertActionSection]
+  Widget _cupertinoDefaultAlertActionSection(BuildContext context){
+    return _CupertinoAlertActionSection(
+      children: _defaultActions(context),
+      scrollController: actionScrollController,
+    );
+  }
+
+
+
+
+
+
+  Widget _buildActions(BuildContext context) {
     Widget actionSection = Container(
       height: 0.0,
     );
-    if (actions.isNotEmpty) {
-      actionSection = _CupertinoAlertActionSection(
-        children: actions,
-        scrollController: actionScrollController,
-      );
+    if(actions != null){
+      if (actions.isNotEmpty) {
+        actionSection = _CupertinoAlertActionSection(
+          children: actions,
+          scrollController: actionScrollController,
+        );
+      } else {
+        actionSection = _cupertinoDefaultAlertActionSection(context);
+      }
+    } else {
+      actionSection = _cupertinoDefaultAlertActionSection(context);
     }
+
 
     return actionSection;
   }
@@ -260,7 +290,7 @@ class CupertinoAlertDialog extends StatelessWidget {
                         label: localizations.alertDialogLabel,
                         child: _CupertinoDialogRenderWidget(
                           contentSection: _buildContent(context),
-                          actionsSection: _buildActions(),
+                          actionsSection: _buildActions(context),
                         ),
                       ),
                     ),

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -54,19 +54,6 @@ void main() {
     expect(find.text('Delete'), findsNothing);
   });
 
-  testWidgets('Alert dialog Default actions test', (WidgetTester tester) async {
-
-    await tester.pumpWidget(
-      createAppWithButtonThatLaunchesDialog(
-        dialogBuilder: (BuildContext context) {
-          return const CupertinoAlertDialog(
-            title: Text('The title'),
-            content: Text('The content'),
-          );
-        },
-      ),
-    );
-  });
 
   testWidgets('Dialog not barrier dismissible by default', (WidgetTester tester) async {
     await tester.pumpWidget(createAppWithCenteredButton(const Text('Go')));
@@ -496,7 +483,7 @@ void main() {
         equals(tester.getSize(find.widgetWithText(CupertinoDialogAction, 'Two')).height));
   });
 
-  testWidgets('Button section is empty, Title section is not empty.', (WidgetTester tester) async {
+  testWidgets('Button section is not empty, Title section is not empty.', (WidgetTester tester) async {
     const double textScaleFactor = 1.0;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -518,23 +505,9 @@ void main() {
 
     await tester.pump();
 
-    // Check that there's no button action section.
-    expect(scrollController.offset, 0.0);
-    expect(find.widgetWithText(CupertinoDialogAction, 'One'), findsNothing);
+    // Check that there's a button action section. By default OK button is created
+    expect(find.widgetWithText(CupertinoDialogAction, 'OK'),findsOneWidget);
 
-    // Check that the dialog size is the same as the content section size. This
-    // ensures that an empty button section doesn't accidentally render some
-    // empty space in the dialog.
-    final Finder contentSectionFinder = find.byElementPredicate((Element element) {
-      return element.widget.runtimeType.toString() == '_CupertinoAlertContentSection';
-    });
-
-    final Finder modalBoundaryFinder = find.byType(ClipRRect);
-
-    expect(
-      tester.getSize(contentSectionFinder),
-      tester.getSize(modalBoundaryFinder),
-    );
   });
 
   testWidgets('Actions section height for 1 button is height of button.', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -54,6 +54,20 @@ void main() {
     expect(find.text('Delete'), findsNothing);
   });
 
+  testWidgets('Alert dialog Default actions test', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesDialog(
+        dialogBuilder: (BuildContext context) {
+          return const CupertinoAlertDialog(
+            title: Text('The title'),
+            content: Text('The content'),
+          );
+        },
+      ),
+    );
+  });
+
   testWidgets('Dialog not barrier dismissible by default', (WidgetTester tester) async {
     await tester.pumpWidget(createAppWithCenteredButton(const Text('Go')));
 


### PR DESCRIPTION
## Description
This PR adds the default actions (OK) on `CupertinoAlertDialog` when action is null or empty. 
The issue was when `this.actions` is empty, it creates a CupertinoAlertDialog which results in a dialog that cannot be dismissed.
Note: I have added OK(Button) as the default action considering the native behavior of IOS in `SwiftUI`

### **Screen Before**

![cup](https://user-images.githubusercontent.com/26821037/87467482-a6aad000-c635-11ea-9210-37b8c8abfd53.png)

### **Screen After**

![Screenshot 2020-07-15 at 12 50 59 AM](https://user-images.githubusercontent.com/26821037/87467592-d3f77e00-c635-11ea-8287-24f2080bc874.png)





## Related Issues
This issue NO: https://github.com/flutter/flutter/issues/49660 (fixed) 


## Tests

I added the following tests:
- Button section is not empty, Title section is not empty.

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
