### PR TITLE
Detect exact device ID matches quickly

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -103,13 +103,13 @@ abstract class DeviceManager {
   bool get hasSpecifiedAllDevices => _specifiedDeviceId == 'all';
 
   Future<List<Device>> getDevicesById(String deviceId) async {
-    deviceId = deviceId.toLowerCase();
+    final String lowerDeviceId = deviceId.toLowerCase();
     bool exactlyMatchesDeviceId(Device device) =>
-        device.id.toLowerCase() == deviceId ||
-        device.name.toLowerCase() == deviceId;
+        device.id.toLowerCase() == lowerDeviceId ||
+        device.name.toLowerCase() == lowerDeviceId;
     bool startsWithDeviceId(Device device) =>
-        device.id.toLowerCase().startsWith(deviceId) ||
-        device.name.toLowerCase().startsWith(deviceId);
+        device.id.toLowerCase().startsWith(lowerDeviceId) ||
+        device.name.toLowerCase().startsWith(lowerDeviceId);
 
     // Some discoverers have hard-coded device IDs and return quickly, and others
     // shell out to other processes and can take longer.
@@ -132,6 +132,9 @@ abstract class DeviceManager {
             }
           }
           return null;
+        }, onError: (dynamic error, StackTrace stackTrace) {
+          // Return matches from other discoverers even if one fails.
+          globals.printTrace('Ignored error discovering $deviceId: $error');
         })
     ];
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -117,9 +117,8 @@ abstract class DeviceManager {
     // found quickly, we don't wait for all the discoverers to complete.
     final List<Device> prefixMatches = <Device>[];
     final Completer<Device> exactMatchCompleter = Completer<Device>();
-    final List<Future<List<Device>>> futureDevices = <Future<List<Device>>>[];
-    for (final DeviceDiscovery discoverer in _platformDiscoverers) {
-      futureDevices.add(
+    final List<Future<List<Device>>> futureDevices = <Future<List<Device>>>[
+      for (final DeviceDiscovery discoverer in _platformDiscoverers)
         discoverer
         .devices
         .then((List<Device> devices) {
@@ -134,8 +133,7 @@ abstract class DeviceManager {
           }
           return null;
         })
-      );
-    }
+    ];
 
     // Wait for an exact match, or for all discoverers to return results.
     await Future.any<dynamic>(<Future<dynamic>>[

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -22,9 +23,11 @@ import '../src/mocks.dart';
 
 void main() {
   MockCache cache;
+  BufferLogger logger;
 
   setUp(() {
     cache = MockCache();
+    logger = BufferLogger.test();
     when(cache.dyLdLibEntry).thenReturn(const MapEntry<String, String>('foo', 'bar'));
   });
 
@@ -47,22 +50,31 @@ void main() {
       final FakeDevice device3 = FakeDevice('iPod touch', '82564b38861a9a5');
       final List<Device> devices = <Device>[device1, device2, device3];
 
-      // Include device discovery that never completes to prove the first exact
-      // match is returned quickly.
+      // Include different device discoveries:
+      // 1. One that never completes to prove the first exact match is
+      // returned quickly.
+      // 2. One that throws, to prove matches can return when some succeed
+      // and others fail.
+      // 3. A device discoverer that succeeds.
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
         testLongPollingDeviceDiscovery: true,
+        testThrowingDeviceDiscovery: true,
       );
 
       Future<void> expectDevice(String id, List<Device> expected) async {
         expect(await deviceManager.getDevicesById(id), expected);
       }
       await expectDevice('01abfc49119c410e', <Device>[device2]);
+      expect(logger.traceText, contains('Ignored error discovering 01abfc49119c410e'));
       await expectDevice('Nexus 5X', <Device>[device2]);
+      expect(logger.traceText, contains('Ignored error discovering Nexus 5X'));
       await expectDevice('0553790d0a4e726f', <Device>[device1]);
+      expect(logger.traceText, contains('Ignored error discovering 0553790d0a4e726f'));
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
       Cache: () => cache,
+      Logger: () => logger,
     });
 
     testUsingContext('getDeviceById prefix matcher', () async {
@@ -70,17 +82,29 @@ void main() {
       final FakeDevice device2 = FakeDevice('Nexus 5X', '01abfc49119c410e');
       final FakeDevice device3 = FakeDevice('iPod touch', '82564b38861a9a5');
       final List<Device> devices = <Device>[device1, device2, device3];
-      final DeviceManager deviceManager = TestDeviceManager(devices);
+
+      // Include different device discoveries:
+      // 1. One that throws, to prove matches can return when some succeed
+      // and others fail.
+      // 2. A device discoverer that succeeds.
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        testThrowingDeviceDiscovery: true
+      );
 
       Future<void> expectDevice(String id, List<Device> expected) async {
         expect(await deviceManager.getDevicesById(id), expected);
       }
       await expectDevice('Nexus 5', <Device>[device1]);
+      expect(logger.traceText, contains('Ignored error discovering Nexus 5'));
       await expectDevice('0553790', <Device>[device1]);
+      expect(logger.traceText, contains('Ignored error discovering 0553790'));
       await expectDevice('Nexus', <Device>[device1, device2]);
+      expect(logger.traceText, contains('Ignored error discovering Nexus'));
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
       Cache: () => cache,
+      Logger: () => logger,
     });
 
     testUsingContext('getAllConnectedDevices caches', () async {
@@ -397,11 +421,14 @@ void main() {
 class TestDeviceManager extends DeviceManager {
     TestDeviceManager(List<Device> allDevices, {
     bool testLongPollingDeviceDiscovery = false,
+    bool testThrowingDeviceDiscovery = false,
   }) {
     _fakeDeviceDiscoverer = FakePollingDeviceDiscovery();
     _deviceDiscoverers = <DeviceDiscovery>[
       if (testLongPollingDeviceDiscovery)
         LongPollingDeviceDiscovery(),
+      if (testThrowingDeviceDiscovery)
+        ThrowingPollingDeviceDiscovery(),
       _fakeDeviceDiscoverer,
     ];
     resetDevices(allDevices);

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -553,6 +553,21 @@ class LongPollingDeviceDiscovery extends PollingDeviceDiscovery {
   bool get canListAnything => true;
 }
 
+class ThrowingPollingDeviceDiscovery extends PollingDeviceDiscovery {
+  ThrowingPollingDeviceDiscovery() : super('throw');
+
+  @override
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
+    throw const ProcessException('fake-discovery', <String>[]);
+  }
+
+  @override
+  bool get supportsPlatform => true;
+
+  @override
+  bool get canListAnything => true;
+}
+
 class MockIosProject extends Mock implements IosProject {
   static const String bundleId = 'com.example.test';
   static const String appBundleName = 'My Super Awesome App.app';

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -526,6 +526,33 @@ class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
   Stream<Device> get onRemoved => _onRemovedController.stream;
 }
 
+class LongPollingDeviceDiscovery extends PollingDeviceDiscovery {
+  LongPollingDeviceDiscovery() : super('forever');
+
+  final Completer<List<Device>> _completer = Completer<List<Device>>();
+
+  @override
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
+    return _completer.future;
+  }
+
+  @override
+  Future<void> stopPolling() async {
+    _completer.complete();
+  }
+
+  @override
+  Future<void> dispose() async {
+    _completer.complete();
+  }
+
+  @override
+  bool get supportsPlatform => true;
+
+  @override
+  bool get canListAnything => true;
+}
+
 class MockIosProject extends Mock implements IosProject {
   static const String bundleId = 'com.example.test';
   static const String appBundleName = 'My Super Awesome App.app';


### PR DESCRIPTION
## Description

When a command is run with `--device` all relevant platform device discoverers gather all devices, which are then checked if the identifier or name exactly matches the specified device ID, then if they match the prefix of the specified device ID.  Some device discoverers with hard-coded return very quickly (`flutter-tester`, `chrome`, `macos`, `linux`), and others that shell out to underlying tools (Android, iOS, Fuschia) take much longer.

Instead of gathering all devices first, process them as they are discovered, and return quickly if an exact match is found.

Here are discovery times for exact matches on top of tree vs this PR (note these times include the overhead of calling a command I hacked the timing into, it's not how long this function took):
|   |master | PR   |
|---|---|---|
|flutter-tester   |1.49s |0.58s   |
|chrome   |1.51s |0.61s   |
|macos   |1.48s |0.59s   |
|iOS device identifier   |1.48s |1.27s   |

Before this change, all times were about the same, because it waited for all platform discoveries to be complete before matching.  After this change, the time takes as long as the relevant discoverer can return.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61466
Fixes https://github.com/flutter/flutter/issues/44898
Relevant for https://github.com/flutter/flutter/issues/15072 increasing discovery times when an exact networking iOS ID is specified without regressing other platforms.

## Tests
`getDeviceById exact matcher` uses new `LongPollingDeviceDiscovery` that never finishes polling. Exact matches are still returned quickly. This test runs forever on master.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*