### PR TITLE
Ban unresolved dartdoc directives from HTML output

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -11,6 +11,8 @@ import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
 
+import 'dartdoc_checker.dart';
+
 const String kDocsRoot = 'dev/docs';
 const String kPublishRoot = '$kDocsRoot/doc';
 const String kSnippetsRoot = 'dev/snippets';
@@ -221,6 +223,7 @@ Future<void> main(List<String> arguments) async {
     exit(exitCode);
 
   sanityCheckDocs();
+  checkForUnresolvedDirectives('$kPublishRoot/api');
 
   createIndexAndCleanup();
 }

--- a/dev/tools/dartdoc_checker.dart
+++ b/dev/tools/dartdoc_checker.dart
@@ -108,7 +108,7 @@ int _scanFile(File file) {
 // inside <code> sections. Since we currently don't do that, doing the matching
 // with a regex is a lot faster than using an HTML parser to strip out the
 // <code> sections.
-final RegExp _pattern = RegExp('({@[^}\n]*}?)(?![^<>]*<\/code)');
+final RegExp _pattern = RegExp(r'({@[^}\n]*}?)(?![^<>]*</code)');
 
 // Usually, the checker is invoked directly from `dartdoc.dart`. Main method
 // is included for convenient local runs without having to regenerate

--- a/dev/tools/dartdoc_checker.dart
+++ b/dev/tools/dartdoc_checker.dart
@@ -1,0 +1,125 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+/// Scans the dartdoc HTML output in the provided `htmlOutputPath` for
+/// unresolved dartdoc directives (`{@foo x y}`).
+///
+/// Dartdoc usually replaces those directives with other content. However,
+/// if the directive is misspelled (or contains other errors) it is placed
+/// verbatim into the HTML output. That's not desirable and this check verifies
+/// that no directives appear verbatim in the output by checking that the
+/// string `{@` does not appear in the HTML output outside of <code> sections.
+///
+/// The string `{@` is allowed in <code> sections, because those may contain
+/// sample code where the sequence is perfectly legal, e.g. for required named
+/// parameters of a method:
+///
+/// ```
+/// void foo({@required int bar});
+/// ```
+void checkForUnresolvedDirectives(String htmlOutputPath) {
+  final Directory dartDocDir = Directory(htmlOutputPath);
+  if (!dartDocDir.existsSync()) {
+    throw Exception('Directory with dartdoc output (${dartDocDir.path}) does not exist.');
+  }
+
+  // Makes sure that the path we were given contains some of the expected
+  // libraries and HTML files.
+  final List<String> canaryLibraries = <String>[
+    'animation',
+    'cupertino',
+    'material',
+    'widgets',
+    'rendering',
+    'flutter_driver',
+  ];
+  final List<String> canaryFiles = <String>[
+    'Widget-class.html',
+    'Material-class.html',
+    'Canvas-class.html',
+  ];
+
+  final List<FileSystemEntity> toScan = dartDocDir.listSync();
+  int count = 0;
+
+  while (toScan.isNotEmpty) {
+    final FileSystemEntity entity = toScan.removeLast();
+    if (entity is File) {
+      if (path.extension(entity.path) != '.html') {
+        continue;
+      }
+      canaryFiles.remove(path.basename(entity.path));
+
+      // TODO(goderbauer): Remove this exception when https://github.com/dart-lang/dartdoc/issues/2272 is fixed.
+      if (entity.path.endsWith('-class.html') || entity.path.endsWith('-library.html') ) {
+        continue;
+      }
+
+      count += _scanFile(entity);
+    } else if (entity is Directory) {
+      canaryLibraries.remove(path.basename(entity.path));
+      toScan.addAll(entity.listSync());
+    } else {
+      throw Exception('$entity is neither file nor directory.');
+    }
+  }
+
+  if (canaryLibraries.isNotEmpty) {
+    throw Exception('Did not find docs for the following libraries: ${canaryLibraries.join(', ')}.');
+  }
+  if (canaryFiles.isNotEmpty) {
+    throw Exception('Did not find docs for the following files: ${canaryFiles.join(', ')}.');
+  }
+  if (count > 0) {
+    throw Exception('Found $count unresolved dartdoc directives (see log above).');
+  }
+  print('No unresolved dartdoc directives detected.');
+}
+
+int _scanFile(File file) {
+  assert(path.extension(file.path) == 'html');
+  Iterable<String> matches = _pattern.allMatches(file.readAsStringSync())
+      .map((RegExpMatch m ) => m.group(0));
+
+  // TODO(goderbauer): Remove this exception when https://github.com/dart-lang/dartdoc/issues/1945 is fixed.
+  matches = matches
+      .where((String m) => m != '{@inject-html}')
+      .where((String m) => m != '{@end-inject-html}');
+
+  if (matches.isNotEmpty) {
+    stderr.writeln('Found unresolved dartdoc directives in ${file.path}:');
+    for (final String match in matches) {
+      stderr.writeln('  $match');
+    }
+  }
+  return matches.length;
+}
+
+// Matches all `{@` that are not within `<code></code>` sections.
+//
+// This regex may lead to false positives if the docs ever contain nested tags
+// inside <code> sections. Since we currently don't do that, doing the matching
+// with a regex is a lot faster than using an HTML parser to strip out the
+// <code> sections.
+final RegExp _pattern = RegExp('({@[^}\n]*}?)(?![^<>]*<\/code)');
+
+// Usually, the checker is invoked directly from `dartdoc.dart`. Main method
+// is included for convenient local runs without having to regenerate
+// the dartdocs every time.
+//
+// Provide the path to the dartdoc HTML output as an argument when running the
+// program.
+void main(List<String> args) {
+  if (args.length != 1) {
+    throw Exception('Must provide the path to the dartdoc HTML output as argument.');
+  }
+  if (!Directory(args.single).existsSync()) {
+    throw Exception('The dartdoc HTML output directory ${args.single} does not exist.');
+  }
+  checkForUnresolvedDirectives(args.single);
+}

--- a/dev/tools/dartdoc_checker.dart
+++ b/dev/tools/dartdoc_checker.dart
@@ -44,6 +44,8 @@ void checkForUnresolvedDirectives(String htmlOutputPath) {
     'Canvas-class.html',
   ];
 
+  print('Scanning for unresolved dartdoc directives...');
+
   final List<FileSystemEntity> toScan = dartDocDir.listSync();
   int count = 0;
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -562,7 +562,7 @@ class InkResponse extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode focusNode;
 
-  /// {@template flutter.widgets.Focus.canRequestFocus}
+  /// {@macro flutter.widgets.Focus.canRequestFocus}
   final bool canRequestFocus;
 
   /// The rectangle to use for the highlight effect and for clipping

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -94,6 +94,7 @@ abstract class GradientTransform {
 ///   transform: GradientRotation(math.pi/4),
 /// );
 /// ```
+/// {@end-tool}
 @immutable
 class GradientRotation extends GradientTransform {
   /// Constructs a [GradientRotation] for the specified angle.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -652,11 +652,6 @@ class EditableText extends StatefulWidget {
   /// text.
   ///
   /// Defaults to the ambient [Directionality], if any.
-  ///
-  /// See also:
-  ///
-  ///  * {@macro flutter.gestures.monodrag.dragStartExample}
-  ///
   /// {@endtemplate}
   final TextDirection textDirection;
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -457,7 +457,7 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
 /// ```dart
 /// BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
 /// ```
-/// (@end-tool}
+/// {@end-tool}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -43,7 +43,7 @@ class TickerMode extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@template flutter.widgets.child}
+  /// {@macro flutter.widgets.child}
   final Widget child;
 
   /// Whether tickers in the given subtree should be enabled or disabled.


### PR DESCRIPTION
## Description

Due to spelling mistakes (or other errors) the HTML of our dartdocs sometimes still contain unresolved dartdoc directives verbatim (e.g. `{@foo x y}`). This usually indicates an error, those should not be part of the final output. This PR adds a check that runs over the generated dartdocs to ensure that no unresolved directives are included in the output. It also fixes all unresolved directives in the framework.

Due to bugs in dartdoc (namely, https://github.com/dart-lang/dartdoc/issues/1945 and https://github.com/dart-lang/dartdoc/issues/2272) some unresolved directives will still appear in the output. The check contains exceptions for those. Once those issues are fixed, those exceptions will be removed.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47652.
https://github.com/dart-lang/dartdoc/issues/1945
https://github.com/dart-lang/dartdoc/issues/2272

## Tests

I added the following tests:

This entire thing is a test for our docs.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
