### PR TITLE
Changed CupertinoSlidingSegmentedControl width to fill the encompassing widget

### DIFF
--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -111,7 +111,7 @@ class _FontWeightTween extends Tween<FontWeight> {
 /// tallest widget provided as a value in the [Map] of [children].
 /// The width of each child in the segmented control will be equal to the width
 /// of widest child, unless the combined width of the children is wider than
-/// the available horizontal space. In this case, the available horizontal space
+/// the available horizontal space or shrinkWrap is true. In this case, the available horizontal space
 /// is divided by the number of provided [children] to determine the width of
 /// each widget. The selection area for each of the widgets in the [Map] of
 /// [children] will then be expanded to fill the calculated space, so each
@@ -123,8 +123,8 @@ class _FontWeightTween extends Tween<FontWeight> {
 ///
 /// See also:
 ///
-///  * [CupertinoSlidingSegmentedControl], a segmented control widget in the
-///    style introduced in iOS 13.
+///  * [CupertinoSegmentedControl], a segmented control widget previously
+///    introduced in iOS.
 ///  * <https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/>
 class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   /// Creates an iOS-style segmented control bar.
@@ -149,10 +149,12 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
     this.groupValue,
     this.thumbColor = _kThumbColor,
     this.padding = _kHorizontalSegmentedControlPadding,
+    this.shrinkWrap = false,
     this.backgroundColor = CupertinoColors.tertiarySystemFill,
   }) : assert(children != null),
        assert(children.length >= 2),
        assert(padding != null),
+       assert(shrinkWrap != null),
        assert(onValueChanged != null),
        assert(
          groupValue == null || children.keys.contains(groupValue),
@@ -237,6 +239,13 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   ///
   /// Defaults to EdgeInsets.symmetric(horizontal: 16.0)
   final EdgeInsetsGeometry padding;
+
+  /// Whether the extent of the [CupertinoSlidingSegmentedControl] should be determined by the contents being viewed.
+  ///
+  /// If the [CupertinoSlidingSegmentedControl] does not shrink wrap, then the [CupertinoSlidingSegmentedControl] will expand to the maximum allowed size in the horizontal axis. If this has unbounded constraints, then shrinkWrap must be true.
+  ///
+  // Defaults to false.
+  final bool shrinkWrap;
 
   @override
   _SegmentedControlState<T> createState() => _SegmentedControlState<T>();
@@ -458,7 +467,7 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
         return UnconstrainedBox(
           constrainedAxis: Axis.horizontal,
           child: Container(
-            width: double.infinity,
+            width: widget.shrinkWrap ? null : double.infinity,
             margin: widget.padding.resolve(Directionality.of(context)),
             padding: _kHorizontalItemPadding,
             decoration: BoxDecoration(

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -148,10 +148,11 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
     @required this.onValueChanged,
     this.groupValue,
     this.thumbColor = _kThumbColor,
-    this.padding,
+    this.padding = _kHorizontalSegmentedControlPadding,
     this.backgroundColor = CupertinoColors.tertiarySystemFill,
   }) : assert(children != null),
        assert(children.length >= 2),
+       assert(padding != null),
        assert(onValueChanged != null),
        assert(
          groupValue == null || children.keys.contains(groupValue),
@@ -458,8 +459,8 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
           constrainedAxis: Axis.horizontal,
           child: Container(
             width: double.infinity,
-            margin: widget.padding ?? _kHorizontalSegmentedControlPadding,
-            padding: _kHorizontalItemPadding.resolve(Directionality.of(context)),
+            margin: widget.padding.resolve(Directionality.of(context)),
+            padding: _kHorizontalItemPadding,
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(Radius.circular(_kCornerRadius)),
               color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -18,6 +18,9 @@ import 'colors.dart';
 
 // Minimum padding from edges of the segmented control to edges of
 // encompassing widget.
+const EdgeInsetsGeometry _kHorizontalSegmentedControlPadding = EdgeInsets.symmetric(horizontal: 16);
+
+// Padding from edges of the thumb to to edges of the segmented control
 const EdgeInsetsGeometry _kHorizontalItemPadding = EdgeInsets.symmetric(vertical: 2, horizontal: 3);
 
 // The corner radius of the thumb.
@@ -145,11 +148,10 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
     @required this.onValueChanged,
     this.groupValue,
     this.thumbColor = _kThumbColor,
-    this.padding = _kHorizontalItemPadding,
+    this.padding,
     this.backgroundColor = CupertinoColors.tertiarySystemFill,
   }) : assert(children != null),
        assert(children.length >= 2),
-       assert(padding != null),
        assert(onValueChanged != null),
        assert(
          groupValue == null || children.keys.contains(groupValue),
@@ -230,9 +232,9 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   /// mode and becomes a gray color in dark mode.
   final Color thumbColor;
 
-  /// The amount of space by which to inset the [children].
+  /// The [CupertinoSlidingSegmentedControl] will be placed inside this padding
   ///
-  /// Must not be null. Defaults to EdgeInsets.symmetric(vertical: 2, horizontal: 3).
+  /// Defaults to EdgeInsets.symmetric(horizontal: 16.0)
   final EdgeInsetsGeometry padding;
 
   @override
@@ -455,7 +457,9 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
         return UnconstrainedBox(
           constrainedAxis: Axis.horizontal,
           child: Container(
-            padding: widget.padding.resolve(Directionality.of(context)),
+            width: double.infinity,
+            margin: widget.padding ?? _kHorizontalSegmentedControlPadding,
+            padding: _kHorizontalItemPadding.resolve(Directionality.of(context)),
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(Radius.circular(_kCornerRadius)),
               color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -179,25 +179,26 @@ void main() {
     };
 
     Future<void> verifyPadding({ EdgeInsets padding }) async {
-      final EdgeInsets effectivePadding = padding ?? const EdgeInsets.symmetric(vertical: 2, horizontal: 3);
+      final EdgeInsets defaultPadding = padding ?? const EdgeInsets.symmetric(horizontal: 16);
+      const EdgeInsets effectivePadding = EdgeInsets.symmetric(vertical: 2, horizontal: 3);
       final Rect segmentedControlRect = tester.getRect(find.byKey(key));
 
       expect(
           tester.getTopLeft(find.ancestor(of: find.byWidget(children[0]), matching: find.byType(Opacity))),
-          segmentedControlRect.topLeft + effectivePadding.topLeft,
+          defaultPadding.topLeft + segmentedControlRect.topLeft + effectivePadding.topLeft,
       );
       expect(
         tester.getBottomLeft(find.ancestor(of: find.byWidget(children[0]), matching: find.byType(Opacity))),
-        segmentedControlRect.bottomLeft + effectivePadding.bottomLeft,
+        defaultPadding.bottomLeft + segmentedControlRect.bottomLeft + effectivePadding.bottomLeft,
       );
 
       expect(
         tester.getTopRight(find.ancestor(of: find.byWidget(children[1]), matching: find.byType(Opacity))),
-        segmentedControlRect.topRight + effectivePadding.topRight,
+        defaultPadding.topRight + segmentedControlRect.topRight + effectivePadding.topRight,
       );
       expect(
         tester.getBottomRight(find.ancestor(of: find.byWidget(children[1]), matching: find.byType(Opacity))),
-        segmentedControlRect.bottomRight + effectivePadding.bottomRight,
+        defaultPadding.bottomRight + segmentedControlRect.bottomRight + effectivePadding.bottomRight,
       );
     }
 
@@ -536,7 +537,7 @@ void main() {
     );
   });
 
-  testWidgets('Width of each segmented control segment is determined by widest widget', (WidgetTester tester) async {
+  testWidgets('Width of each segmented control segment is determined by widest widget when shrinkWrap is true', (WidgetTester tester) async {
     final Map<int, Widget> children = <int, Widget>{
       0: Container(constraints: const BoxConstraints.tightFor(width: 50.0)),
       1: Container(constraints: const BoxConstraints.tightFor(width: 100.0)),
@@ -551,6 +552,8 @@ void main() {
             children: children,
             groupValue: groupValue,
             onValueChanged: defaultCallback,
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
           );
         },
       ),
@@ -567,7 +570,7 @@ void main() {
     expect(childWidth, 200.0 + 9.25 * 2);
   });
 
-  testWidgets('Width is finite in unbounded space', (WidgetTester tester) async {
+  testWidgets('Width is finite in unbounded space when shrinkWrap is true', (WidgetTester tester) async {
     const Map<int, Widget> children = <int, Widget>{
       0: SizedBox(width: 50),
       1: SizedBox(width: 70),
@@ -583,6 +586,8 @@ void main() {
                 children: children,
                 groupValue: groupValue,
                 onValueChanged: defaultCallback,
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
               ),
             ],
           );
@@ -938,7 +943,7 @@ void main() {
     expect(secondThumbRect.center.dx, greaterThan(initialThumbRect.center.dx));
     expect(secondThumbRect.center.dx, lessThan(tester.getCenter(find.text('B')).dx));
 
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
 
     // Eventually moves to C.
     expect(


### PR DESCRIPTION
## Description

* Added default and customizable outer padding feature to `CupertinoSlidingSegmentedControl` following the line of `CupertinoSegmentedControl`
* Removed inner padding feature from `CupertinoSlidingSegmentedControl` following the line of `CupertinoSegmentedControl` and the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/)
* Added shrinkWrap parameter to `CupertinoSlidingSegmentedControl` allowing it to fit the inner content but expanded by default following the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/)
* Added the necessary documentation and corrected some lines of the previous one
* Updated the `CupertinoSlidingSegmentedControl` test to match the new one

![Before and after](https://user-images.githubusercontent.com/17878459/88369846-428bb880-cd67-11ea-9b73-31868c7149d6.gif)

<details>
  <summary>Code to reproduce the resizing issue</summary>

  ```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

void main() {
    runApp(
      MaterialApp(
        theme: ThemeData.dark(), // Just to take care of your eyes
        home: HomePage(),
      ),
    );
}

class HomePage extends StatefulWidget {
    @override
    _HomePageState createState() => _HomePageState();
}

class _HomePageState extends State<HomePage> {
    int groupValue = 0;

    @override
    Widget build(BuildContext context) {
      return Scaffold(
        body: Center(
          child: CupertinoSlidingSegmentedControl(
            groupValue: groupValue,
            onValueChanged: onValueChanged,
            children: {
              0: const Text('1'),
              1: const Text('2, thanks'),
              2: const Text('All of them!'),
            },
          ),
        ),
      );
    }

    void onValueChanged(int newValue) {
      setState(() {
        groupValue = newValue;
      });
    }
}
  ```
</details>

## Related Issues
The following issue is resolved by this PR:
* #62063

## Tests
Sorry for not editing the CupertinoSlidingSegmentedControl test in the first commit, it is my first PR and I didn't realize.

* Updated CupertinoSlidingSegmentedControl test to match the new one

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
