### PR TITLE
fix "The target expression can't be null" error

### DIFF
--- a/packages/flutter/lib/src/foundation/_platform_web.dart
+++ b/packages/flutter/lib/src/foundation/_platform_web.dart
@@ -17,14 +17,19 @@ platform.TargetPlatform get defaultTargetPlatform {
 }
 
 platform.TargetPlatform _browserPlatform() {
-  final String navigatorPlatform = html.window.navigator.platform?.toLowerCase() ?? '';
-  if (navigatorPlatform.startsWith('mac')) {
-    return platform.TargetPlatform.macOS;
+  final String? platformName = html.window.navigator.platform;
+  if (platformName != null) {
+    final String navigatorPlatform = platformName.toLowerCase();
+    if (navigatorPlatform.startsWith('mac')) {
+      return platform.TargetPlatform.macOS;
+    }
+    if (navigatorPlatform.contains('iphone') ||
+        navigatorPlatform.contains('ipad') ||
+        navigatorPlatform.contains('ipod')) {
+      return platform.TargetPlatform.iOS;
+    }
+    return platform.TargetPlatform.android;
+  } else {
+    return platform.TargetPlatform.android;
   }
-  if (navigatorPlatform.contains('iphone') ||
-      navigatorPlatform.contains('ipad') ||
-      navigatorPlatform.contains('ipod')) {
-    return platform.TargetPlatform.iOS;
-  }
-  return platform.TargetPlatform.android;
 }


### PR DESCRIPTION
This error is happening in the engine: https://github.com/flutter/engine/pull/19756/checks?check_run_id=874784064

This PR is changing the _platform_web.dart file to fix the error.