### PR TITLE
Fix overflow issue caused by a long title/subtitle for the vertical stepper

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -520,9 +520,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               _buildLine(!_isLast(index)),
             ],
           ),
-          Container(
-            margin: const EdgeInsetsDirectional.only(start: 12.0),
-            child: _buildHeaderText(index),
+          Expanded(
+            child: Container(
+              margin: const EdgeInsetsDirectional.only(start: 12.0),
+              child: _buildHeaderText(index),
+            )
           ),
         ],
       ),

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -687,9 +687,7 @@ void main() {
       ),
     );
 
-    await tester.pump();
-
-    expect(find.text(longText), findsNWidgets(1));
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('Stepper header subtitle should not overflow', (WidgetTester tester) async {
@@ -716,8 +714,6 @@ void main() {
       ),
     );
 
-    await tester.pump();
-
-    expect(find.text(longText), findsNWidgets(1));
+    expect(tester.takeException(), isNull);
   });
 }

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -663,4 +663,61 @@ void main() {
     await tester.pump();
     expect(disabledNode.hasPrimaryFocus, isFalse);
   });
+
+  testWidgets('Stepper header title should not overflow', (WidgetTester tester) async {
+    const String longText =
+        'A long long long long long long long long long long long long text';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              Stepper(
+                steps: const <Step>[
+                  Step(
+                    title: Text(longText),
+                    content: Text('Text content')
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text(longText), findsNWidgets(1));
+  });
+
+  testWidgets('Stepper header subtitle should not overflow', (WidgetTester tester) async {
+    const String longText =
+        'A long long long long long long long long long long long long text';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              Stepper(
+                steps: const <Step>[
+                  Step(
+                    title: Text('Regular title'),
+                    subtitle: Text(longText),
+                    content: Text('Text content')
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text(longText), findsNWidgets(1));
+  });
 }


### PR DESCRIPTION
## Description

Wraps the vertical stepper header text in an `Expandable` to prevent potential overflow, especially on smaller screens, due to either the title or subtitle being too long

**Before**
![image](https://user-images.githubusercontent.com/46089773/87696412-a96a0a00-c788-11ea-9b10-38a4290a26e7.png)

**After**
![image](https://user-images.githubusercontent.com/46089773/87696400-a5d68300-c788-11ea-81d5-4c8bd53c79ac.png)


## Related Issues

- #61622

## Tests

I added the following tests:

- Stepper header subtitle should not overflow
- Stepper header title should not overflow

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
