### PR TITLE
Fix `ExcludeFocus` so it won't refocus a sibling of the focused node.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -515,6 +515,9 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   ///
   /// Does not affect the value of [canRequestFocus] on the descendants.
   ///
+  /// If a descendant node loses focus when this value is changed, the focus
+  /// will move to the scope enclosing this node.
+  ///
   /// See also:
   ///
   ///  * [ExcludeFocus], a widget that uses this property to conditionally
@@ -531,12 +534,12 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     if (value == _descendantsAreFocusable) {
       return;
     }
-    if (!value && hasFocus) {
-      for (final FocusNode child in children) {
-        child.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
-      }
-    }
+    // Set _descendantsAreFocusable before unfocusing, so the scope won't try
+    // and focus any of the children here again if it is false.
     _descendantsAreFocusable = value;
+    if (!value && hasFocus) {
+      unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
+    }
     _manager?._markPropertiesChanged(this);
   }
 


### PR DESCRIPTION
## Description

This changes `FocusNode.descendantsAreFocusable` so that it doesn't allow the enclosing scope to re-focus a node that is a descendant of the node with `descendantsAreFocusable` set to false.

Because of the order in which the internal state for `descendantsAreFocusable` was being set, setting it to false was causing a sibling node to be focused when `descendantsAreFocusable` of the parent was set to false, even though it shouldn't have been focusable, because the enclosing scope would search for a candidate to be focused before the internal state was set to false.

Instead of looping over the children and telling them all to unfocus (and select the previously focused node), this unfocuses the node that has `descendantsAreFocusable` set to false, with the disposition `UnfocusDisposition.previouslyFocusedChild`, so that its enclosing scope will look for a previously focused child that isn't part of the subtree being excluded.

This affects how the `ExcludeFocus` widget behaves when turning on `exclude`.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/61700

## Tests

- Added a regression test.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.