### PR TITLE
[WIP] [DRAFT] [DEMO][HACK] Demo how a list of itemExtents can speedup scroll

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -16,5 +16,6 @@ const String kFadingChildAnimationRouteName = '/fading_child_animation';
 const String kImageFilteredTransformAnimationRouteName = '/imagefiltered_transform_animation';
 const String kMultiWidgetConstructionRouteName = '/multi_widget_construction';
 const String kHeavyGridViewRouteName = '/heavy_gridview';
+const String kLongListWithVariableExtentItems = '/long_list_variable_extent';
 
 const String kScrollableName = '/macrobenchmark_listview';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -14,6 +14,7 @@ import 'src/backdrop_filter.dart';
 import 'src/cubic_bezier.dart';
 import 'src/cull_opacity.dart';
 import 'src/filtered_child_animation.dart';
+import 'src/long_list_variable_extent.dart';
 import 'src/multi_widget_construction.dart';
 import 'src/post_backdrop_filter.dart';
 import 'src/simple_animation.dart';
@@ -47,6 +48,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kImageFilteredTransformAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.rotateFilter),
         kMultiWidgetConstructionRouteName: (BuildContext context) => const MultiWidgetConstructTable(10, 20),
         kHeavyGridViewRouteName: (BuildContext context) => HeavyGridViewPage(),
+        kLongListWithVariableExtentItems: (BuildContext context) => LongListVariableExtent(),
       },
     );
   }
@@ -158,6 +160,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Heavy Grid View'),
             onPressed: () {
               Navigator.pushNamed(context, kHeavyGridViewRouteName);
+            },
+          ),
+          RaisedButton(
+            key: const Key(kLongListWithVariableExtentItems),
+            child: const Text('Long List with Variable-Extent Items'),
+            onPressed: () {
+              Navigator.pushNamed(context, kLongListWithVariableExtentItems);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/long_list_variable_extent.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/long_list_variable_extent.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+
+class LongListVariableExtent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final ScrollController controller = ScrollController();
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(),
+        body: CupertinoScrollbar(
+          controller: controller,
+          isAlwaysShown: true,
+          child: ListView.builder(
+            controller: controller,
+            itemCount: 1000,
+
+            // !!!!!!!!!! REMOVE THIS LINE TO SEE THE SLOW VERSION !!!!!!!!!!!!
+            itemExtents: List<double>.generate(1000, (int index) => index % 2 * 20 + 20.0),
+
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: index % 2 * 20 + 20.0,
+                child: Container(
+                  color: index % 2 == 0 ? Colors.blue : Colors.green,
+                  child: Center(child: Text('$index')),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1010,6 +1010,7 @@ class ListView extends BoxScrollView {
     bool shrinkWrap = false,
     EdgeInsetsGeometry padding,
     this.itemExtent,
+    this.itemExtents,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
@@ -1080,6 +1081,7 @@ class ListView extends BoxScrollView {
     bool shrinkWrap = false,
     EdgeInsetsGeometry padding,
     this.itemExtent,
+    this.itemExtents,
     @required IndexedWidgetBuilder itemBuilder,
     int itemCount,
     bool addAutomaticKeepAlives = true,
@@ -1182,6 +1184,7 @@ class ListView extends BoxScrollView {
        assert(separatorBuilder != null),
        assert(itemCount != null && itemCount >= 0),
        itemExtent = null,
+       itemExtents = null,
        childrenDelegate = SliverChildBuilderDelegate(
          (BuildContext context, int index) {
            final int itemIndex = index ~/ 2;
@@ -1314,6 +1317,7 @@ class ListView extends BoxScrollView {
     bool shrinkWrap = false,
     EdgeInsetsGeometry padding,
     this.itemExtent,
+    this.itemExtents,
     @required this.childrenDelegate,
     double cacheExtent,
     int semanticChildCount,
@@ -1344,6 +1348,9 @@ class ListView extends BoxScrollView {
   /// the scroll position changes drastically.
   final double itemExtent;
 
+  /// TEST
+  final List<double> itemExtents;
+
   /// A delegate that provides the children for the [ListView].
   ///
   /// The [ListView.custom] constructor lets you specify this delegate
@@ -1358,6 +1365,12 @@ class ListView extends BoxScrollView {
       return SliverFixedExtentList(
         delegate: childrenDelegate,
         itemExtent: itemExtent,
+      );
+    }
+    if (itemExtents != null) {
+      return SliverFixedVariableExtentList(
+        delegate: childrenDelegate,
+        itemExtents: itemExtents,
       );
     }
     return SliverList(delegate: childrenDelegate);

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -890,6 +890,30 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
   }
 }
 
+/// TEST
+class SliverFixedVariableExtentList extends SliverMultiBoxAdaptorWidget {
+  /// TEST
+  const SliverFixedVariableExtentList({
+    Key key,
+    @required SliverChildDelegate delegate,
+    @required this.itemExtents,
+  }) : super(key: key, delegate: delegate);
+
+  /// TEST
+  final List<double> itemExtents;
+
+  @override
+  RenderSliverFixedVariableExtentList createRenderObject(BuildContext context) {
+    final SliverMultiBoxAdaptorElement element = context as SliverMultiBoxAdaptorElement;
+    return RenderSliverFixedVariableExtentList(childManager: element, itemExtents: itemExtents);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderSliverFixedVariableExtentList renderObject) {
+    renderObject.itemExtents = itemExtents;
+  }
+}
+
 /// A sliver that places multiple box children in a two dimensional arrangement.
 ///
 /// [SliverGrid] places its children in arbitrary positions determined by


### PR DESCRIPTION
Drag the CupertinoScrollbar (the Material Scrollbar is unfortunately
undraggable) to see fast scrolling jump.

You can also try the slow version by removing the `itemExtents`.

This is a hack to just demo the idea. There are many places that are very fragile or plainly wrong, but I think it's sufficient to demonstrate the idea how itemExtents could potentially speed things up.

Related issue: https://github.com/flutter/flutter/issues/52207 