### PR TITLE
Corrected splash color for TextButton, ElevatedButton, OutlinedButton

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1071,7 +1071,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     for (final _HighlightType type in _highlights.keys) {
       _highlights[type]?.color = getHighlightColorForType(type);
     }
-    _currentSplash?.color = widget.splashColor ?? Theme.of(context).splashColor;
+
+    const Set<MaterialState> pressed = <MaterialState>{MaterialState.pressed};
+    _currentSplash?.color = widget.overlayColor?.resolve(pressed) ?? widget.splashColor ?? Theme.of(context).splashColor;
+
     final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
       widget.mouseCursor ?? MaterialStateMouseCursor.clickable,
       <MaterialState>{

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -50,8 +50,11 @@ void main() {
     expect(material.type, MaterialType.button);
 
     final Offset center = tester.getCenter(find.byType(ElevatedButton));
-    await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump(); // start the splash animation
+    await tester.pump(const Duration(milliseconds: 100)); // splash is underway
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..circle(color: colorScheme.onPrimary.withAlpha(0x3d))); // splash color is onPrimary(0.24)
 
     // Only elevation changes when enabled and pressed.
     material = tester.widget<Material>(rawButtonMaterial);
@@ -68,6 +71,9 @@ void main() {
     expect(material.textStyle.fontSize, 14);
     expect(material.textStyle.fontWeight, FontWeight.w500);
     expect(material.type, MaterialType.button);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
 
     // Disabled ElevatedButton
     await tester.pumpWidget(

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -56,9 +56,14 @@ void main() {
     expect(material.type, MaterialType.button);
 
     final Offset center = tester.getCenter(find.byType(OutlinedButton));
-    await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump(); // start the splash animation
+    await tester.pump(const Duration(milliseconds: 100)); // splash is underway
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..circle(color: colorScheme.primary.withAlpha(0x1f))); // splash color is primary(0.12)
 
+    await gesture.up();
+    await tester.pumpAndSettle();
     // No change vs enabled and not pressed.
     material = tester.widget<Material>(rawButtonMaterial);
     expect(material.animationDuration, const Duration(milliseconds: 200));

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -50,9 +50,14 @@ void main() {
     expect(material.type, MaterialType.button);
 
     final Offset center = tester.getCenter(find.byType(TextButton));
-    await tester.startGesture(center);
-    await tester.pumpAndSettle();
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump(); // start the splash animation
+    await tester.pump(const Duration(milliseconds: 100)); // splash is underway
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..circle(color: colorScheme.primary.withAlpha(0x1f))); // splash color is primary(0.12)
 
+    await gesture.up();
+    await tester.pumpAndSettle();
     material = tester.widget<Material>(buttonMaterial);
     // No change vs enabled and not pressed.
     expect(material.animationDuration, const Duration(milliseconds: 200));
@@ -969,6 +974,7 @@ void main() {
     );
     expect(paddingWidget.padding, const EdgeInsets.all(22));
   });
+
 }
 
 


### PR DESCRIPTION
@rami-a pointed out that the splash color for the "New Button Universe" buttons, https://github.com/flutter/flutter/pull/59702, was incorrect. Fixed that, and added tests.

![nbu_splash](https://user-images.githubusercontent.com/1377460/87597696-15744180-c6a7-11ea-89a2-241c71a6fb6a.gif)
