### PR TITLE
[flutter] remove unnecessary usage of mockito in some tests

### DIFF
--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 
 void main() {
   setUp(() => _GestureBindingSpy());
@@ -58,7 +57,13 @@ class _GestureBindingSpy extends AutomatedTestWidgetsFlutterBinding {
   PointerRouter get pointerRouter => _testPointerRouter;
 }
 
-class FakeEditableTextState extends TextSelectionDelegate with Mock { }
+class FakeEditableTextState extends TextSelectionDelegate {
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw Exception('unmocked method ${invocation.memberName}');
+  }
+}
 
 class _PointerRouterSpy extends PointerRouter {
   int routeCount = 0;

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -58,7 +58,6 @@ class _GestureBindingSpy extends AutomatedTestWidgetsFlutterBinding {
 }
 
 class FakeEditableTextState extends TextSelectionDelegate {
-
   @override
   dynamic noSuchMethod(Invocation invocation) {
     throw Exception('unmocked method ${invocation.memberName}');

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -7,7 +7,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
-import 'package:mockito/mockito.dart';
 
 import '../rendering/mock_canvas.dart';
 
@@ -439,11 +438,9 @@ void main() {
     );
 
     final RenderBox decoratedBox = tester.renderObject(find.byType(DecoratedBox).last);
-    final PaintingContext context = _MockPaintingContext();
-    final Canvas canvas = _MockCanvas();
-    int saveCount = 0;
-    when(canvas.getSaveCount()).thenAnswer((_) => saveCount++);
-    when(context.canvas).thenReturn(canvas);
+    final _MockPaintingContext context = _MockPaintingContext();
+    final _MockCanvas canvas = _MockCanvas();
+    context.canvas = canvas;
     FlutterError error;
     try {
       decoratedBox.paint(context, const Offset(0, 0));
@@ -561,5 +558,26 @@ void main() {
   });
 }
 
-class _MockPaintingContext extends Mock implements PaintingContext {}
-class _MockCanvas extends Mock implements Canvas {}
+class _MockPaintingContext implements PaintingContext {
+  @override
+  Canvas canvas;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw Exception('Unmocked method ${invocation.memberName}');
+  }
+}
+class _MockCanvas implements Canvas {
+  int saveCount = 0;
+
+  @override
+  int getSaveCount() => saveCount++;
+
+  @override
+  void drawRect(Rect rect, Paint paint) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw Exception('Unmocked method ${invocation.memberName}');
+  }
+}

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -7,7 +7,6 @@
 import 'package:flutter/src/physics/utils.dart' show nearEqual;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 
 const Color _kScrollbarColor = Color(0xFF123456);
 const double _kThickness = 2.5;
@@ -39,12 +38,24 @@ ScrollbarPainter _buildPainter({
   )..update(scrollMetrics, scrollMetrics.axisDirection);
 }
 
-class _DrawRectOnceCanvas extends Mock implements Canvas { }
+class _DrawRectOnceCanvas implements Canvas {
+  Rect lastRect;
+
+  @override
+  void drawRect(Rect rect, Paint paint) {
+    lastRect = rect;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw Exception('Unmocked method ${invocation.memberName}');
+  }
+}
 
 void main() {
   final _DrawRectOnceCanvas testCanvas = _DrawRectOnceCanvas();
   ScrollbarPainter painter;
-  Rect captureRect() => verify(testCanvas.drawRect(captureAny, any)).captured.single as Rect;
+  Rect captureRect() => testCanvas.lastRect;
 
   tearDown(() => painter = null);
 


### PR DESCRIPTION
## Description

Usage of mockito will make it hard/impossible to run tests in sound null safety mode. Some tests don't really need it, remove usage and replace it with "homemade" mock/fakes.