### PR TITLE
Fix SemanticsNode.rect position for nested scrollables with useTwoPan…

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -784,7 +784,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
     _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
     _innerNode
       ..isMergedIntoParent = node.isPartOfNodeMerging
-      ..rect = Offset.zero & node.rect.size;
+      ..rect = node.rect;
 
     int firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode];


### PR DESCRIPTION
…eSemantics

## Description

**Issue**

If a scrolling widget such as `ListView` or `GridView` (with `shrinkWrap: true`) is nested under another scrolling widget such as `SingleChildScrollView`, then new "beyond the fold" content which is revealed by swiping off screen cannot be selected by tap, and continued swiping beyond the fold will eventually make a11y focus jump to a random element on iOS.

<details>
<summary>Repro case</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(A11yApp());

class A11yApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    final appBar =
    AppBar(title: const Icon(Icons.archive));

    return MaterialApp(
      home: Scaffold(
        appBar: appBar,
        body: SingleChildScrollView(
          child: Column(
            children: [_buildGridView(), _buildGridView(), _buildGridView()],
          ),
        ),
      ),
    );
  }

  Widget _buildGridView() {
    return Column(
      children: [
        const Text('Grid header'),
        GridView.count(
          shrinkWrap: true,
          crossAxisSpacing: 10,
          mainAxisSpacing: 10,
          crossAxisCount: 2,
          children: <Widget>[
            for (var i = 0; i < 50; ++i)
              Container(
                padding: const EdgeInsets.all(8),
                color: Colors.green[100],
                child: Text('Number $i'),
              ),
          ],
        ),
      ],
    );
  }
}
```

</details>

**Fix**

The inner [semantics pane](https://api.flutter.dev/flutter/rendering/RenderViewport/useTwoPaneSemantics-constant.html) of the child `ListView`/`GridView` needs to have its position updated to match the outer semantics pane when the parent `SingleChildScrollView` scrolls.

**[This comment](https://github.com/flutter/flutter/issues/61631#issuecomment-663729586) on issue #61631 explains the technical details of the fix.**

## Related Issues

Fixes #61631 

## Tests

I added the following tests:

- `widgets/scrollable_semantics_test.dart`
    - "transform of inner node from useTwoPaneSemantics scrolls correctly with nested scrollables"
        - Ensures the _global_ `rect` of the inner and outer semantics panes of a `ListView` match when nested under a `SingleChildScrollView`. The parent `SingleChildScrollView` is scrolled to the end -> beginning -> middle of the shrink-wrapped `ListView`'s _hidden_ elements to test both scroll directions.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
