### PR TITLE
RenderIntrinsicWidth & RenderIntrinsicHeight should not pass tight constraints to child

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -638,7 +638,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
   @override
   void performLayout() {
     if (child != null) {
-      BoxConstraints childConstraints = constraints;
+      BoxConstraints childConstraints = constraints.copyWith(minWidth: 0);
       if (!childConstraints.hasTightWidth) {
         final double width = child.getMaxIntrinsicWidth(childConstraints.maxHeight);
         assert(width.isFinite);
@@ -650,7 +650,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
         childConstraints = childConstraints.tighten(height: _applyStep(height, _stepHeight));
       }
       child.layout(childConstraints, parentUsesSize: true);
-      size = child.size;
+      size = constraints.constrain(child.size);
     } else {
       performResize();
     }
@@ -708,14 +708,14 @@ class RenderIntrinsicHeight extends RenderProxyBox {
   @override
   void performLayout() {
     if (child != null) {
-      BoxConstraints childConstraints = constraints;
+      BoxConstraints childConstraints = constraints.copyWith(minHeight: 0);
       if (!childConstraints.hasTightHeight) {
         final double height = child.getMaxIntrinsicHeight(childConstraints.maxWidth);
         assert(height.isFinite);
         childConstraints = childConstraints.tighten(height: height);
       }
       child.layout(childConstraints, parentUsesSize: true);
-      size = child.size;
+      size = constraints.constrain(child.size);
     } else {
       performResize();
     }

--- a/packages/flutter/test/rendering/intrinsic_width_test.dart
+++ b/packages/flutter/test/rendering/intrinsic_width_test.dart
@@ -59,6 +59,8 @@ void main() {
     );
     expect(parent.size.width, equals(100.0));
     expect(parent.size.height, equals(110.0));
+    expect(child.size.width, equals(100));
+    expect(child.size.height, equals(110));
 
     expect(parent.getMinIntrinsicWidth(0.0), equals(100.0));
     expect(parent.getMaxIntrinsicWidth(0.0), equals(100.0));
@@ -128,6 +130,8 @@ void main() {
     );
     expect(parent.size.width, equals(3.0 * 47.0));
     expect(parent.size.height, equals(110.0));
+    expect(child.size.width, equals(3 * 47));
+    expect(child.size.height, equals(110));
 
     expect(parent.getMinIntrinsicWidth(0.0), equals(3.0 * 47.0));
     expect(parent.getMaxIntrinsicWidth(0.0), equals(3.0 * 47.0));
@@ -220,6 +224,57 @@ void main() {
     expect(parent.getMaxIntrinsicHeight(double.infinity), equals(5.0 * 47.0));
   });
 
+  test('RenderIntrinsicWidth when parent is given loose constraints smaller than intrinsic width of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicWidth(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 50.0,
+        minHeight: 8.0,
+        maxWidth: 70.0,
+        maxHeight: 800.0,
+      ),
+    );
+    expect(parent.size.width, equals(70));
+    expect(parent.size.height, equals(110));
+    expect(child.size.width, equals(70));
+    expect(child.size.height, equals(110));
+  });
+
+  test('RenderIntrinsicWidth when parent is given tight constraints larger than intrinsic width of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicWidth(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 500.0,
+        minHeight: 8.0,
+        maxWidth: 500.0,
+        maxHeight: 800.0,
+      ),
+    );
+    expect(parent.size.width, equals(500));
+    expect(parent.size.height, equals(110));
+    expect(child.size.width, equals(100));
+    expect(child.size.height, equals(110));
+  });
+
+  test('RenderIntrinsicWidth when parent is given tight constraints smaller than intrinsic width of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicWidth(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 50.0,
+        minHeight: 8.0,
+        maxWidth: 50.0,
+        maxHeight: 800.0,
+      ),
+    );
+    expect(parent.size.width, equals(50));
+    expect(parent.size.height, equals(110));
+    expect(child.size.width, equals(50));
+    expect(child.size.height, equals(110));
+  });
+
   test('Shrink-wrapping height', () {
     final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
     final RenderBox parent = RenderIntrinsicHeight(child: child);
@@ -287,6 +342,57 @@ void main() {
     expect(parent.getMaxIntrinsicWidth(double.infinity), equals(0.0));
     expect(parent.getMinIntrinsicHeight(double.infinity), equals(0.0));
     expect(parent.getMaxIntrinsicHeight(double.infinity), equals(0.0));
+  });
+
+  test('RenderIntrinsicHeight when parent is given loose constraints smaller than intrinsic height of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicHeight(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 5.0,
+        minHeight: 8.0,
+        maxWidth: 500.0,
+        maxHeight: 80.0,
+      ),
+    );
+    expect(parent.size.width, equals(55));
+    expect(parent.size.height, equals(80));
+    expect(child.size.width, equals(55));
+    expect(child.size.height, equals(80));
+  });
+
+  test('RenderIntrinsicHeight when parent is given tight constraints larger than intrinsic height of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicHeight(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 5.0,
+        minHeight: 400.0,
+        maxWidth: 500.0,
+        maxHeight: 400.0,
+      ),
+    );
+    expect(parent.size.width, equals(55));
+    expect(parent.size.height, equals(400));
+    expect(child.size.width, equals(55));
+    expect(child.size.height, equals(200));
+  });
+
+  test('RenderIntrinsicHeight when parent is given tight constraints smaller than intrinsic height of child', () {
+    final RenderBox child = RenderTestBox(const BoxConstraints(minWidth: 10.0, maxWidth: 100.0, minHeight: 20.0, maxHeight: 200.0));
+    final RenderBox parent = RenderIntrinsicHeight(child: child);
+    layout(parent,
+      constraints: const BoxConstraints(
+        minWidth: 5.0,
+        minHeight: 80.0,
+        maxWidth: 500.0,
+        maxHeight: 80.0,
+      ),
+    );
+    expect(parent.size.width, equals(55));
+    expect(parent.size.height, equals(80));
+    expect(child.size.width, equals(55));
+    expect(child.size.height, equals(80));
   });
 
   test('Padding and boring intrinsics', () {


### PR DESCRIPTION
## Description

See description in https://github.com/flutter/flutter/issues/61496

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61496

## Tests

I added the following tests:

* Test RenderIntrinsicWidth layout behavior when given loose constraints smaller than child's intrinsic width
* Test RenderIntrinsicWidth layout behavior when given tight constraints larger than child's intrinsic width
* Test RenderIntrinsicWidth layout behavior when given tight constraints smaller than child's intrinsic width
* Comparable tests for RenderIntrinsicHeight

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
