### PR TITLE
prototype ignore semantics actions

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -930,7 +930,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
         child: EditableText(
           key: editableTextKey,
           controller: controller,
-          readOnly: widget.readOnly,
+          readOnly: widget.readOnly || !enabled,
           toolbarOptions: widget.toolbarOptions,
           showCursor: widget.showCursor,
           showSelectionHandles: _showSelectionHandles,

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1522,14 +1522,16 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
   // Create the semantics configuration for a single value.
   SemanticsConfiguration _createSemanticsConfiguration(
-      double value,
-      double increasedValue,
-      double decreasedValue,
-      String label,
-      VoidCallback increaseAction,
-      VoidCallback decreaseAction,
+    double value,
+    double increasedValue,
+    double decreasedValue,
+    String label,
+    VoidCallback increaseAction,
+    VoidCallback decreaseAction,
+    SemanticsConfiguration parentConfig,
   ) {
     final SemanticsConfiguration config = SemanticsConfiguration();
+    config.inheritedIgnoredActions = parentConfig.inheritedIgnoredActions;
     config.isEnabled = isEnabled;
     config.textDirection = textDirection;
     if (isEnabled) {
@@ -1565,7 +1567,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       labels?.start,
       _increaseStartAction,
       _decreaseStartAction,
+      config
     );
+
     final SemanticsConfiguration endSemanticsConfiguration = _createSemanticsConfiguration(
       values.end,
       _increasedEndValue,
@@ -1573,6 +1577,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       labels?.end,
       _increaseEndAction,
       _decreaseEndAction,
+      config
     );
 
     // Split the semantics node area between the start and end nodes.

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -629,12 +629,12 @@ class RenderCustomPaint extends RenderProxyBox {
     final List<CustomPainterSemantics> backgroundSemantics = _backgroundSemanticsBuilder != null
       ? _backgroundSemanticsBuilder(size)
       : const <CustomPainterSemantics>[];
-    _backgroundSemanticsNodes = _updateSemanticsChildren(_backgroundSemanticsNodes, backgroundSemantics);
+    _backgroundSemanticsNodes = _updateSemanticsChildren(_backgroundSemanticsNodes, backgroundSemantics, config);
 
     final List<CustomPainterSemantics> foregroundSemantics = _foregroundSemanticsBuilder != null
       ? _foregroundSemanticsBuilder(size)
       : const <CustomPainterSemantics>[];
-    _foregroundSemanticsNodes = _updateSemanticsChildren(_foregroundSemanticsNodes, foregroundSemantics);
+    _foregroundSemanticsNodes = _updateSemanticsChildren(_foregroundSemanticsNodes, foregroundSemantics, config);
 
     final bool hasBackgroundSemantics = _backgroundSemanticsNodes != null && _backgroundSemanticsNodes.isNotEmpty;
     final bool hasForegroundSemantics = _foregroundSemanticsNodes != null && _foregroundSemanticsNodes.isNotEmpty;
@@ -678,6 +678,7 @@ class RenderCustomPaint extends RenderProxyBox {
   static List<SemanticsNode> _updateSemanticsChildren(
     List<SemanticsNode> oldSemantics,
     List<CustomPainterSemantics> newChildSemantics,
+    SemanticsConfiguration parentConfig,
   ) {
     oldSemantics = oldSemantics ?? const <SemanticsNode>[];
     newChildSemantics = newChildSemantics ?? const <CustomPainterSemantics>[];
@@ -716,7 +717,7 @@ class RenderCustomPaint extends RenderProxyBox {
       final CustomPainterSemantics newSemantics = newChildSemantics[newChildrenTop];
       if (!_canUpdateSemanticsChild(oldChild, newSemantics))
         break;
-      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics);
+      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics, parentConfig);
       newChildren[newChildrenTop] = newChild;
       newChildrenTop += 1;
       oldChildrenTop += 1;
@@ -766,7 +767,7 @@ class RenderCustomPaint extends RenderProxyBox {
         }
       }
       assert(oldChild == null || _canUpdateSemanticsChild(oldChild, newSemantics));
-      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics);
+      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics, parentConfig);
       assert(oldChild == newChild || oldChild == null);
       newChildren[newChildrenTop] = newChild;
       newChildrenTop += 1;
@@ -784,7 +785,7 @@ class RenderCustomPaint extends RenderProxyBox {
       final SemanticsNode oldChild = oldSemantics[oldChildrenTop];
       final CustomPainterSemantics newSemantics = newChildSemantics[newChildrenTop];
       assert(_canUpdateSemanticsChild(oldChild, newSemantics));
-      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics);
+      final SemanticsNode newChild = _updateSemanticsChild(oldChild, newSemantics, parentConfig);
       assert(oldChild == newChild);
       newChildren[newChildrenTop] = newChild;
       newChildrenTop += 1;
@@ -813,7 +814,11 @@ class RenderCustomPaint extends RenderProxyBox {
   ///
   /// This method requires that `_canUpdateSemanticsChild(oldChild, newSemantics)`
   /// is true prior to calling it.
-  static SemanticsNode _updateSemanticsChild(SemanticsNode oldChild, CustomPainterSemantics newSemantics) {
+  static SemanticsNode _updateSemanticsChild(
+    SemanticsNode oldChild,
+    CustomPainterSemantics newSemantics,
+    SemanticsConfiguration parentConfig,
+  ) {
     assert(oldChild == null || _canUpdateSemanticsChild(oldChild, newSemantics));
 
     final SemanticsNode newChild = oldChild ?? SemanticsNode(
@@ -821,7 +826,8 @@ class RenderCustomPaint extends RenderProxyBox {
     );
 
     final SemanticsProperties properties = newSemantics.properties;
-    final SemanticsConfiguration config = SemanticsConfiguration();
+    final SemanticsConfiguration config = SemanticsConfiguration()
+      ..inheritedIgnoredActions = parentConfig.inheritedIgnoredActions;
     if (properties.sortKey != null) {
       config.sortKey = properties.sortKey;
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2507,6 +2507,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   SemanticsConfiguration get _semanticsConfiguration {
     if (_cachedSemanticsConfiguration == null) {
       _updateInheritedIgnoredSemanticsActions();
+      assert(_inheritedIgnoredSemanticsActions != null);
       _cachedSemanticsConfiguration = SemanticsConfiguration();
       _cachedSemanticsConfiguration.inheritedIgnoredActions = _inheritedIgnoredSemanticsActions;
       describeSemanticsConfiguration(_cachedSemanticsConfiguration);
@@ -2610,8 +2611,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   Set<SemanticsAction> _ignoredSemanticsActions;
 
   Set<SemanticsAction> _getIncomingIgnoredSemanticsActions() {
-    if (parent == null) {
-      // This is a root node.
+    if (parent == null || parent is! RenderObject) {
       return <SemanticsAction>{};
     }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -926,7 +926,8 @@ class RenderParagraph extends RenderBox
         final SemanticsConfiguration configuration = SemanticsConfiguration()
           ..sortKey = OrdinalSortKey(ordinal++)
           ..textDirection = initialDirection
-          ..label = info.semanticsLabel ?? info.text;
+          ..label = info.semanticsLabel ?? info.text
+          ..inheritedIgnoredActions = config.inheritedIgnoredActions;
         final GestureRecognizer recognizer = info.recognizer;
         if (recognizer != null) {
           if (recognizer is TapGestureRecognizer) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2879,8 +2879,10 @@ class SemanticsConfiguration {
   VoidCallback get onTap => _onTap;
   VoidCallback _onTap;
   set onTap(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.tap))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.tap)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.tap, value);
     _onTap = value;
   }
@@ -2896,8 +2898,10 @@ class SemanticsConfiguration {
   VoidCallback get onLongPress => _onLongPress;
   VoidCallback _onLongPress;
   set onLongPress(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.longPress))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.longPress)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.longPress, value);
     _onLongPress = value;
   }
@@ -2916,8 +2920,10 @@ class SemanticsConfiguration {
   VoidCallback get onScrollLeft => _onScrollLeft;
   VoidCallback _onScrollLeft;
   set onScrollLeft(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.scrollLeft))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.scrollLeft)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.scrollLeft, value);
     _onScrollLeft = value;
   }
@@ -2932,8 +2938,10 @@ class SemanticsConfiguration {
   VoidCallback get onDismiss => _onDismiss;
   VoidCallback _onDismiss;
   set onDismiss(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.dismiss))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.dismiss)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.dismiss, value);
     _onDismiss = value;
   }
@@ -2952,8 +2960,10 @@ class SemanticsConfiguration {
   VoidCallback get onScrollRight => _onScrollRight;
   VoidCallback _onScrollRight;
   set onScrollRight(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.scrollRight))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.scrollRight)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.scrollRight, value);
     _onScrollRight = value;
   }
@@ -2972,8 +2982,10 @@ class SemanticsConfiguration {
   VoidCallback get onScrollUp => _onScrollUp;
   VoidCallback _onScrollUp;
   set onScrollUp(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.scrollUp))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.scrollUp)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.scrollUp, value);
     _onScrollUp = value;
   }
@@ -2992,8 +3004,10 @@ class SemanticsConfiguration {
   VoidCallback get onScrollDown => _onScrollDown;
   VoidCallback _onScrollDown;
   set onScrollDown(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.scrollDown))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.scrollDown)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.scrollDown, value);
     _onScrollDown = value;
   }
@@ -3012,8 +3026,10 @@ class SemanticsConfiguration {
   VoidCallback get onIncrease => _onIncrease;
   VoidCallback _onIncrease;
   set onIncrease(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.increase))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.increase)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.increase, value);
     _onIncrease = value;
   }
@@ -3032,8 +3048,10 @@ class SemanticsConfiguration {
   VoidCallback get onDecrease => _onDecrease;
   VoidCallback _onDecrease;
   set onDecrease(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.decrease))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.decrease)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.decrease, value);
     _onDecrease = value;
   }
@@ -3047,8 +3065,10 @@ class SemanticsConfiguration {
   VoidCallback get onCopy => _onCopy;
   VoidCallback _onCopy;
   set onCopy(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.copy))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.copy)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.copy, value);
     _onCopy = value;
   }
@@ -3063,8 +3083,10 @@ class SemanticsConfiguration {
   VoidCallback get onCut => _onCut;
   VoidCallback _onCut;
   set onCut(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.cut))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.cut)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.cut, value);
     _onCut = value;
   }
@@ -3078,8 +3100,10 @@ class SemanticsConfiguration {
   VoidCallback get onPaste => _onPaste;
   VoidCallback _onPaste;
   set onPaste(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.paste))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.paste)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.paste, value);
     _onPaste = value;
   }
@@ -3096,8 +3120,10 @@ class SemanticsConfiguration {
   VoidCallback get onShowOnScreen => _onShowOnScreen;
   VoidCallback _onShowOnScreen;
   set onShowOnScreen(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.showOnScreen))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.showOnScreen)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.showOnScreen, value);
     _onShowOnScreen = value;
   }
@@ -3113,8 +3139,10 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorForwardByCharacter;
   set onMoveCursorForwardByCharacter(MoveCursorHandler value) {
     assert(value != null);
-    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByCharacter))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByCharacter)) {
       return;
+    }
     _addAction(SemanticsAction.moveCursorForwardByCharacter, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3134,8 +3162,10 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorBackwardByCharacter;
   set onMoveCursorBackwardByCharacter(MoveCursorHandler value) {
     assert(value != null);
-    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByCharacter))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByCharacter)) {
       return;
+    }
     _addAction(SemanticsAction.moveCursorBackwardByCharacter, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3155,8 +3185,10 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorForwardByWord;
   set onMoveCursorForwardByWord(MoveCursorHandler value) {
     assert(value != null);
-    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByWord))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByWord)) {
       return;
+    }
     _addAction(SemanticsAction.moveCursorForwardByWord, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3176,8 +3208,10 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorBackwardByWord;
   set onMoveCursorBackwardByWord(MoveCursorHandler value) {
     assert(value != null);
-    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByWord))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByWord)) {
       return;
+    }
     _addAction(SemanticsAction.moveCursorBackwardByWord, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3197,8 +3231,10 @@ class SemanticsConfiguration {
   SetSelectionHandler _onSetSelection;
   set onSetSelection(SetSelectionHandler value) {
     assert(value != null);
-    if (inheritedIgnoredActions.contains(SemanticsAction.setSelection))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.setSelection)) {
       return;
+    }
     _addAction(SemanticsAction.setSelection, (dynamic args) {
       assert(args != null && args is Map);
       final Map<String, int> selection = (args as Map<dynamic, dynamic>).cast<String, int>();
@@ -3231,8 +3267,10 @@ class SemanticsConfiguration {
   VoidCallback get onDidGainAccessibilityFocus => _onDidGainAccessibilityFocus;
   VoidCallback _onDidGainAccessibilityFocus;
   set onDidGainAccessibilityFocus(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.didGainAccessibilityFocus))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.didGainAccessibilityFocus)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.didGainAccessibilityFocus, value);
     _onDidGainAccessibilityFocus = value;
   }
@@ -3257,8 +3295,10 @@ class SemanticsConfiguration {
   VoidCallback get onDidLoseAccessibilityFocus => _onDidLoseAccessibilityFocus;
   VoidCallback _onDidLoseAccessibilityFocus;
   set onDidLoseAccessibilityFocus(VoidCallback value) {
-    if (inheritedIgnoredActions.contains(SemanticsAction.didLoseAccessibilityFocus))
+    if (inheritedIgnoredActions != null &&
+        inheritedIgnoredActions.contains(SemanticsAction.didLoseAccessibilityFocus)) {
       return;
+    }
     _addArgumentlessAction(SemanticsAction.didLoseAccessibilityFocus, value);
     _onDidLoseAccessibilityFocus = value;
   }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2818,7 +2818,8 @@ class SemanticsConfiguration {
 
   /// Aggregated ignored semantics actions from ancestors.
   ///
-  /// This set is used for post filtering of semantics action related api.
+  /// This set is used for blocking the semantics action setter from registering
+  /// semantics action handler.
   Set<SemanticsAction> inheritedIgnoredActions;
 
   /// The actions (with associated action handlers) that this configuration

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2816,6 +2816,11 @@ class SemanticsConfiguration {
   bool get hasBeenAnnotated => _hasBeenAnnotated;
   bool _hasBeenAnnotated = false;
 
+  /// Aggregated ignored semantics actions from ancestors.
+  ///
+  /// This set is used for post filtering of semantics action related api.
+  Set<SemanticsAction> inheritedIgnoredActions;
+
   /// The actions (with associated action handlers) that this configuration
   /// would like to contribute to the semantics tree.
   ///
@@ -2873,6 +2878,8 @@ class SemanticsConfiguration {
   VoidCallback get onTap => _onTap;
   VoidCallback _onTap;
   set onTap(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.tap))
+      return;
     _addArgumentlessAction(SemanticsAction.tap, value);
     _onTap = value;
   }
@@ -2888,6 +2895,8 @@ class SemanticsConfiguration {
   VoidCallback get onLongPress => _onLongPress;
   VoidCallback _onLongPress;
   set onLongPress(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.longPress))
+      return;
     _addArgumentlessAction(SemanticsAction.longPress, value);
     _onLongPress = value;
   }
@@ -2906,6 +2915,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollLeft => _onScrollLeft;
   VoidCallback _onScrollLeft;
   set onScrollLeft(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.scrollLeft))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollLeft, value);
     _onScrollLeft = value;
   }
@@ -2920,6 +2931,8 @@ class SemanticsConfiguration {
   VoidCallback get onDismiss => _onDismiss;
   VoidCallback _onDismiss;
   set onDismiss(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.dismiss))
+      return;
     _addArgumentlessAction(SemanticsAction.dismiss, value);
     _onDismiss = value;
   }
@@ -2938,6 +2951,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollRight => _onScrollRight;
   VoidCallback _onScrollRight;
   set onScrollRight(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.scrollRight))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollRight, value);
     _onScrollRight = value;
   }
@@ -2956,6 +2971,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollUp => _onScrollUp;
   VoidCallback _onScrollUp;
   set onScrollUp(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.scrollUp))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollUp, value);
     _onScrollUp = value;
   }
@@ -2974,6 +2991,8 @@ class SemanticsConfiguration {
   VoidCallback get onScrollDown => _onScrollDown;
   VoidCallback _onScrollDown;
   set onScrollDown(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.scrollDown))
+      return;
     _addArgumentlessAction(SemanticsAction.scrollDown, value);
     _onScrollDown = value;
   }
@@ -2992,6 +3011,8 @@ class SemanticsConfiguration {
   VoidCallback get onIncrease => _onIncrease;
   VoidCallback _onIncrease;
   set onIncrease(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.increase))
+      return;
     _addArgumentlessAction(SemanticsAction.increase, value);
     _onIncrease = value;
   }
@@ -3010,6 +3031,8 @@ class SemanticsConfiguration {
   VoidCallback get onDecrease => _onDecrease;
   VoidCallback _onDecrease;
   set onDecrease(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.decrease))
+      return;
     _addArgumentlessAction(SemanticsAction.decrease, value);
     _onDecrease = value;
   }
@@ -3023,6 +3046,8 @@ class SemanticsConfiguration {
   VoidCallback get onCopy => _onCopy;
   VoidCallback _onCopy;
   set onCopy(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.copy))
+      return;
     _addArgumentlessAction(SemanticsAction.copy, value);
     _onCopy = value;
   }
@@ -3037,6 +3062,8 @@ class SemanticsConfiguration {
   VoidCallback get onCut => _onCut;
   VoidCallback _onCut;
   set onCut(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.cut))
+      return;
     _addArgumentlessAction(SemanticsAction.cut, value);
     _onCut = value;
   }
@@ -3050,6 +3077,8 @@ class SemanticsConfiguration {
   VoidCallback get onPaste => _onPaste;
   VoidCallback _onPaste;
   set onPaste(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.paste))
+      return;
     _addArgumentlessAction(SemanticsAction.paste, value);
     _onPaste = value;
   }
@@ -3066,6 +3095,8 @@ class SemanticsConfiguration {
   VoidCallback get onShowOnScreen => _onShowOnScreen;
   VoidCallback _onShowOnScreen;
   set onShowOnScreen(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.showOnScreen))
+      return;
     _addArgumentlessAction(SemanticsAction.showOnScreen, value);
     _onShowOnScreen = value;
   }
@@ -3081,6 +3112,8 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorForwardByCharacter;
   set onMoveCursorForwardByCharacter(MoveCursorHandler value) {
     assert(value != null);
+    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByCharacter))
+      return;
     _addAction(SemanticsAction.moveCursorForwardByCharacter, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3100,6 +3133,8 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorBackwardByCharacter;
   set onMoveCursorBackwardByCharacter(MoveCursorHandler value) {
     assert(value != null);
+    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByCharacter))
+      return;
     _addAction(SemanticsAction.moveCursorBackwardByCharacter, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3119,6 +3154,8 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorForwardByWord;
   set onMoveCursorForwardByWord(MoveCursorHandler value) {
     assert(value != null);
+    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorForwardByWord))
+      return;
     _addAction(SemanticsAction.moveCursorForwardByWord, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3138,6 +3175,8 @@ class SemanticsConfiguration {
   MoveCursorHandler _onMoveCursorBackwardByWord;
   set onMoveCursorBackwardByWord(MoveCursorHandler value) {
     assert(value != null);
+    if (inheritedIgnoredActions.contains(SemanticsAction.moveCursorBackwardByWord))
+      return;
     _addAction(SemanticsAction.moveCursorBackwardByWord, (dynamic args) {
       final bool extentSelection = args as bool;
       assert(extentSelection != null);
@@ -3157,6 +3196,8 @@ class SemanticsConfiguration {
   SetSelectionHandler _onSetSelection;
   set onSetSelection(SetSelectionHandler value) {
     assert(value != null);
+    if (inheritedIgnoredActions.contains(SemanticsAction.setSelection))
+      return;
     _addAction(SemanticsAction.setSelection, (dynamic args) {
       assert(args != null && args is Map);
       final Map<String, int> selection = (args as Map<dynamic, dynamic>).cast<String, int>();
@@ -3189,6 +3230,8 @@ class SemanticsConfiguration {
   VoidCallback get onDidGainAccessibilityFocus => _onDidGainAccessibilityFocus;
   VoidCallback _onDidGainAccessibilityFocus;
   set onDidGainAccessibilityFocus(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.didGainAccessibilityFocus))
+      return;
     _addArgumentlessAction(SemanticsAction.didGainAccessibilityFocus, value);
     _onDidGainAccessibilityFocus = value;
   }
@@ -3213,6 +3256,8 @@ class SemanticsConfiguration {
   VoidCallback get onDidLoseAccessibilityFocus => _onDidLoseAccessibilityFocus;
   VoidCallback _onDidLoseAccessibilityFocus;
   set onDidLoseAccessibilityFocus(VoidCallback value) {
+    if (inheritedIgnoredActions.contains(SemanticsAction.didLoseAccessibilityFocus))
+      return;
     _addArgumentlessAction(SemanticsAction.didLoseAccessibilityFocus, value);
     _onDidLoseAccessibilityFocus = value;
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6438,9 +6438,10 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
   const IgnorePointer({
     Key key,
     this.ignoring = true,
-    this.ignoringSemantics,
+    this.ignoringSemantics = false,
     Widget child,
   }) : assert(ignoring != null),
+       assert(ignoringSemantics != null),
        super(key: key, child: child);
 
   /// Whether this widget is ignored during hit testing.

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -173,7 +173,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
         child: Listener(
           onPointerDown: _handlePointerDown,
           behavior: HitTestBehavior.opaque,
-          child: IgnorePointer(
+          child: AbsorbPointer(
             ignoringSemantics: false,
             child: widget.child,
           ),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -3991,6 +3991,8 @@ void main() {
       matchesSemantics(
         isEnabled: false,
         hasEnabledState: true,
+        isReadOnly: true,
+        isTextField: true,
         hasTapAction: false,
       ),
     );

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -59,7 +59,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child1',
                   textDirection: TextDirection.ltr,
@@ -101,7 +101,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -155,7 +155,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -197,7 +197,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -37,7 +37,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -91,7 +91,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: true,
+                ignoringSemantics: true,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,
@@ -133,7 +133,7 @@ void main() {
             Container(
               height: 10.0,
               child: IgnorePointer(
-                ignoring: false,
+                ignoringSemantics: false,
                 child: Semantics(
                   label: 'child2',
                   textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/visibility_test.dart
+++ b/packages/flutter/test/widgets/visibility_test.dart
@@ -63,6 +63,20 @@ void main() {
       ignoreTransform: true,
     );
 
+    final Matcher expectedSemanticsWhenPresentNotInteractive = hasSemantics(
+      TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics.rootChild(
+            label: 'a true',
+            textDirection: TextDirection.rtl,
+          ),
+        ],
+      ),
+      ignoreId: true,
+      ignoreRect: true,
+      ignoreTransform: true,
+    );
+
     final Matcher expectedSemanticsWhenAbsent = hasSemantics(TestSemantics.root());
 
     // We now run a sequence of pumpWidget calls one after the other. In
@@ -221,7 +235,7 @@ void main() {
     expect(find.byType(Placeholder), findsNothing);
     expect(find.byType(Visibility), paintsNothing);
     expect(tester.getSize(find.byType(Visibility)), const Size(84.0, 14.0));
-    expect(semantics, expectedSemanticsWhenPresent);
+    expect(semantics, expectedSemanticsWhenPresentNotInteractive);
     expect(log, <String>['created new state']);
     await tester.tap(find.byType(Visibility));
     expect(log, <String>['created new state']);


### PR DESCRIPTION
## Description
Revived from https://github.com/flutter/flutter/pull/37199
The IgnorePointer/SliverIgnorePointer before this pr
```
if ignoringSemantics = true
     no semantics segmantics should be collected from the subtree
else if ignoringSemantics= false
     collect all semantics (including pointer related semantics) even if ignore = true
else if  ignoringSemantics = null
     if ignore = true
           no semantics segmantics should be collected from the subtree
     else
          collect all semantics
```

After this pr, the ignoringSemantics cannot be null

```
if ignoringSemantics = true
     no semantics segmantics should be collected from the subtree
else
     if ignoring= true
           collect all the semantics except pointer related semantics action (tap, longpress, and scrolling etc)
    else
           collect all semantics
```

There are still open question what should we apply the same thing to absorb pointer?

What to do with the SemanticsDebugger that uses IgnorePointer to capture the pointer event but still want the rest of rendering tree untouched?

testing example https://gist.github.com/chunhtai/a8cfdab140538694e7fa1138c5a6fb2d
## Related Issues

Fixes https://github.com/flutter/flutter/issues/59402

## Tests

I added the following tests:

existing test coverage + will add more test if we want to move forward with this prototype

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
