### PR TITLE
Macrobenchmarks e2e version bug fix

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -41,8 +41,7 @@ void macroPerfTestE2E(
   binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive;
 
   testWidgets(testName, (WidgetTester tester) async {
-    assert((tester.binding as LiveTestWidgetsFlutterBinding).framePolicy ==
-        LiveTestWidgetsFlutterBindingFramePolicy.fullyLive);
+    assert(tester.binding == binding);
     app.main();
     await tester.pumpAndSettle();
 
@@ -61,6 +60,8 @@ void macroPerfTestE2E(
     expect(button, findsOneWidget);
     await tester.pumpAndSettle();
     await tester.tap(button);
+    // Cannot be pumpAndSettle because some tests have inifite animation.
+    await tester.pump(const Duration(milliseconds: 20));
 
     if (pageDelay != null) {
       // Wait for the page to load
@@ -108,7 +109,7 @@ class FrameTimingSummarizer {
     final List<Duration> frameRasterizerTime = List<Duration>.unmodifiable(
       data.map<Duration>((FrameTiming datum) => datum.rasterDuration),
     );
-    final List<Duration> frameRasterizerTimeSorted = List<Duration>.from(frameBuildTime)..sort();
+    final List<Duration> frameRasterizerTimeSorted = List<Duration>.from(frameRasterizerTime)..sort();
     final Duration Function(Duration, Duration) add = (Duration a, Duration b) => a + b;
     return FrameTimingSummarizer._(
       frameBuildTime: frameBuildTime,


### PR DESCRIPTION
## Description

This is part of #62171 for fixing bugs in the macrobenchmark/e2e infra codes

## Related Issues

N/A

## Tests

The PR it self is for test

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
