### PR TITLE
Add support for system alert sound

### DIFF
--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -16,6 +16,11 @@ enum SystemSoundType {
   click,
 
   /// A short system alert sound indicating the need for user attention.
+  ///
+  /// Desktop platforms are the only platforms that support a system alert
+  /// sound, so on mobile platforms (Android, iOS), this will be ignored. The
+  /// web platform does not support playing any sounds, so this will be
+  /// ignored on the web as well.
   alert,
 }
 
@@ -29,6 +34,9 @@ class SystemSound {
 
   /// Play the specified system sound. If that sound is not present on the
   /// system, the call is ignored.
+  ///
+  /// The web platform currently does not support playing sounds, so this call
+  /// will yield no behavior on that platform.
   static Future<void> play(SystemSoundType type) async {
     await SystemChannels.platform.invokeMethod<void>(
       'SystemSound.play',

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -9,9 +9,14 @@ import 'dart:async';
 import 'system_channels.dart';
 
 /// A sound provided by the system.
+///
+/// These sounds may be played with [SystemSound.play].
 enum SystemSoundType {
   /// A short indication that a button was pressed.
   click,
+
+  /// A short system alert sound indicating the need for user attention.
+  alert,
 }
 
 /// Provides access to the library of short system specific sounds for common

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 
 import 'basic.dart';
 import 'container.dart';
@@ -103,6 +104,8 @@ class ModalBarrier extends StatelessWidget {
           onDismiss: () {
             if (dismissible)
               Navigator.maybePop(context);
+            else
+              SystemSound.play(SystemSoundType.alert);
           },
           child: Semantics(
             label: semanticsDismissible ? semanticsLabel : null,


### PR DESCRIPTION
## Description

* Add SystemSoundType.alert (supported in the engine in flutter/engine#19970)
* Play system alert sound when user tries to dismiss a non-dismissable modal
  barrier

## Related Issues

https://github.com/flutter/flutter/issues/62143

## Tests

I added the following tests:

* A test that the platform message to play the system alert sound gets sent when an attempt to dismiss a non-dismissable modal barrier is made.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
