### PR TITLE
Updated Material library documentation references to the old button classes.

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -65,7 +65,7 @@ class MaterialBanner extends StatelessWidget {
   /// The set of actions that are displayed at the bottom or trailing side of
   /// the [MaterialBanner].
   ///
-  /// Typically this is a list of [FlatButton] widgets.
+  /// Typically this is a list of [TextButton] widgets.
   ///
   /// These widgets will be wrapped in a [ButtonBar], which introduces 8 pixels
   /// of padding on each side.

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -600,7 +600,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return Center(
-///     child: RaisedButton(
+///     child: ElevatedButton(
 ///       child: const Text('showModalBottomSheet'),
 ///       onPressed: () {
 ///         showModalBottomSheet<void>(
@@ -615,7 +615,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 ///                   mainAxisSize: MainAxisSize.min,
 ///                   children: <Widget>[
 ///                     const Text('Modal BottomSheet'),
-///                     RaisedButton(
+///                     ElevatedButton(
 ///                       child: const Text('Close BottomSheet'),
 ///                       onPressed: () => Navigator.pop(context),
 ///                     )

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1259,8 +1259,8 @@ class FilterChip extends StatelessWidget
 /// Action chips are displayed after primary content, such as below a card or
 /// persistently at the bottom of a screen.
 ///
-/// The material button widgets, [RaisedButton], [FlatButton], and
-/// [OutlineButton], are an alternative to action chips, which should appear
+/// The material button widgets, [ElevatedButton], [TextButton], and
+/// [OutlinedButton], are an alternative to action chips, which should appear
 /// statically and consistently in a UI.
 ///
 /// Requires one of its ancestors to be a [Material] widget.

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -208,7 +208,7 @@ class Dialog extends StatelessWidget {
 ///           ),
 ///         ),
 ///         actions: <Widget>[
-///           FlatButton(
+///           TextButton(
 ///             child: Text('Approve'),
 ///             onPressed: () {
 ///               Navigator.of(context).pop();
@@ -311,9 +311,9 @@ class AlertDialog extends StatelessWidget {
   /// The (optional) set of actions that are displayed at the bottom of the
   /// dialog.
   ///
-  /// Typically this is a list of [FlatButton] widgets. It is recommended to
+  /// Typically this is a list of [TextButton] widgets. It is recommended to
   /// set the [textAlign] to [TextAlign.end] for the [Text] within the
-  /// [FlatButton], so that buttons whose labels wrap to an extra line align
+  /// [TextButton], so that buttons whose labels wrap to an extra line align
   /// with the overall [ButtonBar]'s alignment within the dialog.
   ///
   /// These widgets will be wrapped in a [ButtonBar], which introduces 8 pixels
@@ -341,8 +341,8 @@ class AlertDialog extends StatelessWidget {
   ///   title: Text('Title'),
   ///   content: Container(width: 200, height: 200, color: Colors.green),
   ///   actions: <Widget>[
-  ///     RaisedButton(onPressed: () {}, child: Text('Button 1')),
-  ///     RaisedButton(onPressed: () {}, child: Text('Button 2')),
+  ///     ElevatedButton(onPressed: () {}, child: Text('Button 1')),
+  ///     ElevatedButton(onPressed: () {}, child: Text('Button 2')),
   ///   ],
   ///   actionsPadding: EdgeInsets.symmetric(horizontal: 8.0),
   /// )
@@ -613,7 +613,7 @@ class AlertDialog extends StatelessWidget {
 ///
 ///  * [SimpleDialog], for a dialog in which to use this widget.
 ///  * [showDialog], which actually displays the dialog and returns its result.
-///  * [FlatButton], which are commonly used as actions in other kinds of
+///  * [TextButton], which are commonly used as actions in other kinds of
 ///    dialogs, such as [AlertDialog]s.
 ///  * <https://material.io/design/components/dialogs.html#simple-dialog>
 class SimpleDialogOption extends StatelessWidget {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -785,7 +785,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 ///  * [DropdownMenuItem], the class used to represent the [items].
 ///  * [DropdownButtonHideUnderline], which prevents its descendant dropdown buttons
 ///    from displaying their underlines.
-///  * [RaisedButton], [FlatButton], ordinary buttons that trigger a single action.
+///  * [ElevatedButton], [TextButton], ordinary buttons that trigger a single action.
 ///  * <https://material.io/design/components/menus.html#dropdown-menu>
 class DropdownButton<T> extends StatefulWidget {
   /// Creates a dropdown button.

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -280,7 +280,7 @@ typedef _CheckContext = bool Function(BuildContext context);
 /// See also:
 ///
 ///  * [GestureDetector], for listening for gestures without ink splashes.
-///  * [RaisedButton] and [FlatButton], two kinds of buttons in material design.
+///  * [ElevatedButton] and [TextButton], two kinds of buttons in material design.
 ///  * [IconButton], which combines [InkResponse] with an [Icon].
 class InkResponse extends StatelessWidget {
   /// Creates an area of a [Material] that responds to touch.
@@ -1198,7 +1198,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 /// See also:
 ///
 ///  * [GestureDetector], for listening for gestures without ink splashes.
-///  * [RaisedButton] and [FlatButton], two kinds of buttons in material design.
+///  * [ElevatedButton] and [TextButton], two kinds of buttons in material design.
 ///  * [InkResponse], a variant of [InkWell] that doesn't force a rectangular
 ///    shape on the ink reaction.
 class InkWell extends InkResponse {

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -231,7 +231,7 @@ class TextTheme with Diagnosticable {
   /// Used for auxiliary text associated with images.
   final TextStyle caption;
 
-  /// Used for text on [RaisedButton] and [FlatButton].
+  /// Used for text on [ElevatedButton], [TextButton] and [OutlinedButton].
   final TextStyle button;
 
   /// The smallest style.

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -71,6 +71,9 @@ const Color _kDarkThemeSplashColor = Color(0x40CCCCCC);
 ///
 ///   * [FloatingActionButton], only the mini tap target size is increased.
 ///   * [MaterialButton]
+///   * [OutlinedButton]
+///   * [TextButton]
+///   * [ElevatedButton]
 ///   * [OutlineButton]
 ///   * [FlatButton]
 ///   * [RaisedButton]


### PR DESCRIPTION
Updated the documentation examples and references to the old button classes (`FlatButton`, `RaisedButton`, `OutlineButton`) with their new counterparts (`TextButton`, `ElevatedButton`, `OutlinedButton`). This is part of the transition to the new button universe (https://github.com/flutter/flutter/pull/59702).
