### PR TITLE
Prefer null-aware operators

### DIFF
--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -268,7 +268,7 @@ class GestureArenaManager {
   bool _debugLogDiagnostic(int pointer, String message, [ _GestureArena state ]) {
     assert(() {
       if (debugPrintGestureArenaDiagnostics) {
-        final int count = state != null ? state.members.length : null;
+        final int count = state?.members?.length;
         final String s = count != 1 ? 's' : '';
         debugPrint('Gesture arena ${pointer.toString().padRight(4)} ❙ $message${ count != null ? " with $count member$s." : ""}');
       }

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -674,7 +674,7 @@ class RadialGradient extends Gradient {
       radius * rect.shortestSide,
       colors, _impliedStops(), tileMode,
       _resolveTransform(rect, textDirection),
-      focal == null  ? null : focal.resolve(textDirection).withinRect(rect),
+      focal?.resolve(textDirection)?.withinRect(rect),
       focalRadius * rect.shortestSide,
     );
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -651,7 +651,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
       onListen: _start,
       onCancel: _stop,
     );
-    _appName = app == null ? null : app.name.replaceAll('.app', '');
+    _appName = app?.name?.replaceAll('.app', '');
   }
 
   final IOSSimulator device;


### PR DESCRIPTION
## Description

Update a few call sites to use null-aware operators where possible.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
