### PR TITLE
Updated date pickers to use the new TextButton in place of FlatButton.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -14,9 +14,9 @@ import '../button_theme.dart';
 import '../color_scheme.dart';
 import '../debug.dart';
 import '../dialog.dart';
-import '../flat_button.dart';
 import '../icons.dart';
 import '../material_localizations.dart';
+import '../text_button.dart';
 import '../text_theme.dart';
 import '../theme.dart';
 
@@ -387,11 +387,11 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
       buttonTextTheme: ButtonTextTheme.primary,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
       children: <Widget>[
-        FlatButton(
+        TextButton(
           child: Text(widget.cancelText ?? localizations.cancelButtonLabel),
           onPressed: _handleCancel,
         ),
-        FlatButton(
+        TextButton(
           child: Text(widget.confirmText ?? localizations.okButtonLabel),
           onPressed: _handleOk,
         ),

--- a/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
@@ -18,11 +18,11 @@ import '../color_scheme.dart';
 import '../debug.dart';
 import '../dialog.dart';
 import '../dialog_theme.dart';
-import '../flat_button.dart';
 import '../icon_button.dart';
 import '../icons.dart';
 import '../material_localizations.dart';
 import '../scaffold.dart';
+import '../text_button.dart';
 import '../text_theme.dart';
 import '../theme.dart';
 
@@ -512,7 +512,7 @@ class _CalendarRangePickerDialog extends StatelessWidget {
             if (orientation == Orientation.landscape) entryModeIcon,
             ButtonTheme(
               minWidth: 64,
-              child: FlatButton(
+              child: TextButton(
                 onPressed: onConfirm,
                 child: Text(confirmText, style: saveButtonStyle),
               ),
@@ -659,11 +659,11 @@ class _InputDateRangePickerDialog extends StatelessWidget {
       buttonTextTheme: ButtonTextTheme.primary,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
       children: <Widget>[
-        FlatButton(
+        TextButton(
           child: Text(cancelText ?? localizations.cancelButtonLabel),
           onPressed: onCancel,
         ),
-        FlatButton(
+        TextButton(
           child: Text(confirmText ?? localizations.okButtonLabel),
           onPressed: onConfirm,
         ),


### PR DESCRIPTION
Updated the Material Date Pickers to use `TextButton` instead of `FlatButton` as part of the transition to the new button universe (#59702).