### PR TITLE
Update Actions.invoke to return the result of invoking the action.

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -582,6 +582,10 @@ class Actions extends StatefulWidget {
   ///
   /// Setting `nullOk` to true means that if no ambient [Actions] widget is
   /// found, then this method will return false instead of throwing.
+  ///
+  /// Returns the result of invoking the action's [Action.invoke] method. If
+  /// no action mapping was found for the specified intent, or if the action
+  /// that was found was disabled, then this returns null.
   static Object invoke<T extends Intent>(
     BuildContext context,
     T intent, {
@@ -624,7 +628,7 @@ class Actions extends StatefulWidget {
     }());
     // Invoke the action we found using the relevant dispatcher from the Actions
     // Element we found.
-    return actionElement != null ? _findDispatcher(actionElement).invokeAction(action, intent, context) != null : null;
+    return actionElement != null ? _findDispatcher(actionElement).invokeAction(action, intent, context) : null;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -581,11 +581,13 @@ class Actions extends StatefulWidget {
   /// that are found.
   ///
   /// Setting `nullOk` to true means that if no ambient [Actions] widget is
-  /// found, then this method will return false instead of throwing.
+  /// found, then this method will return null instead of throwing.
   ///
   /// Returns the result of invoking the action's [Action.invoke] method. If
   /// no action mapping was found for the specified intent, or if the action
-  /// that was found was disabled, then this returns null.
+  /// that was found was disabled, then this returns null. Callers can detect
+  /// whether or not the action is available (found, and not disabled) using
+  /// [Actions.find] with its `nullOk` argument set to true.
   static Object invoke<T extends Intent>(
     BuildContext context,
     T intent, {

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -423,6 +423,36 @@ void main() {
 
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
     });
+    testWidgets('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      final Object sentinel = Object();
+      bool invoked = false;
+      const TestIntent intent = TestIntent();
+      final Action<Intent> testAction = TestAction(
+        onInvoke: (Intent intent) {
+          invoked = true;
+          return sentinel;
+        },
+      );
+
+      await tester.pumpWidget(
+        Actions(
+          dispatcher: TestDispatcher(postInvoke: collect),
+          actions: <Type, Action<Intent>>{
+            TestIntent: testAction,
+          },
+          child: Container(key: containerKey),
+        ),
+      );
+
+      await tester.pump();
+      final Object result = Actions.invoke<TestIntent>(
+        containerKey.currentContext,
+        intent,
+      );
+      expect(identical(result, sentinel), isTrue);
+      expect(invoked, isTrue);
+    });
   });
 
   group('Listening', () {
@@ -484,7 +514,7 @@ void main() {
         const TestIntent(),
       );
       expect(enabled1, isFalse);
-      expect(result, isFalse);
+      expect(result, isNull);
       expect(invoked1, isFalse);
 
       action1.enabled = true;
@@ -523,7 +553,7 @@ void main() {
       );
       expect(enabledChanged, isNull);
       expect(enabled2, isFalse);
-      expect(result, isFalse);
+      expect(result, isNull);
       expect(invoked2, isFalse);
 
       action2.enabled = true;


### PR DESCRIPTION
## Description

`Actions.invoke()` was returning a boolean value corresponding to whether the dispatcher's `invokeAction()` method returned a non-null value.  True meant that the action was enabled and itself returned a non-null value, and false indicated that either the action was disabled, or it returned a null value from its `invoke()` method.

This boolean value is less useful than just returning the result of invoking the action itself. In my (admittedly limited) experience in playing with actions so far, the caller is likely going to want to just get the value that the action returned when it was invoked.

## Tests

I added a test for the return value and updated a test that was relying on getting "false" back for a null value.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
