### PR TITLE
Update Cirrus pub cache directory to %LOCALAPPDATA%

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -350,7 +350,7 @@ task:
     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\$FLUTTER_SDK_PATH_WITH_SPACE"
     PATH: "$CIRRUS_WORKING_DIR/bin;$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin;$PATH"
   pub_cache:
-    folder: $APPDATA\Pub\Cache
+    folder: $LOCALAPPDATA\Pub\Cache
     fingerprint_script:
       - ps: $Environment:OS; Get-ChildItem -Path "$Environment:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
     reupload_on_changes: false


### PR DESCRIPTION
## Description

Cirrus is failing to upload the pub cache, looks like the default location changed from `%APPDATA%` -> `% LOCALAPPDATA%`

https://github.com/dart-lang/pub/blob/82e60a3dcb3afe753563e7d304827fb650bc4833/lib/src/system_cache.dart#L38-L42

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*