### PR TITLE
Simplify macrobencharks/picture_cache

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/picture_cache.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/picture_cache.dart
@@ -10,65 +10,35 @@ class PictureCachePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: DefaultTabController(
-        length: kTabNames.length, // This is the number of tabs.
-        child: NestedScrollView(
-          key: const Key('nested-scroll'), // this key is used by the driver test
-          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-            // These are the slivers that show up in the "outer" scroll view.
-            return <Widget>[
-              SliverOverlapAbsorber(
-                handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                sliver: SliverAppBar(
-                  title: const Text('Picture Cache'),
-                  pinned: true,
-                  expandedHeight: 50.0,
-                  forceElevated: innerBoxIsScrolled,
-                  bottom: TabBar(
-                    tabs: kTabNames.map((String name) => Tab(text: name)).toList(),
-                  ),
-                ),
-              ),
-            ];
-          },
-          body: TabBarView(
-            children: kTabNames.map((String name) {
-              return SafeArea(
-                top: false,
-                bottom: false,
-                child: Builder(
-                  builder: (BuildContext context) {
-                    return VerticalList();
-                  },
-                ),
-              );
-            }).toList(),
+    return DefaultTabController(
+      length: kTabNames.length, // This is the number of tabs.
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Picture Cache'),
+          // pinned: true,
+          // expandedHeight: 50.0,
+          // forceElevated: innerBoxIsScrolled,
+          bottom: TabBar(
+            tabs: kTabNames.map((String name) => Tab(text: name)).toList(),
           ),
+        ),
+        body: TabBarView(
+          key: const Key('tabbar_view'), // this key is used by the driver test
+          children: kTabNames.map((String name) {
+            return SafeArea(
+              top: false,
+              bottom: false,
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ListView.builder(
+                    itemBuilder: (BuildContext context, int index) => ListItem(index: index),
+                  );
+                },
+              ),
+            );
+          }).toList(),
         ),
       ),
-    );
-  }
-}
-
-class VerticalList extends StatelessWidget {
-  static const int kItemCount = 100;
-
-  @override
-  Widget build(BuildContext context) {
-    return CustomScrollView(
-      slivers: <Widget>[
-        SliverOverlapInjector(
-          // This is the flip side of the SliverOverlapAbsorber above.
-          handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-        ),
-        SliverList(
-          delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => ListItem(index: index),
-            childCount: kItemCount,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
@@ -13,9 +13,10 @@ void main() {
     kPictureCacheRouteName,
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
-      final SerializableFinder nestedScroll = find.byValueKey('nested-scroll');
+      final SerializableFinder tabbarScroll = find.byValueKey('tabbar_view');
       Future<void> _scrollOnce(double offset) async {
-        await driver.scroll(nestedScroll, offset, 0.0, const Duration(milliseconds: 300));
+        // Technically it's not scrolling but moving
+        await driver.scroll(tabbarScroll, offset, 0.0, const Duration(milliseconds: 300));
         await Future<void>.delayed(const Duration(milliseconds: 500));
       }
       for (int i = 0; i < 3; i += 1) {

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
@@ -13,10 +13,10 @@ void main() {
     kPictureCacheRouteName,
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
-      final SerializableFinder tabbarScroll = find.byValueKey('tabbar_view');
+      final SerializableFinder tabBarView = find.byValueKey('tabbar_view');
       Future<void> _scrollOnce(double offset) async {
         // Technically it's not scrolling but moving
-        await driver.scroll(tabbarScroll, offset, 0.0, const Duration(milliseconds: 300));
+        await driver.scroll(tabBarView, offset, 0.0, const Duration(milliseconds: 300));
         await Future<void>.delayed(const Duration(milliseconds: 500));
       }
       for (int i = 0; i < 3; i += 1) {


### PR DESCRIPTION
## Description

The feature of `NestedScrollView` is not used in this test app. Simplify it to a straight tabview. 
No significant difference in performance is observed. 

## Related Issues

N/A

## Tests

The PR itself is a modification to test. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
