### PR TITLE
[flutter_tools] add flutterRoot field to JSON machine output

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -317,7 +317,9 @@ class FlutterCommandRunner extends CommandRunner<void> {
           globals.flutterVersion.fetchTagsAndUpdate();
           String status;
           if (machineFlag) {
-            status = const JsonEncoder.withIndent('  ').convert(globals.flutterVersion.toJson());
+            final Map<String, Object> jsonOut = globals.flutterVersion.toJson();
+            jsonOut['flutterRoot'] = Cache.flutterRoot;
+            status = const JsonEncoder.withIndent('  ').convert(jsonOut);
           } else {
             status = globals.flutterVersion.toString();
           }

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -318,7 +318,9 @@ class FlutterCommandRunner extends CommandRunner<void> {
           String status;
           if (machineFlag) {
             final Map<String, Object> jsonOut = globals.flutterVersion.toJson();
-            jsonOut['flutterRoot'] = Cache.flutterRoot;
+            if (jsonOut != null) {
+              jsonOut['flutterRoot'] = Cache.flutterRoot;
+            }
             status = const JsonEncoder.withIndent('  ').convert(jsonOut);
           } else {
             status = globals.flutterVersion.toString();

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -142,6 +142,7 @@ void main() {
     final Map<String, Object> versionInfo = json.decode(result.stdout
       .toString()
       .replaceAll('Building flutter tool...', '')
+      .replaceAll('Waiting for another flutter command to release the startup lock...', '')
       .trim()) as Map<String, Object>;
 
     expect(versionInfo, containsPair('flutterRoot', isNotNull));

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/features.dart';
@@ -127,5 +129,21 @@ void main() {
 
     // Only printed by verbose tool.
     expect(result.stdout, isNot(contains('exiting with code 0')));
+  });
+
+  test('flutter --version --machine outputs JSON with flutterRoot', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await const LocalProcessManager().run(<String>[
+      flutterBin,
+      '--version',
+      '--machine',
+    ]);
+
+    final Map<String, Object> versionInfo = json.decode(result.stdout
+      .toString()
+      .replaceAll('Building flutter tool...', '')
+      .trim()) as Map<String, Object>;
+
+    expect(versionInfo, containsPair('flutterRoot', isNotNull));
   });
 }


### PR DESCRIPTION
## Description

Exposes the root of the current flutter SDK through `flutter --machine --version`. Allows editors that access flutter through another script to find the original SDK sources. Example output:

```json
{
  "frameworkVersion": "1.21.0-2.0.pre.96",
  "channel": "master",
  "repositoryUrl": "git@github.com:flutter/flutter.git",
  "frameworkRevision": "a0d00903cce5ce21892473d5a0aad17ba8dc77eb",
  "frameworkCommitDate": "2020-07-22 12:19:07 -0700",
  "engineRevision": "5a73d4dc250304e107a3fc8a4e3a4ad9fc680bfd",
  "dartSdkVersion": "2.9.0 (build 2.9.0-21.0.dev 84e5eeaea4)",
  "flutterRoot": "/Users/jonahwilliams/Documents/flutter"
}
```