### PR TITLE
[flutter_tools] turn off fuchsia support by default

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_device.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
@@ -106,6 +107,7 @@ Future<void> main(List<String> args) async {
     muteCommandLogging: false,
     verboseHelp: false,
     overrides: <Type, Generator>{
+      FeatureFlags: () => const _FuchsiaFeatureFlags(),
       DeviceManager: () => _FuchsiaDeviceManager(),
       FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig, devFinder: devFinder),
       Artifacts: () => OverrideArtifacts(
@@ -170,4 +172,32 @@ class _FuchsiaAttachCommand extends AttachCommand {
     Cache.flutterRoot = '$originalWorkingDirectory/third_party/dart-pkg/git/flutter';
     return super.runCommand();
   }
+}
+
+class _FuchsiaFeatureFlags extends FeatureFlags {
+  const _FuchsiaFeatureFlags();
+
+  @override
+  bool get isLinuxEnabled => false;
+
+  @override
+  bool get isMacOSEnabled => false;
+
+  @override
+  bool get isWebEnabled => false;
+
+  @override
+  bool get isWindowsEnabled => false;
+
+  @override
+  bool get isAndroidEnabled => false;
+
+  @override
+  bool get isIOSEnabled => false;
+
+  @override
+  bool get isFuchsiaEnabled => true;
+
+  @override
+  bool get isSingleWidgetReloadEnabled => false;
 }

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/features.dart';
 import 'package:meta/meta.dart';
 
 import '../base/common.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../features.dart';
 import '../fuchsia/fuchsia_build.dart';
 import '../fuchsia/fuchsia_pm.dart';
 import '../globals.dart' as globals;

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/features.dart';
 import 'package:meta/meta.dart';
 
 import '../base/common.dart';
@@ -59,6 +60,12 @@ class BuildFuchsiaCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    if (!featureFlags.isFuchsiaEnabled) {
+      throwToolExit(
+        '"build fuchsia" is currently disabled. See "flutter config" for more '
+        'information.'
+      );
+    }
     final BuildInfo buildInfo = getBuildInfo();
     final FlutterProject flutterProject = FlutterProject.current();
     if (!globals.platform.isLinux && !globals.platform.isMacOS) {

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -227,7 +227,7 @@ const Feature flutterFuchsiaFeature = Feature(
   environmentOverride: 'FLUTTER_FUCHSIA',
   master: FeatureChannelSetting(
     available: true,
-    enabledByDefault: true,
+    enabledByDefault: false,
   ),
 );
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_kernel_compiler.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_pm.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
@@ -20,6 +21,7 @@ import 'package:process/process.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
+import '../../src/testbed.dart';
 
 // Defined globally for mocks to use.
 FileSystem fileSystem;
@@ -47,6 +49,23 @@ void main() {
   });
 
   group('Fuchsia build fails gracefully when', () {
+    testUsingContext('The feature is disabled', () async {
+      final BuildCommand command = BuildCommand();
+      fileSystem.directory('fuchsia').createSync(recursive: true);
+      fileSystem.file('.packages').createSync();
+      fileSystem.file('pubspec.yaml').createSync();
+      fileSystem.file('lib/main.dart').createSync(recursive: true);
+
+      expect(
+        createTestCommandRunner(command).run(const <String>['build', 'fuchsia']),
+        throwsToolExit(message: '"build fuchsia" is currently disabled'),
+      );
+    }, overrides: <Type, Generator>{
+      Platform: () => linuxPlatform,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: false),
+    });
     testUsingContext('there is no Fuchsia project', () async {
       final BuildCommand command = BuildCommand();
 
@@ -58,6 +77,7 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: true),
     });
 
     testUsingContext('there is no cmx file', () async {
@@ -74,6 +94,7 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: true),
     });
 
     testUsingContext('on Windows platform', () async {
@@ -95,6 +116,7 @@ void main() {
       Platform: () => windowsPlatform,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: true),
     });
 
     testUsingContext('there is no Fuchsia kernel compiler', () async {
@@ -117,6 +139,7 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: true),
     });
   });
 
@@ -145,6 +168,7 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FuchsiaSdk: () => fuchsiaSdk,
+    FeatureFlags: () => TestFeatureFlags(isFuchsiaEnabled: true),
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -216,6 +216,7 @@ void main() {
         isLinuxEnabled: true,
         isMacOSEnabled: true,
         isWindowsEnabled: true,
+        isFuchsiaEnabled: true,
       ),
       platform: FakePlatform(environment: <String, String>{}),
     );
@@ -329,6 +330,7 @@ void main() {
         isLinuxEnabled: true,
         isMacOSEnabled: true,
         isWindowsEnabled: true,
+        isFuchsiaEnabled: true,
       ),
       platform: FakePlatform(environment: <String, String>{}),
     );

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -732,7 +732,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isSingleWidgetReloadEnabled = false,
     this.isAndroidEnabled = true,
     this.isIOSEnabled = true,
-    this.isFuchsiaEnabled = true,
+    this.isFuchsiaEnabled = false,
 });
 
   @override


### PR DESCRIPTION
## Description

Disables fuchsia/ build fuchsia unless `flutter config` has been used to enable it.


Fixes https://github.com/flutter/flutter/issues/52859