### PR TITLE
Updated obsolete button references in Scaffold, IconButton

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -124,7 +124,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 ///    current platform's conventions.
 ///  * [CloseButton], an icon button for closing pages.
 ///  * [AppBar], to show a toolbar at the top of an application.
-///  * [RaisedButton] and [FlatButton], for buttons with text in them.
+///  * [TextButton], [ElevatedButton], [OutlinedButton], for buttons with text labels and an optional icon.
 ///  * [InkResponse] and [InkWell], for the ink splash effect itself.
 class IconButton extends StatelessWidget {
   /// Creates an icon button.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1681,7 +1681,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   ///
   /// ```dart
   ///   Widget build(BuildContext context) {
-  ///     return OutlineButton(
+  ///     return OutlinedButton(
   ///       onPressed: () {
   ///         Scaffold.of(context).showSnackBar(
   ///           SnackBar(


### PR DESCRIPTION
Updated one more Scaffold API doc example to use OutlinedButton instead of OutlineButton. Similar API doc update for IconButon. All per #59702.