### PR TITLE
Tweak message about debugging with web-server

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -451,8 +451,8 @@ class WebServerDevice extends Device {
       _logger.printStatus('$mainPath is being served at $url', emphasis: true);
     }
     _logger.printStatus(
-      'The web-server device does not support debugging. Consider using '
-      'the Chrome or Edge devices for an improved development workflow.'
+      'The web-server device requires the Dart Debug Chrome extension for debugging. '
+      'Consider using the Chrome or Edge devices for an improved development workflow.'
     );
     _logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': false});
     return LaunchResult.succeeded(observatoryUri: url != null ? Uri.parse(url): null);


### PR DESCRIPTION
This tweaks the message shown when running with web-service slightly. Debugging is supported via the Debug Extension, and this text is currently shown to users that can't use the Chrome device (for example in GitPod/Codespaces/VS Code Remoting).

@jonahwilliams it would be nice if we could hide this prompt when running in a remove context (eg. where the Chrome an Edge devices are not available), or report it in some way that the IDE could suppress it (eg. report it as a warning with a well-known code or something) if it knows it's not relevant for the environment. I can't think of a particularly clean way to do it though.