### PR TITLE
Allow transparent barrierColor in showDialog methods

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1435,7 +1435,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   OverlayEntry _modalBarrier;
   Widget _buildModalBarrier(BuildContext context) {
     Widget barrier;
-    if (barrierColor != null && !offstage) { // changedInternalState is called if barrierColor or offstage updates
+    if (barrierColor != null && barrierColor.alpha != 0 && !offstage) { // changedInternalState is called if barrierColor or offstage updates
       assert(barrierColor != _kTransparent);
       final Animation<Color> color = animation.drive(
         ColorTween(

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -966,6 +966,84 @@ void main() {
       expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
     });
 
+    testWidgets('showGeneralDialog handles transparent barrier color', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) {
+                return RaisedButton(
+                  onPressed: () {
+                    showGeneralDialog<void>(
+                      context: context,
+                      barrierDismissible: true,
+                      barrierLabel: 'barrier_label',
+                      barrierColor: const Color(0x00000000),
+                      transitionDuration: Duration.zero,
+                      pageBuilder: (BuildContext innerContext, _, __) {
+                        return const SizedBox();
+                      },
+                    );
+                  },
+                  child: const Text('Show Dialog'),
+                );
+              },
+            );
+          },
+        ),
+      ));
+
+      // Open the dialog.
+      await tester.tap(find.byType(RaisedButton));
+      await tester.pump();
+      expect(find.byType(ModalBarrier), findsNWidgets(3));
+
+      // Close the dialog.
+      await tester.tapAt(Offset.zero);
+      await tester.pump();
+      expect(find.byType(ModalBarrier), findsNWidgets(2));
+    });
+
+    testWidgets('showGeneralDialog adds no modal barriers when barrierDismissable is false', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) {
+                return RaisedButton(
+                  onPressed: () {
+                    showGeneralDialog<void>(
+                      context: context,
+                      barrierDismissible: false,
+                      transitionDuration: Duration.zero,
+                      pageBuilder: (BuildContext innerContext, _, __) {
+                        return const SizedBox();
+                      },
+                    );
+                  },
+                  child: const Text('Show Dialog'),
+                );
+              },
+            );
+          },
+        ),
+      ));
+
+      // Open the dialog.
+      await tester.tap(find.byType(RaisedButton));
+      await tester.pump();
+      expect(find.byType(ModalBarrier), findsNWidgets(3));
+      final ModalBarrier barrier = find.byType(ModalBarrier).evaluate().last.widget as ModalBarrier;
+      expect(barrier.dismissible, isFalse);
+
+      // Close the dialog.
+      final StatefulElement navigatorElement = find.byType(Navigator).evaluate().last as StatefulElement;
+      final NavigatorState navigatorState = navigatorElement.state as NavigatorState;
+      navigatorState.pop();
+      await tester.pumpAndSettle();
+      expect(find.byType(ModalBarrier), findsNWidgets(2));
+    });
+
     testWidgets('showGeneralDialog uses root navigator by default', (WidgetTester tester) async {
       final DialogObserver rootObserver = DialogObserver();
       final DialogObserver nestedObserver = DialogObserver();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -968,26 +968,22 @@ void main() {
 
     testWidgets('showGeneralDialog handles transparent barrier color', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
-        home: Navigator(
-          onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return RaisedButton(
-                  onPressed: () {
-                    showGeneralDialog<void>(
-                      context: context,
-                      barrierDismissible: true,
-                      barrierLabel: 'barrier_label',
-                      barrierColor: const Color(0x00000000),
-                      transitionDuration: Duration.zero,
-                      pageBuilder: (BuildContext innerContext, _, __) {
-                        return const SizedBox();
-                      },
-                    );
+        home: Builder(
+          builder: (BuildContext context) {
+            return RaisedButton(
+              onPressed: () {
+                showGeneralDialog<void>(
+                  context: context,
+                  barrierDismissible: true,
+                  barrierLabel: 'barrier_label',
+                  barrierColor: const Color(0x00000000),
+                  transitionDuration: Duration.zero,
+                  pageBuilder: (BuildContext innerContext, _, __) {
+                    return const SizedBox();
                   },
-                  child: const Text('Show Dialog'),
                 );
               },
+              child: const Text('Show Dialog'),
             );
           },
         ),
@@ -996,34 +992,30 @@ void main() {
       // Open the dialog.
       await tester.tap(find.byType(RaisedButton));
       await tester.pump();
-      expect(find.byType(ModalBarrier), findsNWidgets(3));
+      expect(find.byType(ModalBarrier), findsNWidgets(2));
 
       // Close the dialog.
       await tester.tapAt(Offset.zero);
       await tester.pump();
-      expect(find.byType(ModalBarrier), findsNWidgets(2));
+      expect(find.byType(ModalBarrier), findsNWidgets(1));
     });
 
-    testWidgets('showGeneralDialog adds no modal barriers when barrierDismissable is false', (WidgetTester tester) async {
+    testWidgets('showGeneralDialog adds non-dismissable barrier when barrierDismissable is false', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
-        home: Navigator(
-          onGenerateRoute: (RouteSettings settings) {
-            return MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) {
-                return RaisedButton(
-                  onPressed: () {
-                    showGeneralDialog<void>(
-                      context: context,
-                      barrierDismissible: false,
-                      transitionDuration: Duration.zero,
-                      pageBuilder: (BuildContext innerContext, _, __) {
-                        return const SizedBox();
-                      },
-                    );
+        home: Builder(
+          builder: (BuildContext context) {
+            return RaisedButton(
+              onPressed: () {
+                showGeneralDialog<void>(
+                  context: context,
+                  barrierDismissible: false,
+                  transitionDuration: Duration.zero,
+                  pageBuilder: (BuildContext innerContext, _, __) {
+                    return const SizedBox();
                   },
-                  child: const Text('Show Dialog'),
                 );
               },
+              child: const Text('Show Dialog'),
             );
           },
         ),
@@ -1032,7 +1024,7 @@ void main() {
       // Open the dialog.
       await tester.tap(find.byType(RaisedButton));
       await tester.pump();
-      expect(find.byType(ModalBarrier), findsNWidgets(3));
+      expect(find.byType(ModalBarrier), findsNWidgets(2));
       final ModalBarrier barrier = find.byType(ModalBarrier).evaluate().last.widget as ModalBarrier;
       expect(barrier.dismissible, isFalse);
 
@@ -1041,7 +1033,7 @@ void main() {
       final NavigatorState navigatorState = navigatorElement.state as NavigatorState;
       navigatorState.pop();
       await tester.pumpAndSettle();
-      expect(find.byType(ModalBarrier), findsNWidgets(2));
+      expect(find.byType(ModalBarrier), findsNWidgets(1));
     });
 
     testWidgets('showGeneralDialog uses root navigator by default', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

`showDialog()` and `showGeneralDialog()` were allowing transparent
colors but then triggering an assertion down the stack while building
the modal barrier. The assertion existed to keep from animating from
transparent to transparent, but there's no need for the assertion,
since we can just treat the transparent case as the same as the null
case -- no animation necessary.

## Tests

I added the following tests:

* A test that ensures that you can create a dialog with a transparent barrier color
* A test for barrierDismissable, since such a test didn't exist

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
