### PR TITLE
Remove unused FlutterErrorDetails subclasses

### DIFF
--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -80,9 +80,9 @@ class PointerRouter {
       InformationCollector collector;
       assert(() {
         collector = () sync* {
-          yield DiagnosticsProperty<PointerRouter>('PointerRouter', this, style: DiagnosticsTreeStyle.errorProperty);
-          yield DiagnosticsProperty<PointerRoute>('PointerRoute', route, style: DiagnosticsTreeStyle.errorProperty);
-          yield DiagnosticsProperty<PointerEvent>('PointerEvent', event, style: DiagnosticsTreeStyle.errorProperty);
+          yield DiagnosticsProperty<PointerRouter>('router', this, level: DiagnosticLevel.debug);
+          yield DiagnosticsProperty<PointerRoute>('route', route, level: DiagnosticLevel.debug);
+          yield DiagnosticsProperty<PointerEvent>('event', event, level: DiagnosticLevel.debug);
         };
         return true;
       }());

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -80,18 +80,17 @@ class PointerRouter {
       InformationCollector collector;
       assert(() {
         collector = () sync* {
-          yield DiagnosticsProperty<PointerEvent>('Event', event, style: DiagnosticsTreeStyle.errorProperty);
+          yield DiagnosticsProperty<PointerRouter>('PointerRouter', this, style: DiagnosticsTreeStyle.errorProperty);
+          yield DiagnosticsProperty<PointerRoute>('PointerRoute', route, style: DiagnosticsTreeStyle.errorProperty);
+          yield DiagnosticsProperty<PointerEvent>('PointerEvent', event, style: DiagnosticsTreeStyle.errorProperty);
         };
         return true;
       }());
-      FlutterError.reportError(FlutterErrorDetailsForPointerRouter(
+      FlutterError.reportError(FlutterErrorDetails(
         exception: exception,
         stack: stack,
         library: 'gesture library',
         context: ErrorDescription('while routing a pointer event'),
-        router: this,
-        route: route,
-        event: event,
         informationCollector: collector
       ));
     }
@@ -125,49 +124,4 @@ class PointerRouter {
       }
     });
   }
-}
-
-/// Variant of [FlutterErrorDetails] with extra fields for the gestures
-/// library's pointer router ([PointerRouter]).
-///
-/// See also:
-///
-///  * [FlutterErrorDetailsForPointerEventDispatcher], which is also used
-///    by the gestures library.
-class FlutterErrorDetailsForPointerRouter extends FlutterErrorDetails {
-  /// Creates a [FlutterErrorDetailsForPointerRouter] object with the given
-  /// arguments setting the object's properties.
-  ///
-  /// The gestures library calls this constructor when catching an exception
-  /// that will subsequently be reported using [FlutterError.onError].
-  const FlutterErrorDetailsForPointerRouter({
-    dynamic exception,
-    StackTrace stack,
-    String library,
-    DiagnosticsNode context,
-    this.router,
-    this.route,
-    this.event,
-    InformationCollector informationCollector,
-    bool silent = false,
-  }) : super(
-    exception: exception,
-    stack: stack,
-    library: library,
-    context: context,
-    informationCollector: informationCollector,
-    silent: silent,
-  );
-
-  /// The pointer router that caught the exception.
-  ///
-  /// In a typical application, this is the value of [GestureBinding.pointerRouter] on
-  /// the binding ([GestureBinding.instance]).
-  final PointerRouter router;
-
-  /// The callback that threw the exception.
-  final PointerRoute route;
-
-  /// The pointer event that was being routed when the exception was raised.
-  final PointerEvent event;
 }

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -249,7 +249,6 @@ mixin DebugOverflowIndicatorMixin on RenderObject {
         informationCollector: () sync* {
           if (debugCreator != null)
             yield DiagnosticsDebugCreator(debugCreator);
-          yield DiagnosticsProperty<RenderObject>('RenderObject', this, style: DiagnosticsTreeStyle.errorProperty);
           yield* overflowHints;
           yield describeForError('The specific $runtimeType in question is');
           // TODO(jacobr): this line is ascii art that it would be nice to

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -242,14 +242,14 @@ mixin DebugOverflowIndicatorMixin on RenderObject {
     // TODO(jacobr): add the overflows in pixels as structured data so they can
     // be visualized in debugging tools.
     FlutterError.reportError(
-      FlutterErrorDetailsForRendering(
+      FlutterErrorDetails(
         exception: FlutterError('A $runtimeType overflowed by $overflowText.'),
         library: 'rendering library',
         context: ErrorDescription('during layout'),
-        renderObject: this,
         informationCollector: () sync* {
           if (debugCreator != null)
             yield DiagnosticsDebugCreator(debugCreator);
+          yield DiagnosticsProperty<RenderObject>('RenderObject', this, style: DiagnosticsTreeStyle.errorProperty);
           yield* overflowHints;
           yield describeForError('The specific $runtimeType in question is');
           // TODO(jacobr): this line is ascii art that it would be nice to

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1319,16 +1319,16 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   dynamic debugCreator;
 
   void _debugReportException(String method, dynamic exception, StackTrace stack) {
-    FlutterError.reportError(FlutterErrorDetailsForRendering(
+    FlutterError.reportError(FlutterErrorDetails(
       exception: exception,
       stack: stack,
       library: 'rendering library',
       context: ErrorDescription('during $method()'),
-      renderObject: this,
       informationCollector: () sync* {
         if (debugCreator != null)
           yield DiagnosticsDebugCreator(debugCreator);
         yield describeForError('The following RenderObject was being processed when the exception was fired');
+        yield DiagnosticsProperty<RenderObject>('RenderObject', this, style: DiagnosticsTreeStyle.errorProperty);
         // TODO(jacobr): this error message has a code smell. Consider whether
         // displaying the truncated children is really useful for command line
         // users. Inspector users can see the full tree by clicking on the
@@ -3382,35 +3382,6 @@ mixin RelayoutWhenSystemFontsChangeMixin on RenderObject {
     PaintingBinding.instance.systemFonts.removeListener(systemFontsDidChange);
     super.detach();
   }
-}
-
-/// Variant of [FlutterErrorDetails] with extra fields for the rendering
-/// library.
-class FlutterErrorDetailsForRendering extends FlutterErrorDetails {
-  /// Creates a [FlutterErrorDetailsForRendering] object with the given
-  /// arguments setting the object's properties.
-  ///
-  /// The rendering library calls this constructor when catching an exception
-  /// that will subsequently be reported using [FlutterError.onError].
-  const FlutterErrorDetailsForRendering({
-    dynamic exception,
-    StackTrace stack,
-    String library,
-    DiagnosticsNode context,
-    this.renderObject,
-    InformationCollector informationCollector,
-    bool silent = false,
-  }) : super(
-    exception: exception,
-    stack: stack,
-    library: library,
-    context: context,
-    informationCollector: informationCollector,
-    silent: silent,
-  );
-
-  /// The RenderObject that was being processed when the exception was caught.
-  final RenderObject renderObject;
 }
 
 /// Describes the semantics information a [RenderObject] wants to add to its

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1328,7 +1328,6 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         if (debugCreator != null)
           yield DiagnosticsDebugCreator(debugCreator);
         yield describeForError('The following RenderObject was being processed when the exception was fired');
-        yield DiagnosticsProperty<RenderObject>('RenderObject', this, style: DiagnosticsTreeStyle.errorProperty);
         // TODO(jacobr): this error message has a code smell. Consider whether
         // displaying the truncated children is really useful for command line
         // users. Inspector users can see the full tree by clicking on the

--- a/packages/flutter/test/gestures/pointer_router_test.dart
+++ b/packages/flutter/test/gestures/pointer_router_test.dart
@@ -153,6 +153,17 @@ void main() {
     FlutterError.onError = previousErrorHandler;
   });
 
+  test('Exceptions include router, route & event', () {
+    try {
+      final PointerRouter router = PointerRouter();
+      router.addRoute(2, (PointerEvent event) => throw 'Pointer exception');
+    } catch (e) {
+      expect(e, contains('router: Instance of \'PointerRouter\''));
+      expect(e, contains('route: Closure: (PointerEvent) => Null'));
+      expect(e, contains('event: PointerDownEvent#[a-zA-Z0-9]{5}(position: Offset(0.0, 0.0))'));
+    }
+  });
+
   test('Should transform events', () {
     final List<PointerEvent> events = <PointerEvent>[];
     final List<PointerEvent> globalEvents = <PointerEvent>[];

--- a/packages/flutter/test/widgets/widget_inspector_init_with_structured_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_init_with_structured_error_test.dart
@@ -47,7 +47,7 @@ class StructuredErrorTestService extends TestWidgetInspectorService {
       expect(flutterErrorEvents, hasLength(0));
 
       // Create an error.
-      FlutterError.reportError(FlutterErrorDetailsForRendering(
+      FlutterError.reportError(FlutterErrorDetails(
         library: 'rendering library',
         context: ErrorDescription('during layout'),
         exception: StackTrace.current,

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -76,7 +76,7 @@ class StructureErrorTestWidgetInspectorService extends Object with WidgetInspect
           equals('true'));
 
         // Creates an error.
-        final FlutterErrorDetails expectedError = FlutterErrorDetailsForRendering(
+        final FlutterErrorDetails expectedError = FlutterErrorDetails(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
           exception: StackTrace.current,

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2239,7 +2239,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             equals('true'));
 
         // Create an error.
-        FlutterError.reportError(FlutterErrorDetailsForRendering(
+        FlutterError.reportError(FlutterErrorDetails(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
           exception: StackTrace.current,
@@ -2262,7 +2262,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                 '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞════════════'));
 
         // Send a second error.
-        FlutterError.reportError(FlutterErrorDetailsForRendering(
+        FlutterError.reportError(FlutterErrorDetails(
           library: 'rendering library',
           context: ErrorDescription('also during layout'),
           exception: StackTrace.current,
@@ -2290,7 +2290,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         binding.postTest();
 
         // Send another error.
-        FlutterError.reportError(FlutterErrorDetailsForRendering(
+        FlutterError.reportError(FlutterErrorDetails(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
           exception: StackTrace.current,


### PR DESCRIPTION
## Description

This removes unused `FlutterErrorDetails` subclasses `FlutterErrorDetailsForPointerRouter` and `FlutterErrorDetailsForRendering`. 
I may deprecate them instead, checking to see if these uncommon classes are actually breaking.

## Related Issues

Fixes #27695

## Tests

Just re-factoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
