### PR TITLE
Add a test for 3D transform with needsCompositing

### DIFF
--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
@@ -360,4 +361,48 @@ void main() {
     await tester.tap(find.byKey(key1));
     expect(_pointerDown, isTrue);
   });
+
+  Widget _generateTransform(bool needsCompositing, double angle) {
+    final Widget customPaint = CustomPaint(painter: TestRectPainter());
+    return Transform(
+      transform: MatrixUtils.createCylindricalProjectionTransform(
+        radius: 100,
+        angle: angle,
+        perspective: 0.003,
+      ),
+      // A RepaintBoundary child forces the Transform to needsCompositing
+      child: needsCompositing ? RepaintBoundary(child: customPaint) : customPaint,
+    );
+  }
+
+  testWidgets(
+    '3D transform renders the same with or without needsCompositing',
+    (WidgetTester tester) async {
+      for (double angle = 0; angle <= math.pi/4; angle += 0.01) {
+        await tester.pumpWidget(RepaintBoundary(child: _generateTransform(true, angle)));
+        final RenderBox renderBox = tester.binding.renderView.child;
+        final OffsetLayer layer = renderBox.debugLayer as OffsetLayer;
+        final ui.Image imageWithCompositing = await layer.toImage(renderBox.paintBounds);
+
+        await tester.pumpWidget(RepaintBoundary(child: _generateTransform(false, angle)));
+        try {
+          await expectLater(find.byType(RepaintBoundary).first, matchesReferenceImage(imageWithCompositing));
+        } catch (e) {
+          print(angle);
+        }
+      }
+    },
+  );
+}
+
+class TestRectPainter extends CustomPainter {
+  @override
+  void paint(ui.Canvas canvas, ui.Size size) {
+    canvas.drawRect(
+      const Offset(200, 200) & const Size(10, 10),
+      Paint()..color = const Color(0xFFFF0000),
+    );
+  }
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
 }

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -377,7 +377,6 @@ void main() {
 
   testWidgets(
     '3D transform renders the same with or without needsCompositing',
-    skip: isBrowser, // due to https://github.com/flutter/flutter/issues/42767
     (WidgetTester tester) async {
       for (double angle = 0; angle <= math.pi/4; angle += 0.01) {
         await tester.pumpWidget(RepaintBoundary(child: _generateTransform(true, angle)));
@@ -389,6 +388,7 @@ void main() {
         await expectLater(find.byType(RepaintBoundary).first, matchesReferenceImage(imageWithCompositing));
       }
     },
+    skip: isBrowser, // due to https://github.com/flutter/flutter/issues/42767
   );
 }
 

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -377,6 +377,7 @@ void main() {
 
   testWidgets(
     '3D transform renders the same with or without needsCompositing',
+    skip: isBrowser, // due to https://github.com/flutter/flutter/issues/42767
     (WidgetTester tester) async {
       for (double angle = 0; angle <= math.pi/4; angle += 0.01) {
         await tester.pumpWidget(RepaintBoundary(child: _generateTransform(true, angle)));

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -385,11 +385,7 @@ void main() {
         final ui.Image imageWithCompositing = await layer.toImage(renderBox.paintBounds);
 
         await tester.pumpWidget(RepaintBoundary(child: _generateTransform(false, angle)));
-        try {
-          await expectLater(find.byType(RepaintBoundary).first, matchesReferenceImage(imageWithCompositing));
-        } catch (e) {
-          print(angle);
-        }
+        await expectLater(find.byType(RepaintBoundary).first, matchesReferenceImage(imageWithCompositing));
       }
     },
   );


### PR DESCRIPTION
The test was first written in
https://github.com/flutter/flutter/issues/41654#issuecomment-558416745

This will ensure that https://github.com/flutter/flutter/issues/41654
won't have regressions.

This test would fail without https://github.com/flutter/engine/pull/18160
