### PR TITLE
Find the target platform more accurately on the web.

### DIFF
--- a/packages/flutter/lib/src/foundation/_platform_web.dart
+++ b/packages/flutter/lib/src/foundation/_platform_web.dart
@@ -7,9 +7,9 @@ import 'platform.dart' as platform;
 
 /// The dart:html implementation of [platform.defaultTargetPlatform].
 platform.TargetPlatform get defaultTargetPlatform {
-  // To getter a better guess at the targetPlatform we need to be able to
-  // reference the window, but that won't be available until we fix the
-  // platforms configuration for Flutter.
+  // To get a better guess at the targetPlatform we need to be able to reference
+  // the window, but that won't be available until we fix the platforms
+  // configuration for Flutter.
   platform.TargetPlatform result = _browserPlatform();
   if (platform.debugDefaultTargetPlatformOverride != null)
     result = platform.debugDefaultTargetPlatformOverride!;
@@ -21,10 +21,24 @@ platform.TargetPlatform _browserPlatform() {
   if (navigatorPlatform.startsWith('mac')) {
     return platform.TargetPlatform.macOS;
   }
+  if (navigatorPlatform.startsWith('win')) {
+    return platform.TargetPlatform.windows;
+  }
   if (navigatorPlatform.contains('iphone') ||
       navigatorPlatform.contains('ipad') ||
       navigatorPlatform.contains('ipod')) {
     return platform.TargetPlatform.iOS;
+  }
+  if (navigatorPlatform.contains('android')) {
+    return platform.TargetPlatform.android;
+  }
+  // Since some phones can report a window.navigator.platform as Linux, fall
+  // back to use CSS to disambiguate Android vs Linux desktop. If the CSS
+  // indicates that a device has a "fine pointer" (mouse) as the primary
+  // pointing device, then we'll assume desktop linux, and otherwise we'll
+  // assume Android.
+  if (html.window.matchMedia('only screen and (pointer: fine)').matches) {
+    return platform.TargetPlatform.linux;
   }
   return platform.TargetPlatform.android;
 }

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -23,9 +23,12 @@ import '_platform_io.dart'
 /// adaptations for iOS later). Tests can check iOS behavior by using the
 /// platform override APIs (such as [ThemeData.platform] in the material
 /// library) or by setting [debugDefaultTargetPlatformOverride].
+///
+/// Tests can also create specific platform tests by and adding a `variant:`
+/// argument to the test and using a [TargetPlatformVariant].
 //
-// When adding support for a new platform (e.g. Windows Phone, macOS), first
-// create a new value on the [TargetPlatform] enum, then add a rule for
+// When adding support for a new platform (e.g. Windows Phone, Rasberry Pi),
+// first create a new value on the [TargetPlatform] enum, then add a rule for
 // selecting that platform here.
 //
 // It would be incorrect to make a platform that isn't supported by
@@ -42,7 +45,7 @@ enum TargetPlatform {
   /// Android: <https://www.android.com/>
   android,
 
-  /// Fuchsia: <https://fuchsia.googlesource.com/>
+  /// Fuchsia: <https://fuchsia.dev/fuchsia-src/concepts>
   fuchsia,
 
   /// iOS: <https://www.apple.com/ios/>


### PR DESCRIPTION
## Description

This updates the target platform detection for the web so that it can disambiguate Linux, Windows, and Android platforms.

Currently, when we try to guess which focus highlight scheme to use initially (before we have any pointer data), we guess incorrectly because the web defaults to `TargetPlatform.android` on all non-Apple platforms.

## Related Issues

- https://github.com/flutter/flutter/issues/60271
- https://github.com/flutter/flutter/issues/58130

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.
