### PR TITLE
Handle hyphens in iOS UDIDs

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -334,8 +334,9 @@ class XCDevice {
   }
 
   // Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
+  // Attach: 00008027-00192736010F802E
   // Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
-  final RegExp _observationIdentifierPattern = RegExp(r'^(\w*): (\w*)$');
+  final RegExp _observationIdentifierPattern = RegExp(r'^(\w*): ([\w-]*)$');
 
   Future<void> _startObservingTetheredIOSDevices() async {
     try {
@@ -367,6 +368,7 @@ class XCDevice {
         //
         // Listening for all devices, on both interfaces.
         // Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
+        // Attach: 00008027-00192736010F802E
         // Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
         // Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
         final RegExpMatch match = _observationIdentifierPattern.firstMatch(line);

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -356,8 +356,8 @@ void main() {
       );
 
       device2 = IOSDevice(
-        '43ad2fda7991b34fe1acbda82f9e2fd3d6ddc9f7',
-        name: 'iPhone 6s',
+        '00008027-00192736010F802E',
+        name: 'iPad Pro',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -400,29 +400,37 @@ void main() {
               'observe',
               '--both',
             ], stdout: 'Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418\n'
-            'Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418',
+              'Attach: 00008027-00192736010F802E\n'
+              'Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418',
             stderr: 'Some error',
           ));
 
-          final Completer<void> attach = Completer<void>();
-          final Completer<void> detach = Completer<void>();
+          final Completer<void> attach1 = Completer<void>();
+          final Completer<void> attach2 = Completer<void>();
+          final Completer<void> detach1 = Completer<void>();
 
           // Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
+          // Attach: 00008027-00192736010F802E
           // Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
           xcdevice.observedDeviceEvents().listen((Map<XCDeviceEvent, String> event) {
             expect(event.length, 1);
             if (event.containsKey(XCDeviceEvent.attach)) {
-              expect(event[XCDeviceEvent.attach], 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
-              attach.complete();
+              if (event[XCDeviceEvent.attach] == 'd83d5bc53967baa0ee18626ba87b6254b2ab5418') {
+                attach1.complete();
+              } else
+              if (event[XCDeviceEvent.attach] == '00008027-00192736010F802E') {
+                attach2.complete();
+              }
             } else if (event.containsKey(XCDeviceEvent.detach)) {
               expect(event[XCDeviceEvent.detach], 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
-              detach.complete();
+              detach1.complete();
             } else {
               fail('Unexpected event');
             }
           });
-          await attach.future;
-          await detach.future;
+          await attach1.future;
+          await attach2.future;
+          await detach1.future;
           expect(logger.traceText, contains('xcdevice observe error: Some error'));
         });
       });
@@ -463,7 +471,7 @@ void main() {
     "available" : true,
     "platform" : "com.apple.platform.iphoneos",
     "modelCode" : "iPhone8,1",
-    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "identifier" : "00008027-00192736010F802E",
     "architecture" : "arm64",
     "modelName" : "iPhone 6s",
     "name" : "An iPhone (Space Gray)"
@@ -542,7 +550,7 @@ void main() {
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
           expect(devices, hasLength(3));
-          expect(devices[0].id, 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
+          expect(devices[0].id, '00008027-00192736010F802E');
           expect(devices[0].name, 'An iPhone (Space Gray)');
           expect(await devices[0].sdkNameAndVersion, 'iOS 13.3');
           expect(devices[0].cpuArchitecture, DarwinArch.arm64);


### PR DESCRIPTION
## Description

Newer iOS device identifiers can contain a hyphen. Handle it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62100

## Tests

Updated xcode_test to make sure it handles UDIDs with hyphens.  This test does not pass on master.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*