### PR TITLE
Fix Border.symmetric: phase 2

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -332,20 +332,16 @@ class Border extends BoxBorder {
   ///
   /// All arguments default to [BorderSide.none] and must not be null.
   ///
-  /// Currently, the `vertical` argument will apply to the top and bottom
-  /// borders, and the `horizontal` argument will apply to the left and right
-  /// borders. This is not consistent with the use of "vertical" and
-  /// "horizontal" elsewhere in the framework, so the
-  /// `invertMeaningOfVerticalAndHorizontal` argument exists to facilitate
-  /// the transition of this constructor to using the correct semantics of
-  /// these arguments. Callers are encouraged to pass false to that argument
-  /// to get the correct semantics. In a future change, the default value of
-  /// the argument will be changed to false, followed by the removal of the
-  /// argument altogether.
+  /// If the `invertMeaningOfVerticalAndHorizontal` argument is set to true,
+  /// then the `vertical` argument will apply to the top and bottom borders, and
+  /// the `horizontal` argument will apply to the left and right borders. This
+  /// is not consistent with the use of "vertical" and "horizontal" elsewhere in
+  /// the framework, so callers are discouraged from overriding the default
+  /// value of that argument. In a future change, the argument will be removed.
   const Border.symmetric({
     BorderSide vertical = BorderSide.none,
     BorderSide horizontal = BorderSide.none,
-    bool invertMeaningOfVerticalAndHorizontal = true,
+    bool invertMeaningOfVerticalAndHorizontal = false,
   }) : assert(vertical != null),
        assert(horizontal != null),
        assert(invertMeaningOfVerticalAndHorizontal != null),

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -31,19 +31,19 @@ void main() {
     const BorderSide side1 = BorderSide(color: Color(0xFFFFFFFF));
     const BorderSide side2 = BorderSide(color: Color(0xFF000000));
     const Border border = Border.symmetric(vertical: side1, horizontal: side2);
-    expect(border.left, same(side2));
-    expect(border.top, same(side1));
-    expect(border.right, same(side2));
-    expect(border.bottom, same(side1));
+    expect(border.left, same(side1));
+    expect(border.top, same(side2));
+    expect(border.right, same(side1));
+    expect(border.bottom, same(side2));
     const Border border2 = Border.symmetric(
       vertical: side1,
       horizontal: side2,
-      invertMeaningOfVerticalAndHorizontal: false,
+      invertMeaningOfVerticalAndHorizontal: true,
     );
-    expect(border2.left, same(side1));
-    expect(border2.top, same(side2));
-    expect(border2.right, same(side1));
-    expect(border2.bottom, same(side2));
+    expect(border2.left, same(side2));
+    expect(border2.top, same(side1));
+    expect(border2.right, same(side2));
+    expect(border2.bottom, same(side1));
   });
 
   test('Border.merge', () {


### PR DESCRIPTION
## Description

This updates the default value of the `invertMeaningOfVerticalAndHorizontal`
argument from true to false.

## Related Issues

https://github.com/flutter/flutter/issues/61470

## Tests

I updated the relevant tests.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
