### PR TITLE
[Material] Ensure banner reads banner theme's leading padding property

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -117,7 +117,7 @@ class MaterialBanner extends StatelessWidget {
         ? const EdgeInsetsDirectional.only(start: 16.0, top: 2.0)
         : const EdgeInsetsDirectional.only(start: 16.0, top: 24.0, end: 16.0, bottom: 4.0));
     final EdgeInsetsGeometry leadingPadding = this.leadingPadding
-        ?? bannerTheme.padding
+        ?? bannerTheme.leadingPadding
         ?? const EdgeInsetsDirectional.only(end: 16.0);
 
     final Widget buttonBar = ButtonBar(

--- a/packages/flutter/test/material/banner_theme_test.dart
+++ b/packages/flutter/test/material/banner_theme_test.dart
@@ -101,9 +101,9 @@ void main() {
     final Offset containerTopLeft = tester.getTopLeft(_containerFinder());
     final Offset leadingTopLeft = tester.getTopLeft(find.byIcon(Icons.ac_unit));
     expect(contentTopLeft.dy - containerTopLeft.dy, 24);
-    expect(contentTopLeft.dx - containerTopLeft.dx, 39);
+    expect(contentTopLeft.dx - containerTopLeft.dx, 41);
     expect(leadingTopLeft.dy - containerTopLeft.dy, 19);
-    expect(leadingTopLeft.dx - containerTopLeft.dx, 10);
+    expect(leadingTopLeft.dx - containerTopLeft.dx, 11);
   });
 
   testWidgets('MaterialBanner widget properties take priority over theme', (WidgetTester tester) async {
@@ -120,7 +120,7 @@ void main() {
           contentTextStyle: textStyle,
           content: const Text(contentText),
           padding: const EdgeInsets.all(10),
-          leadingPadding: const EdgeInsets.all(10),
+          leadingPadding: const EdgeInsets.all(12),
           actions: <Widget>[
             FlatButton(
               child: const Text('Action'),
@@ -140,9 +140,9 @@ void main() {
     final Offset containerTopLeft = tester.getTopLeft(_containerFinder());
     final Offset leadingTopLeft = tester.getTopLeft(find.byIcon(Icons.ac_unit));
     expect(contentTopLeft.dy - containerTopLeft.dy, 29);
-    expect(contentTopLeft.dx - containerTopLeft.dx, 54);
+    expect(contentTopLeft.dx - containerTopLeft.dx, 58);
     expect(leadingTopLeft.dy - containerTopLeft.dy, 24);
-    expect(leadingTopLeft.dx - containerTopLeft.dx, 20);
+    expect(leadingTopLeft.dx - containerTopLeft.dx, 22);
   });
 
   testWidgets('MaterialBanner uses color scheme when necessary', (WidgetTester tester) async {
@@ -172,7 +172,7 @@ MaterialBannerThemeData _bannerTheme() {
     backgroundColor: Colors.orange,
     contentTextStyle: TextStyle(color: Colors.pink),
     padding: EdgeInsets.all(5),
-    leadingPadding: EdgeInsets.all(5),
+    leadingPadding: EdgeInsets.all(6),
   );
 }
 


### PR DESCRIPTION
## Description

The banner theme's `padding` param was being used instead of `leadingPadding`. This change fixes that bug.

## Related Issues

Closes #62128 

## Tests

I updated the existing banner theme tests to adequately catch this bug

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
