### PR TITLE
Fix build (fix references to _flutter -> flutter)

### DIFF
--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -37,10 +37,10 @@ void main() {
   });
 
   test('multiple overlapping hot reload are debounced and queued', () async {
-    await _flutter.run();
+    await flutter.run();
     // Capture how many *real* hot reloads occur.
     int numReloads = 0;
-    final StreamSubscription<void> subscription = _flutter.stdout
+    final StreamSubscription<void> subscription = flutter.stdout
         .map(parseFlutterResponse)
         .where(_isHotReloadCompletionEvent)
         .listen((_) => numReloads++);
@@ -52,7 +52,7 @@ void main() {
     const Duration delay = Duration(milliseconds: hotReloadDebounceOverrideMs * 2);
 
     Future<void> doReload([void _]) =>
-        _flutter.hotReload(debounce: true, debounceDurationOverrideMs: hotReloadDebounceOverrideMs);
+        flutter.hotReload(debounce: true, debounceDurationOverrideMs: hotReloadDebounceOverrideMs);
 
     try {
       await Future.wait<void>(<Future<void>>[


### PR DESCRIPTION
My PR #55376 broke the build because it used some variables that were renamed in #61413 (and I hadn't rebased after it landed). This updates those references.

@jonahwilliams 

(feel free to land this if you're LGTM'ing it and the bots are green, as I may not be at my machine for the rest of the day)