### PR TITLE
Clean up Objective-C code in ios_host_app integration test

### DIFF
--- a/dev/integration_tests/ios_host_app/Host/AppDelegate.h
+++ b/dev/integration_tests/ios_host_app/Host/AppDelegate.h
@@ -2,12 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
-#import <Flutter/Flutter.h>
+@import UIKit;
+@import Flutter;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface AppDelegate : FlutterAppDelegate
 
-@property(nonatomic, strong) FlutterEngine* engine;
-@property(nonatomic, strong) FlutterBasicMessageChannel* reloadMessageChannel;
+@property(readonly, nullable) FlutterEngine* engine;
+@property(readonly, nullable) FlutterBasicMessageChannel* reloadMessageChannel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_host_app/Host/AppDelegate.m
+++ b/dev/integration_tests/ios_host_app/Host/AppDelegate.m
@@ -6,43 +6,31 @@
 #import "MainViewController.h"
 
 @interface AppDelegate ()
-
+@property(readwrite) FlutterEngine* engine;
+@property(readwrite) FlutterBasicMessageChannel* reloadMessageChannel;
+@property(nullable) MainViewController* mainViewController;
+@property(nullable) UINavigationController* navigationController;
 @end
 
-static NSString *_kReloadChannelName = @"reload";
+@implementation AppDelegate
 
-@implementation AppDelegate {
-  MainViewController *_mainViewController;
-  UINavigationController *_navigationController;
-  FlutterEngine *_engine;
-  FlutterBasicMessageChannel *_reloadMessageChannel;
-}
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions {
+  self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+  
+  self.mainViewController = [[MainViewController alloc] init];
+  self.navigationController = [[UINavigationController alloc]
+                               initWithRootViewController:_mainViewController];
 
-- (FlutterEngine *)engine {
-  return _engine;
-}
+  self.navigationController.navigationBar.translucent = NO;
 
-- (FlutterBasicMessageChannel *)reloadMessabeChannel {
-  return _reloadMessageChannel;
-}
-
-- (BOOL)application:(UIApplication *)application
-    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-
-  _mainViewController = [[MainViewController alloc] init];
-  _navigationController = [[UINavigationController alloc]
-      initWithRootViewController:_mainViewController];
-
-  _navigationController.navigationBar.translucent = NO;
-
-  _engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  [_engine runWithEntrypoint:nil];
-
-  _reloadMessageChannel = [[FlutterBasicMessageChannel alloc]
-         initWithName:_kReloadChannelName
-      binaryMessenger:_engine.binaryMessenger
-                codec:[FlutterStringCodec sharedInstance]];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  self.engine = engine;
+  [engine runWithEntrypoint:nil];
+  
+  self.reloadMessageChannel = [[FlutterBasicMessageChannel alloc]
+                               initWithName:@"reload"
+                               binaryMessenger:engine.binaryMessenger
+                               codec:[FlutterStringCodec sharedInstance]];
 
   self.window.rootViewController = _navigationController;
   [self.window makeKeyAndVisible];

--- a/dev/integration_tests/ios_host_app/Host/DualFlutterViewController.h
+++ b/dev/integration_tests/ios_host_app/Host/DualFlutterViewController.h
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DualFlutterViewController : UIViewController
 
-@property (readonly, strong, nonatomic) FlutterViewController* topFlutterViewController;
-@property (readonly, strong, nonatomic) FlutterViewController* bottomFlutterViewController;
+@property (readonly) FlutterViewController* topFlutterViewController;
+@property (readonly) FlutterViewController* bottomFlutterViewController;
 
 @end
 

--- a/dev/integration_tests/ios_host_app/Host/DualFlutterViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/DualFlutterViewController.m
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <Flutter/Flutter.h>
+@import Flutter;
 
 #import "DualFlutterViewController.h"
 
 @interface DualFlutterViewController ()
-
+@property (readwrite) FlutterViewController* topFlutterViewController;
+@property (readwrite) FlutterViewController* bottomFlutterViewController;
 @end
 
 @implementation DualFlutterViewController
@@ -16,10 +17,10 @@
   [super viewDidLoad];
   self.title = @"Dual Flutter Views";
   self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc]
-                                              initWithTitle:@"Back"
-                                                      style:UIBarButtonItemStylePlain
-                                                     target:nil
-                                                     action:nil];
+                                           initWithTitle:@"Back"
+                                           style:UIBarButtonItemStylePlain
+                                           target:nil
+                                           action:nil];
 
   UIStackView* stackView = [[UIStackView alloc] initWithFrame:self.view.frame];
   stackView.axis = UILayoutConstraintAxisVertical;
@@ -28,18 +29,18 @@
   stackView.layoutMarginsRelativeArrangement = YES;
   [self.view addSubview:stackView];
 
-  _topFlutterViewController = [[FlutterViewController alloc] init];
-  _bottomFlutterViewController= [[FlutterViewController alloc] init];
+  self.topFlutterViewController = [[FlutterViewController alloc] init];
+  self.bottomFlutterViewController= [[FlutterViewController alloc] init];
 
-  [_topFlutterViewController setInitialRoute:@"marquee_green"];
+  [self.topFlutterViewController setInitialRoute:@"marquee_green"];
   [self addChildViewController:_topFlutterViewController];
   [stackView addArrangedSubview:_topFlutterViewController.view];
-  [_topFlutterViewController didMoveToParentViewController:self];
+  [self.topFlutterViewController didMoveToParentViewController:self];
 
-  [_bottomFlutterViewController setInitialRoute:@"marquee_purple"];
+  [self.bottomFlutterViewController setInitialRoute:@"marquee_purple"];
   [self addChildViewController:_bottomFlutterViewController];
   [stackView addArrangedSubview:_bottomFlutterViewController.view];
-  [_bottomFlutterViewController didMoveToParentViewController:self];
+  [self.bottomFlutterViewController didMoveToParentViewController:self];
 }
 
 @end

--- a/dev/integration_tests/ios_host_app/Host/FullScreenViewController.h
+++ b/dev/integration_tests/ios_host_app/Host/FullScreenViewController.h
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <Flutter/Flutter.h>
+@import Flutter;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FullScreenViewController : FlutterViewController
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_host_app/Host/FullScreenViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/FullScreenViewController.m
@@ -5,19 +5,18 @@
 #import "FullScreenViewController.h"
 
 @interface FullScreenViewController ()
-
 @end
 
 @implementation FullScreenViewController
 
--(void)viewWillAppear:(BOOL)animated {
+- (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
   self.title = @"Full Screen Flutter";
   self.navigationController.navigationBarHidden = YES;
   self.navigationController.hidesBarsOnSwipe = YES;
 }
 
--(void)viewWillDisappear:(BOOL)animated {
+- (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
   self.navigationController.navigationBarHidden = NO;
   self.navigationController.hidesBarsOnSwipe = NO;
@@ -28,11 +27,11 @@
     // just going back to the navigation controller.
     // If we needed Flutter to tell us when we could actually go away,
     // we'd need to communicate over a method channel with it.
-    [self.engine setViewController:nil];
+    self.engine.viewController = nil;
   }
 }
 
--(BOOL)prefersStatusBarHidden {
+- (BOOL)prefersStatusBarHidden {
   return true;
 }
 

--- a/dev/integration_tests/ios_host_app/Host/HybridViewController.h
+++ b/dev/integration_tests/ios_host_app/Host/HybridViewController.h
@@ -2,16 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 #import "NativeViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HybridViewController : UIViewController<NativeViewControllerDelegate>
-
-@property (readonly, strong, nonatomic) FlutterViewController* flutterViewController;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_host_app/Host/HybridViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/HybridViewController.m
@@ -2,21 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <Flutter/Flutter.h>
+@import Flutter;
 
 #import "AppDelegate.h"
 #import "HybridViewController.h"
 
 @interface HybridViewController ()
-
+@property FlutterBasicMessageChannel* messageChannel;
+@property(readonly) FlutterEngine *engine;
+@property(readonly) FlutterBasicMessageChannel *reloadMessageChannel;
+@property FlutterViewController* flutterViewController;
 @end
 
-static NSString *_kChannel = @"increment";
-static NSString *_kPing = @"ping";
-
-@implementation HybridViewController {
-  FlutterBasicMessageChannel *_messageChannel;
-}
+@implementation HybridViewController
 
 - (FlutterEngine *)engine {
   return [(AppDelegate *)[[UIApplication sharedApplication] delegate] engine];
@@ -37,40 +35,40 @@ static NSString *_kPing = @"ping";
   stackView.layoutMarginsRelativeArrangement = YES;
   [self.view addSubview:stackView];
   self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc]
-                                              initWithTitle:@"Back"
-                                                      style:UIBarButtonItemStylePlain
-                                                     target:nil
-                                                     action:nil];
+                                           initWithTitle:@"Back"
+                                           style:UIBarButtonItemStylePlain
+                                           target:nil
+                                           action:nil];
 
   NativeViewController *nativeViewController =
-      [[NativeViewController alloc] initWithDelegate:self];
+  [[NativeViewController alloc] initWithDelegate:self];
   [self addChildViewController:nativeViewController];
   [stackView addArrangedSubview:nativeViewController.view];
   [nativeViewController didMoveToParentViewController:self];
 
-  _flutterViewController =
-      [[FlutterViewController alloc] initWithEngine:[self engine]
-                                            nibName:nil
-                                             bundle:nil];
-  [[self reloadMessageChannel] sendMessage:@"hybrid"];
+  self.flutterViewController =
+  [[FlutterViewController alloc] initWithEngine:self.engine
+                                        nibName:nil
+                                         bundle:nil];
+  [self.reloadMessageChannel sendMessage:@"hybrid"];
 
-  _messageChannel = [[FlutterBasicMessageChannel alloc]
-         initWithName:_kChannel
-      binaryMessenger:_flutterViewController.binaryMessenger
-                codec:[FlutterStringCodec sharedInstance]];
-  [self addChildViewController:_flutterViewController];
-  [stackView addArrangedSubview:_flutterViewController.view];
-  [_flutterViewController didMoveToParentViewController:self];
-
+  self.messageChannel = [[FlutterBasicMessageChannel alloc]
+                         initWithName:@"increment"
+                         binaryMessenger:self.flutterViewController.binaryMessenger
+                         codec:[FlutterStringCodec sharedInstance]];
+  [self addChildViewController:self.flutterViewController];
+  [stackView addArrangedSubview:self.flutterViewController.view];
+  [self.flutterViewController didMoveToParentViewController:self];
+  
   __weak NativeViewController *weakNativeViewController = nativeViewController;
-  [_messageChannel setMessageHandler:^(id message, FlutterReply reply) {
+  [self.messageChannel setMessageHandler:^(id message, FlutterReply reply) {
     [weakNativeViewController didReceiveIncrement];
     reply(@"");
   }];
 }
 
 - (void)didTapIncrementButton {
-  [_messageChannel sendMessage:_kPing];
+  [self.messageChannel sendMessage:@"ping"];
 }
 
 @end

--- a/dev/integration_tests/ios_host_app/Host/MainViewController.h
+++ b/dev/integration_tests/ios_host_app/Host/MainViewController.h
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
-#import <Flutter/Flutter.h>
+@import UIKit;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface MainViewController : UIViewController
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_host_app/Host/MainViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/MainViewController.m
@@ -11,13 +11,12 @@
 #import "NativeViewController.h"
 
 @interface MainViewController ()
-
+@property UIStackView *stackView;
+@property(readonly) FlutterEngine *engine;
+@property(readonly) FlutterBasicMessageChannel *reloadMessageChannel;
 @end
 
-
-@implementation MainViewController {
-  UIStackView *_stackView;
-}
+@implementation MainViewController
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -26,15 +25,15 @@
   self.title = @"Flutter iOS Demos Home";
   self.view.backgroundColor = UIColor.whiteColor;
 
-  _stackView = [[UIStackView alloc] initWithFrame:self.view.frame];
-  _stackView.axis = UILayoutConstraintAxisVertical;
-  _stackView.distribution = UIStackViewDistributionEqualSpacing;
-  _stackView.alignment = UIStackViewAlignmentCenter;
-  _stackView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _stackView.layoutMargins = UIEdgeInsetsMake(0, 0, 50, 0);
-  _stackView.layoutMarginsRelativeArrangement = YES;
-  [self.view addSubview:_stackView];
+  UIStackView *stackView = [[UIStackView alloc] initWithFrame:self.view.frame];
+  self.stackView = stackView;
+  stackView.axis = UILayoutConstraintAxisVertical;
+  stackView.distribution = UIStackViewDistributionEqualSpacing;
+  stackView.alignment = UIStackViewAlignmentCenter;
+  stackView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  stackView.layoutMargins = UIEdgeInsetsMake(0, 0, 50, 0);
+  stackView.layoutMarginsRelativeArrangement = YES;
+  [self.view addSubview:self.stackView];
 
   [self addButton:@"Native iOS View" action:@selector(showNative)];
   [self addButton:@"Full Screen (Cold)" action:@selector(showFullScreenCold)];
@@ -53,61 +52,54 @@
 }
 
 - (void)showDualView {
-  DualFlutterViewController *dualViewController =
-      [[DualFlutterViewController alloc] init];
+  DualFlutterViewController *dualViewController = [[DualFlutterViewController alloc] init];
   [self.navigationController pushViewController:dualViewController
                                        animated:YES];
 }
 
 - (void)showHybridView {
-  HybridViewController *hybridViewController =
-      [[HybridViewController alloc] init];
+  HybridViewController *hybridViewController = [[HybridViewController alloc] init];
   [self.navigationController pushViewController:hybridViewController
                                        animated:YES];
 }
 - (void)showNative {
-  NativeViewController *nativeViewController =
-      [[NativeViewController alloc] init];
+  NativeViewController *nativeViewController = [[NativeViewController alloc] init];
   [self.navigationController pushViewController:nativeViewController
                                        animated:YES];
 }
 
 - (void)showFullScreenCold {
-  FullScreenViewController *flutterViewController =
-      [[FullScreenViewController alloc] init];
+  FullScreenViewController *flutterViewController = [[FullScreenViewController alloc] init];
   [flutterViewController setInitialRoute:@"full"];
-  [[self reloadMessageChannel] sendMessage:@"full"];
-  [self.navigationController
-      pushViewController:flutterViewController
-                animated:NO]; // Animating this is janky because of
-                              // transitions with header on the native side.
-                              // It's especially bad with a cold engine.
+  [self.reloadMessageChannel sendMessage:@"full"];
+
+  // Animating this is janky because of transitions with header on the native side.
+  // It's especially bad with a cold engine.
+  [self.navigationController pushViewController:flutterViewController animated:NO];
 }
 
 - (void)showFullScreenWarm {
-  [[self engine].navigationChannel invokeMethod:@"setInitialRoute"
-                                      arguments:@"full"];
-  [[self reloadMessageChannel] sendMessage:@"full"];
+  [self.engine.navigationChannel invokeMethod:@"setInitialRoute"
+                                    arguments:@"full"];
+  [self.reloadMessageChannel sendMessage:@"full"];
 
   FullScreenViewController *flutterViewController =
-      [[FullScreenViewController alloc] initWithEngine:[self engine]
-                                               nibName:nil
-                                                bundle:nil];
-  [self.navigationController
-      pushViewController:flutterViewController
-                animated:NO]; // Animating this is problematic.
+  [[FullScreenViewController alloc] initWithEngine:self.engine
+                                           nibName:nil
+                                            bundle:nil];
+  // Animating this is problematic.
+  [self.navigationController pushViewController:flutterViewController animated:NO];
 }
 
 - (void)showFlutterViewWarm {
-  [[self engine].navigationChannel invokeMethod:@"setInitialRoute"
-                                      arguments:@"/"];
-  [[self reloadMessageChannel] sendMessage:@"/"];
-
+  [self.engine.navigationChannel invokeMethod:@"setInitialRoute"
+                                    arguments:@"/"];
+  [self.reloadMessageChannel sendMessage:@"/"];
 
   FlutterViewController *flutterViewController =
-      [[FlutterViewController alloc] initWithEngine:[self engine]
-                                            nibName:nil
-                                             bundle:nil];
+  [[FlutterViewController alloc] initWithEngine:self.engine
+                                        nibName:nil
+                                         bundle:nil];
   [self.navigationController pushViewController:flutterViewController
                                        animated:YES];
 }
@@ -115,10 +107,8 @@
 - (void)addButton:(NSString *)title action:(SEL)action {
   UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
   [button setTitle:title forState:UIControlStateNormal];
-  [button addTarget:self
-                action:action
-      forControlEvents:UIControlEventTouchUpInside];
-  [_stackView addArrangedSubview:button];
+  [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+  [self.stackView addArrangedSubview:button];
 }
 
 @end

--- a/dev/integration_tests/ios_host_app/Host/NativeViewController.h
+++ b/dev/integration_tests/ios_host_app/Host/NativeViewController.h
@@ -2,21 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
+@import UIKit;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol NativeViewControllerDelegate
+
 /// Triggered when the increment button from the NativeViewController is tapped.
--(void)didTapIncrementButton;
+- (void)didTapIncrementButton;
 
 @end
 
 @interface NativeViewController : UIViewController
 
-- (instancetype)initWithDelegate:(id<NativeViewControllerDelegate>)delegate
-    NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(nullable id<NativeViewControllerDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
 @property(nonatomic, weak) id<NativeViewControllerDelegate> delegate;
 
--(void)didReceiveIncrement;
+- (void)didReceiveIncrement;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/dev/integration_tests/ios_host_app/Host/NativeViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/NativeViewController.m
@@ -5,18 +5,16 @@
 #import "NativeViewController.h"
 
 @interface NativeViewController ()
-
+@property NSUInteger counter;
+@property UILabel* incrementLabel;
 @end
 
-@implementation NativeViewController {
-  int _counter;
-  UILabel* _incrementLabel;
-}
+@implementation NativeViewController
 
-- (instancetype)initWithDelegate:(id<NativeViewControllerDelegate>)delegate {
+- (instancetype)initWithDelegate:(nullable id<NativeViewControllerDelegate>)delegate {
   self = [super initWithNibName:nil bundle:nil];
   if (self) {
-    self.delegate = delegate;
+    _delegate = delegate;
   }
   return self;
 }
@@ -25,47 +23,43 @@
   return [self initWithDelegate:nil];
 }
 
--(instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
-   return [self initWithDelegate:nil];
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  return [self initWithDelegate:nil];
 }
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-
-    self.title = @"Native iOS View";
-    self.view.backgroundColor = UIColor.lightGrayColor;
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc]
-                                                initWithTitle:@"Back"
-                                                        style:UIBarButtonItemStylePlain
-                                                       target:nil
-                                                       action:nil];
-
-    _incrementLabel = [self addIncrementLabel];
-    UIStackView* footer = [self addFooter];
-
-    _incrementLabel.translatesAutoresizingMaskIntoConstraints = false;
-    footer.translatesAutoresizingMaskIntoConstraints = false;
-    UILayoutGuide* marginsGuide = self.view.layoutMarginsGuide;
-    NSMutableArray* array = [[NSMutableArray alloc] init];
-    [array addObject:[_incrementLabel.centerXAnchor
-                         constraintEqualToAnchor:self.view.centerXAnchor]];
-    [array addObject:[_incrementLabel.centerYAnchor
-                         constraintEqualToAnchor:self.view.centerYAnchor]];
-    [array addObject:[footer.centerXAnchor
-                         constraintEqualToAnchor:self.view.centerXAnchor]];
-    [array addObject:[footer.widthAnchor
-                         constraintEqualToAnchor:marginsGuide.widthAnchor]];
-    [array addObject:[footer.bottomAnchor
-                         constraintEqualToAnchor:marginsGuide.bottomAnchor]];
-
-    [NSLayoutConstraint activateConstraints:array];
-    [self updateIncrementLabel];
+  [super viewDidLoad];
+  
+  self.title = @"Native iOS View";
+  self.view.backgroundColor = UIColor.lightGrayColor;
+  self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc]
+                                           initWithTitle:@"Back"
+                                           style:UIBarButtonItemStylePlain
+                                           target:nil
+                                           action:nil];
+  
+  self.incrementLabel = [self addIncrementLabel];
+  UIStackView* footer = [self addFooter];
+  
+  self.incrementLabel.translatesAutoresizingMaskIntoConstraints = false;
+  footer.translatesAutoresizingMaskIntoConstraints = false;
+  UILayoutGuide* marginsGuide = self.view.layoutMarginsGuide;
+  NSArray<NSLayoutConstraint*>* constraints = @[
+    [self.incrementLabel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+    [self.incrementLabel.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    [footer.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+    [footer.widthAnchor constraintEqualToAnchor:marginsGuide.widthAnchor],
+    [footer.bottomAnchor constraintEqualToAnchor:marginsGuide.bottomAnchor]
+  ];
+  
+  [NSLayoutConstraint activateConstraints:constraints];
+  [self updateIncrementLabel];
 }
 
 /// Adds a label to the view that will contain the counter text.
 ///
 /// - Returns: The new label.
--(UILabel*) addIncrementLabel {
+- (UILabel*)addIncrementLabel {
   UILabel* incrementLabel = [[UILabel alloc] init];
   incrementLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
   incrementLabel.textColor = UIColor.blackColor;
@@ -77,7 +71,7 @@
 /// Adds a horizontal stack to the view, anchored to the bottom.
 ///
 /// - Returns: The new stack.
--(UIStackView*) addFooter {
+- (UIStackView*)addFooter {
   UILabel* mainLabel = [self createMainLabel];
   UIButton* incrementButton = [self createIncrementButton];
   UIStackView* stackView = [[UIStackView alloc] initWithFrame:self.view.frame];
@@ -92,7 +86,7 @@
 /// Creates a label identifying this view.  Does not add it to the view.
 ///
 /// - Returns: The new label.
--(UILabel*) createMainLabel {
+- (UILabel*)createMainLabel {
   UILabel* mainLabel = [[UILabel alloc] init];
   mainLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1];
   mainLabel.textColor = UIColor.blackColor;
@@ -103,7 +97,7 @@
 /// Creates a button that will increment a counter.  Does not add it to the view.
 ///
 /// - Returns: The new button.
--(UIButton*) createIncrementButton {
+- (UIButton*)createIncrementButton {
   UIButton *incrementButton = [UIButton buttonWithType:UIButtonTypeSystem];
   incrementButton.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle2];
   [incrementButton setTitle:@"Add" forState:UIControlStateNormal];
@@ -119,7 +113,7 @@
 
 /// Action triggered from tapping on the increment button.  Triggers a corresponding event in the
 /// delegate if one is available, otherwise increments our internal counter.
--(void) handleIncrement:(UIButton*)sender {
+- (void)handleIncrement:(UIButton*)sender {
   if (self.delegate) {
     [self.delegate didTapIncrementButton];
   } else {
@@ -128,16 +122,16 @@
 }
 
 /// Updates the increment label text to match the increment counter.
--(void) updateIncrementLabel {
-  _incrementLabel.text = [NSString
-      stringWithFormat:@"%@ tapped %d %@.",
-                       self.delegate == nil ? @"Button" : @"Flutter button",
-                       _counter, _counter == 1 ? @"time" : @"times"];
+- (void)updateIncrementLabel {
+  self.incrementLabel.text = [NSString
+                              stringWithFormat:@"%@ tapped %lu %@.",
+                              self.delegate == nil ? @"Button" : @"Flutter button",
+                              self.counter, self.counter == 1 ? @"time" : @"times"];
 }
 
 /// Increments our internal counter and updates the view.
--(void) didReceiveIncrement {
-  _counter += 1;
+- (void)didReceiveIncrement {
+  self.counter += 1;
   [self updateIncrementLabel];
 }
 

--- a/dev/integration_tests/ios_host_app/Host/main.m
+++ b/dev/integration_tests/ios_host_app/Host/main.m
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <UIKit/UIKit.h>
+@import UIKit;
+
 #import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {
   @autoreleasepool {
-      return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
   }
 }


### PR DESCRIPTION
## Description

I tidied up some of the Objective-C code in this integration test when I was working on https://github.com/flutter/flutter/pull/61007 but it made the review too confusing.  Split it out into its own review.
- Prefer properties to ivars
- nullability
- Dot notation
- clang imports

## Related Issues

https://github.com/flutter/flutter/pull/61007

## Tests
module_test_ios still passes
```
Task result:
{
  "success": true,
  "data": null,
  "benchmarkScoreKeys": []
}
```

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*