### PR TITLE
Add defaults to `showGeneralDialog()`

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1799,10 +1799,10 @@ class _DialogRoute<T> extends PopupRoute<T> {
 Future<T> showGeneralDialog<T>({
   @required BuildContext context,
   @required RoutePageBuilder pageBuilder,
-  bool barrierDismissible,
+  bool barrierDismissible = true,
   String barrierLabel,
-  Color barrierColor,
-  Duration transitionDuration,
+  Color barrierColor = const Color(0x80000000),
+  Duration transitionDuration = const Duration(milliseconds: 200),
   RouteTransitionsBuilder transitionBuilder,
   bool useRootNavigator = true,
   RouteSettings routeSettings,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1799,7 +1799,7 @@ class _DialogRoute<T> extends PopupRoute<T> {
 Future<T> showGeneralDialog<T>({
   @required BuildContext context,
   @required RoutePageBuilder pageBuilder,
-  bool barrierDismissible = true,
+  bool barrierDismissible = false,
   String barrierLabel,
   Color barrierColor = const Color(0x80000000),
   Duration transitionDuration = const Duration(milliseconds: 200),


### PR DESCRIPTION
## Description

`showGeneralDialog()` passes most of its arguments through to `_DialogRoute`, but it wasn't providing the default values that `_DialogRoute` was, causing it to inadvertently override the defaults will null values.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
