### PR TITLE
Fix some broken doc references

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -49,7 +49,6 @@ export 'src/material/circle_avatar.dart';
 export 'src/material/color_scheme.dart';
 export 'src/material/colors.dart';
 export 'src/material/constants.dart';
-export 'src/material/curves.dart';
 export 'src/material/data_table.dart';
 export 'src/material/data_table_source.dart';
 export 'src/material/debug.dart';

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -49,6 +49,7 @@ export 'src/material/circle_avatar.dart';
 export 'src/material/color_scheme.dart';
 export 'src/material/colors.dart';
 export 'src/material/constants.dart';
+export 'src/material/curves.dart';
 export 'src/material/data_table.dart';
 export 'src/material/data_table_source.dart';
 export 'src/material/debug.dart';

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -303,7 +303,7 @@ class CupertinoDatePicker extends StatefulWidget {
   /// The minimum selectable date that the picker can settle on.
   ///
   /// When non-null, the user can still scroll the picker to [DateTime]s earlier
-  /// than [minimumDate], but the [onDateChangeCallback] will not be called on
+  /// than [minimumDate], but the [onDateTimeChanged] will not be called on
   /// these [DateTime]s. Once let go, the picker will scroll back to [minimumDate].
   ///
   /// In [CupertinoDatePickerMode.time] mode, a time becomes unselectable if the
@@ -318,7 +318,7 @@ class CupertinoDatePicker extends StatefulWidget {
   /// The maximum selectable date that the picker can settle on.
   ///
   /// When non-null, the user can still scroll the picker to [DateTime]s later
-  /// than [maximumDate], but the [onDateChangeCallback] will not be called on
+  /// than [maximumDate], but the [onDateTimeChanged] will not be called on
   /// these [DateTime]s. Once let go, the picker will scroll back to [maximumDate].
   ///
   /// In [CupertinoDatePickerMode.time] mode, a time becomes unselectable if the

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -77,7 +77,7 @@ class CupertinoTheme extends StatelessWidget {
   /// on the value of [CupertinoThemeData.brightness] in the given [context].
   ///
   /// If no [CupertinoTheme] can be found in the given [context], or its `brightness`
-  /// is null, it will fall back to [MediaQueryData.brightness].
+  /// is null, it will fall back to [MediaQueryData.platformBrightness].
   ///
   /// Throws an exception if no valid [CupertinoTheme] or [MediaQuery] widgets
   /// exist in the ancestry tree, unless [nullOk] is set to true.

--- a/packages/flutter/lib/src/foundation/collections.dart
+++ b/packages/flutter/lib/src/foundation/collections.dart
@@ -13,7 +13,7 @@
 /// The term "deep" above refers to the first level of equality: if the elements
 /// are maps, lists, sets, or other collections/composite objects, then the
 /// values of those elements are not compared element by element unless their
-/// equality operators ([Object.operator==]) do so.
+/// equality operators ([Object.==]) do so.
 ///
 /// See also:
 ///
@@ -42,7 +42,7 @@ bool setEquals<T>(Set<T>? a, Set<T>? b) {
 /// The term "deep" above refers to the first level of equality: if the elements
 /// are maps, lists, sets, or other collections/composite objects, then the
 /// values of those elements are not compared element by element unless their
-/// equality operators ([Object.operator==]) do so.
+/// equality operators ([Object.==]) do so.
 ///
 /// See also:
 ///
@@ -71,7 +71,7 @@ bool listEquals<T>(List<T>? a, List<T>? b) {
 /// The term "deep" above refers to the first level of equality: if the elements
 /// are maps, lists, sets, or other collections/composite objects, then the
 /// values of those elements are not compared element by element unless their
-/// equality operators ([Object.operator==]) do so.
+/// equality operators ([Object.==]) do so.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -65,7 +65,7 @@ class HitTestEntry {
   ///
   /// See also:
   ///
-  ///  * [HitTestResult.addWithPaintTransform], which is used during hit testing
+  ///  * [BoxHitTestResult.addWithPaintTransform], which is used during hit testing
   ///    to build up this transform.
   Matrix4 get transform => _transform;
   Matrix4 _transform;

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -120,7 +120,7 @@ class ChipTheme extends InheritedTheme {
 ///
 /// The simplest way to create a ChipThemeData is to use [copyWith] on the one
 /// you get from [ChipTheme.of], or create an entirely new one with
-/// [ChipThemeData..fromDefaults].
+/// [ChipThemeData.fromDefaults].
 ///
 /// {@tool snippet}
 ///

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -30,7 +30,7 @@ import 'theme_data.dart';
 /// An elevated button is a label [child] displayed on a [Material]
 /// widget whose [Material.elevation] increases when the button is
 /// pressed. The label's [Text] and [Icon] widgets are displayed in
-/// [style]'s [ButtonStyle.onForegroundColor] and the button's filled
+/// [style]'s [ButtonStyle.foregroundColor] and the button's filled
 /// background is the [ButtonStyle.backgroundColor].
 ///
 /// The elevated button's default style is defined by
@@ -39,7 +39,7 @@ import 'theme_data.dart';
 /// buttons in a subtree can be overridden with the
 /// [ElevatedButtonTheme], and the style of all of the contained
 /// buttons in an app can be overridden with the [Theme]'s
-/// [ThemeData.ElevatedButtonTheme] property.
+/// [ThemeData.elevatedButtonTheme] property.
 ///
 /// The static [styleFrom] method is a convenient way to create a
 /// elevated button [ButtonStyle] from simple values.

--- a/packages/flutter/lib/src/material/elevated_button_theme.dart
+++ b/packages/flutter/lib/src/material/elevated_button_theme.dart
@@ -12,7 +12,7 @@ import 'theme.dart';
 
 /// A [ButtonStyle] that overrides the default appearance of
 /// [ElevatedButton]s when it's used with [ElevatedButtonTheme] or with the
-/// overall [Theme]'s [ThemeData.ElevatedButtonTheme].
+/// overall [Theme]'s [ThemeData.elevatedButtonTheme].
 ///
 /// The [style]'s properties override [ElevatedButton]'s default style,
 /// i.e.  the [ButtonStyle] returned by [ElevatedButton.defaultStyleOf]. Only
@@ -24,11 +24,11 @@ import 'theme.dart';
 ///  * [ElevatedButtonTheme], the theme which is configured with this class.
 ///  * [ElevatedButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for text buttons.
-///  * [ElevatedButton.styleOf], which converts simple values into a
+///  * [ElevatedButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [ElevatedButton]'s defaults.
 ///  * [MaterialStateProperty.resolve], "resolve" a material state property
 ///    to a simple value based on a set of [MaterialState]s.
-///  * [ThemeData.ElevatedButtonTheme], which can be used to override the default
+///  * [ThemeData.elevatedButtonTheme], which can be used to override the default
 ///    [ButtonStyle] for [ElevatedButton]s below the overall [Theme].
 @immutable
 class ElevatedButtonThemeData with Diagnosticable {
@@ -84,9 +84,9 @@ class ElevatedButtonThemeData with Diagnosticable {
 ///  * [ElevatedButtonThemeData], which is used to configure this theme.
 ///  * [ElevatedButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for elevated buttons.
-///  * [ElevatedButton.styleOf], which converts simple values into a
+///  * [ElevatedButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [ElevatedButton]'s defaults.
-///  * [ThemeData.ElevatedButtonTheme], which can be used to override the default
+///  * [ThemeData.elevatedButtonTheme], which can be used to override the default
 ///    [ButtonStyle] for [ElevatedButton]s below the overall [Theme].
 class ElevatedButtonTheme extends InheritedTheme {
   /// Create a [ElevatedButtonTheme].
@@ -104,7 +104,7 @@ class ElevatedButtonTheme extends InheritedTheme {
   /// The closest instance of this class that encloses the given context.
   ///
   /// If there is no enclosing [ElevatedButtonsTheme] widget, then
-  /// [ThemeData.ElevatedButtonTheme] is used.
+  /// [ThemeData.elevatedButtonTheme] is used.
   ///
   /// Typical usage is as follows:
   ///

--- a/packages/flutter/lib/src/material/outlined_button_theme.dart
+++ b/packages/flutter/lib/src/material/outlined_button_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///  * [OutlinedButtonTheme], the theme which is configured with this class.
 ///  * [OutlinedButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for outlined buttons.
-///  * [OutlinedButton.styleOf], which converts simple values into a
+///  * [OutlinedButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [OutlinedButton]'s defaults.
 ///  * [MaterialStateProperty.resolve], "resolve" a material state property
 ///    to a simple value based on a set of [MaterialState]s.
@@ -84,7 +84,7 @@ class OutlinedButtonThemeData with Diagnosticable {
 ///  * [OutlinedButtonThemeData], which is used to configure this theme.
 ///  * [OutlinedButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for outlined buttons.
-///  * [OutlinedButton.styleOf], which converts simple values into a
+///  * [OutlinedButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [OutlinedButton]'s defaults.
 ///  * [ThemeData.outlinedButtonTheme], which can be used to override the default
 ///    [ButtonStyle] for [OutlinedButton]s below the overall [Theme].

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -94,7 +94,7 @@ typedef PaintRangeValueIndicator = void Function(PaintingContext context, Offset
 /// The range slider widget itself does not maintain any state. Instead, when
 /// the state of the slider changes, the widget calls the [onChanged] callback.
 /// Most widgets that use a range slider will listen for the [onChanged] callback
-/// and rebuild the slider with a new [value] to update the visual appearance of
+/// and rebuild the slider with new [values] to update the visual appearance of
 /// the slider. To know when the value starts to change, or when it is done
 /// changing, set the optional callbacks [onChangeStart] and/or [onChangeEnd].
 ///

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -68,8 +68,8 @@ Future<T> showSearch<T>({
 ///
 /// The search page always shows an [AppBar] at the top where users can
 /// enter their search queries. The buttons shown before and after the search
-/// query text field can be customized via [SearchDelegate.leading] and
-/// [SearchDelegate.actions].
+/// query text field can be customized via [SearchDelegate.buildLeading] and
+/// [SearchDelegate.buildActions].
 ///
 /// The body below the [AppBar] can either show suggested queries (returned by
 /// [SearchDelegate.buildSuggestions]) or - once the user submits a search  - the

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -790,7 +790,7 @@ class SliderThemeData with Diagnosticable {
 /// See also:
 ///
 ///  * [RoundSliderThumbShape], which is the default [Slider]'s thumb shape that
-///     paints a solid circle.
+///    paints a solid circle.
 ///  * [RoundSliderOverlayShape], which is the default [Slider] and
 ///    [RangeSlider]'s overlay shape that paints a transparent circle.
 ///  * [PaddleSliderValueIndicatorShape], which is the default [Slider]'s value

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -774,85 +774,6 @@ class SliderThemeData with Diagnosticable {
   }
 }
 
-/// {@template flutter.material.slider.shape.center}
-/// [center] is the offset for where this shape's center should be painted.
-/// This offset is relative to the origin of the [context] canvas.
-/// {@endtemplate}
-///
-/// {@template flutter.material.slider.shape.context}
-/// [context] is the same as the one that includes the [Slider]'s render box.
-/// {@endtemplate}
-///
-/// {@template flutter.material.slider.shape.enableAnimation}
-/// [enableAnimation] is an animation triggered when the [Slider] is enabled,
-/// and it reverses when the slider is disabled. Enabled is the
-/// [Slider.isInteractive] state. Use this to paint intermediate frames for
-/// this shape when the slider changes enabled state.
-/// {@endtemplate}
-///
-/// {@template flutter.material.slider.shape.isDiscrete}
-/// [isDiscrete] is true if [Slider.divisions] is non-null. If true, the
-/// slider will render tick marks on top of the track.
-/// {@endtemplate}
-///
-/// {@template flutter.material.slider.shape.isEnabled}
-/// [isEnabled] has the same value as [Slider.isInteractive]. If true, the
-/// slider will respond to input.
-/// {@endtemplate}
-///
-/// {@template flutter.material.slider.shape.parentBox}
-/// [parentBox] is the [RenderBox] of the [Slider]. Its attributes, such as
-/// size, can be used to assist in painting this shape.
-/// {@endtemplate}
-//
-/// {@template flutter.material.slider.shape.sliderTheme}
-/// [sliderTheme] is the theme assigned to the [Slider] that this shape
-/// belongs to.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.activationAnimation}
-/// [activationAnimation] is an animation triggered when the user begins
-/// to interact with the [RangeSlider]. It reverses when the user stops
-/// interacting with the slider.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.context}
-/// [context] is the same as the one that includes the [RangeSlider]'s render
-/// box.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.enableAnimation}
-/// [enableAnimation] is an animation triggered when the [RangeSlider] is
-/// enabled, and it reverses when the slider is disabled. Enabled is the
-/// [RangeSlider.isEnabled] state. Use this to paint intermediate frames for
-/// this shape when the slider changes enabled state.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.isDiscrete}
-/// [isDiscrete] is true if [RangeSlider.divisions] is non-null. If true, the
-/// slider will render tick marks on top of the track.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.isEnabled}
-/// [isEnabled] has the same value as [RangeSlider.isEnabled]. If true, the
-/// slider will respond to input.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.parentBox}
-/// [parentBox] is the [RenderBox] of the [RangeSlider]. Its attributes, such as
-/// size, can be used to assist in painting this shape.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.sliderTheme}
-/// [sliderTheme] is the theme assigned to the [RangeSlider] that this shape
-/// belongs to.
-/// {@endtemplate}
-///
-/// {@template flutter.material.rangeSlider.shape.thumb}
-/// [thumb] Is the specifier for which of the two thumbs this method should
-/// paint, start or end.
-/// {@endtemplate}
-
 /// Base class for slider thumb, thumb overlay, and value indicator shapes.
 ///
 /// Create a subclass of this if you would like a custom shape.
@@ -868,18 +789,12 @@ class SliderThemeData with Diagnosticable {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.roundSliderThumbShape}
 ///  * [RoundSliderThumbShape], which is the default [Slider]'s thumb shape that
-///    paints a solid circle.
-/// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.roundSliderOverlayShape}
+///     paints a solid circle.
 ///  * [RoundSliderOverlayShape], which is the default [Slider] and
-///   [RangeSlider]'s overlay shape that paints a transparent circle.
-/// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.paddleSliderValueIndicatorShape}
+///    [RangeSlider]'s overlay shape that paints a transparent circle.
 ///  * [PaddleSliderValueIndicatorShape], which is the default [Slider]'s value
 ///    indicator shape that paints a custom path with text in it.
-/// {@endtemplate}
 abstract class SliderComponentShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -890,44 +805,67 @@ abstract class SliderComponentShape {
 
   /// Paints the shape, taking into account the state passed to it.
   ///
-  /// {@macro flutter.material.slider.shape.context}
-  ///
-  /// {@macro flutter.material.slider.shape.center}
-  ///
-  /// [activationAnimation] is an animation triggered when the user begins
-  /// to interact with the slider. It reverses when the user stops interacting
-  /// with the slider.
-  ///
-  /// {@macro flutter.material.slider.shape.enableAnimation}
-  ///
-  /// {@macro flutter.material.slider.shape.isDiscrete}
-  ///
-  /// If [labelPainter] is non-null, then [labelPainter.paint] should be
-  /// called with the location that the label should appear. If the labelPainter
-  /// parameter is null, then no label was supplied to the [Slider].
-  ///
-  /// {@macro flutter.material.slider.shape.parentBox}
-  ///
-  /// {@macro flutter.material.slider.shape.sliderTheme}
-  ///
-  /// [textDirection] can be used to determine how any extra text or graphics,
-  /// besides the text painted by the [labelPainter] should be positioned. The
-  /// [labelPainter] already has the [textDirection] set.
-  ///
-  /// [value] is the current parametric value (from 0.0 to 1.0) of the slider.
-  ///
-  /// {@template flutter.material.slider.shape.textScaleFactor}
-  /// Can be used to determine whether the component should
-  /// paint larger or smaller, depending on whether [textScaleFactor] is greater
-  /// than 1 for larger, and between 0 and 1 for smaller. It usually comes from
-  /// [MediaQueryData.textScaleFactor].
+  /// {@template flutter.material.slider.shape.argument.context}
+  /// The `context` argument is the same as the one that includes the [Slider]'s
+  /// render box.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.slider.shape.sizeWithOverflow}
-  /// Can be used to determine the bounds the drawing of the
-  /// components that are outside of the regular slider bounds. It's the size of
-  /// the box, whose center is aligned with the slider's bounds, that the value
-  /// indicators must be drawn within. Typically, it is bigger than the slider.
+  /// {@template flutter.material.slider.shape.argument.center}
+  /// The `center` argument is the offset for where this shape's center should be
+  /// painted. This offset is relative to the origin of the [context] canvas.
+  /// {@endtemplate}
+  ///
+  /// The `activationAnimation` argument is an animation triggered when the user
+  /// begins to interact with the slider. It reverses when the user stops interacting
+  /// with the slider.
+  ///
+  /// {@template flutter.material.slider.shape.argument.enableAnimation}
+  /// The `enableAnimation` argument is an animation triggered when the [Slider]
+  /// is enabled, and it reverses when the slider is disabled. Enabled is the
+  /// [Slider.isInteractive] state. Use this to paint intermediate frames for
+  /// this shape when the slider changes enabled state.
+  /// {@endtemplate}
+  ///
+  /// {@template flutter.material.slider.shape.argument.isDiscrete}
+  /// The `isDiscrete` argument is true if [Slider.divisions] is non-null. When
+  /// true, the slider will render tick marks on top of the track.
+  /// {@endtemplate}
+  ///
+  /// If the `labelPainter` argument is non-null, then [TextPainter.paint]
+  /// should be called on the `labelPainter` with the location that the label
+  /// should appear. If the `labelPainter` argument is null, then no label was
+  /// supplied to the [Slider].
+  ///
+  /// {@template flutter.material.slider.shape.argument.parentBox}
+  /// The `parentBox` argument is the [RenderBox] of the [Slider]. Its attributes,
+  /// such as size, can be used to assist in painting this shape.
+  /// {@endtemplate}
+  ///
+  /// {@template flutter.material.slider.shape.argument.sliderTheme}
+  /// the `sliderTheme` argument is the theme assigned to the [Slider] that this
+  /// shape belongs to.
+  /// {@endtemplate}
+  ///
+  /// The `textDirection` argument can be used to determine how any extra text
+  /// or graphics (besides the text painted by the `labelPainter`) should be
+  /// positioned. The `labelPainter` already has the [textDirection] set.
+  ///
+  /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
+  /// the slider.
+  ///
+  /// {@template flutter.material.slider.shape.argument.textScaleFactor}
+  /// The `textScaleFactor` argument can be used to determine whether the
+  /// component should paint larger or smaller, depending on whether
+  /// [textScaleFactor] is greater than 1 for larger, and between 0 and 1 for
+  /// smaller. It usually comes from [MediaQueryData.textScaleFactor].
+  /// {@endtemplate}
+  ///
+  /// {@template flutter.material.slider.shape.argument.sizeWithOverflow}
+  /// The `sizeWithOverflow` argument can be used to determine the bounds the
+  /// drawing of the components that are outside of the regular slider bounds.
+  /// It's the size of the box, whose center is aligned with the slider's
+  /// bounds, that the value indicators must be drawn within. Typically, it is
+  /// bigger than the slider.
   /// {@endtemplate}
   void paint(
     PaintingContext context,
@@ -970,10 +908,8 @@ abstract class SliderComponentShape {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.roundSliderTickMarkShape}
 ///  * [RoundSliderTickMarkShape], which is the default [Slider]'s tick mark
 ///    shape that paints a solid circle.
-/// {@endtemplate}
 /// {@macro flutter.material.slider.seeAlso.sliderTrackShape}
 /// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
 abstract class SliderTickMarkShape {
@@ -985,9 +921,12 @@ abstract class SliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.slider.shape.sliderTheme}
+  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.isEnabled}
+  /// {@template flutter.material.slider.shape.argument.isEnabled}
+  /// The `isEnabled` argument has the same value as [Slider.isInteractive]. When
+  /// true, the slider will respond to input.
+  /// {@endtemplate}
   Size getPreferredSize({
     SliderThemeData sliderTheme,
     bool isEnabled,
@@ -995,25 +934,25 @@ abstract class SliderTickMarkShape {
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.slider.shape.context}
+  /// {@macro flutter.material.slider.shape.argument.context}
   ///
-  /// {@macro flutter.material.slider.shape.center}
+  /// {@macro flutter.material.slider.shape.argument.center}
   ///
-  /// {@macro flutter.material.slider.shape.parentBox}
+  /// {@macro flutter.material.slider.shape.argument.parentBox}
   ///
-  /// {@macro flutter.material.slider.shape.sliderTheme}
+  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.enableAnimation}
+  /// {@macro flutter.material.slider.shape.argument.enableAnimation}
   ///
-  /// {@macro flutter.material.slider.shape.isEnabled}
+  /// {@macro flutter.material.slider.shape.argument.isEnabled}
   ///
-  /// [textDirection] can be used to determine how the tick marks are painting
-  /// depending on whether they are on an active track segment or not. The track
-  /// segment between the start of the slider and the thumb is the active track
-  /// segment. The track segment between the thumb and the end of the slider is
-  /// the inactive track segment. In LTR text direction, the start of the slider
-  /// is on the left, and in RTL text direction, the start of the slider is on
-  /// the right.
+  /// The `textDirection` argument can be used to determine how the tick marks
+  /// are painting depending on whether they are on an active track segment or
+  /// not. The track segment between the start of the slider and the thumb is
+  /// the active track segment. The track segment between the thumb and the end
+  /// of the slider is the inactive track segment. In LTR text direction, the
+  /// start of the slider is on the left, and in RTL text direction, the start
+  /// of the slider is on the right.
   void paint(
     PaintingContext context,
     Offset center, {
@@ -1059,17 +998,17 @@ abstract class SliderTrackShape {
   /// It is used to provide horizontal boundaries for the thumb's position, and
   /// to help position the slider thumb and tick marks relative to the track.
   ///
-  /// The [parentBox] argument can be used to help determine the preferredRect relative to
+  /// The `parentBox` argument can be used to help determine the preferredRect relative to
   /// attributes of the render box of the slider itself, such as size.
   ///
-  /// The [offset] argument is relative to the caller's bounding box. It can be used to
+  /// The `offset` argument is relative to the caller's bounding box. It can be used to
   /// convert gesture coordinates from global to slider-relative coordinates.
   ///
-  /// {@macro flutter.material.slider.shape.sliderTheme}
+  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.isEnabled}
+  /// {@macro flutter.material.slider.shape.argument.isEnabled}
   ///
-  /// {@macro flutter.material.slider.shape.isDiscrete}
+  /// {@macro flutter.material.slider.shape.argument.isDiscrete}
   Rect getPreferredRect({
     RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -1080,28 +1019,28 @@ abstract class SliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.slider.shape.context}
+  /// {@macro flutter.material.slider.shape.argument.context}
   ///
-  /// [offset] is the offset of the origin of the [parentBox] to the origin of
-  /// its [context] canvas. This shape must be painted relative to this
-  /// offset. See [PaintingContextCallback].
+  /// The `offset` argument the offset of the origin of the `parentBox` to the
+  /// origin of its `context` canvas. This shape must be painted relative to
+  /// this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.slider.shape.parentBox}
+  /// {@macro flutter.material.slider.shape.argument.parentBox}
   ///
-  /// {@macro flutter.material.slider.shape.sliderTheme}
+  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.enableAnimation}
+  /// {@macro flutter.material.slider.shape.argument.enableAnimation}
   ///
-  /// The [thumbCenter] argument is the offset of the center of the thumb relative to the
-  /// origin of the [PaintingContext.canvas]. It can be used as the point that
-  /// divides the track into 2 segments.
+  /// The `thumbCenter` argument is the offset of the center of the thumb
+  /// relative to the origin of the [PaintingContext.canvas]. It can be used as
+  /// the point that divides the track into 2 segments.
   ///
-  /// {@macro flutter.material.slider.shape.isEnabled}
+  /// {@macro flutter.material.slider.shape.argument.isEnabled}
   ///
-  /// {@macro flutter.material.slider.shape.isDiscrete}
+  /// {@macro flutter.material.slider.shape.argument.isDiscrete}
   ///
-  /// The [textDirection] argument can be used to determine how the track segments are
-  /// painted depending on whether they are active or not.
+  /// The `textDirection` argument can be used to determine how the track
+  /// segments are painted depending on whether they are active or not.
   ///
   /// {@template flutter.material.slider.trackSegment}
   /// The track segment between the start of the slider and the thumb is the
@@ -1127,10 +1066,8 @@ abstract class SliderTrackShape {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.roundRangeSliderThumbShape}
 ///  * [RoundRangeSliderThumbShape] for the default [RangeSlider]'s thumb shape
 ///    that paints a solid circle.
-/// {@endtemplate}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
@@ -1142,38 +1079,63 @@ abstract class RangeSliderThumbShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@template flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// The `isDiscrete` argument is true if [RangeSlider.divisions] is non-null.
+  /// When true, the slider will render tick marks on top of the track.
+  /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@template flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// The `isEnabled` argument has the same value as [RangeSlider.isEnabled].
+  /// When true, the slider will respond to input.
+  /// {@endtemplate}
   Size getPreferredSize(bool isEnabled, bool isDiscrete);
 
   /// Paints the thumb shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.context}
+  /// {@template flutter.material.rangeSlider.shape.argument.context}
+  /// The `context` argument represents the [RangeSlider]'s render box.
+  /// {@endtemplate}
   ///
-  /// {@macro flutter.material.slider.shape.center}
+  /// {@macro flutter.material.slider.shape.argument.center}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.activationAnimation}
+  /// {@template flutter.material.rangeSlider.shape.argument.activationAnimation}
+  /// The `activationAnimation` argument is an animation triggered when the user
+  /// begins to interact with the [RangeSlider]. It reverses when the user stops
+  /// interacting with the slider.
+  /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.enableAnimation}
+  /// {@template flutter.material.rangeSlider.shape.argument.enableAnimation}
+  /// The `enableAnimation` argument is an animation triggered when the
+  /// [RangeSlider] is enabled, and it reverses when the slider is disabled.
+  /// Enabled is the [RangeSlider.isEnabled] state. Use this to paint
+  /// intermediate frames for this shape when the slider changes enabled state.
+  /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   ///
-  /// If [isOnTop] is true this thumb is painted on top of the other slider
-  /// thumb because this thumb is the one that was most recently selected.
+  /// If the `isOnTop` argument is true, this thumb is painted on top of the
+  /// other slider thumb because this thumb is the one that was most recently
+  /// selected.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@template flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// The `sliderTheme` argument is the theme assigned to the [RangeSlider] that
+  /// this shape belongs to.
+  /// {@endtemplate}
   ///
-  /// [textDirection] can be used to determine how the orientation of either
-  /// slider thumb should be changed, such as drawing different shapes for the
-  /// left and right thumb.
+  /// The `textDirection` argument can be used to determine how the orientation
+  /// of either slider thumb should be changed, such as drawing different
+  /// shapes for the left and right thumb.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.thumb}
+  /// {@template flutter.material.rangeSlider.shape.argument.thumb}
+  /// The `thumb` argument is the specifier for which of the two thumbs this
+  /// method should paint (start or end).
+  /// {@endtemplate}
   ///
-  /// [isPressed] can be used to give the selected thumb additional selected
-  /// or pressed state visual feedback, such as a larger shadow.
+  /// The `isPressed` argument can be used to give the selected thumb
+  /// additional selected or pressed state visual feedback, such as a larger
+  /// shadow.
   void paint(
     PaintingContext context,
     Offset center, {
@@ -1193,10 +1155,8 @@ abstract class RangeSliderThumbShape {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.paddleRangeSliderValueIndicatorShape}
 ///  * [PaddleRangeSliderValueIndicatorShape] for the default [RangeSlider]'s
 ///    value indicator shape that paints a custom path with text in it.
-/// {@endtemplate}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
@@ -1208,14 +1168,14 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
   ///
-  /// [labelPainter] helps determine the width of the shape. It is variable
-  /// width because it is derived from a formatted string.
+  /// The `labelPainter` argument helps determine the width of the shape. It is
+  /// variable width because it is derived from a formatted string.
   ///
-  /// {@macro flutter.material.slider.shape.textScaleFactor}
+  /// {@macro flutter.material.slider.shape.argument.textScaleFactor}
   Size getPreferredSize(
     bool isEnabled,
     bool isDiscrete, {
@@ -1240,36 +1200,41 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Paints the value indicator shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.context}
+  /// {@macro flutter.material.rangeSlider.shape.argument.context}
   ///
-  /// {@macro flutter.material.slider.shape.center}
+  /// {@macro flutter.material.slider.shape.argument.center}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.activationAnimation}
+  /// {@macro flutter.material.rangeSlider.shape.argument.activationAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.enableAnimation}
+  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
   ///
-  /// The [isOnTop] argument is the top-most value indicator between the two value
+  /// The `isOnTop` argument is the top-most value indicator between the two value
   /// indicators, which is always the indicator for the most recently selected thumb. In
   /// the default case, this is used to paint a stroke around the top indicator
   /// for better visibility between the two indicators.
   ///
-  /// {@macro flutter.material.slider.shape.textScaleFactor}
+  /// {@macro flutter.material.slider.shape.argument.textScaleFactor}
   ///
-  /// {@macro flutter.material.slider.shape.sizeWithOverflow}
+  /// {@macro flutter.material.slider.shape.argument.sizeWithOverflow}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.parentBox}
+  /// {@template flutter.material.rangeSlider.shape.argument.parentBox}
+  /// The `parentBox` argument is the [RenderBox] of the [RangeSlider]. Its
+  /// attributes, such as size, can be used to assist in painting this shape.
+  /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
   ///
-  /// [textDirection] can be used to determine how any extra text or graphics,
-  /// besides the text painted by the [labelPainter] should be positioned. The
-  /// [labelPainter] already has the [textDirection] set.
+  /// The `textDirection` argument can be used to determine how any extra text
+  /// or graphics, besides the text painted by the [labelPainter] should be
+  /// positioned. The `labelPainter` argument already has the `textDirection`
+  /// set.
   ///
-  /// [value] is the current parametric value (from 0.0 to 1.0) of the slider.
+  /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
+  /// the slider.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.thumb}
+  /// {@macro flutter.material.rangeSlider.shape.argument.thumb}
   void paint(
     PaintingContext context,
     Offset center, {
@@ -1295,10 +1260,8 @@ abstract class RangeSliderValueIndicatorShape {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.roundRangeSliderTickMarkShape}
 ///  * [RoundRangeSliderTickMarkShape] for the default [RangeSlider]'s tick mark
 ///    shape that paints a solid circle.
-/// {@endtemplate}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
@@ -1312,9 +1275,9 @@ abstract class RangeSliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   Size getPreferredSize({
     SliderThemeData sliderTheme,
     bool isEnabled,
@@ -1322,20 +1285,20 @@ abstract class RangeSliderTickMarkShape {
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.context}
+  /// {@macro flutter.material.rangeSlider.shape.argument.context}
   ///
-  /// {@macro flutter.material.slider.shape.center}
+  /// {@macro flutter.material.slider.shape.argument.center}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.parentBox}
+  /// {@macro flutter.material.rangeSlider.shape.argument.parentBox}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.enableAnimation}
+  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   ///
-  /// The [textDirection] argument can be used to determine how the tick marks are painted
-  /// depending on whether they are on an active track segment or not.
+  /// The `textDirection` argument can be used to determine how the tick marks
+  /// are painted depending on whether they are on an active track segment or not.
   ///
   /// {@template flutter.material.rangeSlider.trackSegment}
   /// The track segment between the two thumbs is the active track segment. The
@@ -1367,10 +1330,8 @@ abstract class RangeSliderTickMarkShape {
 ///
 /// See also:
 ///
-/// {@template flutter.material.slider.seeAlso.roundedRectRangeSliderTrackShape}
 ///  * [RoundedRectRangeSliderTrackShape] for the default [RangeSlider]'s track
 ///    shape that paints a stadium-like track.
-/// {@endtemplate}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
@@ -1386,17 +1347,19 @@ abstract class RangeSliderTrackShape {
   /// thumbs, and to help position the slider thumbs and tick marks relative to
   /// the track.
   ///
-  /// The [parentBox] argument can be used to help determine the preferredRect relative to
-  /// attributes of the render box of the slider itself, such as size.
+  /// The `parentBox` argument can be used to help determine the preferredRect
+  /// relative to attributes of the render box of the slider itself, such as
+  /// size.
   ///
-  /// The [offset] argument is relative to the caller's bounding box. It can be used to
-  /// convert gesture coordinates from global to slider-relative coordinates.
+  /// The `offset` argument is relative to the caller's bounding box. It can be
+  /// used to convert gesture coordinates from global to slider-relative
+  /// coordinates.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
   Rect getPreferredRect({
     RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -1407,32 +1370,34 @@ abstract class RangeSliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.slider.shape.context}
+  /// {@macro flutter.material.slider.shape.argument.context}
   ///
-  /// [offset] is the offset of the origin of the [parentBox] to the origin of
-  /// its [context] canvas. This shape must be painted relative to this
-  /// offset. See [PaintingContextCallback].
+  /// The `offset` argument is the offset of the origin of the `parentBox` to
+  /// the origin of its `context` canvas. This shape must be painted relative
+  /// to this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.rangeSlider.shape.parentBox}
+  /// {@macro flutter.material.rangeSlider.shape.argument.parentBox}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.sliderTheme}
+  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.enableAnimation}
+  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
   ///
-  /// [startThumbCenter] is the offset of the center of the start thumb relative
-  /// to the origin of the [PaintingContext.canvas]. It can be used as one point
-  /// that divides the track between inactive and active.
+  /// The `startThumbCenter` argument is the offset of the center of the start
+  /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
+  /// used as one point that divides the track between inactive and active.
   ///
-  /// [endThumbCenter] is the offset of the center of the end thumb relative
-  /// to the origin of the [PaintingContext.canvas]. It can be used as one point
-  /// that divides the track between inactive and active.
+  /// The `endThumbCenter` argument is the offset of the center of the end
+  /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
+  /// used as one point that divides the track between inactive and active.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isEnabled}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.isDiscrete}
+  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
   ///
-  /// [textDirection] can be used to determine how the track segments are
-  /// painted depending on whether they are on an active track segment or not.
+  /// The `textDirection` argument can be used to determine how the track
+  /// segments are painted depending on whether they are on an active track
+  /// segment or not.
+  ///
   /// {@macro flutter.material.rangeSlider.trackSegment}
   void paint(
     PaintingContext context,
@@ -1500,7 +1465,7 @@ abstract class BaseSliderTrackShape {
 /// A [Slider] track that's a simple rectangle.
 ///
 /// It paints a solid colored rectangle, vertically centered in the
-/// [parentBox]. The track rectangle extends to the bounds of the [parentBox],
+/// `parentBox`. The track rectangle extends to the bounds of the `parentBox`,
 /// but is padded by the [RoundSliderOverlayShape] radius. The height is defined
 /// by the [SliderThemeData.trackHeight]. The color is determined by the
 /// [Slider]'s enabled state and the track segment's active state which are
@@ -1608,8 +1573,8 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 /// The default shape of a [Slider]'s track.
 ///
 /// It paints a solid colored rectangle with rounded edges, vertically centered
-/// in the [parentBox]. The track rectangle extends to the bounds of the
-/// [parentBox], but is padded by the larger of [RoundSliderOverlayShape]'s
+/// in the `parentBox`. The track rectangle extends to the bounds of the
+/// `parentBox`, but is padded by the larger of [RoundSliderOverlayShape]'s
 /// radius and [RoundSliderThumbShape]'s radius. The height is defined by the
 /// [SliderThemeData.trackHeight]. The color is determined by the [Slider]'s
 /// enabled state and the track segment's active state which are defined by:
@@ -1723,7 +1688,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 /// A [RangeSlider] track that's a simple rectangle.
 ///
 /// It paints a solid colored rectangle, vertically centered in the
-/// [parentBox]. The track rectangle extends to the bounds of the [parentBox],
+/// `parentBox`. The track rectangle extends to the bounds of the `parentBox`,
 /// but is padded by the [RoundSliderOverlayShape] radius. The height is
 /// defined by the [SliderThemeData.trackHeight]. The color is determined by the
 /// [Slider]'s enabled state and the track segment's active state which are
@@ -1852,8 +1817,8 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
 /// The default shape of a [RangeSlider]'s track.
 ///
 /// It paints a solid colored rectangle with rounded edges, vertically centered
-/// in the [parentBox]. The track rectangle extends to the bounds of the
-/// [parentBox], but is padded by the larger of [RoundSliderOverlayShape]'s
+/// in the `parentBox`. The track rectangle extends to the bounds of the
+/// `parentBox`, but is padded by the larger of [RoundSliderOverlayShape]'s
 /// radius and [RoundRangeSliderThumbShape]'s radius. The height is defined by
 /// the [SliderThemeData.trackHeight]. The color is determined by the
 /// [RangeSlider]'s enabled state and the track segment's active state which are
@@ -3289,7 +3254,7 @@ typedef RangeThumbSelector = Thumb Function(
 /// Object for representing range slider thumb values.
 ///
 /// This object is passed into [RangeSlider.values] to set its values, and it
-/// is emitted in [RangeSlider.onChange], [RangeSlider.onChangeStart], and
+/// is emitted in [RangeSlider.onChanged], [RangeSlider.onChangeStart], and
 /// [RangeSlider.onChangeEnd] when the values change.
 @immutable
 class RangeValues {
@@ -3329,7 +3294,7 @@ class RangeValues {
 /// Object for setting range slider label values that appear in the value
 /// indicator for each thumb.
 ///
-/// Used in combination with [RangeSlider.showValueIndicator] to display
+/// Used in combination with [SliderThemeData.showValueIndicator] to display
 /// labels above the thumbs.
 @immutable
 class RangeLabels {

--- a/packages/flutter/lib/src/material/text_button_theme.dart
+++ b/packages/flutter/lib/src/material/text_button_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///  * [TextButtonTheme], the theme which is configured with this class.
 ///  * [TextButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for text buttons.
-///  * [TextButton.styleOf], which converts simple values into a
+///  * [TextButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [TextButton]'s defaults.
 ///  * [MaterialStateProperty.resolve], "resolve" a material state property
 ///    to a simple value based on a set of [MaterialState]s.
@@ -84,7 +84,7 @@ class TextButtonThemeData with Diagnosticable {
 ///  * [TextButtonThemeData], which is used to configure this theme.
 ///  * [TextButton.defaultStyleOf], which returns the default [ButtonStyle]
 ///    for text buttons.
-///  * [TextButton.styleOf], which converts simple values into a
+///  * [TextButton.styleFrom], which converts simple values into a
 ///    [ButtonStyle] that's consistent with [TextButton]'s defaults.
 ///  * [ThemeData.textButtonTheme], which can be used to override the default
 ///    [ButtonStyle] for [TextButton]s below the overall [Theme].

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -158,8 +158,9 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
 ///
-/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
-/// This will ensure we discard any resources used by the object.
+/// Remember to call [TextEditingController.dispose] of the [TextEditingController]
+/// when it is no longer needed. This will ensure we discard any resources used
+/// by the object.
 ///
 /// {@tool snippet}
 /// This example shows how to create a [TextField] that will obscure input. The

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -33,8 +33,9 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 /// If a [controller] is not specified, [initialValue] can be used to give
 /// the automatically generated controller an initial value.
 ///
-/// Remember to [dispose] of the [TextEditingController] when it is no longer needed.
-/// This will ensure we discard any resources used by the object.
+/// Remember to call [TextEditingController.dispose] of the [TextEditingController]
+/// when it is no longer needed. This will ensure we discard any resources used
+/// by the object.
 ///
 /// By default, [TextFormField.decoration] will apply the
 /// [ThemeData.inputDecorationTheme] for the current context to the
@@ -122,7 +123,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 ///    integration.
 ///  * [InputDecorator], which shows the labels and other visual elements that
 ///    surround the actual text editing widget.
-///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipes](https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller).
 class TextFormField extends FormField<String> {
   /// Creates a [FormField] that contains a [TextField].
   ///

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -41,7 +41,7 @@ enum ScriptCategory {
   tall,
 }
 
-/// The color and geometry [TextThemes] for Material apps.
+/// The color and geometry [TextTheme]s for Material apps.
 ///
 /// The text themes provided by the overall [Theme], like
 /// [ThemeData.textTheme], are based on the current locale's
@@ -56,7 +56,7 @@ enum ScriptCategory {
 /// `Theme.of(context).accentTextTheme`.
 ///
 /// The color text themes are [blackMountainView], [whiteMountainView],
-/// [blackCupertino], and [whiteCupertino]. The Mountain View theme [TextStyles]
+/// [blackCupertino], and [whiteCupertino]. The Mountain View theme [TextStyle]s
 /// are based on the Roboto fonts as used on Android. The Cupertino themes are
 /// based on the [San Francisco
 /// font](https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/)

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1050,6 +1050,7 @@ typedef FastReassemblePredicate = bool Function(Object);
 /// the provided predicate and use it to mark specific elements dirty wherever
 /// [Element.widget] is a `Foo`. Afterwards, the internal field will be nulled
 /// out.
+FastReassemblePredicate get debugFastReassembleMethod => _debugFastReassembleMethod;
 set debugFastReassembleMethod(FastReassemblePredicate fastReassemblePredicate) {
   assert(() {
     _debugFastReassembleMethod = fastReassemblePredicate;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1202,7 +1202,7 @@ class EditableText extends StatefulWidget {
   ///   [associated domains](https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app).
   /// * Some autofill hints only work with specific [keyboardType]s. For example,
   ///   [AutofillHints.name] requires [TextInputType.name] and [AutofillHints.email]
-  ///   works only with [TextInputType.email]. Make sure the input field has a
+  ///   works only with [TextInputType.emailAddress]. Make sure the input field has a
   ///   compatible [keyboardType]. Empirically, [TextInputType.name] works well
   ///   with many autofill hints that are predefined on iOS.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1227,11 +1227,11 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// pops. If this is not necessary, this can be set to false to allow the
   /// framework to entirely discard the route's widget hierarchy when it is not
   /// visible.
+  /// {@endtemplate}
   ///
   /// If this getter would ever start returning a different value, the
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
-  /// {@endtemplate}
   bool get maintainState;
 
 


### PR DESCRIPTION
## Description

This begins to fix our broken doc references.  There's too many breakages to fix outright, so I'm gonna bail on the direct fix and send a PR to add an allowed list for the existing failures, so we can drive that list to zero and keep from making things worse.  In the meantime, this PR makes things slightly better.

## Related Issues

https://github.com/flutter/flutter/issues/31931

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
