### PR TITLE
Updated references to the old button classes to the new classes in widgets, services, and rendering packages

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2980,7 +2980,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   ///     return RepaintBoundary(
   ///       key: globalKey,
   ///       child: Center(
-  ///         child: FlatButton(
+  ///         child: TextButton(
   ///           child: Text('Hello World', textDirection: TextDirection.ltr),
   ///           onPressed: _capturePng,
   ///         ),

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -375,7 +375,7 @@ class SystemChrome {
   ///   return AnnotatedRegion(
   ///     value: _currentStyle,
   ///     child: Center(
-  ///       child: RaisedButton(
+  ///       child: ElevatedButton(
   ///         child: const Text('Change Color'),
   ///         onPressed: _changeColor,
   ///        ),

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -863,7 +863,7 @@ class _ActionsMarker extends InheritedWidget {
 ///         children: <Widget>[
 ///           Padding(
 ///             padding: const EdgeInsets.all(8.0),
-///             child: FlatButton(onPressed: () {}, child: Text('Press Me')),
+///             child: TextButton(onPressed: () {}, child: Text('Press Me')),
 ///           ),
 ///           Padding(
 ///             padding: const EdgeInsets.all(8.0),

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -120,7 +120,7 @@ typedef AnimatedSwitcherLayoutBuilder = Widget Function(Widget currentChild, Lis
 ///             style: Theme.of(context).textTheme.headline4,
 ///           ),
 ///         ),
-///         RaisedButton(
+///         ElevatedButton(
 ///           child: const Text('Increment'),
 ///           onPressed: () {
 ///             setState(() {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6204,7 +6204,7 @@ class MouseRegion extends StatefulWidget {
   ///   Widget build(BuildContext context) {
   ///     return Column(
   ///       children: <Widget>[
-  ///         RaisedButton(
+  ///         ElevatedButton(
   ///           onPressed: () {
   ///             setState(() { key = UniqueKey(); });
   ///           },

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -926,7 +926,7 @@ class EditableText extends StatefulWidget {
   ///                   title: const Text('Thats correct!'),
   ///                   content: Text ('13 is the right answer.'),
   ///                   actions: <Widget>[
-  ///                     FlatButton(
+  ///                     TextButton(
   ///                       onPressed: () { Navigator.pop(context); },
   ///                       child: const Text('OK'),
   ///                     ),

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -823,7 +823,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   ///                   ],
   ///                 );
   ///               }),
-  ///               OutlineButton(
+  ///               OutlinedButton(
   ///                 child: const Text('UNFOCUS'),
   ///                 onPressed: () {
   ///                   setState(() {

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -801,7 +801,7 @@ class _FocusState extends State<Focus> {
 ///               children: <Widget>[
 ///                 // This button would be not visible, but still focusable from
 ///                 // the foreground pane without the FocusScope.
-///                 RaisedButton(
+///                 ElevatedButton(
 ///                   onPressed: () => print('You pressed the other button!'),
 ///                   child: Text('ANOTHER BUTTON TO FOCUS'),
 ///                 ),

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -20,7 +20,7 @@ import 'will_pop_scope.dart';
 ///
 /// {@tool dartpad --template=stateful_widget_scaffold}
 /// This example shows a [Form] with one [TextFormField] to enter an email
-/// address and a [RaisedButton] to submit the form. A [GlobalKey] is used here
+/// address and an [ElevatedButton] to submit the form. A [GlobalKey] is used here
 /// to identify the [Form] and validate input.
 ///
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/widgets/form.png)
@@ -48,7 +48,7 @@ import 'will_pop_scope.dart';
 ///         ),
 ///         Padding(
 ///           padding: const EdgeInsets.symmetric(vertical: 16.0),
-///           child: RaisedButton(
+///           child: ElevatedButton(
 ///             onPressed: () {
 ///               // Validate will return true if the form is valid, or false if
 ///               // the form is invalid.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2037,7 +2037,7 @@ typedef ElementVisitor = void Function(Element element);
 ///       appBar: AppBar(title: Text('Demo')),
 ///       body: Builder(
 ///         builder: (BuildContext context) {
-///           return FlatButton(
+///           return TextButton(
 ///             child: Text('BUTTON'),
 ///             onPressed: () {
 ///               // here, Scaffold.of(context) returns the locally created Scaffold

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1305,7 +1305,7 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///           duration: Duration(seconds: 3),
 ///           child: FlutterLogo(),
 ///         ),
-///         RaisedButton(
+///         ElevatedButton(
 ///           child: Text('Fade Logo'),
 ///           onPressed: _changeOpacity,
 ///         ),

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1081,7 +1081,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///     return Scaffold(
 ///       appBar: AppBar(title: Text('My Page')),
 ///       body: Center(
-///         child: FlatButton(
+///         child: TextButton(
 ///           child: Text('POP'),
 ///           onPressed: () {
 ///             Navigator.pop(context);

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -44,7 +44,7 @@ import 'viewport.dart';
 /// {@tool snippet}
 ///
 /// This widget introduces a [MaterialApp], [Scaffold] and [PageView] with two pages
-/// using the default constructor. Both pages contain a [RaisedButton] allowing you
+/// using the default constructor. Both pages contain an [ElevatedButton] allowing you
 /// to animate the [PageView] using a [PageController].
 ///
 /// ```dart
@@ -79,8 +79,7 @@ import 'viewport.dart';
 ///             Container(
 ///               color: Colors.red,
 ///               child: Center(
-///                 child: RaisedButton(
-///                   color: Colors.white,
+///                 child: ElevatedButton(
 ///                   onPressed: () {
 ///                     if (_pageController.hasClients) {
 ///                       _pageController.animateToPage(
@@ -97,8 +96,7 @@ import 'viewport.dart';
 ///             Container(
 ///               color: Colors.blue,
 ///               child: Center(
-///                 child: RaisedButton(
-///                   color: Colors.white,
+///                 child: ElevatedButton(
 ///                   onPressed: () {
 ///                     if (_pageController.hasClients) {
 ///                       _pageController.animateToPage(
@@ -660,7 +658,7 @@ class PageView extends StatefulWidget {
   ///         child: Row(
   ///           mainAxisAlignment: MainAxisAlignment.center,
   ///           children: <Widget>[
-  ///             FlatButton(
+  ///             TextButton(
   ///               onPressed: () => _reverse(),
   ///               child: Text('Reverse items'),
   ///             ),

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -523,7 +523,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///           children: <Widget>[
   ///             Text('HomePage'),
   ///             // Press this button to open the SecondPage.
-  ///             RaisedButton(
+  ///             ElevatedButton(
   ///               child: Text('Second Page >'),
   ///               onPressed: () {
   ///                 Navigator.pushNamed(context, '/second_page');
@@ -568,7 +568,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///           height: 100.0,
   ///           color: Colors.red,
   ///         )
-  ///       : RaisedButton(
+  ///       : ElevatedButton(
   ///           child: Text('Show Rectangle'),
   ///           onPressed: _navigateLocallyToShowRectangle,
   ///         );
@@ -579,7 +579,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///           mainAxisAlignment: MainAxisAlignment.center,
   ///           children: <Widget>[
   ///             localNavContent,
-  ///             RaisedButton(
+  ///             ElevatedButton(
   ///               child: Text('< Back'),
   ///               onPressed: () {
   ///                 // Pop a route. If this is pressed while the red rectangle is

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1278,7 +1278,7 @@ class ListView extends BoxScrollView {
   ///         child: Row(
   ///           mainAxisAlignment: MainAxisAlignment.center,
   ///           children: <Widget>[
-  ///             FlatButton(
+  ///             TextButton(
   ///               onPressed: () => _reverse(),
   ///               child: Text('Reverse items'),
   ///             ),

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -373,7 +373,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///             alignment: Alignment.bottomCenter,
 ///             child: Padding(
 ///               padding: const EdgeInsets.all(16.0),
-///               child: RaisedButton(
+///               child: ElevatedButton(
 ///                 onPressed: () {
 ///                   /* Place your onPressed code here! */
 ///                 },

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -322,7 +322,7 @@ class DefaultTextHeightBehavior extends InheritedTheme {
 /// To make [Text] react to touch events, wrap it in a [GestureDetector] widget
 /// with a [GestureDetector.onTap] handler.
 ///
-/// In a material design application, consider using a [FlatButton] instead, or
+/// In a material design application, consider using a [TextButton] instead, or
 /// if that isn't appropriate, at least using an [InkWell] instead of
 /// [GestureDetector].
 ///


### PR DESCRIPTION
Updated the documentation examples and references to the old button classes (`FlatButton`, `RaisedButton`, `OutlineButton`) with their new counterparts (`TextButton`, `ElevatedButton`, `OutlinedButton`). This is part of the transition to the new button universe (https://github.com/flutter/flutter/pull/59702).
