### PR TITLE
WidgetController.pump use optional duration

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -423,8 +423,7 @@ abstract class WidgetController {
   /// See [PointerEventRecord].
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records);
 
-  /// Called to indicate that there should be a new frame and if necessary,
-  /// time should advance.
+  /// Called to indicate that there should be a new frame after an optional delay.
   ///
   /// This is invoked by [flingFrom], for instance, so that the sequence of
   /// pointer events occurs over time.

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -423,7 +423,8 @@ abstract class WidgetController {
   /// See [PointerEventRecord].
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records);
 
-  /// Called to indicate that time should advance.
+  /// Called to indicate that there should be a new frame and if necessary,
+  /// time should advance.
   ///
   /// This is invoked by [flingFrom], for instance, so that the sequence of
   /// pointer events occurs over time.
@@ -432,7 +433,7 @@ abstract class WidgetController {
   ///
   /// See also [SchedulerBinding.endOfFrame], which returns a future that could
   /// be appropriate to return in the implementation of this method.
-  Future<void> pump(Duration duration);
+  Future<void> pump([Duration duration]);
 
   /// Attempts to drag the given widget by the given offset, by
   /// starting a drag in the middle of the widget.
@@ -710,7 +711,7 @@ class LiveWidgetController extends WidgetController {
   LiveWidgetController(WidgetsBinding binding) : super(binding);
 
   @override
-  Future<void> pump(Duration duration) async {
+  Future<void> pump([Duration duration]) async {
     if (duration != null)
       await Future<void>.delayed(duration);
     binding.scheduleFrame();

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -423,7 +423,11 @@ abstract class WidgetController {
   /// See [PointerEventRecord].
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records);
 
-  /// Called to indicate that there should be a new frame after an optional delay.
+  /// Called to indicate that there should be a new frame after an optional
+  /// delay.
+  ///
+  /// The frame is pumped after a delay of [duration] if [duration] is not null,
+  /// or immediately otherwise.
   ///
   /// This is invoked by [flingFrom], for instance, so that the sequence of
   /// pointer events occurs over time.

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -9,7 +9,41 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Future<void> main() async {
+class CountButton extends StatefulWidget {
+  @override
+  _CountButtonState createState() => _CountButtonState();
+}
+
+class _CountButtonState extends State<CountButton> {
+  int counter = 0;
+  @override
+  Widget build(BuildContext context) {
+    return RaisedButton(
+      child: Text('Counter $counter'),
+      onPressed: () {
+        setState(() {
+          counter += 1;
+        });
+      },
+    );
+  }
+}
+
+void main() {
+  test('Test pump on LiveWidgetController', () async {
+    runApp(MaterialApp(home:Center(child: CountButton())));
+
+    await SchedulerBinding.instance.endOfFrame;
+    final WidgetController controller =
+        LiveWidgetController(WidgetsBinding.instance);
+    await controller.tap(find.text('Counter 0'));
+    expect(find.text('Counter 0'), findsOneWidget);
+    expect(find.text('Counter 1'), findsNothing);
+    await controller.pump();
+    expect(find.text('Counter 0'), findsNothing);
+    expect(find.text('Counter 1'), findsOneWidget);
+  });
+
   test('Input event array on LiveWidgetController', () async {
     final List<String> logs = <String>[];
     runApp(

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -31,7 +31,7 @@ class _CountButtonState extends State<CountButton> {
 
 void main() {
   test('Test pump on LiveWidgetController', () async {
-    runApp(MaterialApp(home:Center(child: CountButton())));
+    runApp(MaterialApp(home: Center(child: CountButton())));
 
     await SchedulerBinding.instance.endOfFrame;
     final WidgetController controller =


### PR DESCRIPTION
## Description

`WidgetController` has two implementation: `LiveWidgetController` and `WidgetTester`. 

Dart allows subclasses override method with different argument argument tables, as long as the subclass's version can align with the superclass's after using default arguments. For this PR, the `pump` method in `WidgetController` is defined with a required argument: 

https://github.com/flutter/flutter/blob/b8df8a836823190aebdd1950205ca5cba6f4562a/packages/flutter_test/lib/src/controller.dart#L435

`LiveWidgetController.pump` implements like: 
https://github.com/flutter/flutter/blob/b8df8a836823190aebdd1950205ca5cba6f4562a/packages/flutter_test/lib/src/controller.dart#L712-L718
which looks like designed for an optional (default `null`) argument.

And for `WidgetTester` it is optional:
https://github.com/flutter/flutter/blob/b8df8a836823190aebdd1950205ca5cba6f4562a/packages/flutter_test/lib/src/widget_tester.dart#L561-L567

If we respect the design of the `if` statement for `LiveWidgetController.pump`, the argument should be optional, which is semantically the same as `WidgetTester.pump()`. And since `LiveWidgetController` and `WidgetTester` are only implementations of `WidgetController`, I would naturally expect `WidgetController` to also make the argument optional. 

Another justification is that there are a lot of test cases where we write `await tester.pump();`. Most of the time those codes should be able to be re-used by simply change `WidgetTester` to `WidgetControllor` so that they can be more widely used (see #61511). 

## Related Issues

#61511

## Tests

Refactoring. I don't think I need one. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
