### PR TITLE
fix: MaterialColor Swatch Map comparison

### DIFF
--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -5,7 +5,7 @@
 
 import 'dart:math' as math;
 import 'dart:ui' show Color, lerpDouble, hashValues;
-
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
 double _getHue(double red, double green, double blue, double max, double delta) {
@@ -60,7 +60,8 @@ Color _colorFromHue(
     green = 0.0;
     blue = secondary;
   }
-  return Color.fromARGB((alpha * 0xFF).round(), ((red + match) * 0xFF).round(), ((green + match) * 0xFF).round(), ((blue + match) * 0xFF).round());
+  return Color.fromARGB((alpha * 0xFF).round(), ((red + match) * 0xFF).round(),
+      ((green + match) * 0xFF).round(), ((blue + match) * 0xFF).round());
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [value].
@@ -90,18 +91,18 @@ class HSVColor {
   /// All the arguments must not be null and be in their respective ranges. See
   /// the fields for each parameter for a description of their ranges.
   const HSVColor.fromAHSV(this.alpha, this.hue, this.saturation, this.value)
-    : assert(alpha != null),
-      assert(hue != null),
-      assert(saturation != null),
-      assert(value != null),
-      assert(alpha >= 0.0),
-      assert(alpha <= 1.0),
-      assert(hue >= 0.0),
-      assert(hue <= 360.0),
-      assert(saturation >= 0.0),
-      assert(saturation <= 1.0),
-      assert(value >= 0.0),
-      assert(value <= 1.0);
+      : assert(alpha != null),
+        assert(hue != null),
+        assert(saturation != null),
+        assert(value != null),
+        assert(alpha >= 0.0),
+        assert(alpha <= 1.0),
+        assert(hue >= 0.0),
+        assert(hue <= 360.0),
+        assert(saturation >= 0.0),
+        assert(saturation <= 1.0),
+        assert(value >= 0.0),
+        assert(value <= 1.0);
 
   /// Creates an [HSVColor] from an RGB [Color].
   ///
@@ -172,7 +173,8 @@ class HSVColor {
   /// Returns this color in RGB.
   Color toColor() {
     final double chroma = saturation * value;
-    final double secondary = chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
+    final double secondary =
+        chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
     final double match = value - chroma;
 
     return _colorFromHue(alpha, hue, chroma, secondary, match);
@@ -216,20 +218,20 @@ class HSVColor {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    return other is HSVColor
-        && other.alpha == alpha
-        && other.hue == hue
-        && other.saturation == saturation
-        && other.value == value;
+    if (identical(this, other)) return true;
+    return other is HSVColor &&
+        other.alpha == alpha &&
+        other.hue == hue &&
+        other.saturation == saturation &&
+        other.value == value;
   }
 
   @override
   int get hashCode => hashValues(alpha, hue, saturation, value);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'HSVColor')}($alpha, $hue, $saturation, $value)';
+  String toString() =>
+      '${objectRuntimeType(this, 'HSVColor')}($alpha, $hue, $saturation, $value)';
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [lightness].
@@ -259,18 +261,18 @@ class HSLColor {
   /// All the arguments must not be null and be in their respective ranges. See
   /// the fields for each parameter for a description of their ranges.
   const HSLColor.fromAHSL(this.alpha, this.hue, this.saturation, this.lightness)
-    : assert(alpha != null),
-      assert(hue != null),
-      assert(saturation != null),
-      assert(lightness != null),
-      assert(alpha >= 0.0),
-      assert(alpha <= 1.0),
-      assert(hue >= 0.0),
-      assert(hue <= 360.0),
-      assert(saturation >= 0.0),
-      assert(saturation <= 1.0),
-      assert(lightness >= 0.0),
-      assert(lightness <= 1.0);
+      : assert(alpha != null),
+        assert(hue != null),
+        assert(saturation != null),
+        assert(lightness != null),
+        assert(alpha >= 0.0),
+        assert(alpha <= 1.0),
+        assert(hue >= 0.0),
+        assert(hue <= 360.0),
+        assert(saturation >= 0.0),
+        assert(saturation <= 1.0),
+        assert(lightness >= 0.0),
+        assert(lightness <= 1.0);
 
   /// Creates an [HSLColor] from an RGB [Color].
   ///
@@ -290,8 +292,9 @@ class HSLColor {
     final double lightness = (max + min) / 2.0;
     // Saturation can exceed 1.0 with rounding errors, so clamp it.
     final double saturation = lightness == 1.0
-      ? 0.0
-      : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0) as double);
+        ? 0.0
+        : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0)
+            as double);
     return HSLColor.fromAHSL(alpha, hue, saturation, lightness);
   }
 
@@ -346,7 +349,8 @@ class HSLColor {
   /// Returns this HSL color in RGB.
   Color toColor() {
     final double chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
-    final double secondary = chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
+    final double secondary =
+        chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
     final double match = lightness - chroma / 2.0;
 
     return _colorFromHue(alpha, hue, chroma, secondary, match);
@@ -400,20 +404,20 @@ class HSLColor {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    return other is HSLColor
-        && other.alpha == alpha
-        && other.hue == hue
-        && other.saturation == saturation
-        && other.lightness == lightness;
+    if (identical(this, other)) return true;
+    return other is HSLColor &&
+        other.alpha == alpha &&
+        other.hue == hue &&
+        other.saturation == saturation &&
+        other.lightness == lightness;
   }
 
   @override
   int get hashCode => hashValues(alpha, hue, saturation, lightness);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'HSLColor')}($alpha, $hue, $saturation, $lightness)';
+  String toString() =>
+      '${objectRuntimeType(this, 'HSLColor')}($alpha, $hue, $saturation, $lightness)';
 }
 
 /// A color that has a small table of related colors called a "swatch".
@@ -444,20 +448,19 @@ class ColorSwatch<T> extends Color {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return super == other
-        && other is ColorSwatch<T>
-        && other._swatch == _swatch;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return super == other &&
+        other is ColorSwatch<T> &&
+        MapEquality().equals(other._swatch, _swatch);
   }
 
   @override
   int get hashCode => hashValues(runtimeType, value, _swatch);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'ColorSwatch')}(primary value: ${super.toString()})';
+  String toString() =>
+      '${objectRuntimeType(this, 'ColorSwatch')}(primary value: ${super.toString()})';
 }
 
 /// [DiagnosticsProperty] that has an [Color] as value.
@@ -472,15 +475,17 @@ class ColorProperty extends DiagnosticsProperty<Color> {
     Object? defaultValue = kNoDefaultValue,
     DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
     DiagnosticLevel level = DiagnosticLevel.info,
-  }) : assert(showName != null),
-       assert(style != null),
-       assert(level != null),
-       super(name, value,
-         defaultValue: defaultValue,
-         showName: showName,
-         style: style,
-         level: level,
-       );
+  })  : assert(showName != null),
+        assert(style != null),
+        assert(level != null),
+        super(
+          name,
+          value,
+          defaultValue: defaultValue,
+          showName: showName,
+          style: style,
+          level: level,
+        );
 
   @override
   Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -60,8 +60,7 @@ Color _colorFromHue(
     green = 0.0;
     blue = secondary;
   }
-  return Color.fromARGB((alpha * 0xFF).round(), ((red + match) * 0xFF).round(),
-      ((green + match) * 0xFF).round(), ((blue + match) * 0xFF).round());
+  return Color.fromARGB((alpha * 0xFF).round(), ((red + match) * 0xFF).round(), ((green + match) * 0xFF).round(), ((blue + match) * 0xFF).round());
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [value].
@@ -91,18 +90,18 @@ class HSVColor {
   /// All the arguments must not be null and be in their respective ranges. See
   /// the fields for each parameter for a description of their ranges.
   const HSVColor.fromAHSV(this.alpha, this.hue, this.saturation, this.value)
-      : assert(alpha != null),
-        assert(hue != null),
-        assert(saturation != null),
-        assert(value != null),
-        assert(alpha >= 0.0),
-        assert(alpha <= 1.0),
-        assert(hue >= 0.0),
-        assert(hue <= 360.0),
-        assert(saturation >= 0.0),
-        assert(saturation <= 1.0),
-        assert(value >= 0.0),
-        assert(value <= 1.0);
+    : assert(alpha != null),
+      assert(hue != null),
+      assert(saturation != null),
+      assert(value != null),
+      assert(alpha >= 0.0),
+      assert(alpha <= 1.0),
+      assert(hue >= 0.0),
+      assert(hue <= 360.0),
+      assert(saturation >= 0.0),
+      assert(saturation <= 1.0),
+      assert(value >= 0.0),
+      assert(value <= 1.0);
 
   /// Creates an [HSVColor] from an RGB [Color].
   ///
@@ -173,8 +172,7 @@ class HSVColor {
   /// Returns this color in RGB.
   Color toColor() {
     final double chroma = saturation * value;
-    final double secondary =
-        chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
+    final double secondary = chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
     final double match = value - chroma;
 
     return _colorFromHue(alpha, hue, chroma, secondary, match);
@@ -218,20 +216,20 @@ class HSVColor {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    return other is HSVColor &&
-        other.alpha == alpha &&
-        other.hue == hue &&
-        other.saturation == saturation &&
-        other.value == value;
+    if (identical(this, other))
+      return true;
+    return other is HSVColor
+        && other.alpha == alpha
+        && other.hue == hue
+        && other.saturation == saturation
+        && other.value == value;
   }
 
   @override
   int get hashCode => hashValues(alpha, hue, saturation, value);
 
   @override
-  String toString() =>
-      '${objectRuntimeType(this, 'HSVColor')}($alpha, $hue, $saturation, $value)';
+  String toString() => '${objectRuntimeType(this, 'HSVColor')}($alpha, $hue, $saturation, $value)';
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [lightness].
@@ -261,18 +259,18 @@ class HSLColor {
   /// All the arguments must not be null and be in their respective ranges. See
   /// the fields for each parameter for a description of their ranges.
   const HSLColor.fromAHSL(this.alpha, this.hue, this.saturation, this.lightness)
-      : assert(alpha != null),
-        assert(hue != null),
-        assert(saturation != null),
-        assert(lightness != null),
-        assert(alpha >= 0.0),
-        assert(alpha <= 1.0),
-        assert(hue >= 0.0),
-        assert(hue <= 360.0),
-        assert(saturation >= 0.0),
-        assert(saturation <= 1.0),
-        assert(lightness >= 0.0),
-        assert(lightness <= 1.0);
+    : assert(alpha != null),
+      assert(hue != null),
+      assert(saturation != null),
+      assert(lightness != null),
+      assert(alpha >= 0.0),
+      assert(alpha <= 1.0),
+      assert(hue >= 0.0),
+      assert(hue <= 360.0),
+      assert(saturation >= 0.0),
+      assert(saturation <= 1.0),
+      assert(lightness >= 0.0),
+      assert(lightness <= 1.0);
 
   /// Creates an [HSLColor] from an RGB [Color].
   ///
@@ -292,9 +290,8 @@ class HSLColor {
     final double lightness = (max + min) / 2.0;
     // Saturation can exceed 1.0 with rounding errors, so clamp it.
     final double saturation = lightness == 1.0
-        ? 0.0
-        : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0)
-            as double);
+      ? 0.0
+      : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0) as double);
     return HSLColor.fromAHSL(alpha, hue, saturation, lightness);
   }
 
@@ -349,8 +346,7 @@ class HSLColor {
   /// Returns this HSL color in RGB.
   Color toColor() {
     final double chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
-    final double secondary =
-        chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
+    final double secondary = chroma * (1.0 - (((hue / 60.0) % 2.0) - 1.0).abs());
     final double match = lightness - chroma / 2.0;
 
     return _colorFromHue(alpha, hue, chroma, secondary, match);
@@ -404,20 +400,20 @@ class HSLColor {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    return other is HSLColor &&
-        other.alpha == alpha &&
-        other.hue == hue &&
-        other.saturation == saturation &&
-        other.lightness == lightness;
+    if (identical(this, other))
+      return true;
+    return other is HSLColor
+        && other.alpha == alpha
+        && other.hue == hue
+        && other.saturation == saturation
+        && other.lightness == lightness;
   }
 
   @override
   int get hashCode => hashValues(alpha, hue, saturation, lightness);
 
   @override
-  String toString() =>
-      '${objectRuntimeType(this, 'HSLColor')}($alpha, $hue, $saturation, $lightness)';
+  String toString() => '${objectRuntimeType(this, 'HSLColor')}($alpha, $hue, $saturation, $lightness)';
 }
 
 /// A color that has a small table of related colors called a "swatch".
@@ -448,19 +444,20 @@ class ColorSwatch<T> extends Color {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return super == other &&
-        other is ColorSwatch<T> &&
-        MapEquality().equals(other._swatch, _swatch);
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return super == other
+        && other is ColorSwatch<T>
+        && MapEquality<T, Color>().equals(other._swatch, _swatch);
   }
 
   @override
   int get hashCode => hashValues(runtimeType, value, _swatch);
 
   @override
-  String toString() =>
-      '${objectRuntimeType(this, 'ColorSwatch')}(primary value: ${super.toString()})';
+  String toString() => '${objectRuntimeType(this, 'ColorSwatch')}(primary value: ${super.toString()})';
 }
 
 /// [DiagnosticsProperty] that has an [Color] as value.
@@ -475,17 +472,15 @@ class ColorProperty extends DiagnosticsProperty<Color> {
     Object? defaultValue = kNoDefaultValue,
     DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
     DiagnosticLevel level = DiagnosticLevel.info,
-  })  : assert(showName != null),
-        assert(style != null),
-        assert(level != null),
-        super(
-          name,
-          value,
-          defaultValue: defaultValue,
-          showName: showName,
-          style: style,
-          level: level,
-        );
+  }) : assert(showName != null),
+       assert(style != null),
+       assert(level != null),
+       super(name, value,
+         defaultValue: defaultValue,
+         showName: showName,
+         style: style,
+         level: level,
+       );
 
   @override
   Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -5,6 +5,7 @@
 
 import 'dart:math' as math;
 import 'dart:ui' show Color, lerpDouble, hashValues;
+
 import 'package:flutter/foundation.dart';
 
 double _getHue(double red, double green, double blue, double max, double delta) {

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -5,7 +5,6 @@
 
 import 'dart:math' as math;
 import 'dart:ui' show Color, lerpDouble, hashValues;
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
 double _getHue(double red, double green, double blue, double max, double delta) {
@@ -450,7 +449,7 @@ class ColorSwatch<T> extends Color {
       return false;
     return super == other
         && other is ColorSwatch<T>
-        && MapEquality<T, Color>().equals(other._swatch, _swatch);
+        && mapEquals<T, Color>(other._swatch, _swatch);
   }
 
   @override

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -443,10 +443,19 @@ void main() {
   });
 
   test('MaterialColor swatch comparison', () {
-    const Map<int, MaterialColor> sampleMap = <int, MaterialColor>{0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
+    const Map<int, MaterialColor> sampleMap = <int, MaterialColor>{
+      0: Colors.lightBlue,
+      1: Colors.deepOrange,
+      2: Colors.blueGrey,
+    };
     const MaterialColor first = MaterialColor(0, sampleMap);
     const MaterialColor second = MaterialColor(0, sampleMap);
-    const MaterialColor third = MaterialColor(0, <int, MaterialColor>{0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
+    const MaterialColor third = MaterialColor(
+        0, <int, MaterialColor>{
+          0: Colors.lightBlue,
+          1: Colors.deepOrange,
+          2: Colors.blueGrey,
+        });
     expect(first == second, true);
     expect(first == third, true);
   });

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -443,11 +443,11 @@ void main() {
   });
 
   test('MaterialColor swatch comparison', () {
-    Map<int, Color> sampleMap = {0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
-    MaterialColor first = new MaterialColor(0, sampleMap);
-    MaterialColor second = new MaterialColor(0, sampleMap);
-    MaterialColor third = new MaterialColor(0, {0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
-    expect((first == second), true);
-    expect((first == third), true);
+    const Map<int, MaterialColor> sampleMap = {0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
+    const MaterialColor first = MaterialColor(0, sampleMap);
+    const MaterialColor second = MaterialColor(0, sampleMap);
+    const MaterialColor third = MaterialColor(0, {0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
+    expect(first == second, true);
+    expect(first == third, true);
   });
 }

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -443,10 +443,10 @@ void main() {
   });
 
   test('MaterialColor swatch comparison', () {
-    const Map<int, MaterialColor> sampleMap = {0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
+    const Map<int, MaterialColor> sampleMap = <int, MaterialColor>{0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
     const MaterialColor first = MaterialColor(0, sampleMap);
     const MaterialColor second = MaterialColor(0, sampleMap);
-    const MaterialColor third = MaterialColor(0, {0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
+    const MaterialColor third = MaterialColor(0, <int, MaterialColor>{0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
     expect(first == second, true);
     expect(first == third, true);
   });

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 
 const double _doubleColorPrecision = 0.01;
 
@@ -439,5 +440,14 @@ void main() {
     property = ColorProperty('foo', null);
     final Map<String, Object> json = property.toJsonMap(const DiagnosticsSerializationDelegate());
     expect(json.containsKey('valueProperties'), isFalse);
+  });
+
+  test('MaterialColor swatch comparison', () {
+    Map<int, Color> sampleMap = {0: Colors.lightBlue, 1: Colors.deepOrange, 2: Colors.blueGrey};
+    MaterialColor first = new MaterialColor(0, sampleMap);
+    MaterialColor second = new MaterialColor(0, sampleMap);
+    MaterialColor third = new MaterialColor(0, {0: Colors.lightBlue, 1: Colors.deepOrange, 2:Colors.blueGrey});
+    expect((first == second), true);
+    expect((first == third), true);
   });
 }


### PR DESCRIPTION
## Description
fixed the map comparison bug.
since ` _swatch` is a Map and the comparison `other._swatch == _swatch;` will always return false if the Maps have different hashCodes.

therefore the `==` is replaced by `MapEquality().equals(other._swatch,_swatch)`

## Related Issues

Fixes #61888

## Tests
This is the bug reproducible code
```
import 'package:flutter/material.dart';

void main() {
 var map = {0:Colors.lightBlue,1:Colors.deepOrange,2:Colors.blueGrey};
 var first = new MaterialColor(0, map);
 var second = new MaterialColor(0, map);
 var third = new MaterialColor(0, {0:Colors.lightBlue,1:Colors.deepOrange,2:Colors.blueGrey});
 print("Comparison of the same map object in MaterialColor constructor: " + (first == second).toString());
 print("Comparison of different map objects with same values in MaterialColor constructor: " + (first == third).toString());
}
```
before changing the `==` by `MapEquality().equals(other._swatch,_swatch)`
the output was
```
I/flutter (17640): Comparison of the same map object in MaterialColor constructor: true
I/flutter (17640): Comparison of different map objects with same values in MaterialColor constructor: false
```
after implementing changes the output is as expected
```
I/flutter (17640): Comparison of the same map object in MaterialColor constructor: true
I/flutter (17640): Comparison of different map objects with same values in MaterialColor constructor: true
```





## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
