### PR TITLE
Updated material and cupertino tests to use the new button classes

### DIFF
--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1170,7 +1170,7 @@ Widget createAppWithButtonThatLaunchesDialog({ WidgetBuilder dialogBuilder }) {
     home: Material(
       child: Center(
         child: Builder(builder: (BuildContext context) {
-          return RaisedButton(
+          return ElevatedButton(
             onPressed: () {
               showDialog<void>(
                 context: context,
@@ -1196,7 +1196,7 @@ Widget createAppWithCenteredButton(Widget child) {
   return MaterialApp(
     home: Material(
       child: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: null,
           child: child
         ),

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -358,7 +358,7 @@ void main() {
             onGenerateRoute: (RouteSettings settings) {
               return PageRouteBuilder<dynamic>(
                 pageBuilder: (BuildContext context, _, __) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     onPressed: () {
                       showLicensePage(
                         context: context,
@@ -376,7 +376,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.licensePageCount, 0);
     expect(nestedObserver.licensePageCount, 1);
@@ -396,7 +396,7 @@ void main() {
             onGenerateRoute: (RouteSettings settings) {
               return PageRouteBuilder<dynamic>(
                 pageBuilder: (BuildContext context, _, __) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     onPressed: () {
                       showLicensePage(
                         context: context,
@@ -415,7 +415,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.licensePageCount, 1);
     expect(nestedObserver.licensePageCount, 0);
@@ -432,7 +432,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showAboutDialog(
                     context: context,
@@ -448,7 +448,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.dialogCount, 1);
     expect(nestedObserver.dialogCount, 0);
@@ -465,7 +465,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showAboutDialog(
                     context: context,
@@ -482,7 +482,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.dialogCount, 0);
     expect(nestedObserver.dialogCount, 1);
@@ -515,7 +515,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showAboutDialog(
                     context: context,

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1729,7 +1729,7 @@ void main() {
                     floating: true,
                     snap: snap,
                     actions: <Widget>[
-                      FlatButton(
+                      TextButton(
                         child: const Text('snap=false'),
                         onPressed: () {
                           setState(() {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -98,7 +98,7 @@ void main() {
         home: Builder(
           builder: (BuildContext context) {
             return Material(
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('X'),
                 onPressed: () { Navigator.of(context).pushNamed('/next'); },
               ),
@@ -255,7 +255,7 @@ void main() {
           home: Builder(
               builder: (BuildContext context) {
                 return Material(
-                  child: RaisedButton(
+                  child: ElevatedButton(
                       child: const Text('X'),
                       onPressed: () async {
                         result = Navigator.of(context).pushNamed('/a');
@@ -267,7 +267,7 @@ void main() {
           routes: <String, WidgetBuilder>{
             '/a': (BuildContext context) {
               return Material(
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: const Text('Y'),
                   onPressed: () {
                     Navigator.of(context).pop('all done');

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -17,7 +17,7 @@ void main() {
           backgroundColor: color,
           content: const Text('I am a banner'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -39,7 +39,7 @@ void main() {
           contentTextStyle: contentTextStyle,
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -60,11 +60,11 @@ void main() {
         home: MaterialBanner(
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action 1'),
               onPressed: () { },
             ),
-            FlatButton(
+            TextButton(
               child: const Text('Action 2'),
               onPressed: () { },
             ),
@@ -87,7 +87,7 @@ void main() {
         home: MaterialBanner(
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -109,7 +109,7 @@ void main() {
         home: MaterialBanner(
           content: const Text('Content'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -132,7 +132,7 @@ void main() {
           child: MaterialBanner(
             content: const Text('Content'),
             actions: <Widget>[
-              FlatButton(
+              TextButton(
                 child: const Text('Action'),
                 onPressed: () { },
               ),
@@ -156,7 +156,7 @@ void main() {
           forceActionsBelow: true,
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),

--- a/packages/flutter/test/material/banner_theme_test.dart
+++ b/packages/flutter/test/material/banner_theme_test.dart
@@ -57,7 +57,7 @@ void main() {
         body: MaterialBanner(
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -83,7 +83,7 @@ void main() {
           leading: const Icon(Icons.ac_unit),
           content: const Text(contentText),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -122,7 +122,7 @@ void main() {
           padding: const EdgeInsets.all(10),
           leadingPadding: const EdgeInsets.all(10),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),
@@ -153,7 +153,7 @@ void main() {
         body: MaterialBanner(
           content: const Text('Content'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Action'),
               onPressed: () { },
             ),

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1338,7 +1338,7 @@ void main() {
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
               body: Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: const Text('green'),
                   onPressed: () {
                     setState(() {

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -738,7 +738,7 @@ class _TestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: FlatButton(
+      child: TextButton(
         child: const Text('Show bottom sheet'),
         onPressed: () {
           if (useRootNavigator != null) {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -93,7 +93,7 @@ void main() {
       home: Material(
         child: Builder(
           builder: (BuildContext context) {
-            return RaisedButton(
+            return ElevatedButton(
               onPressed: () {
                 buttonContext = context;
               },
@@ -211,7 +211,7 @@ void main() {
             child: Center(
               child: Builder(
                 builder: (BuildContext context) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     child: const Text('X'),
                     onPressed: () {
                       showDatePicker(
@@ -265,7 +265,7 @@ void main() {
           onGenerateRoute: (RouteSettings settings) {
             return MaterialPageRoute<dynamic>(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   onPressed: () {
                     showDatePicker(
                       context: context,
@@ -285,7 +285,7 @@ void main() {
       ));
 
       // Open the dialog.
-      await tester.tap(find.byType(RaisedButton));
+      await tester.tap(find.byType(ElevatedButton));
 
       expect(rootObserver.datePickerCount, 0);
       expect(nestedObserver.datePickerCount, 1);
@@ -304,7 +304,7 @@ void main() {
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('X'),
                   onPressed: () {
                     showDatePicker(
@@ -339,7 +339,7 @@ void main() {
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('X'),
                   onPressed: () {
                     showDatePicker(
@@ -705,7 +705,7 @@ void main() {
         home: Material(
           child: Builder(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   buttonContext = context;
                 },

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -60,7 +60,7 @@ void main() {
       home: Material(
         child: Builder(
           builder: (BuildContext context) {
-            return RaisedButton(
+            return ElevatedButton(
               onPressed: () {
                 buttonContext = context;
               },
@@ -629,7 +629,7 @@ void main() {
         home: Material(
           child: Builder(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   buttonContext = context;
                 },

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -20,7 +20,7 @@ MaterialApp _buildAppWithDialog(Widget dialog, { ThemeData theme, double textSca
       child: Builder(
         builder: (BuildContext context) {
           return Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               child: const Text('X'),
               onPressed: () {
                 showDialog<void>(
@@ -61,7 +61,7 @@ void main() {
         color: Colors.green[500],
       ),
       actions: <Widget>[
-        FlatButton(
+        TextButton(
             onPressed: () {
               didPressOk = true;
             },
@@ -224,7 +224,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: null,
               child: Text('Go'),
             ),
@@ -333,7 +333,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: null,
               child: Text('Go'),
             ),
@@ -427,7 +427,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: null,
               child: Text(buttonText),
             ),
@@ -461,7 +461,7 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           onPressed: () {},
           child: const Text('button'),
         ),
@@ -494,7 +494,7 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           onPressed: () {},
           child: const Text('button'),
         ),
@@ -531,12 +531,12 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           key: key1,
           onPressed: () {},
           child: const Text('button 1'),
         ),
-        RaisedButton(
+        ElevatedButton(
           key: key2,
           onPressed: () {},
           child: const Text('button 2'),
@@ -591,12 +591,12 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           key: key1,
           onPressed: () {},
           child: const Text('button 1'),
         ),
-        RaisedButton(
+        ElevatedButton(
           key: key2,
           onPressed: () {},
           child: const Text('button 2'),
@@ -765,7 +765,7 @@ void main() {
       key: contentKey,
     );
     final List<Widget> actions = <Widget>[
-      RaisedButton(
+      ElevatedButton(
         onPressed: () {},
         child: const Text('button'),
       ),
@@ -1049,12 +1049,12 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           key: key1,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 1'),
         ),
-        RaisedButton(
+        ElevatedButton(
           key: key2,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 2'),
@@ -1072,7 +1072,7 @@ void main() {
 
     final Rect buttonOneRect = tester.getRect(find.byKey(key1));
     final Rect buttonTwoRect = tester.getRect(find.byKey(key2));
-    // Second [RaisedButton] should appear above the first.
+    // Second [ElevatedButton] should appear above the first.
     expect(buttonTwoRect.bottom, lessThanOrEqualTo(buttonOneRect.top));
   });
 
@@ -1084,12 +1084,12 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           key: key1,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 1'),
         ),
-        RaisedButton(
+        ElevatedButton(
           key: key2,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 2'),
@@ -1117,12 +1117,12 @@ void main() {
       title: const Text('title'),
       content: const Text('content'),
       actions: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           key: key1,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 1'),
         ),
-        RaisedButton(
+        ElevatedButton(
           key: key2,
           onPressed: () {},
           child: const Text('Looooooooooooooong button 2'),
@@ -1283,7 +1283,7 @@ void main() {
           child: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: const Text('X'),
                   onPressed: () {
                     showDialog<void>(
@@ -1333,13 +1333,13 @@ void main() {
         builder: (BuildContext context) {
           return AlertDialog(
             actions: <Widget>[
-              FlatButton(
+              TextButton(
                 child: const Text('TRUE'),
                 onPressed: () {
                   Navigator.pop(context, true); // showDialog() returns true
                 },
               ),
-              FlatButton(
+              TextButton(
                 child: const Text('FALSE'),
                 onPressed: () {
                   Navigator.pop(context, false); // showDialog() returns false
@@ -1460,7 +1460,7 @@ void main() {
           child: Builder(
             key: builderKey,
             builder: (BuildContext outerContext) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showDialog<void>(
                     context: outerContext,
@@ -1480,7 +1480,7 @@ void main() {
     await tester.pumpWidget(buildFrame(UniqueKey()));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
     await tester.pumpAndSettle();
 
     // Force the Builder to be recreated (new key) which causes outerContext to
@@ -1542,7 +1542,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showDialog<void>(
                     context: context,
@@ -1560,7 +1560,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.dialogCount, 1);
     expect(nestedObserver.dialogCount, 0);
@@ -1577,7 +1577,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showDialog<void>(
                     context: context,
@@ -1596,7 +1596,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.dialogCount, 0);
     expect(nestedObserver.dialogCount, 1);
@@ -1694,7 +1694,7 @@ void main() {
         ],
         home: const Material(
           child: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: null,
               child: Text('Go'),
             ),

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -15,7 +15,7 @@ MaterialApp _appWithDialog(WidgetTester tester, Widget dialog, { ThemeData theme
       child: Builder(
         builder: (BuildContext context) {
           return Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               child: const Text('X'),
               onPressed: () {
                 showDialog<void>(

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -678,7 +678,7 @@ void main() {
                           onPressed: () { },
                         ),
                         body: Center(
-                          child: RaisedButton(
+                          child: ElevatedButton(
                             child: const Text('POP'),
                             onPressed: () {
                               Navigator.pop(context);

--- a/packages/flutter/test/material/inherited_theme_test.dart
+++ b/packages/flutter/test/material/inherited_theme_test.dart
@@ -40,7 +40,7 @@ void main() {
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: <Widget>[
-                          RaisedButton(
+                          ElevatedButton(
                             child: const Text('push unwrapped'),
                             onPressed: () {
                               Navigator.of(context).push<void>(
@@ -51,7 +51,7 @@ void main() {
                               );
                             },
                           ),
-                          RaisedButton(
+                          ElevatedButton(
                             child: const Text('push wrapped'),
                             onPressed: () {
                               Navigator.of(context).push<void>(
@@ -169,7 +169,7 @@ void main() {
     final Widget banner = MaterialBanner(
       content: const Text('hello'),
       actions: <Widget>[
-        FlatButton(
+        TextButton(
           child: const Text('action'),
           onPressed: () { },
         ),
@@ -193,7 +193,7 @@ void main() {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push unwrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -204,7 +204,7 @@ void main() {
                           );
                         },
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push wrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -283,7 +283,7 @@ void main() {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push unwrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -294,7 +294,7 @@ void main() {
                           );
                         },
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push wrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -387,7 +387,7 @@ void main() {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push unwrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -398,7 +398,7 @@ void main() {
                           );
                         },
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push wrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -487,7 +487,7 @@ void main() {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push unwrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -498,7 +498,7 @@ void main() {
                           );
                         },
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push wrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -572,7 +572,7 @@ void main() {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push unwrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(
@@ -583,7 +583,7 @@ void main() {
                           );
                         },
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: const Text('push wrapped'),
                         onPressed: () {
                           Navigator.of(context).push<void>(

--- a/packages/flutter/test/material/ink_splash_test.dart
+++ b/packages/flutter/test/material/ink_splash_test.dart
@@ -14,12 +14,9 @@ void main() {
       home: Scaffold(
       appBar: AppBar(title: const Text('Button Border Test')),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: const Text('Test'),
           onPressed: () { },
-          shape: Border.all(
-            color: Colors.blue,
-          ),
         ),
       ),
     )));

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -229,10 +229,11 @@ void main() {
         home: Scaffold(
           body: Stack(
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () {
                   pressed = true;
                 },
+                child: null,
               ),
               Material(
                 type: MaterialType.transparency,
@@ -246,7 +247,7 @@ void main() {
         ),
       ),
     );
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
     expect(pressed, isTrue);
   });
 

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -282,7 +282,7 @@ void main() {
   testWidgets('back gesture while OS changes', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('PUSH'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -582,7 +582,7 @@ void main() {
         home: Scaffold(
           key: scaffoldKey,
           body: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: () {
                 Navigator.push<void>(scaffoldKey.currentContext, MaterialPageRoute<void>(
                   builder: (BuildContext context) {

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -26,7 +26,7 @@ void main() {
   testWidgets('Default PageTransitionsTheme builds a CupertionPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -52,7 +52,7 @@ void main() {
   testWidgets('Default PageTransitionsTheme builds a _FadeUpwardsPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -85,7 +85,7 @@ void main() {
   testWidgets('PageTransitionsTheme override builds a _OpenUpwardsPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -125,7 +125,7 @@ void main() {
   testWidgets('PageTransitionsTheme override builds a _ZoomPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -169,7 +169,7 @@ void main() {
 
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
-        child: FlatButton(
+        child: TextButton(
           child: const Text('push'),
           onPressed: () { Navigator.of(context).pushNamed('/b'); },
         ),
@@ -177,7 +177,7 @@ void main() {
       '/b': (BuildContext context) => StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           builtCount++; // Increase [builtCount] each time the widget build
-          return FlatButton(
+          return TextButton(
             child: const Text('pop'),
             onPressed: () { Navigator.pop(context); },
           );

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -433,7 +433,7 @@ void main() {
             height: 200.0,
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('showModalBottomSheet'),
                   onPressed: () {
                     showModalBottomSheet<void>(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1017,7 +1017,7 @@ void main() {
           child: Center(
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   onPressed: () {
                     // Ensure showMenu throws an assertion without a position
                     expect(() {
@@ -1356,7 +1356,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showMenu<int>(
                     context: context,
@@ -1377,7 +1377,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.menuCount, 0);
     expect(nestedObserver.menuCount, 1);
@@ -1394,7 +1394,7 @@ void main() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showMenu<int>(
                     context: context,
@@ -1416,7 +1416,7 @@ void main() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.menuCount, 1);
     expect(nestedObserver.menuCount, 0);

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1370,13 +1370,13 @@ void main() {
                     divisions: divisions,
                     onChanged: onChanged,
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     child: const Text('Next'),
                     onPressed: () {
                       Navigator.of(context).pushReplacement(
                         MaterialPageRoute<void>(
                           builder: (BuildContext context) {
-                            return RaisedButton(
+                            return ElevatedButton(
                               child: const Text('Inner page'),
                               onPressed: () { Navigator.of(context).pop(); },
                             );

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -431,7 +431,7 @@ void main() {
             ),
           ),
           persistentFooterButtons: <Widget>[
-            FlatButton(
+            TextButton(
               onPressed: () {
                 didPressButton = true;
               },
@@ -657,7 +657,7 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: Scaffold(
-            body: FlatButton(
+            body: TextButton(
               key: testKey,
               onPressed: () { },
               child: const Text(''),
@@ -665,7 +665,7 @@ void main() {
           ),
         ),
       ));
-      expect(tester.element(find.byKey(testKey)).size, const Size(88.0, 48.0));
+      expect(tester.element(find.byKey(testKey)).size, const Size(64.0, 48.0));
       expect(tester.renderObject<RenderBox>(find.byKey(testKey)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
     });
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2041,13 +2041,13 @@ void main() {
                       value = newValue;
                     },
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                     child: const Text('Next'),
                     onPressed: () {
                       Navigator.of(context).pushReplacement(
                         MaterialPageRoute<void>(
                           builder: (BuildContext context) {
-                            return RaisedButton(
+                            return ElevatedButton(
                               child: const Text('Inner page'),
                               onPressed: () { Navigator.of(context).pop(); },
                             );
@@ -2100,7 +2100,7 @@ void main() {
       ),
     );
 
-    // Represents the RaisedButton with inner Text, inner page.
+    // Represents the ElevatedButton with inner Text, inner page.
     expect(valueIndicatorBox, paintsExactlyCountTimes(#drawPath, 1));
     expect(valueIndicatorBox, paintsExactlyCountTimes(#drawParagraph, 1));
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2463,7 +2463,7 @@ void main() {
                   tabs: List<Widget>.generate(controller.length, (int index) => Tab(text: 'Tab$index')),
                 ),
                 actions: <Widget>[
-                  FlatButton(
+                  TextButton(
                     child: const Text('Change TabController length'),
                     onPressed: () {
                       setState(() {

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -164,7 +164,7 @@ void main() {
             body: Center(
               child: Builder(
                 builder: (BuildContext context) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     onPressed: () {
                       showModalBottomSheet<void>(
                         context: context,
@@ -201,7 +201,7 @@ void main() {
             body: Center(
               child: Builder(
                 builder: (BuildContext context) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     onPressed: () {
                       showDialog<void>(
                         context: context,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -39,7 +39,7 @@ class _TimePickerLauncher extends StatelessWidget {
         child: Center(
           child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('X'),
                   onPressed: () async {
                     onChanged(await showTimePicker(
@@ -69,7 +69,7 @@ Future<Offset> startPicker(
 }
 
 Future<void> finishPicker(WidgetTester tester) async {
-  final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(tester.element(find.byType(RaisedButton)));
+  final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(tester.element(find.byType(ElevatedButton)));
   await tester.tap(find.text(materialLocalizations.okButtonLabel));
   await tester.pumpAndSettle(const Duration(seconds: 1));
 }
@@ -499,7 +499,7 @@ void _tests() {
           child: Center(
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('X'),
                   onPressed: () {
                     showTimePicker(
@@ -551,7 +551,7 @@ void _tests() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showTimePicker(
                     context: context,
@@ -567,7 +567,7 @@ void _tests() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.pickerCount, 1);
     expect(nestedObserver.pickerCount, 0);
@@ -584,7 +584,7 @@ void _tests() {
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<dynamic>(
             builder: (BuildContext context) {
-              return RaisedButton(
+              return ElevatedButton(
                 onPressed: () {
                   showTimePicker(
                     context: context,
@@ -601,7 +601,7 @@ void _tests() {
     ));
 
     // Open the dialog.
-    await tester.tap(find.byType(RaisedButton));
+    await tester.tap(find.byType(ElevatedButton));
 
     expect(rootObserver.pickerCount, 0);
     expect(nestedObserver.pickerCount, 1);
@@ -616,7 +616,7 @@ void _tests() {
           child: Center(
             child: Builder(
                 builder: (BuildContext context) {
-                  return RaisedButton(
+                  return ElevatedButton(
                     child: const Text('X'),
                     onPressed: () async {
                       await showTimePicker(
@@ -805,7 +805,7 @@ Future<void> mediaQueryBoilerplate(
             child: Navigator(
               onGenerateRoute: (RouteSettings settings) {
                 return MaterialPageRoute<void>(builder: (BuildContext context) {
-                  return FlatButton(
+                  return TextButton(
                     onPressed: () {
                       showTimePicker(
                         context: context,

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -426,7 +426,7 @@ class _TimePickerLauncher extends StatelessWidget {
         child: Center(
           child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('X'),
                   onPressed: () async {
                     await showTimePicker(

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -84,7 +84,7 @@ void main() {
           body: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: FlatButton(
+                child: TextButton(
                   child: const Text('X'),
                   onPressed: () {
                     showDialog<void>(
@@ -138,7 +138,7 @@ void main() {
           body: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: FlatButton(
+                child: TextButton(
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push(MaterialPageRoute<void>(
@@ -183,7 +183,7 @@ void main() {
           body: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: FlatButton(
+                child: TextButton(
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push(MaterialPageRoute<void>(
@@ -236,11 +236,11 @@ void main() {
         builder: (BuildContext context) {
           return AlertDialog(
             actions: <Widget> [
-              FlatButton(
+              TextButton(
                 child: const Text('YES'),
                 onPressed: () { Navigator.of(context).pop(true); },
               ),
-              FlatButton(
+              TextButton(
                 child: const Text('NO'),
                 onPressed: () { Navigator.of(context).pop(false); },
               ),
@@ -257,7 +257,7 @@ void main() {
           body: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: FlatButton(
+                child: TextButton(
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push(MaterialPageRoute<void>(
@@ -343,7 +343,7 @@ void main() {
           body: Builder(
             builder: (BuildContext context) {
               return Center(
-                child: FlatButton(
+                child: TextButton(
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push(route);


### PR DESCRIPTION
Updated the material and cupertino tests to replace old button classes (`FlatButton`, `RaisedButton`, `OutlineButton`) with their new counterparts (`TextButton`, `ElevatedButton`, `OutlinedButton`). This is part of the transition to the new button universe (https://github.com/flutter/flutter/pull/59702).
