### PR TITLE
Add template flutter.widgets.transitionRoute.reverseTransitionDuration

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -103,10 +103,12 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// {@endtemplate}
   Duration get transitionDuration;
 
+  /// {@template flutter.widgets.transitionRoute.reverseTransitionDuration}
   /// The duration the transition going in reverse.
   ///
   /// By default, the reverse transition duration is set to the value of
   /// the forwards [transitionDuration].
+  /// {@endtemplate}
   Duration get reverseTransitionDuration => transitionDuration;
 
   /// {@template flutter.widgets.transitionRoute.opaque}


### PR DESCRIPTION
## Description

This PR fixes missing template shown in https://cirrus-ci.com/task/5290495779799040?command=main#L1680:

```
dartdoc:stderr:   error: undefined macro [flutter.widgets.transitionRoute.reverseTransitionDuration], from widgets.TransitionBuilderPage.reverseTransitionDuration: (file:///tmp/flutter%20sdk/packages/flutter/lib/src/widgets/pages.dart:169:18)
```
