### PR TITLE
Add minWidth and height parameter into FlatButton widget

### DIFF
--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -126,10 +126,14 @@ class FlatButton extends MaterialButton {
     bool autofocus = false,
     MaterialTapTargetSize materialTapTargetSize,
     @required Widget child,
+    double height,
+    double minWidth,
   }) : assert(clipBehavior != null),
        assert(autofocus != null),
        super(
          key: key,
+         height: height,
+         minWidth: minWidth,
          onPressed: onPressed,
          onLongPress: onLongPress,
          onHighlightChanged: onHighlightChanged,
@@ -185,6 +189,8 @@ class FlatButton extends MaterialButton {
     MaterialTapTargetSize materialTapTargetSize,
     @required Widget icon,
     @required Widget label,
+    double minWidth,
+    double height,
   }) = _FlatButtonWithIcon;
 
   @override
@@ -209,7 +215,10 @@ class FlatButton extends MaterialButton {
       disabledElevation: buttonTheme.getDisabledElevation(this),
       padding: buttonTheme.getPadding(this),
       visualDensity: visualDensity ?? theme.visualDensity,
-      constraints: buttonTheme.getConstraints(this),
+      constraints: buttonTheme.getConstraints(this).copyWith(
+        minWidth: minWidth,
+        minHeight: height,
+      ),
       shape: buttonTheme.getShape(this),
       clipBehavior: clipBehavior,
       focusNode: focusNode,
@@ -250,6 +259,8 @@ class _FlatButtonWithIcon extends FlatButton with MaterialButtonWithIconMixin {
     MaterialTapTargetSize materialTapTargetSize,
     @required Widget icon,
     @required Widget label,
+    double minWidth,
+    double height,
   }) : assert(icon != null),
        assert(label != null),
        assert(clipBehavior != null),
@@ -284,6 +295,8 @@ class _FlatButtonWithIcon extends FlatButton with MaterialButtonWithIconMixin {
              label,
            ],
          ),
+         minWidth: minWidth,
+         height: height,
        );
 
 }

--- a/packages/flutter/test/material/flat_button_test.dart
+++ b/packages/flutter/test/material/flat_button_test.dart
@@ -824,6 +824,66 @@ void main() {
     expect(box.size, equals(const Size(76, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
+
+    testWidgets('FlatButton height parameter is used when provided', (WidgetTester tester) async {
+      const double buttonHeight = 100;
+      const double buttonDefaultMinHeight = 36.0;
+
+      Future<void> buildWidget({double buttonHeight}) {
+        return tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: FlatButton(
+              height: buttonHeight,
+              child: const Text('button'),
+              onPressed: () {
+                /*ununsed*/
+              },
+            ),
+          ),
+        );
+      }
+
+      final Finder rawMaterialButtonFinder = find.byType(RawMaterialButton);
+
+      // If height is not provided we expect the default height to be used.
+      await buildWidget();
+      expect(tester.widget<RawMaterialButton>(rawMaterialButtonFinder).constraints.minHeight, buttonDefaultMinHeight);
+
+      // When the height is provided we expect that is used by the internal widget.
+      await buildWidget(buttonHeight: buttonHeight);
+      expect(tester.widget<RawMaterialButton>(rawMaterialButtonFinder).constraints.minHeight, buttonHeight);
+    });
+
+    testWidgets('FlatButton minWidth parameter is used when provided', (WidgetTester tester) async {
+      const double buttonMinWidth = 100;
+      const double buttonDefaultMinWidth = 88.0;
+
+      Future<void> buildWidget({double buttonMinWidth}) {
+        return tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: FlatButton(
+              minWidth: buttonMinWidth,
+              child: const Text('button'),
+              onPressed: () {
+                /*ununsed*/
+              },
+            ),
+          ),
+        );
+      }
+
+      final Finder rawMaterialButtonFinder = find.byType(RawMaterialButton);
+
+      // If minWidth is not provided we expect the default minWidth to be used.
+      await buildWidget();
+      expect(tester.widget<RawMaterialButton>(rawMaterialButtonFinder).constraints.minWidth, buttonDefaultMinWidth);
+
+      // When minWidth is provided we expect that the internal widget uses it.
+      await buildWidget(buttonMinWidth: buttonMinWidth);
+      expect(tester.widget<RawMaterialButton>(rawMaterialButtonFinder).constraints.minWidth, buttonMinWidth);
+    });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
## Description

The `FlatButton` widget extends from `MaterialButton` but it does not provide a way to change the button's `minWidth` and `height`. This PR fixes this by providing those two parameter for the `FlatButton`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29220

## Tests

- [x] Verify that the minWidth value is passed to the parent widget
- [x] Verify that the height value is passed to the parent widget

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.