### PR TITLE
Add Crane test to the new Gallery app

### DIFF
--- a/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/new_gallery.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+
+  final Directory galleryParentDir =
+      Directory.systemTemp.createTempSync('new_gallery_test');
+  final Directory galleryDir =
+      Directory(path.join(galleryParentDir.path, 'gallery'));
+
+  try {
+    await task(
+      NewGalleryPerfTest(
+        galleryDir,
+        timelineFileName: 'transitions-crane',
+        dartDefine: 'onlyCrane=true',
+      ).run,
+    );
+  } finally {
+    rmTree(galleryParentDir);
+  }
+}

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -12,14 +12,23 @@ import '../framework/framework.dart';
 import '../framework/utils.dart';
 
 class NewGalleryPerfTest extends PerfTest {
-  NewGalleryPerfTest(this.galleryDir) : super(galleryDir.path, 'test_driver/transitions_perf.dart', 'transitions');
+  NewGalleryPerfTest(
+    this.galleryDir, {
+    String timelineFileName = 'transitions',
+    String dartDefine = '',
+  }) : super(
+    galleryDir.path,
+    'test_driver/transitions_perf.dart',
+    timelineFileName,
+    dartDefine: dartDefine,
+  );
 
   @override
   Future<TaskResult> run() async {
     // Manually roll the new gallery version for now. If the new gallery repo
     // turns out to be updated frequently in the future, we can set up an auto
     // roller to update this version.
-    await getNewGallery('d00362e6bdd0f9b30bba337c358b9e4a6e4ca950', galleryDir);
+    await getNewGallery('e6357bccc49ec542ca127ca4b26b2b87216d07d5', galleryDir);
     return await super.run();
   }
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -357,6 +357,7 @@ class PerfTest {
     this.testDriver,
     this.needsFullTimeline = true,
     this.benchmarkScoreKeys,
+    this.dartDefine = '',
   });
 
   /// The directory where the app under test is defined.
@@ -395,6 +396,9 @@ class PerfTest {
   /// ```
   final List<String> benchmarkScoreKeys;
 
+  /// Additional flags for `--dart-define` to control the test
+  final String dartDefine;
+
   Future<TaskResult> run() {
     return internalRun();
   }
@@ -427,6 +431,8 @@ class PerfTest {
         if (writeSkslFileName != null)
           ...<String>['--write-sksl-on-exit', writeSkslFileName],
         if (cacheSkSL) '--cache-sksl',
+        if (dartDefine.isNotEmpty)
+          ...<String>['--dart-define', dartDefine],
         '-d',
         deviceId,
       ]);

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -821,6 +821,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
 
+  new_gallery__crane_perf:
+    description: >
+      Measures the performance of the Crane page in the new Flutter Gallery on Android.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+
   fast_scroll_large_images__memory:
     description: >
       Measures memory usage for scrolling through a list of large images.


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/61193

This also rolls the new Gallery app's version to include
https://github.com/flutter/gallery/pull/228
