### PR TITLE
Fix error handling for errors with empty stack traces

### DIFF
--- a/packages/flutter/lib/src/foundation/stack_frame.dart
+++ b/packages/flutter/lib/src/foundation/stack_frame.dart
@@ -86,6 +86,7 @@ class StackFrame {
     return stack
         .trim()
         .split('\n')
+        .where((String line) => line.isNotEmpty)
         .map(fromStackTraceLine)
         // On the Web in non-debug builds the stack trace includes the exception
         // message that precedes the stack trace itself. fromStackTraceLine will

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -201,4 +201,23 @@ Future<void> main() async {
     console.clear();
     FlutterError.resetErrorCount();
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/62223
+  test('Error reporting - empty stack', () async {
+    expect(console, isEmpty);
+    FlutterError.dumpErrorToConsole(FlutterErrorDetails(
+      exception: 'exception - empty stack',
+      stack: StackTrace.fromString(''),
+    ));
+    expect(console.join('\n'), matches(
+      r'^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
+      r'The following message was thrown:\n'
+      r'exception - empty stack\n'
+      r'\n'
+      r'When the exception was thrown, this was the stack:\n'
+      r'...\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
+    ));
+    console.clear();
+  });
 }


### PR DESCRIPTION
## Description

If callers specify an empty stack trace when creating the `FlutterErrorDetails` instance, then try to dump those details to the console, then it currently crashes (see associated issue).  This change filters out blank lines in the stack trace to keep the crash from being triggered.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62223

## Tests

I added the following tests:

* A regression test for this error condition.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
