### PR TITLE
[flutter_tools] fix exit label for batchfile

### DIFF
--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -32,6 +32,3 @@ REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
 "%dart%" %* & exit /B !ERRORLEVEL!
-
-:final_exit
-EXIT /B %exit_code%

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -52,4 +52,3 @@ REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
 "%dart%" --disable-dart-dev --packages="%flutter_tools_dir%\.packages" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & exit /B !ERRORLEVEL!
-

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -53,5 +53,3 @@ REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
 "%dart%" --disable-dart-dev --packages="%flutter_tools_dir%\.packages" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & exit /B !ERRORLEVEL!
 
-:final_exit
-EXIT /B %exit_code%

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -158,3 +158,6 @@ GOTO :after_subroutine
   EXIT /B
 
 :after_subroutine
+
+:final_exit
+  EXIT /B %exit_code%

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -161,3 +161,4 @@ GOTO :after_subroutine
 
 :final_exit
   EXIT /B %exit_code%
+  

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -161,4 +161,3 @@ GOTO :after_subroutine
 
 :final_exit
   EXIT /B %exit_code%
-  


### PR DESCRIPTION
## Description

move the final_exit label to the correct script location for the flutter/dart entrypoints.
