### PR TITLE
Ensure analytics are sent before disabling

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -113,9 +113,15 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('analytics')) {
       final bool value = boolArg('analytics');
-      // We send the analytics event *before* toggling the flag intentionally
-      // to be sure that opt-out events are sent correctly.
+      // The tool sends the analytics event *before* toggling the flag
+      // intentionally to be sure that opt-out events are sent correctly.
       AnalyticsConfigEvent(enabled: value).send();
+      if (!value) {
+        // Normally, the tool waits for the analytics to all send before the
+        // tool exits, but only when analytics are enabled. When reporting that
+        // analytics have been disable, the wait must be done here instead.
+        await globals.flutterUsage.ensureAnalyticsSent();
+      }
       globals.flutterUsage.enabled = value;
       globals.printStatus('Analytics reporting ${value ? 'enabled' : 'disabled'}.');
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -233,6 +233,9 @@ void main() {
 
       expect(mockUsage.enabled, false);
 
+      // Verify that we flushed the analytics queue.
+      verify(mockUsage.ensureAnalyticsSent());
+
       // Verify that we only send the analytics disable event, and no other
       // info.
       verifyNever(mockUsage.sendCommand(


### PR DESCRIPTION
## Description

Normally the tool blocks for a short time to wait for all analytics to be sent right before exiting, but only if analytics are enabled. When disabling analytics, this PR adds a call to wait because it won't happen later.

## Tests

I added the following tests:

Updated config_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

