### PR TITLE
Check if a double is NaN before converting to it int

### DIFF
--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -128,8 +128,8 @@ class MatrixUtils {
   /// This function assumes the given point has a z-coordinate of 0.0. The
   /// z-coordinate of the result is ignored.
   ///
-  /// While not common, this method may return [Offset.infinite] if `offset`
-  /// results in a point at infinity in homogeneous coordinates, after applying
+  /// While not common, this method may return (NaN, NaN) if `offset` results in
+  /// a point at infinity in homogeneous coordinates, after applying
   /// `transform`. For example, a render object may set its transform to the
   /// zero matrix to indicate its content should not be made visible. Trying to
   /// convert an `Offset` to its coordinate space always results in (NaN, NaN).

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -128,8 +128,8 @@ class MatrixUtils {
   /// This function assumes the given point has a z-coordinate of 0.0. The
   /// z-coordinate of the result is ignored.
   ///
-  /// While not common, this method may return (NaN, NaN) if `offset` results in
-  /// a point at infinity in homogeneous coordinates, after applying
+  /// While not common, this method may return (NaN, NaN) if the given `point`
+  /// results in a point at infinity in homogeneous coordinates after applying
   /// `transform`. For example, a render object may set its transform to the
   /// zero matrix to indicate its content should not be made visible. Trying to
   /// convert an `Offset` to its coordinate space always results in (NaN, NaN).

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -128,11 +128,12 @@ class MatrixUtils {
   /// This function assumes the given point has a z-coordinate of 0.0. The
   /// z-coordinate of the result is ignored.
   ///
-  /// While not common, this method may return (NaN, NaN) if the given `point`
-  /// results in a point at infinity in homogeneous coordinates after applying
-  /// `transform`. For example, a render object may set its transform to the
-  /// zero matrix to indicate its content should not be made visible. Trying to
-  /// convert an `Offset` to its coordinate space always results in (NaN, NaN).
+  /// While not common, this method may return (NaN, NaN), iff the given `point`
+  /// results in a "point at infinity" in homogeneous coordinates after applying
+  /// the `transform`. For example, a [RenderObject] may set its transform to
+  /// the zero matrix to indicate its content is currently not visible. Trying
+  /// to convert an `Offset` to its coordinate space always results in
+  /// (NaN, NaN).
   static Offset transformPoint(Matrix4 transform, Offset point) {
     final Float64List storage = transform.storage;
     final double x = point.dx;

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -127,6 +127,12 @@ class MatrixUtils {
   ///
   /// This function assumes the given point has a z-coordinate of 0.0. The
   /// z-coordinate of the result is ignored.
+  ///
+  /// While not common, this method may return [Offset.infinite] if `offset`
+  /// results in a point at infinity in homogeneous coordinates, after applying
+  /// `transform`. For example, a render object may set its transform to the
+  /// zero matrix to indicate its content should not be made visible. Trying to
+  /// convert an `Offset` to its coordinate space always results in (NaN, NaN).
   static Offset transformPoint(Matrix4 transform, Offset point) {
     final Float64List storage = transform.storage;
     final double x = point.dx;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2293,7 +2293,8 @@ abstract class RenderBox extends RenderObject {
   /// coordinate system of `ancestor` (which must be an ancestor of this render
   /// object) instead of to the global coordinate system.
   ///
-  /// This method is implemented in terms of [getTransformTo].
+  /// This method is implemented in terms of [getTransformTo]. If the transform
+  /// matrix is the zero matrix, this method returns [Offset.infinite].
   Offset localToGlobal(Offset point, { RenderObject ancestor }) {
     return MatrixUtils.transformPoint(getTransformTo(ancestor), point);
   }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2294,7 +2294,7 @@ abstract class RenderBox extends RenderObject {
   /// object) instead of to the global coordinate system.
   ///
   /// This method is implemented in terms of [getTransformTo]. If the transform
-  /// matrix is the zero matrix, this method returns [Offset.infinite].
+  /// matrix is the zero matrix, this method returns (NaN, NaN).
   Offset localToGlobal(Offset point, { RenderObject ancestor }) {
     return MatrixUtils.transformPoint(getTransformTo(ancestor), point);
   }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2294,7 +2294,8 @@ abstract class RenderBox extends RenderObject {
   /// object) instead of to the global coordinate system.
   ///
   /// This method is implemented in terms of [getTransformTo]. If the transform
-  /// matrix is the zero matrix, this method returns (NaN, NaN).
+  /// matrix puts the given `point` on the line at infinity (for instance, when
+  /// the transform matrix is the zero matrix), this method returns (NaN, NaN).
   Offset localToGlobal(Offset point, { RenderObject ancestor }) {
     return MatrixUtils.transformPoint(getTransformTo(ancestor), point);
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1923,10 +1923,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   Offset _getPixelPerfectCursorOffset(Rect caretRect) {
     final Offset caretPosition = localToGlobal(caretRect.topLeft);
     final double pixelMultiple = 1.0 / _devicePixelRatio;
-    final int quotientX = (caretPosition.dx / pixelMultiple).round();
-    final int quotientY = (caretPosition.dy / pixelMultiple).round();
-    final double pixelPerfectOffsetX = quotientX * pixelMultiple - caretPosition.dx;
-    final double pixelPerfectOffsetY = quotientY * pixelMultiple - caretPosition.dy;
+    final double pixelPerfectOffsetX = caretPosition.dx.isNaN
+      ? caretPosition.dx
+      : (caretPosition.dx / pixelMultiple).round() * pixelMultiple - caretPosition.dx;
+    final double pixelPerfectOffsetY = caretPosition.dy.isNaN
+      ? caretPosition.dy
+      : (caretPosition.dy / pixelMultiple).round() * pixelMultiple - caretPosition.dy;
     return Offset(pixelPerfectOffsetX, pixelPerfectOffsetY);
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1923,12 +1923,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   Offset _getPixelPerfectCursorOffset(Rect caretRect) {
     final Offset caretPosition = localToGlobal(caretRect.topLeft);
     final double pixelMultiple = 1.0 / _devicePixelRatio;
-    final double pixelPerfectOffsetX = caretPosition.dx.isNaN
-      ? caretPosition.dx
-      : (caretPosition.dx / pixelMultiple).round() * pixelMultiple - caretPosition.dx;
-    final double pixelPerfectOffsetY = caretPosition.dy.isNaN
-      ? caretPosition.dy
-      : (caretPosition.dy / pixelMultiple).round() * pixelMultiple - caretPosition.dy;
+    final double pixelPerfectOffsetX = caretPosition.dx.isFinite
+      ? (caretPosition.dx / pixelMultiple).round() * pixelMultiple - caretPosition.dx
+      : caretPosition.dx;
+    final double pixelPerfectOffsetY = caretPosition.dy.isFinite
+      ? (caretPosition.dy / pixelMultiple).round() * pixelMultiple - caretPosition.dy
+      : caretPosition.dy;
     return Offset(pixelPerfectOffsetX, pixelPerfectOffsetY);
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2699,6 +2699,8 @@ class SemanticsOwner extends ChangeNotifier {
       if (inverse.copyInverse(node.transform) == 0.0)
         return null;
       position = MatrixUtils.transformPoint(inverse, position);
+      if (position.isInfinite)
+        return null;
     }
     if (!node.rect.contains(position))
       return null;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2699,8 +2699,6 @@ class SemanticsOwner extends ChangeNotifier {
       if (inverse.copyInverse(node.transform) == 0.0)
         return null;
       position = MatrixUtils.transformPoint(inverse, position);
-      if (position.isInfinite)
-        return null;
     }
     if (!node.rect.contains(position))
       return null;

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4320,6 +4320,33 @@ void main() {
     expect(scrollController.offset, 0);
   });
 
+  testWidgets('getLocalRectForCaret does not throw when it sees an infinite point', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SkipPainting(
+          child: Transform(
+            transform: Matrix4.zero(),
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: textStyle,
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    try {
+      final Rect rect = state.renderEditable.getLocalRectForCaret(const TextPosition(offset: 0));
+      expect(rect.isFinite, false);
+    } catch (e) {
+      expect(e, isNull);
+    }
+  });
+
   testWidgets('obscured multiline fields throw an exception', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
     expect(
@@ -5348,4 +5375,16 @@ class NoImplicitScrollPhysics extends AlwaysScrollableScrollPhysics {
   NoImplicitScrollPhysics applyTo(ScrollPhysics ancestor) {
     return NoImplicitScrollPhysics(parent: buildParent(ancestor));
   }
+}
+
+class SkipPainting extends SingleChildRenderObjectWidget {
+  const SkipPainting({ Key key, Widget child }): super(key: key, child: child);
+
+  @override
+  SkipPaintingRenderObject createRenderObject(BuildContext context) => SkipPaintingRenderObject();
+}
+
+class SkipPaintingRenderObject extends RenderProxyBox {
+  @override
+  void paint(PaintingContext context, Offset offset) { }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4339,12 +4339,9 @@ void main() {
     );
 
     final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-    try {
-      final Rect rect = state.renderEditable.getLocalRectForCaret(const TextPosition(offset: 0));
-      expect(rect.isFinite, false);
-    } catch (e) {
-      expect(e, isNull);
-    }
+    final Rect rect = state.renderEditable.getLocalRectForCaret(const TextPosition(offset: 0));
+    expect(rect.isFinite, false);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('obscured multiline fields throw an exception', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

`RenderObject.localToGlobal` may return `(NaN, NaN)` when `(x, y, 0, 1)` is transformed to a point at infinity. This is generally not a problem, as painting is usually skipped when the transform is set to zero. But trying to convert the point's coordinates to int or json will throw.

## Related Issues

https://github.com/flutter/flutter/issues/9344

## Tests

I added the following tests:

- getLocalRectForCaret does not throw when it sees an infinite point

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
