### PR TITLE
LiveTestWidgetsFlutterBinding support for non-touch event

### DIFF
--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -25,7 +25,7 @@ void main() {
     final TestGesture gesture = await tester.createGesture(
        kind: PointerDeviceKind.mouse);
     final Offset location = tester.getCenter(find.text('Test'));
-    // for moust input without a down, the moveTo generate a hover event
+    // for mouse input without a down event, moveTo generates a hover event
     await gesture.moveTo(location);
     await gesture.removePointer();
   });

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,5 +17,17 @@ void main() {
     // This mimics the start of a gesture as seen on a device, where inputs
     // starts with a PointerAddedEvent.
     await gesture.addPointer();
+  });
+
+  testWidgets('Input PointerHoverEvent', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: Text('Test')));
+    await tester.pump();
+    final TestGesture gesture = await tester.createGesture(
+       kind: PointerDeviceKind.mouse);
+    // This mimics the start of a gesture as seen on a device, where inputs
+    // starts with a PointerAddedEvent.
+    final Offset location = tester.getCenter(find.text('Test'));
+    await gesture.moveTo(location);
+    await gesture.removePointer();
   });
 }

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -24,9 +24,8 @@ void main() {
     await tester.pump();
     final TestGesture gesture = await tester.createGesture(
        kind: PointerDeviceKind.mouse);
-    // This mimics the start of a gesture as seen on a device, where inputs
-    // starts with a PointerAddedEvent.
     final Offset location = tester.getCenter(find.text('Test'));
+    // for moust input without a down, the moveTo generate a hover event
     await gesture.moveTo(location);
     await gesture.removePointer();
   });


### PR DESCRIPTION
## Description

This is a follow up to #61102. 

Changed the logic in `LiveTestWidgetsFlutterBinding.dispatchEvent` to clarify its usage on events that's not up/down touch. Effectively it adds support to hover event (see the added unit test). 

The original `LiveTestWidgetsFlutterBinding.dispatchEvent` implements recording the events that are down, and so it can be plotted on screen. However the original logic does not take into consideration of operations coming from non-touch device, which can have hover event, scroll event, etc, before down event. 

The new version tracks the events that are already in the record, or adds to the record if it's down event, which is equivalent for down-move-up event streams for the version before #61102 and by-passes other events that will falsely trigger the assert #61102. Other events are by-passed because we are not expecting to track those for plotting. 

Compared to the version in  #61102, this version is more general for hover and scroll events. 

(It might be worth to add a todo for plotting events like hover and scroll. )

## Related Issues

Closes #61100

## Tests

I added the following tests:

- `'Input PointerHoverEvent'` in `packages/flutter_test/test/live_binding_test.dart` 

Due to lack of feature mentioned in #61871, `scroll` is not tested. 

For future reference, the typical stream for hover and scroll is like (tested on macos): 

- if the mouse move into the app after the app starts, it will be `PointerAddedEvent` - `PointerHoverEvent` - `PointerRemoveEvent`. One significant difference to touch input is, `PointerAddedEvent` comes in a packet with a single event/`PointerData`, while in touch events, `PointerAddedEvent` and `PointerDownEvent` usually shows at the same time in one packet (the packet would have two `PointerData`). 
- if the mouse is already in the app, `PointerAddedEvent` may not appear. 
- `PointerScrollEvent` (`signalKind=scroll` for the `PointerData`) shows directly after a `PointerHoverEvent`. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
