### PR TITLE
Mark smoke_catalina_start_up_ios as not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -665,7 +665,6 @@ tasks:
       A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
-    flaky: true
 
   smoke_catalina_hot_mode_dev_cycle_ios__benchmark:
     description: >


### PR DESCRIPTION
## Description

Flakiness seems to have went away.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61736

<img width="23" alt="Screen Shot 2020-07-22 at 6 50 46 PM" src="https://user-images.githubusercontent.com/682784/88245497-47a81500-cc4c-11ea-97ed-911561ff0612.png">
