### PR TITLE
Skip printing rendered error text in machine mode

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -53,6 +53,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
     @required UrlTunneller urlTunneller,
+    bool machine = false,
   }) {
     return _ResidentWebRunner(
       device,
@@ -62,6 +63,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
       ipv6: ipv6,
       stayResident: stayResident,
       urlTunneller: urlTunneller,
+      machine: machine,
     );
   }
 }
@@ -79,12 +81,14 @@ abstract class ResidentWebRunner extends ResidentRunner {
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
     bool stayResident = true,
+    bool machine = false,
   }) : super(
           <FlutterDevice>[device],
           target: target ?? globals.fs.path.join('lib', 'main.dart'),
           debuggingOptions: debuggingOptions,
           ipv6: ipv6,
           stayResident: stayResident,
+          machine: machine,
         );
 
   FlutterDevice get device => flutterDevices.first;
@@ -390,6 +394,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
     @required DebuggingOptions debuggingOptions,
     bool stayResident = true,
     @required this.urlTunneller,
+    bool machine = false,
   }) : super(
           device,
           flutterProject: flutterProject,
@@ -397,6 +402,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           debuggingOptions: debuggingOptions,
           ipv6: ipv6,
           stayResident: stayResident,
+          machine: machine,
         );
 
   final UrlTunneller urlTunneller;

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -448,6 +448,7 @@ class AppDomain extends Domain {
     String dillOutputPath,
     bool ipv6 = false,
     String isolateFilter,
+    bool machine = false,
   }) async {
     if (!await device.supportsRuntimeMode(options.buildInfo.mode)) {
       throw Exception(
@@ -480,6 +481,7 @@ class AppDomain extends Domain {
         ipv6: ipv6,
         stayResident: true,
         urlTunneller: options.webEnableExposeUrl ? daemon.daemonDomain.exposeUrl : null,
+        machine: machine,
       );
     } else if (enableHotReload) {
       runner = HotRunner(
@@ -491,6 +493,7 @@ class AppDomain extends Domain {
         dillOutputPath: dillOutputPath,
         ipv6: ipv6,
         hostIsIde: true,
+        machine: machine,
       );
     } else {
       runner = ColdRunner(
@@ -499,6 +502,7 @@ class AppDomain extends Domain {
         debuggingOptions: options,
         applicationBinary: applicationBinary,
         ipv6: ipv6,
+        machine: machine,
       );
     }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -448,7 +448,7 @@ class AppDomain extends Domain {
     String dillOutputPath,
     bool ipv6 = false,
     String isolateFilter,
-    bool machine = false,
+    bool machine = true,
   }) async {
     if (!await device.supportsRuntimeMode(options.buildInfo.mode)) {
       throw Exception(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -450,6 +450,7 @@ class RunCommand extends RunCommandBase {
           packagesFilePath: globalResults['packages'] as String,
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6,
+          machine: true,
         );
       } on Exception catch (error) {
         throwToolExit(error.toString());

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -705,6 +705,7 @@ abstract class ResidentRunner {
     this.stayResident = true,
     this.hotMode = true,
     String dillOutputPath,
+    this.machine = false,
   }) : mainPath = findMainDartFile(target),
        packagesFilePath = debuggingOptions.buildInfo.packagesPath,
        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
@@ -741,6 +742,7 @@ abstract class ResidentRunner {
   final AssetBundle assetBundle;
 
   final CommandHelp commandHelp;
+  final bool machine;
 
   io.HttpServer _devtoolsServer;
 
@@ -1141,7 +1143,7 @@ abstract class ResidentRunner {
   }
 
   void printStructuredErrorLog(vm_service.Event event) {
-    if (event.extensionKind == 'Flutter.Error') {
+    if (event.extensionKind == 'Flutter.Error' && !machine) {
       final Map<dynamic, dynamic> json = event.extensionData?.data;
       if (json != null && json.containsKey('renderedErrorText')) {
         globals.printStatus('\n${json['renderedErrorText']}');

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -23,12 +23,16 @@ class ColdRunner extends ResidentRunner {
     this.applicationBinary,
     bool ipv6 = false,
     bool stayResident = true,
-  }) : super(devices,
-             target: target,
-             debuggingOptions: debuggingOptions,
-             hotMode: false,
-             stayResident: stayResident,
-             ipv6: ipv6);
+    bool machine = false,
+  }) : super(
+          devices,
+          target: target,
+          debuggingOptions: debuggingOptions,
+          hotMode: false,
+          stayResident: stayResident,
+          ipv6: ipv6,
+          machine: machine,
+        );
 
   final bool traceStartup;
   final bool awaitFirstFrameWhenTracing;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -74,14 +74,18 @@ class HotRunner extends ResidentRunner {
     String dillOutputPath,
     bool stayResident = true,
     bool ipv6 = false,
-  }) : super(devices,
-             target: target,
-             debuggingOptions: debuggingOptions,
-             projectRootPath: projectRootPath,
-             stayResident: stayResident,
-             hotMode: true,
-             dillOutputPath: dillOutputPath,
-             ipv6: ipv6);
+    bool machine = false,
+  }) : super(
+          devices,
+          target: target,
+          debuggingOptions: debuggingOptions,
+          projectRootPath: projectRootPath,
+          stayResident: stayResident,
+          hotMode: true,
+          dillOutputPath: dillOutputPath,
+          ipv6: ipv6,
+          machine: machine,
+        );
 
   final bool benchmarkMode;
   final File applicationBinary;

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -25,5 +25,6 @@ abstract class WebRunnerFactory {
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
     @required UrlTunneller urlTunneller,
+    bool machine = false,
   });
 }

--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -3,9 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:process/process.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
 
 import '../src/common.dart';
 import 'test_data/project_with_early_error.dart';
@@ -29,41 +34,50 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test('flutter run reports an early error in an application', () async {
+  test('flutter run in non-machine mode reports an early error in an application', () async {
+    final String flutterBin = globals.fs.path.join(
+        getFlutterRoot(), 'bin', 'flutter');
+
     final StringBuffer stdout = StringBuffer();
 
-    await _flutter.run(
-      startPaused: true,
-      withDebugger: true,
-      structuredErrors: true,
-      // This seems to cause run command to hang - why?
-      machine: false,
-    );
-    await _flutter.resume();
+    final Process process = await const LocalProcessManager().start(<String>[
+      flutterBin,
+      'run',
+      '--disable-service-auth-codes',
+      '--show-test-device',
+      '-dflutter-tester',
+      '--start-paused',
+      '--dart-define=flutter.inspector.structuredErrors=true',
+    ], workingDirectory: tempDir.path);
 
-    final Completer<void> completer = Completer<void>();
-    bool lineFound = false;
+    transformToLines(process.stdout).listen((String line) async {
+      stdout.writeln(line);
 
-    await Future<void>(() async {
-      _flutter.stdout.listen((String line) {
-        stdout.writeln(line);
-        if (line.startsWith('Another exception was thrown') && !lineFound) {
-          lineFound = true;
-          completer.complete();
+      if (line.startsWith('An Observatory debugger')) {
+        final RegExp exp = RegExp(r'http://127.0.0.1:(\d+)/');
+        final RegExpMatch match = exp.firstMatch(line);
+        final String port = match.group(1);
+        if (port != null) {
+          final VmService vmService =
+              await vmServiceConnectUri('ws://localhost:$port/ws');
+          final VM vm = await vmService.getVM();
+          for (final IsolateRef isolate in vm.isolates) {
+            await vmService.resume(isolate.id);
+          }
         }
-      });
-      await completer.future;
-    }).timeout(const Duration(seconds: 15), onTimeout: () {
-      // Complete anyway in case we don't see the 'Another exception' line.
-      completer.complete();
+      }
+
+      if (line.startsWith('Another exception was thrown')) {
+        process.kill();
+      }
     });
 
-    await _flutter.stop();
+    await process.exitCode;
 
     expect(stdout.toString(), contains(_exceptionStart));
   });
 
-  test('flutter run NOT in machine mode does not print an error', () async {
+  test('flutter run in machine mode does not print an error', () async {
     final StringBuffer stdout = StringBuffer();
 
     await _flutter.run(
@@ -74,19 +88,14 @@ void main() {
     await _flutter.resume();
 
     final Completer<void> completer = Completer<void>();
-    bool lineFound = false;
 
     await Future<void>(() async {
       _flutter.stdout.listen((String line) {
         stdout.writeln(line);
-        if (line.startsWith('Another exception was thrown') && !lineFound) {
-          lineFound = true;
-          completer.complete();
-        }
       });
       await completer.future;
-    }).timeout(const Duration(seconds: 15), onTimeout: () {
-      // Complete anyway in case we don't see the 'Another exception' line.
+    }).timeout(const Duration(seconds: 5), onTimeout: () {
+      // We don't expect to see any output but want to write to stdout anyway.
       completer.complete();
     });
 

--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -36,7 +36,10 @@ void main() {
 
   test('flutter run in non-machine mode reports an early error in an application', () async {
     final String flutterBin = globals.fs.path.join(
-        getFlutterRoot(), 'bin', 'flutter');
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
 
     final StringBuffer stdout = StringBuffer();
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -439,6 +439,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     bool chrome = false,
     bool expressionEvaluation = true,
     bool structuredErrors = false,
+    bool machine = true,
     File pidFile,
     String script,
   }) async {
@@ -447,7 +448,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
         'run',
         if (!chrome)
           '--disable-service-auth-codes',
-        '--machine',
+        if (machine) '--machine',
         '-d',
         if (chrome)
           ...<String>[


### PR DESCRIPTION
## Description

At the end of making changes related to structured errors, we enabled printing out error text to stdout so that we can continue to see errors when running with structured errors enabled on the command line (this is so that we will be able to enable structured errors uniformly for internal users). However, this also resulted in structured errors being seen twice for IDEs, since they display once from stdout and once from their own error formatting. 

This change skips printing error text to stdout in machine mode.

## Related Issues

https://github.com/Dart-Code/Dart-Code/issues/2648

## Tests

I added the following tests:
- Added an integration test to verify that in machine mode, errors are not printed to stdout

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
