### PR TITLE
Add WidgetController.scrollUntilVisible

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -701,14 +701,15 @@ abstract class WidgetController {
   Future<void> ensureVisible(Finder finder) => Scrollable.ensureVisible(element(finder));
 
   /// Repeatedly scrolls the `scrollable` by `delta` in the
-  /// [Scrpllable.axisDirection] until `finder` is visible or
-  /// throws if `finder` is not found for maximum `timeout` times.
+  /// [Scrpllable.axisDirection] until `finder` is visible.
   ///
   /// Between each scroll, wait for `duration` time for settling.
   ///
+  /// Throws a [StateError] if `finder` is not found for maximum `timeout` times.
+  ///
   /// This is different from [ensureVisible] in that this allows looking for
   /// `finder` that is not built yet, but the caller must specify the scrollable
-  /// that builds child specified by finder.
+  /// that will build child specified by `finder`.
   Future<void> scrollUntilVisible(
     Finder finder,
     Finder scrollable,

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -705,7 +705,8 @@ abstract class WidgetController {
   ///
   /// Between each scroll, wait for `duration` time for settling.
   ///
-  /// Throws a [StateError] if `finder` is not found for maximum `timeout` times.
+  /// Throws a [StateError] if `finder` is not found for maximum `maxScrolls`
+  /// times.
   ///
   /// This is different from [ensureVisible] in that this allows looking for
   /// `finder` that is not built yet, but the caller must specify the scrollable
@@ -714,14 +715,14 @@ abstract class WidgetController {
     Finder finder,
     Finder scrollable,
     double delta, {
-      int timeout = 50,
+      int maxScrolls = 50,
       Duration duration = const Duration(milliseconds: 50),
     }
   ) async {
     assert(finder != null);
     assert(scrollable != null);
     assert(scrollable.evaluate().isNotEmpty);
-    assert(timeout > 0);
+    assert(maxScrolls > 0);
     Offset moveStep;
     switch(widget<Scrollable>(scrollable).axisDirection) {
       case AxisDirection.up:
@@ -737,10 +738,10 @@ abstract class WidgetController {
         moveStep = Offset(-delta, 0);
         break;
     }
-    while(timeout > 0 && finder.evaluate().isEmpty) {
+    while(maxScrolls > 0 && finder.evaluate().isEmpty) {
       await drag(scrollable, moveStep);
       await pump(duration);
-      timeout -= 1;
+      maxScrolls -= 1;
     }
     await Scrollable.ensureVisible(element(finder));
   }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -718,32 +718,34 @@ abstract class WidgetController {
       int maxScrolls = 50,
       Duration duration = const Duration(milliseconds: 50),
     }
-  ) async {
+  ) {
     assert(finder != null);
     assert(scrollable != null);
     assert(scrollable.evaluate().isNotEmpty);
     assert(maxScrolls > 0);
-    Offset moveStep;
-    switch(widget<Scrollable>(scrollable).axisDirection) {
-      case AxisDirection.up:
-        moveStep = Offset(0, delta);
-        break;
-      case AxisDirection.down:
-        moveStep = Offset(0, -delta);
-        break;
-      case AxisDirection.left:
-        moveStep = Offset(delta, 0);
-        break;
-      case AxisDirection.right:
-        moveStep = Offset(-delta, 0);
-        break;
-    }
-    while(maxScrolls > 0 && finder.evaluate().isEmpty) {
-      await drag(scrollable, moveStep);
-      await pump(duration);
-      maxScrolls -= 1;
-    }
-    await Scrollable.ensureVisible(element(finder));
+    return TestAsyncUtils.guard<void>(() async {
+      Offset moveStep;
+      switch(widget<Scrollable>(scrollable).axisDirection) {
+        case AxisDirection.up:
+          moveStep = Offset(0, delta);
+          break;
+        case AxisDirection.down:
+          moveStep = Offset(0, -delta);
+          break;
+        case AxisDirection.left:
+          moveStep = Offset(delta, 0);
+          break;
+        case AxisDirection.right:
+          moveStep = Offset(-delta, 0);
+          break;
+      }
+      while(maxScrolls > 0 && finder.evaluate().isEmpty) {
+        await drag(scrollable, moveStep);
+        await pump(duration);
+        maxScrolls -= 1;
+      }
+      await Scrollable.ensureVisible(element(finder));
+    });
   }
 }
 

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -719,9 +719,6 @@ abstract class WidgetController {
       Duration duration = const Duration(milliseconds: 50),
     }
   ) {
-    assert(finder != null);
-    assert(scrollable != null);
-    assert(scrollable.evaluate().isNotEmpty);
     assert(maxScrolls > 0);
     return TestAsyncUtils.guard<void>(() async {
       Offset moveStep;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -718,6 +718,9 @@ abstract class WidgetController {
       Duration duration = const Duration(milliseconds: 50),
     }
   ) async {
+    assert(finder != null);
+    assert(scrollable != null);
+    assert(scrollable.evaluate().isNotEmpty);
     assert(timeout > 0);
     Offset moveStep;
     switch(widget<Scrollable>(scrollable).axisDirection) {

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -700,19 +700,19 @@ abstract class WidgetController {
   /// Shorthand for `Scrollable.ensureVisible(element(finder))`
   Future<void> ensureVisible(Finder finder) => Scrollable.ensureVisible(element(finder));
 
-  /// Repeatedly scrolls the `scrollable` by `dScroll` until `finder` and
+  /// Repeatedly scrolls the `scrollable` by `delta` in the
+  /// [Scrpllable.axisDirection] until `finder` is visible or
   /// throws if `finder` is not found for maximum `timeout` times.
   ///
   /// Between each scroll, wait for `duration` time for settling.
   ///
   /// This is different from [ensureVisible] in that this allows looking for
-  /// `finder` that is not built yet, but requires to specify the scrollable.
-  ///
-  /// If the `scrollable` is infinite and `dScroll`
+  /// `finder` that is not built yet, but the caller must specify the scrollable
+  /// that builds child specified by finder.
   Future<void> scrollUntilVisible(
     Finder finder,
     Finder scrollable,
-    double dScroll, {
+    double delta, {
       int timeout = 50,
       Duration duration = const Duration(milliseconds: 50),
     }
@@ -721,16 +721,16 @@ abstract class WidgetController {
     Offset moveStep;
     switch(widget<Scrollable>(scrollable).axisDirection) {
       case AxisDirection.up:
-        moveStep = Offset(0, dScroll);
+        moveStep = Offset(0, delta);
         break;
       case AxisDirection.down:
-        moveStep = Offset(0, -dScroll);
+        moveStep = Offset(0, -delta);
         break;
       case AxisDirection.left:
-        moveStep = Offset(dScroll, 0);
+        moveStep = Offset(delta, 0);
         break;
       case AxisDirection.right:
-        moveStep = Offset(-dScroll, 0);
+        moveStep = Offset(-delta, 0);
         break;
     }
     while(timeout > 0 && finder.evaluate().isEmpty) {

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -502,5 +502,32 @@ void main() {
         expect(find.text('Item 45', skipOffstage: true), findsOneWidget);
       },
     );
+
+    testWidgets(
+      'Fail',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ListView.builder(
+                itemCount: 50,
+                shrinkWrap: true,
+                itemBuilder: (BuildContext context, int i) => ListTile(title: Text('Item $i')),
+              ),
+            ),
+          ),
+        );
+
+        try {
+          await tester.scrollUntilVisible(
+            find.text('Item 55', skipOffstage: false),
+            find.byType(Scrollable),
+            100,
+          );
+        } on StateError catch (e) {
+          expect(e.message, 'No element');
+        }
+      },
+    );
   });
 }

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -439,4 +439,68 @@ void main() {
       expect(find.text('Item 15', skipOffstage: true), findsOneWidget);
     },
   );
+
+  group('scrollUntilVisible: scrolls to make unbuilt widget visible', () {
+    testWidgets(
+      'Vertical',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ListView.builder(
+                itemCount: 50,
+                shrinkWrap: true,
+                itemBuilder: (BuildContext context, int i) => ListTile(title: Text('Item $i')),
+              ),
+            ),
+          ),
+        );
+
+        // Make sure widget isn't built yet.
+        expect(find.text('Item 45', skipOffstage: false), findsNothing);
+
+        await tester.scrollUntilVisible(
+          find.text('Item 45', skipOffstage: false),
+          find.byType(Scrollable),
+          100,
+        );
+        await tester.pumpAndSettle();
+
+        // Now the widget is on screen.
+        expect(find.text('Item 45', skipOffstage: true), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Horizontal',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ListView.builder(
+                itemCount: 50,
+                shrinkWrap: true,
+                scrollDirection: Axis.horizontal,
+                // ListTile does not support horizontal list
+                itemBuilder: (BuildContext context, int i) => Container(child: Text('Item $i')),
+              ),
+            ),
+          ),
+        );
+
+        // Make sure widget isn't built yet.
+        expect(find.text('Item 45', skipOffstage: false), findsNothing);
+
+        await tester.scrollUntilVisible(
+          find.text('Item 45', skipOffstage: false),
+          find.byType(Scrollable),
+          100,
+        );
+        await tester.pumpAndSettle();
+
+        // Now the widget is on screen.
+        expect(find.text('Item 45', skipOffstage: true), findsOneWidget);
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Description

This is an equivalence for `FlutterDriver.scrollUntilVisible`, to find the widgets long below a scrollable, that's not built yet. 

It's necessary for migrating tests like #62064

## Related Issues

Fixes #61458

## Tests

I added the following tests:

- `'scrollUntilVisible: scrolls to make unbuilt widget visible'` group in `packages/flutter_test/test/controller_test.dart`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
