### PR TITLE
Make sure all isolates start during flutter driver tests.

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -127,27 +127,6 @@ class VMServiceFlutterDriver extends FlutterDriver {
 
     driver._dartVmReconnectUrl = dartVmServiceUrl;
 
-    // Attempts to resume the isolate, but does not crash if it fails because
-    // the isolate is already resumed. There could be a race with other tools,
-    // such as a debugger, any of which could have resumed the isolate.
-    Future<dynamic> resumeLeniently(VMIsolate isolate) {
-      _log('Attempting to resume isolate');
-      return isolate.resume().catchError((dynamic e) {
-        const int vmMustBePausedCode = 101;
-        if (e is rpc.RpcException && e.code == vmMustBePausedCode) {
-          // No biggie; something else must have resumed the isolate
-          _log(
-              'Attempted to resume an already resumed isolate. This may happen '
-                  'when we lose a race with another tool (usually a debugger) that '
-                  'is connected to the same isolate.'
-          );
-        } else {
-          // Failed to resume due to another reason. Fail hard.
-          throw e;
-        }
-      });
-    }
-
     /// Waits for a signal from the VM service that the extension is registered.
     ///
     /// Looks at the list of loaded extensions for the current [isolateRef], as
@@ -199,14 +178,14 @@ class VMServiceFlutterDriver extends FlutterDriver {
     // Set a listener to unpause new isolates as they are ready to run,
     // otherwise they'll hang indefinitely.
     client.onIsolateRunnable.listen((VMIsolateRef isolateRef) async {
-      resumeLeniently(await isolateRef.load());
+      _resumeLeniently(await isolateRef.load());
     });
 
     // Attempt to resume isolate if it was paused
     if (isolate.pauseEvent is VMPauseStartEvent) {
       _log('Isolate is paused at start.');
 
-      await resumeLeniently(isolate);
+      await _resumeLeniently(isolate);
     } else if (isolate.pauseEvent is VMPauseExitEvent ||
         isolate.pauseEvent is VMPauseBreakpointEvent ||
         isolate.pauseEvent is VMPauseExceptionEvent ||
@@ -214,7 +193,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
       // If the isolate is paused for any other reason, assume the extension is
       // already there.
       _log('Isolate is paused mid-flight.');
-      await resumeLeniently(isolate);
+      await _resumeLeniently(isolate);
     } else if (isolate.pauseEvent is VMResumeEvent) {
       _log('Isolate is not paused. Assuming application is ready.');
     } else {
@@ -245,6 +224,27 @@ class VMServiceFlutterDriver extends FlutterDriver {
 
     _log('Connected to Flutter application.');
     return driver;
+  }
+
+  /// Attempts to resume the isolate, but does not crash if it fails because
+  /// the isolate is already resumed. There could be a race with other tools,
+  /// such as a debugger, any of which could have resumed the isolate.
+  static Future<dynamic> _resumeLeniently(VMIsolate isolate) {
+    _log('Attempting to resume isolate');
+    return isolate.resume().catchError((dynamic e) {
+      const int vmMustBePausedCode = 101;
+      if (e is rpc.RpcException && e.code == vmMustBePausedCode) {
+        // No biggie; something else must have resumed the isolate
+        _log(
+            'Attempted to resume an already resumed isolate. This may happen '
+                'when we lose a race with another tool (usually a debugger) that '
+                'is connected to the same isolate.'
+        );
+      } else {
+        // Failed to resume due to another reason. Fail hard.
+        throw e;
+      }
+    });
   }
 
   static int _nextDriverId = 0;

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -50,7 +50,7 @@ void main() {
       mockPeer = MockPeer();
       when(mockClient.getVM()).thenAnswer((_) => Future<MockVM>.value(mockVM));
       when(mockClient.onIsolateRunnable).thenAnswer((Invocation invocation) {
-        return Stream<VMIsolateRef>.fromIterable([otherIsolate]);
+        return Stream<VMIsolateRef>.fromIterable(<VMIsolateRef>[otherIsolate]);
       });
       when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenAnswer((_) => Future<MockIsolate>.value(mockIsolate));

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -47,6 +47,9 @@ void main() {
       mockIsolate = MockIsolate();
       mockPeer = MockPeer();
       when(mockClient.getVM()).thenAnswer((_) => Future<MockVM>.value(mockVM));
+      when(mockClient.onIsolateRunnable).thenAnswer((Invocation invocation) {
+        return Stream<VMIsolateRef>.fromIterable([]);
+      });
       when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenAnswer((_) => Future<MockIsolate>.value(mockIsolate));
       when(mockIsolate.extensionRpcs).thenReturn(<String>[]);

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -35,6 +35,7 @@ void main() {
     MockVM mockVM;
     MockIsolate mockIsolate;
     MockPeer mockPeer;
+    MockIsolate otherIsolate;
 
     void expectLogContains(String message) {
       expect(log, anyElement(contains(message)));
@@ -45,10 +46,11 @@ void main() {
       mockClient = MockVMServiceClient();
       mockVM = MockVM();
       mockIsolate = MockIsolate();
+      otherIsolate = MockIsolate();
       mockPeer = MockPeer();
       when(mockClient.getVM()).thenAnswer((_) => Future<MockVM>.value(mockVM));
       when(mockClient.onIsolateRunnable).thenAnswer((Invocation invocation) {
-        return Stream<VMIsolateRef>.fromIterable([]);
+        return Stream<VMIsolateRef>.fromIterable([otherIsolate]);
       });
       when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenAnswer((_) => Future<MockIsolate>.value(mockIsolate));
@@ -63,6 +65,10 @@ void main() {
           VMServiceClientConnection(mockClient, mockPeer)
         );
       };
+      when(otherIsolate.load()).thenAnswer((_) => Future<MockIsolate>.value(otherIsolate));
+      when(otherIsolate.resume()).thenAnswer((Invocation invocation) {
+        return Future<dynamic>.value(null);
+      });
     });
 
     tearDown(() async {
@@ -80,15 +86,20 @@ void main() {
         connectionLog.add('resume');
         return Future<dynamic>.value(null);
       });
+      when(otherIsolate.pauseEvent).thenReturn(MockVMPauseStartEvent());
       when(mockIsolate.onExtensionAdded).thenAnswer((Invocation invocation) {
         connectionLog.add('onExtensionAdded');
         return Stream<String>.fromIterable(<String>['ext.flutter.driver']);
+      });
+      when(otherIsolate.resume()).thenAnswer((Invocation invocation) {
+        connectionLog.add('other-resume');
+        return Future<dynamic>.value(null);
       });
 
       final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is paused at start');
-      expect(connectionLog, <String>['resume', 'streamListen', 'onExtensionAdded']);
+      expect(connectionLog, <String>['resume', 'streamListen', 'other-resume', 'onExtensionAdded']);
     });
 
     test('connects to isolate paused mid-flight', () async {


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/24703.
Fixes #30641
Fixes https://github.com/flutter/flutter/issues/30641

Flutter driver has problems when flutter apps use more than a single isolate. The other isolates don't start, so apps malfunction. This PR fixes the problem by listening for new isolates to become runnable, and automatically starting them.

## Related Issues

https://github.com/flutter/flutter/issues/24703

## Tests

* Manually tested against an app that requires isolates.
* Added checks in flutter_driver_test.dart to verify that all isolates have resume() invoked.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 
