### PR TITLE
fixes the overflow issue cause by a long subtitle on a narrow screen …

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -520,9 +520,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               _buildLine(!_isLast(index)),
             ],
           ),
-          Container(
-            margin: const EdgeInsetsDirectional.only(start: 12.0),
-            child: _buildHeaderText(index),
+          Expanded(
+              child: Container(
+                margin: const EdgeInsetsDirectional.only(start: 12.0),
+                child: _buildHeaderText(index),
+            )
           ),
         ],
       ),

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -663,4 +663,32 @@ void main() {
     await tester.pump();
     expect(disabledNode.hasPrimaryFocus, isFalse);
   });
+
+  testWidgets('Stepper title should not overflow', (WidgetTester tester) async {
+    const String longTitle = 'A long long long long long long long long long long long long title';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              Stepper(
+                steps: const <Step>[
+                  Step(
+                      title: Text(longTitle),
+                      content: Text('Text content')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(
+        find.text(longTitle),
+        findsNWidgets(1));
+  });
 }


### PR DESCRIPTION
…device


## Description

This fix wraps the content column of the vertical stepper in Expandable() to avoid potential overflow.

Before:

![image](https://user-images.githubusercontent.com/6916509/87521368-94a44e00-c684-11ea-86ae-109ca9b3de96.png)


After:

![image](https://user-images.githubusercontent.com/6916509/87521406-a38b0080-c684-11ea-8a59-ea60612c8694.png)
