### PR TITLE
Only try to get build settings if the Xcode project exists

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -521,7 +521,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   Map<String, Map<String, String>> _buildSettingsByScheme;
 
   Future<XcodeProjectInfo> projectInfo() async {
-    if (!existsSync() || !globals.xcodeProjectInterpreter.isInstalled) {
+    if (!xcodeProject.existsSync() || !globals.xcodeProjectInterpreter.isInstalled) {
       return null;
     }
     return _projectInfo ??= await globals.xcodeProjectInterpreter.getInfo(hostAppRoot.path);

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -332,6 +332,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('from build settings, if no plist', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
                 (_) {
               return Future<Map<String,String>>.value(<String, String>{
@@ -362,6 +363,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('from build settings and plist, if default variable', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
                 (_) {
               return Future<Map<String,String>>.value(<String, String>{
@@ -379,6 +381,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('from build settings and plist, by substitution', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         project.ios.defaultHostInfoPlist.createSync(recursive: true);
         when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
           (_) {
@@ -398,6 +401,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('fails with no flavor and defined schemes', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getInfo(any, projectFilename: anyNamed('projectFilename'))).thenAnswer( (_) {
           return Future<XcodeProjectInfo>.value(XcodeProjectInfo(<String>[], <String>[], <String>['free', 'paid'], logger));
         });
@@ -409,6 +413,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('handles case insensitive flavor', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
                 (_) {
               return Future<Map<String,String>>.value(<String, String>{
@@ -426,6 +431,7 @@ apply plugin: 'kotlin-android'
 
       testWithMocks('fails with flavor and default schemes', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getInfo(any, projectFilename: anyNamed('projectFilename'))).thenAnswer( (_) {
           return Future<XcodeProjectInfo>.value(XcodeProjectInfo(<String>[], <String>[], <String>['Runner'], logger));
         });
@@ -479,6 +485,7 @@ apply plugin: 'kotlin-android'
 
       testUsingContext('app product name xcodebuild settings', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer((_) {
           return Future<Map<String,String>>.value(<String, String>{
             'FULL_PRODUCT_NAME': 'My App.app'
@@ -648,6 +655,7 @@ apply plugin: 'kotlin-android'
 
       testUsingContext('has watch companion', () async {
         final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
         project.ios.hostAppRoot.childDirectory('WatchTarget').childFile('Info.plist').createSync(recursive: true);
         when(mockPlistUtils.getValueFromFile(any, 'WKCompanionAppBundleIdentifier')).thenReturn('io.flutter.someProject');
 


### PR DESCRIPTION
## Description

Don't run `xcodebuild` to get the bundle identifier in a plugin `ios` directory, since there's no Xcode project in that directory.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61805

## Tests

Update project_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*