### PR TITLE
Fix doc generation scripts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -272,6 +272,7 @@ task:
     - name: hostonly_devicelab_tests-3_last-linux
       << : *LINUX_SHARD_TEMPLATE
 
+    # This task populates `docs_cache`
     - name: docs-linux # linux-only
       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'packages/flutter_goldens/**', 'bin/**') || $CIRRUS_PR == ''"
       environment:
@@ -285,17 +286,8 @@ task:
       script:
         - ./dev/bots/docs.sh docs
 
-    - name: docs_offline-linux # linux-only
-      only_if: "$CIRRUS_PR == ''"
-      depends_on:
-        - docs-linux
-      docs_cache:
-        folder: dev/docs
-        fingerprint_script:
-          - echo "docs_${CIRRUS_CHANGE_IN_REPO}_${CIRRUS_BUILD_ID}"
-      script:
-        - ./dev/bots/docs.sh offline
-
+    # This task relies on `docs_cache` having been populated in `docs-linux`.
+    # It updates the cache with the docset gzip file it generates.
     - name: docs_docset-linux # linux-only
       only_if: "$CIRRUS_PR == ''"
       depends_on:
@@ -304,16 +296,17 @@ task:
         CPU: 2
       docs_cache:
         folder: dev/docs
+        reupload_on_changes: true
         fingerprint_script:
           - echo "docs_${CIRRUS_CHANGE_IN_REPO}_${CIRRUS_BUILD_ID}"
       script:
         - ./dev/bots/docs.sh docset
 
+    # This task relies on an updated `docs_cache` from `docs_docset-linux`
     - name: docs_deploy-linux # linux-only
       only_if: "$CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH == 'stable'"
       depends_on:
         - docs-linux
-        - docs_offline-linux
         - docs_docset-linux
       environment:
         # For uploading master docs to Firebase master branch staging site

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -175,10 +175,9 @@ fi
 case "$COMMAND" in
     docs)
         generate_docs
-        ;;
-    offline)
-        assert_not_in_pr
-        (cd "$FLUTTER_ROOT/dev/docs"; create_offline_zip)
+        if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
+            (cd "$FLUTTER_ROOT/dev/docs"; create_offline_zip)
+        fi
         ;;
     docset)
         assert_not_in_pr
@@ -189,6 +188,6 @@ case "$COMMAND" in
         deploy_docs
         ;;
     *)
-        >&2 echo "Usage: $0 {docs|offline|docset|deploy}"
+        >&2 echo "Usage: $0 {docs|docset|deploy}"
         exit 1
 esac


### PR DESCRIPTION
## Description

The caches need to be updated serially so they don't clobber each other, and we need to set the `reupload_on_changes` Cirrus flag to ensure that the caches get updated.

## Related Issues

https://github.com/flutter/flutter/issues/60646

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
