### PR TITLE
fix intrinsic height and width for widget span

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -382,6 +382,8 @@ class RenderParagraph extends RenderBox
     RenderBox child = firstChild;
     final List<PlaceholderDimensions> placeholderDimensions = List<PlaceholderDimensions>(childCount);
     int childIndex = 0;
+    if (_applyTextScaleFactorToWidgetSpan)
+      height = height / textScaleFactor;
     while (child != null) {
       // Height and baseline is irrelevant as all text will be laid
       // out in a single line.
@@ -400,6 +402,8 @@ class RenderParagraph extends RenderBox
     RenderBox child = firstChild;
     final List<PlaceholderDimensions> placeholderDimensions = List<PlaceholderDimensions>(childCount);
     int childIndex = 0;
+    if (_applyTextScaleFactorToWidgetSpan)
+      height = height / textScaleFactor;
     while (child != null) {
       final double intrinsicWidth = child.getMinIntrinsicWidth(height);
       final double intrinsicHeight = child.getMinIntrinsicHeight(intrinsicWidth);
@@ -418,6 +422,8 @@ class RenderParagraph extends RenderBox
     RenderBox child = firstChild;
     final List<PlaceholderDimensions> placeholderDimensions = List<PlaceholderDimensions>(childCount);
     int childIndex = 0;
+    if (_applyTextScaleFactorToWidgetSpan)
+      width = width / textScaleFactor;
     while (child != null) {
       final double intrinsicHeight = child.getMinIntrinsicHeight(width);
       final double intrinsicWidth = child.getMinIntrinsicWidth(intrinsicHeight);

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -326,6 +326,97 @@ void main() {
     expect(paragraph.locale, const Locale('ja', 'JP'));
   });
 
+  test('can compute IntrinsicHeight for widget span', () {
+    // Regression test for https://github.com/flutter/flutter/issues/59316
+    const double screenWidth = 100.0;
+    const String sentence = 'one two';
+    List<RenderBox> renderBoxes = <RenderBox>[
+      RenderParagraph(const TextSpan(text: sentence), textDirection: TextDirection.ltr),
+    ];
+    RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(
+        children: <InlineSpan> [
+          WidgetSpan(child: Text(sentence))
+        ]
+      ),
+      textScaleFactor: 1.0,
+      children: renderBoxes,
+      textDirection: TextDirection.ltr,
+      applyTextScaleFactorToWidgetSpan: true,
+    );
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: screenWidth));
+    final double singleLineHeight = paragraph.computeMaxIntrinsicHeight(screenWidth);
+    expect(singleLineHeight, 14.0);
+
+    pumpFrame();
+    renderBoxes = <RenderBox>[
+      RenderParagraph(const TextSpan(text: sentence), textDirection: TextDirection.ltr),
+    ];
+    paragraph = RenderParagraph(
+      const TextSpan(
+        children: <InlineSpan> [
+          WidgetSpan(child: Text(sentence))
+        ]
+      ),
+      textScaleFactor: 2.0,
+      children: renderBoxes,
+      textDirection: TextDirection.ltr,
+      applyTextScaleFactorToWidgetSpan: true,
+    );
+
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: screenWidth));
+    final double maxIntrinsicHeight = paragraph.computeMaxIntrinsicHeight(screenWidth);
+    final double minIntrinsicHeight = paragraph.computeMinIntrinsicHeight(screenWidth);
+    // intrinsicHeight = singleLineHeight * textScaleFactor * two lines.
+    expect(maxIntrinsicHeight, singleLineHeight * 2.0 * 2);
+    expect(maxIntrinsicHeight, minIntrinsicHeight);
+  });
+
+  test('can compute IntrinsicWidth for widget span', () {
+    // Regression test for https://github.com/flutter/flutter/issues/59316
+    const double screenWidth = 1000.0;
+    const double fixedHeight = 1000.0;
+    const String sentence = 'one two';
+    List<RenderBox> renderBoxes = <RenderBox>[
+      RenderParagraph(const TextSpan(text: sentence), textDirection: TextDirection.ltr),
+    ];
+    RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(
+        children: <InlineSpan> [
+          WidgetSpan(child: Text(sentence))
+        ]
+      ),
+      textScaleFactor: 1.0,
+      children: renderBoxes,
+      textDirection: TextDirection.ltr,
+      applyTextScaleFactorToWidgetSpan: true,
+    );
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: screenWidth));
+    final double widthForOneLine = paragraph.computeMaxIntrinsicWidth(fixedHeight);
+    expect(widthForOneLine, 98.0);
+
+    pumpFrame();
+    renderBoxes = <RenderBox>[
+      RenderParagraph(const TextSpan(text: sentence), textDirection: TextDirection.ltr),
+    ];
+    paragraph = RenderParagraph(
+      const TextSpan(
+        children: <InlineSpan> [
+          WidgetSpan(child: Text(sentence))
+        ]
+      ),
+      textScaleFactor: 2.0,
+      children: renderBoxes,
+      textDirection: TextDirection.ltr,
+      applyTextScaleFactorToWidgetSpan: true,
+    );
+
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: screenWidth));
+    final double maxIntrinsicWidth = paragraph.computeMaxIntrinsicWidth(fixedHeight);
+    // maxIntrinsicWidth = widthForOneLine * textScaleFactor
+    expect(maxIntrinsicWidth, widthForOneLine * 2.0);
+  });
+
   test('inline widgets test', () {
     const TextSpan text = TextSpan(
       text: 'a',

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -370,7 +370,7 @@ void main() {
     // intrinsicHeight = singleLineHeight * textScaleFactor * two lines.
     expect(maxIntrinsicHeight, singleLineHeight * 2.0 * 2);
     expect(maxIntrinsicHeight, minIntrinsicHeight);
-  });
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61020
 
   test('can compute IntrinsicWidth for widget span', () {
     // Regression test for https://github.com/flutter/flutter/issues/59316
@@ -415,7 +415,7 @@ void main() {
     final double maxIntrinsicWidth = paragraph.computeMaxIntrinsicWidth(fixedHeight);
     // maxIntrinsicWidth = widthForOneLine * textScaleFactor
     expect(maxIntrinsicWidth, widthForOneLine * 2.0);
-  });
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61020
 
   test('inline widgets test', () {
     const TextSpan text = TextSpan(


### PR DESCRIPTION
## Description

The widgetspan returns wrong intrinsic height and widget when textscalefactor !=1.0. This pr fixes it.

## Related Issues

https://github.com/flutter/flutter/issues/59316

## Tests

I added the following tests:
See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
