### PR TITLE
Disable the deferred loading variant of gen_l10n_test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -151,15 +151,10 @@ void main() {
     );
   }
 
+  // TODO(jsimmons): need a localization test that uses deferred loading
+  // (see https://github.com/flutter/flutter/issues/61911)
   test('generated l10n classes produce expected localized strings', () async {
     await project.setUpIn(tempDir);
-    flutter = FlutterRunTestDriver(tempDir);
-    final StringBuffer stdout = await runApp();
-    expectOutput(stdout);
-  });
-
-  test('generated l10n classes produce expected localized strings with deferred loading', () async {
-    await project.setUpIn(tempDir, useDeferredLoading: true);
     flutter = FlutterRunTestDriver(tempDir);
     final StringBuffer stdout = await runApp();
     expectOutput(stdout);


### PR DESCRIPTION
This test is unreliable because it makes assumptions about Dart implementation
details.  It uses app_localizations libraries with deferred loading but expects
that the LocalizationsDelegate futures based on those libraries will be
completed synchronously when the app's widget tree is instantiated.

See https://github.com/flutter/flutter/issues/61911