### PR TITLE
Make dartdoc warnings fatal (& cleanup of warnings)

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -13,9 +13,24 @@ dartdoc:
       command: ["dev/snippets/lib/main.dart", "--type=sample", "--dartpad"]
       description: "Creates full application sample code documentation output from embedded documentation samples and displays it in an embedded DartPad."
   errors:
-    - tool-error  # enabled by default
-    - duplicate-file  # enabled by default
-    - invalid-parameter  # enabled by default
-    - unresolved-export  # enabled by default
-    - unknown-macro  # a {@macro foo} reference cannot be resolved
-    - invalid-parameter  # an invalid parameter is passed to a {@foo x y} directive
+    # The following are always errors:
+    - duplicate-file
+    - invalid-parameter
+    - tool-error
+    - unresolved-export
+    # The following are elevated from warnings because we currently don't
+    # fail on warnings:
+    - ambiguous-doc-reference
+    - ambiguous-reexport
+    - ignored-canonical-for
+    - no-canonical-found
+    - not-implemented
+    - no-library-level-docs
+    - category-order-gives-missing-package-name
+    - reexported-private-api-across-packages
+    # - unresolved-doc-reference # Too many failures, needs clean-up
+    - broken-link
+    - unknown-macro
+    - orphaned-file
+    - unknown-file
+    - missing-from-search-index

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -141,9 +141,7 @@ Future<void> main(List<String> arguments) async {
     '--footer-text', 'lib/footer.html',
     '--allow-warnings-in-packages',
     <String>[
-      'material',
-      'rendering',
-      'widgets',
+      'flutter',
     ].join(','),
     '--exclude-packages',
     <String>[

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -141,12 +141,9 @@ Future<void> main(List<String> arguments) async {
     '--footer-text', 'lib/footer.html',
     '--allow-warnings-in-packages',
     <String>[
-      'Flutter',
-      'flutter',
-      'platform_integration',
-      'flutter_test',
-      'flutter_driver',
-      'flutter_localizations',
+      'material',
+      'rendering',
+      'widgets',
     ].join(','),
     '--exclude-packages',
     <String>[

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -230,11 +230,6 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
 /// Variant of [FlutterErrorDetails] with extra fields for the gesture
 /// library's binding's pointer event dispatcher ([GestureBinding.dispatchEvent]).
-///
-/// See also:
-///
-///  * [FlutterErrorDetailsForPointerRouter], which is also used by the
-///    gesture library.
 class FlutterErrorDetailsForPointerEventDispatcher extends FlutterErrorDetails {
   /// Creates a [FlutterErrorDetailsForPointerEventDispatcher] object with the given
   /// arguments setting the object's properties.

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -81,7 +81,7 @@ class BorderSide {
   ///
   /// If one of the sides is zero-width with [BorderStyle.none], then the other
   /// side is return as-is. If both of the sides are zero-width with
-  /// [BorderStyle.none], then [BorderSide.zero] is returned.
+  /// [BorderStyle.none], then [BorderSide.none] is returned.
   ///
   /// The arguments must not be null.
   static BorderSide merge(BorderSide a, BorderSide b) {

--- a/packages/flutter/lib/src/painting/clip.dart
+++ b/packages/flutter/lib/src/painting/clip.dart
@@ -6,7 +6,7 @@
 
 import 'dart:ui' show Canvas, Clip, Path, Paint, Rect, RRect;
 
-/// Clip utilities used by [PaintingContext] and [TestRecordingPaintingContext].
+/// Clip utilities used by [PaintingContext].
 abstract class ClipContext {
   /// The canvas on which to paint.
   Canvas get canvas;

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -34,12 +34,12 @@ HttpClientProvider debugNetworkImageHttpClientProvider;
 
 typedef PaintImageCallback = void Function(ImageSizeInfo);
 
-/// Tracks the bytes used by a [ui.Image] compared to the bytes needed to paint
-/// that image without scaling it.
+/// Tracks the bytes used by a [dart:ui.Image] compared to the bytes needed to
+/// paint that image without scaling it.
 @immutable
 class ImageSizeInfo {
-  /// Creates an object to track the backing size of a [ui.Image] compared to
-  /// its display size on a [Canvas].
+  /// Creates an object to track the backing size of a [dart:ui.Image] compared
+  /// to its display size on a [Canvas].
   ///
   /// This class is used by the framework when it paints an image to a canvas
   /// to report to `dart:developer`'s [postEvent], as well as to the

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -660,7 +660,7 @@ class RadialGradient extends Gradient {
   ///
   /// For example, if a radial gradient is painted on a box that is
   /// 100.0 pixels wide and 200.0 pixels tall, then a radius of 1.0
-  /// will place the 1.0 stop at 100.0 pixels from the [focus].
+  /// will place the 1.0 stop at 100.0 pixels from the [focal] point.
   ///
   /// If this value is specified and is greater than 0.0, either [focal] or
   /// [center] must not resolve to [Offset.zero], which would fail to create

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -637,7 +637,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   const AssetBundleImageProvider();
 
   /// Converts a key into an [ImageStreamCompleter], and begins fetching the
-  /// image using [loadAsync].
+  /// image.
   @override
   ImageStreamCompleter load(AssetBundleImageKey key, DecoderCallback decode) {
     InformationCollector collector;
@@ -802,8 +802,8 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
 ///
 /// The image will be cached regardless of cache headers from the server.
 ///
-/// When a network image is used on the Web platform, the [cacheWidth] and
-/// [cacheHeight] parameters of the [DecoderCallback] are ignored as the Web
+/// When a network image is used on the Web platform, the `cacheWidth` and
+/// `cacheHeight` parameters of the [DecoderCallback] are ignored as the Web
 /// engine delegates image decoding of network images to the Web, which does
 /// not support custom decode sizes.
 ///
@@ -977,7 +977,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 ///
 /// When fetching an image provided by the app itself, use the [assetName]
 /// argument to name the asset to choose. For instance, consider a directory
-/// `icons` with an image `heart.png`. First, the [pubspec.yaml] of the project
+/// `icons` with an image `heart.png`. First, the `pubspec.yaml` of the project
 /// should specify its assets in the `flutter` section:
 ///
 /// ```yaml
@@ -1127,8 +1127,8 @@ class _ErrorImageCompleter extends ImageStreamCompleter {
 
 /// The exception thrown when the HTTP request to load a network image fails.
 class NetworkImageLoadException implements Exception {
-  /// Creates a [NetworkImageLoadException] with the specified http status
-  /// [code] and the [uri]
+  /// Creates a [NetworkImageLoadException] with the specified http [statusCode]
+  /// and [uri].
   NetworkImageLoadException({@required this.statusCode, @required this.uri})
       : assert(uri != null),
         assert(statusCode != null),

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -213,8 +213,8 @@ class ImageChunkEvent with Diagnosticable {
 ///
 /// The [ImageCache] will consider an image to be live until the listener count
 /// drops to zero after adding at least one listener. The
-/// [addOnLastListenerRemovedCallback] method is used for tracking this
-/// information.
+/// [ImageStreamCompleter.addOnLastListenerRemovedCallback] method is used for
+/// tracking this information.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -294,7 +294,7 @@ abstract class InlineSpan extends DiagnosticableTree {
 
   /// Returns the UTF-16 code unit at the given `index` in the flattened string.
   ///
-  /// This only accounts for the [TextSpan.text] values and ignores [PlaceholderSpans].
+  /// This only accounts for the [TextSpan.text] values and ignores [PlaceholderSpan]s.
   ///
   /// Returns null if the `index` is out of bounds.
   int codeUnitAt(int index) {

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -54,9 +54,9 @@ class PlaceholderDimensions {
   /// See also:
   ///
   ///  * [baseline], the baseline to align to when using
-  ///    [ui.PlaceholderAlignment.baseline],
-  ///    [ui.PlaceholderAlignment.aboveBaseline],
-  ///    or [ui.PlaceholderAlignment.underBaseline].
+  ///    [dart:ui.PlaceholderAlignment.baseline],
+  ///    [dart:ui.PlaceholderAlignment.aboveBaseline],
+  ///    or [dart:ui.PlaceholderAlignment.belowBaseline].
   ///  * [baselineOffset], the distance of the alphabetic baseline from the upper
   ///    edge of the placeholder.
   final ui.PlaceholderAlignment alignment;
@@ -70,7 +70,7 @@ class PlaceholderDimensions {
   ///
   ///  * [ui.PlaceholderAlignment.baseline]
   ///  * [ui.PlaceholderAlignment.aboveBaseline]
-  ///  * [ui.PlaceholderAlignment.underBaseline]
+  ///  * [ui.PlaceholderAlignment.belowBaseline]
   ///  * [ui.PlaceholderAlignment.middle]
   final TextBaseline baseline;
 
@@ -318,7 +318,7 @@ class TextPainter {
   ///
   /// Omitting or providing null for any properties of [StrutStyle] will result in
   /// default values being used. It is highly recommended to at least specify a
-  /// [fontSize].
+  /// [StrutStyle.fontSize].
   ///
   /// See [StrutStyle] for details.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -285,7 +285,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 /// ```
 /// {@end-tool}
 ///
-/// To use a font family defined in a package, the [package] argument must be
+/// To use a font family defined in a package, the `package` argument must be
 /// provided. For instance, suppose the font declaration above is in the
 /// `pubspec.yaml` of a package named `my_package` which the app depends on.
 /// Then creating the TextStyle is done as follows:

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -384,8 +384,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   /// sent to the GPU.
   ///
   /// 7. The semantics phase: All the dirty [RenderObject]s in the system have
-  /// their semantics updated (see [RenderObject.semanticsAnnotator]). This
-  /// generates the [SemanticsNode] tree. See
+  /// their semantics updated. This generates the [SemanticsNode] tree. See
   /// [RenderObject.markNeedsSemanticsUpdate] for further details on marking an
   /// object dirty for semantics.
   ///

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -39,9 +39,9 @@ set timeDilation(double value) {
 /// common time base.
 typedef FrameCallback = void Function(Duration timeStamp);
 
-/// Signature for [Scheduler.scheduleTask] callbacks.
+/// Signature for [SchedulerBinding.scheduleTask] callbacks.
 ///
-/// The type argument `T` is the task's return value. Consider [void] if the
+/// The type argument `T` is the task's return value. Consider `void` if the
 /// task does not return a value.
 typedef TaskCallback<T> = T Function();
 
@@ -138,14 +138,14 @@ class _FrameCallbackEntry {
 ///    to generate a frame.
 enum SchedulerPhase {
   /// No frame is being processed. Tasks (scheduled by
-  /// [WidgetsBinding.scheduleTask]), microtasks (scheduled by
+  /// [SchedulerBinding.scheduleTask]), microtasks (scheduled by
   /// [scheduleMicrotask]), [Timer] callbacks, event handlers (e.g. from user
   /// input), and other callbacks (e.g. from [Future]s, [Stream]s, and the like)
   /// may be executing.
   idle,
 
   /// The transient callbacks (scheduled by
-  /// [WidgetsBinding.scheduleFrameCallback]) are currently executing.
+  /// [SchedulerBinding.scheduleFrameCallback]) are currently executing.
   ///
   /// Typically, these callbacks handle updating objects to new animation
   /// states.
@@ -161,14 +161,14 @@ enum SchedulerPhase {
   midFrameMicrotasks,
 
   /// The persistent callbacks (scheduled by
-  /// [WidgetsBinding.addPersistentFrameCallback]) are currently executing.
+  /// [SchedulerBinding.addPersistentFrameCallback]) are currently executing.
   ///
   /// Typically, this is the build/layout/paint pipeline. See
   /// [WidgetsBinding.drawFrame] and [SchedulerBinding.handleDrawFrame].
   persistentCallbacks,
 
   /// The post-frame callbacks (scheduled by
-  /// [WidgetsBinding.addPostFrameCallback]) are currently executing.
+  /// [SchedulerBinding.addPostFrameCallback]) are currently executing.
   ///
   /// Typically, these callbacks handle cleanup and scheduling of work for the
   /// next frame.
@@ -806,7 +806,7 @@ mixin SchedulerBinding on BindingBase {
   /// schedules a frame, set [debugPrintScheduleFrameStacks] to true.
   ///
   /// Prefer using [scheduleFrame] unless it is imperative that a frame be
-  /// scheduled immediately, since using [scheduleForceFrame] will cause
+  /// scheduled immediately, since using [scheduleForcedFrame] will cause
   /// significantly higher battery usage when the device should be idle.
   ///
   /// Consider using [scheduleWarmUpFrame] instead if the goal is to update the

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -105,9 +105,9 @@ class Ticker {
   /// ticking. In that case, the ticker will not call its callback, and
   /// [isTicking] will be false, but time will still be progressing.
   ///
-  /// This will return false if the [Scheduler.lifecycleState] is one that
-  /// indicates the application is not currently visible (e.g. if the device's
-  /// screen is turned off).
+  /// This will return false if the [SchedulerBinding.lifecycleState] is one
+  /// that indicates the application is not currently visible (e.g. if the
+  /// device's screen is turned off).
   bool get isTicking {
     if (_future == null)
       return false;

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -50,7 +50,8 @@ mixin SemanticsBinding on BindingBase {
   /// a flag is changed.
   ///
   /// To listen to changes to accessibility features, create a
-  /// [WidgetsBindingObserver] and listen to [didChangeAccessibilityFeatures].
+  /// [WidgetsBindingObserver] and listen to
+  /// [WidgetsBindingObserver.didChangeAccessibilityFeatures].
   ui.AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
   ui.AccessibilityFeatures _accessibilityFeatures;
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -763,8 +763,9 @@ class SemanticsProperties extends DiagnosticableTree {
   /// If non-null, whether the node corresponds to the root of a subtree for
   /// which a route name should be announced.
   ///
-  /// Generally, this is set in combination with [explicitChildNodes], since
-  /// nodes with this flag are not considered focusable by Android or iOS.
+  /// Generally, this is set in combination with
+  /// [SemanticsConfiguration.explicitChildNodes], since nodes with this flag
+  /// are not considered focusable by Android or iOS.
   ///
   /// See also:
   ///
@@ -783,7 +784,7 @@ class SemanticsProperties extends DiagnosticableTree {
   ///
   /// See also:
   ///
-  ///  * [SemanticsFlag.image], for the flag this setting controls.
+  ///  * [SemanticsFlag.isImage], for the flag this setting controls.
   final bool image;
 
   /// If non-null, whether the node should be considered a live region.
@@ -796,14 +797,14 @@ class SemanticsProperties extends DiagnosticableTree {
   /// On iOS, no announcements are made but the node is marked as
   /// `UIAccessibilityTraitUpdatesFrequently`.
   ///
-  /// An example of a live region is the [Snackbar] widget. When it appears
+  /// An example of a live region is the [SnackBar] widget. When it appears
   /// on the screen it may be difficult to focus to read the label. A live
   /// region causes an initial polite announcement to be generated
   /// automatically.
   ///
   /// See also:
   ///
-  ///  * [SemanticsFlag.liveRegion], the semantics flag this setting controls.
+  ///  * [SemanticsFlag.isLiveRegion], the semantics flag this setting controls.
   ///  * [SemanticsConfiguration.liveRegion], for a full description of a live region.
   final bool liveRegion;
 
@@ -1034,7 +1035,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// menu of a text field, for example.
   final VoidCallback onPaste;
 
-  /// The handler for [SemanticsAction.onMoveCursorForwardByCharacter].
+  /// The handler for [SemanticsAction.moveCursorForwardByCharacter].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field forward by one character.
@@ -1043,7 +1044,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// input focus is in a text field.
   final MoveCursorHandler onMoveCursorForwardByCharacter;
 
-  /// The handler for [SemanticsAction.onMoveCursorBackwardByCharacter].
+  /// The handler for [SemanticsAction.moveCursorBackwardByCharacter].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one character.
@@ -1052,7 +1053,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// input focus is in a text field.
   final MoveCursorHandler onMoveCursorBackwardByCharacter;
 
-  /// The handler for [SemanticsAction.onMoveCursorForwardByWord].
+  /// The handler for [SemanticsAction.moveCursorForwardByWord].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one word.
@@ -1061,7 +1062,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// input focus is in a text field.
   final MoveCursorHandler onMoveCursorForwardByWord;
 
-  /// The handler for [SemanticsAction.onMoveCursorBackwardByWord].
+  /// The handler for [SemanticsAction.moveCursorBackwardByWord].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one word.
@@ -1129,7 +1130,7 @@ class SemanticsProperties extends DiagnosticableTree {
   /// A map from each supported [CustomSemanticsAction] to a provided handler.
   ///
   /// The handler associated with each custom action is called whenever a
-  /// semantics event of type [SemanticsEvent.customEvent] is received. The
+  /// semantics action of type [SemanticsAction.customAction] is received. The
   /// provided argument will be an identifier used to retrieve an instance of
   /// a custom action which can then retrieve the correct handler from this map.
   ///
@@ -1284,7 +1285,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// The [elevation] property is relative to the elevation of the parent
   /// [SemanticsNode]. However, as [SemanticsConfiguration]s from various
-  /// ascending [RenderObjects] are merged into each other to form that
+  /// ascending [RenderObject]s are merged into each other to form that
   /// [SemanticsNode] the parent’s elevation may change. This requires an
   /// adjustment of the child’s relative elevation which is represented by this
   /// value.
@@ -2157,12 +2158,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// Semantics events should be sent to inform interested parties (like
   /// the accessibility system of the operating system) about changes to the UI.
-  ///
-  /// For example, if this semantics node represents a scrollable list, a
-  /// [ScrollCompletedSemanticsEvent] should be sent after a scroll action is completed.
-  /// That way, the operating system can give additional feedback to the user
-  /// about the state of the UI (e.g. on Android a ping sound is played to
-  /// indicate a successful scroll in accessibility mode).
   void sendEvent(SemanticsEvent event) {
     if (!attached)
       return;
@@ -2765,7 +2760,7 @@ class SemanticsConfiguration {
   /// information to the [SemanticsNode] introduced by this configuration
   /// is controlled by [explicitChildNodes].
   ///
-  /// This has to be true if [isMergingDescendantsIntoOneNode] is also true.
+  /// This has to be true if [isMergingSemanticsOfDescendants] is also true.
   bool get isSemanticBoundary => _isSemanticBoundary;
   bool _isSemanticBoundary = false;
   set isSemanticBoundary(bool value) {
@@ -3070,7 +3065,7 @@ class SemanticsConfiguration {
     _onShowOnScreen = value;
   }
 
-  /// The handler for [SemanticsAction.onMoveCursorForwardByCharacter].
+  /// The handler for [SemanticsAction.moveCursorForwardByCharacter].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field forward by one character.
@@ -3089,7 +3084,7 @@ class SemanticsConfiguration {
     _onMoveCursorForwardByCharacter = value;
   }
 
-  /// The handler for [SemanticsAction.onMoveCursorBackwardByCharacter].
+  /// The handler for [SemanticsAction.moveCursorBackwardByCharacter].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one character.
@@ -3108,7 +3103,7 @@ class SemanticsConfiguration {
     _onMoveCursorBackwardByCharacter = value;
   }
 
-  /// The handler for [SemanticsAction.onMoveCursorForwardByWord].
+  /// The handler for [SemanticsAction.moveCursorForwardByWord].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one word.
@@ -3127,7 +3122,7 @@ class SemanticsConfiguration {
     _onMoveCursorForwardByCharacter = value;
   }
 
-  /// The handler for [SemanticsAction.onMoveCursorBackwardByWord].
+  /// The handler for [SemanticsAction.moveCursorBackwardByWord].
   ///
   /// This handler is invoked when the user wants to move the cursor in a
   /// text field backward by one word.
@@ -3219,10 +3214,6 @@ class SemanticsConfiguration {
 
   /// Returns the action handler registered for [action] or null if none was
   /// registered.
-  ///
-  /// See also:
-  ///
-  ///  * [addAction] to add an action.
   _SemanticsActionHandler getActionHandler(SemanticsAction action) => _actions[action];
 
   /// Determines the position of this node among its siblings in the traversal
@@ -3345,7 +3336,7 @@ class SemanticsConfiguration {
   /// The handlers for each supported [CustomSemanticsAction].
   ///
   /// Whenever a custom accessibility action is added to a node, the action
-  /// [SemanticAction.customAction] is automatically added. A handler is
+  /// [SemanticsAction.customAction] is automatically added. A handler is
   /// created which uses the passed argument to lookup the custom action
   /// handler from this map and invoke it, if present.
   Map<CustomSemanticsAction, VoidCallback> get customSemanticsActions => _customSemanticsActions;
@@ -3526,7 +3517,7 @@ class SemanticsConfiguration {
   /// announcement occurs even if the node is not focused, but only if the label
   /// has changed since the last update.
   ///
-  /// An example of a live region is the [Snackbar] widget. When it appears
+  /// An example of a live region is the [SnackBar] widget. When it appears
   /// on the screen it may be difficult to focus to read the label. A live
   /// region causes an initial polite announcement to be generated
   /// automatically.
@@ -3686,7 +3677,7 @@ class SemanticsConfiguration {
 
   /// Whether the [value] should be obscured.
   ///
-  /// This option is usually set in combination with [textField] to indicate
+  /// This option is usually set in combination with [isTextField] to indicate
   /// that the text field contains a password (or other sensitive information).
   /// Doing so instructs screen readers to not read out the [value].
   bool get isObscured => _hasFlag(SemanticsFlag.isObscured);
@@ -3696,7 +3687,7 @@ class SemanticsConfiguration {
 
   /// Whether the text field is multiline.
   ///
-  /// This option is usually set in combination with [textField] to indicate
+  /// This option is usually set in combination with [isTextField] to indicate
   /// that the text field is configured to be multiline.
   bool get isMultiline => _hasFlag(SemanticsFlag.isMultiline);
   set isMultiline(bool value) {
@@ -3800,7 +3791,7 @@ class SemanticsConfiguration {
   ///
   /// See also:
   ///
-  ///  * [RenderSemanticsGestureHandler.excludeFromScrolling] for an example of
+  ///  * [RenderViewport.excludeFromScrolling] for an example of
   ///    how tags are used.
   void addTagForChildren(SemanticsTag tag) {
     _tagsForChildren ??= <SemanticsTag>{};

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -149,7 +149,7 @@ class TapSemanticEvent extends SemanticsEvent {
 ///
 /// See also:
 ///
-///  * [SemanticsFlag.liveRegion], for a description of live regions.
+///  * [SemanticsFlag.isLiveRegion], for a description of live regions.
 ///
 @Deprecated(
   'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -722,8 +722,8 @@ abstract class AutofillClient {
   /// [TextInputConfiguration.autofillConfiguration] must not be null.
   TextInputConfiguration get textInputConfiguration;
 
-  /// Requests this [AutofillClient] update its [TextEditingState] to the given
-  /// state.
+  /// Requests this [AutofillClient] update its [TextEditingValue] to the given
+  /// value.
   void updateEditingValue(TextEditingValue newEditingValue);
 }
 

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -167,13 +167,14 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
 
   // App life cycle
 
-  /// Initializes the [lifecycleState] with the [initialLifecycleState] from the
-  /// window.
+  /// Initializes the [lifecycleState] with the [Window.initialLifecycleState]
+  /// from the window.
   ///
   /// Once the [lifecycleState] is populated through any means (including this
   /// method), this method will do nothing. This is because the
-  /// [initialLifecycleState] may already be stale and it no longer makes sense
-  /// to use the initial state at dart vm startup as the current state anymore.
+  /// [Window.initialLifecycleState] may already be stale and it no longer makes
+  /// sense to use the initial state at dart vm startup as the current state
+  /// anymore.
   ///
   /// The latest state should be obtained by subscribing to
   /// [WidgetsBindingObserver.didChangeAppLifecycleState].

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -14,6 +14,12 @@ import 'package:flutter/gestures.dart';
 import 'message_codec.dart';
 import 'system_channels.dart';
 
+/// Converts a given point from the global coordinate system in logical pixels
+/// to the local coordinate system for a box.
+///
+/// Used by [AndroidViewController.pointTransformer].
+typedef PointTransformer = Offset Function(Offset position);
+
 /// The [PlatformViewsRegistry] responsible for generating unique identifiers for platform views.
 final PlatformViewsRegistry platformViewsRegistry = PlatformViewsRegistry._instance();
 
@@ -33,7 +39,7 @@ class PlatformViewsRegistry {
   /// A platform view identifier can refer to a platform view that was never created,
   /// a platform view that was disposed, or a platform view that is alive.
   ///
-  /// Typically a platform view identifier is passed to a [PlatformView] widget
+  /// Typically a platform view identifier is passed to a platform view widget
   /// which creates the platform view and manages its lifecycle.
   int getNextPlatformViewId() => _nextPlatformViewId++;
 }
@@ -497,9 +503,9 @@ class _AndroidMotionEventConverter {
       <int, AndroidPointerProperties>{};
   final Set<int> usedAndroidPointerIds = <int>{};
 
-  Offset Function(Offset position) _pointTransformer;
+  PointTransformer _pointTransformer;
 
-  set pointTransformer(Offset Function(Offset position) transformer) {
+  set pointTransformer(PointTransformer transformer) {
     assert(transformer != null);
     _pointTransformer = transformer;
   }
@@ -797,7 +803,7 @@ abstract class AndroidViewController extends PlatformViewController {
   ///
   /// This is required to convert a [PointerEvent] to an [AndroidMotionEvent].
   /// It is typically provided by using [RenderBox.globalToLocal].
-  set pointTransformer(Offset Function(Offset position) transformer) {
+  set pointTransformer(PointTransformer transformer) {
     assert(transformer != null);
     _motionEventConverter._pointTransformer = transformer;
   }
@@ -1135,7 +1141,7 @@ abstract class PlatformViewController {
   ///
   /// See also:
   ///
-  ///  * [PlatformViewRegistry], which is a helper for managing platform view ids.
+  ///  * [PlatformViewsRegistry], which is a helper for managing platform view ids.
   int get viewId;
 
   /// Dispatches the `event` to the platform view.

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -13,7 +13,7 @@ import 'raw_keyboard.dart';
 /// Platform-specific key event data for Linux.
 ///
 /// Different window toolkit implementations can map to different key codes. This class
-/// will use the correct mapping depending on the [toolkit] provided.
+/// will use the correct mapping depending on the [keyHelper] provided.
 ///
 /// See also:
 ///
@@ -21,7 +21,7 @@ import 'raw_keyboard.dart';
 class RawKeyEventDataLinux extends RawKeyEventData {
   /// Creates a key event data structure specific for Linux.
   ///
-  /// The [toolkit], [scanCode], [unicodeScalarValues], [keyCode], and [modifiers],
+  /// The [keyHelper], [scanCode], [unicodeScalarValues], [keyCode], and [modifiers],
   /// arguments must not be null.
   const RawKeyEventDataLinux({
     @required this.keyHelper,
@@ -169,44 +169,45 @@ abstract class KeyHelper {
 
 /// Helper class that uses GLFW-specific key mappings.
 class GLFWKeyHelper with KeyHelper {
-  /// This mask is used to check the [modifiers] field to test whether the CAPS
-  /// LOCK modifier key is on.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether the CAPS LOCK modifier key is on.
   ///
   /// {@template flutter.services.glfwKeyHelper.modifiers}
-  /// Use this value if you need to decode the [modifiers] field yourself, but
-  /// it's much easier to use [isModifierPressed] if you just want to know if a
-  /// modifier is pressed. This is especially true on GLFW, since its modifiers
-  /// don't include the effects of the current key event.
+  /// Use this value if you need to decode the [RawKeyEventDataLinux.modifiers]
+  /// field yourself, but it's much easier to use [isModifierPressed] if you
+  /// just want to know if a modifier is pressed. This is especially true on
+  /// GLFW, since its modifiers don't include the effects of the current key
+  /// event.
   /// {@endtemplate}
   static const int modifierCapsLock = 0x0010;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// SHIFT modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the SHIFT modifier keys is pressed.
   ///
   /// {@macro flutter.services.glfwKeyHelper.modifiers}
   static const int modifierShift = 0x0001;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// CTRL modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the CTRL modifier keys is pressed.
   ///
   /// {@macro flutter.services.glfwKeyHelper.modifiers}
   static const int modifierControl = 0x0002;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// ALT modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the ALT modifier keys is pressed.
   ///
   /// {@macro flutter.services.glfwKeyHelper.modifiers}
   static const int modifierAlt = 0x0004;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// Meta(SUPER) modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the Meta(SUPER) modifier keys is pressed.
   ///
   /// {@macro flutter.services.glfwKeyHelper.modifiers}
   static const int modifierMeta = 0x0008;
 
 
-  /// This mask is used to check the [modifiers] field to test whether any key in
-  /// the numeric keypad is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether any key in the numeric keypad is pressed.
   ///
   /// {@macro flutter.services.glfwKeyHelper.modifiers}
   static const int modifierNumericPad = 0x0020;
@@ -319,39 +320,45 @@ class GLFWKeyHelper with KeyHelper {
 
 /// Helper class that uses GTK-specific key mappings.
 class GtkKeyHelper with KeyHelper {
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// SHIFT modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the SHIFT modifier keys is pressed.
   ///
   /// {@template flutter.services.gtkKeyHelper.modifiers}
-  /// Use this value if you need to decode the [modifiers] field yourself, but
+  /// Use this value if you need to decode the [RawKeyEventDataLinux.modifiers] field yourself, but
   /// it's much easier to use [isModifierPressed] if you just want to know if a
   /// modifier is pressed. This is especially true on GTK, since its modifiers
   /// don't include the effects of the current key event.
   /// {@endtemplate}
   static const int modifierShift = 1 << 0;
 
-  /// This mask is used to check the [modifiers] field to test whether the CAPS
-  /// LOCK modifier key is on.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether the CAPS LOCK modifier key is on.
+  ///
   /// {@macro flutter.services.gtkKeyHelper.modifiers}
   static const int modifierCapsLock = 1 << 1;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// CTRL modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the CTRL modifier keys is pressed.
+  ///
   /// {@macro flutter.services.gtkKeyHelper.modifiers}
   static const int modifierControl = 1 << 2;
 
-  /// This mask is used to check the [modifiers] field to test whether the first
-  /// modifier key is pressed (usually mapped to alt).
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether the first modifier key is pressed (usually mapped to alt).
+  ///
   /// {@macro flutter.services.gtkKeyHelper.modifiers}
   static const int modifierMod1 = 1 << 3;
 
-  /// This mask is used to check the [modifiers] field to test whether the second
-  /// modifier key is pressed (assumed to be mapped to num lock).
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether the second modifier key is pressed (assumed to be mapped to
+  /// num lock).
+  ///
   /// {@macro flutter.services.gtkKeyHelper.modifiers}
   static const int modifierMod2 = 1 << 4;
 
-  /// This mask is used to check the [modifiers] field to test whether one of the
-  /// Meta(SUPER) modifier keys is pressed.
+  /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
+  /// test whether one of the Meta(SUPER) modifier keys is pressed.
+  ///
   /// {@macro flutter.services.gtkKeyHelper.modifiers}
   static const int modifierMeta = 1 << 28;
 

--- a/packages/flutter/lib/src/services/raw_keyboard_web.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_web.dart
@@ -19,7 +19,7 @@ import 'raw_keyboard.dart';
 class RawKeyEventDataWeb extends RawKeyEventData {
   /// Creates a key event data structure specific for Web.
   ///
-  /// The [keyCode] and [metaState] arguments must not be null.
+  /// The [code] and [metaState] arguments must not be null.
   const RawKeyEventDataWeb({
     @required this.code,
     @required this.key,

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -131,7 +131,7 @@ class SystemChannels {
   ///    a [List] whose first value is an integer representing a previously
   ///    unused transaction identifier, and the second is a [String] with a
   ///    JSON-encoded object with five keys, as obtained from
-  ///    [TextInputConfiguration.toJSON]. This method must be invoked before any
+  ///    [TextInputConfiguration.toJson]. This method must be invoked before any
   ///    others (except `TextInput.hide`). See [TextInput.attach].
   ///
   ///  * `TextInput.show`: Show the keyboard. See [TextInputConnection.show].
@@ -154,8 +154,8 @@ class SystemChannels {
   ///
   ///  * `TextInputClient.updateEditingState`: The user has changed the contents
   ///    of the text control. The second argument is a [String] containing a
-  ///    JSON-encoded object with seven keys, in the form expected by [new
-  ///    TextEditingValue.fromJSON].
+  ///    JSON-encoded object with seven keys, in the form expected by
+  ///    [TextEditingValue.fromJSON].
   ///
   ///  * `TextInputClient.performAction`: The user has triggered an action. The
   ///    second argument is a [String] consisting of the stringification of one

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -336,7 +336,7 @@ class SystemChrome {
   /// {@end-tool}
   ///
   /// For more complex control of the system overlay styles, consider using
-  /// an [AnnotatedRegion] widget instead of calling [setSystemUiOverlayStyle]
+  /// an [AnnotatedRegion] widget instead of calling [setSystemUIOverlayStyle]
   /// directly. This widget places a value directly into the layer tree where
   /// it can be hit-tested by the framework. On every frame, the framework will
   /// hit-test and select the annotated region it finds under the status and

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -92,11 +92,12 @@ class FilteringTextInputFormatter extends TextInputFormatter {
   ///
   /// If [allow] is true, then the filter pattern is an allow list,
   /// and characters must match the pattern to be accepted. See also
-  /// [new FilteringTextInputFormatter.allow].
+  /// the `FilteringTextInputFormatter.allow` constructor.
+  // TODO(goderbauer): Cannot link to the constructor because of https://github.com/dart-lang/dartdoc/issues/2276.
   ///
   /// If [allow] is false, then the filter pattern is a deny list,
   /// and characters that match the pattern are rejected. See also
-  /// [new FilteringTextInputFormatter.deny].
+  /// the [FilteringTextInputFormatter.deny] constructor.
   ///
   /// The [filterPattern], [allow], and [replacementString] arguments
   /// must not be null.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -32,7 +32,6 @@ export 'dart:ui' show TextAffinity;
 /// See also:
 ///
 ///  * [TextField.smartDashesType]
-///  * [TextFormField.smartDashesType]
 ///  * [CupertinoTextField.smartDashesType]
 ///  * [EditableText.smartDashesType]
 ///  * [SmartQuotesType]
@@ -56,10 +55,8 @@ enum SmartDashesType {
 /// See also:
 ///
 ///  * [TextField.smartQuotesType]
-///  * [TextFormField.smartQuotesType]
 ///  * [CupertinoTextField.smartQuotesType]
 ///  * [EditableText.smartQuotesType]
-///  * [SmartDashesType]
 ///  * <https://developer.apple.com/documentation/uikit/uitextinputtraits>
 enum SmartQuotesType {
   /// Smart quotes is disabled.
@@ -79,7 +76,7 @@ enum SmartQuotesType {
 ///
 /// On Android, behavior may vary across device and keyboard provider.
 ///
-/// This class stays as close to [Enum] interface as possible, and allows
+/// This class stays as close to `Enum` interface as possible, and allows
 /// for additional flags for some input types. For example, numeric input
 /// can specify whether it supports decimal numbers and/or signed numbers.
 @immutable

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2171,7 +2171,7 @@ abstract class BuildContext {
   )
   InheritedWidget inheritFromWidgetOfExactType(Type targetType, { Object aspect });
 
-  /// Obtains the nearest widget of the given type [T], which must be the type of a
+  /// Obtains the nearest widget of the given type `T`, which must be the type of a
   /// concrete [InheritedWidget] subclass, and registers this build context with
   /// that widget such that when that widget changes (or a new widget of that
   /// type is introduced, or the widget goes away), this build context is
@@ -2206,7 +2206,7 @@ abstract class BuildContext {
   /// the widget or one of its ancestors is moved (for example, because an
   /// ancestor is added or removed).
   ///
-  /// The [aspect] parameter is only used when [T] is an
+  /// The [aspect] parameter is only used when `T` is an
   /// [InheritedWidget] subclasses that supports partial updates, like
   /// [InheritedModel]. It specifies what "aspect" of the inherited
   /// widget this context depends on.
@@ -2223,7 +2223,7 @@ abstract class BuildContext {
   )
   InheritedElement ancestorInheritedElementForWidgetOfExactType(Type targetType);
 
-  /// Obtains the element corresponding to the nearest widget of the given type [T],
+  /// Obtains the element corresponding to the nearest widget of the given type `T`,
   /// which must be the type of a concrete [InheritedWidget] subclass.
   ///
   /// Returns null if no such element is found.
@@ -2252,7 +2252,7 @@ abstract class BuildContext {
   )
   Widget ancestorWidgetOfExactType(Type targetType);
 
-  /// Returns the nearest ancestor widget of the given type [T], which must be the
+  /// Returns the nearest ancestor widget of the given type `T`, which must be the
   /// type of a concrete [Widget] subclass.
   ///
   /// In general, [dependOnInheritedWidgetOfExactType] is more useful, since
@@ -2290,7 +2290,7 @@ abstract class BuildContext {
   State ancestorStateOfType(TypeMatcher matcher);
 
   /// Returns the [State] object of the nearest ancestor [StatefulWidget] widget
-  /// that is an instance of the given type [T].
+  /// that is an instance of the given type `T`.
   ///
   /// This should not be used from build methods, because the build context will
   /// not be rebuilt if the value that would be returned by this method changes.
@@ -2334,10 +2334,10 @@ abstract class BuildContext {
   State rootAncestorStateOfType(TypeMatcher matcher);
 
   /// Returns the [State] object of the furthest ancestor [StatefulWidget] widget
-  /// that is an instance of the given type [T].
+  /// that is an instance of the given type `T`.
   ///
   /// Functions the same way as [findAncestorStateOfType] but keeps visiting subsequent
-  /// ancestors until there are none of the type instance of [T] remaining.
+  /// ancestors until there are none of the type instance of `T` remaining.
   /// Then returns the last one found.
   ///
   /// This operation is O(N) as well though N is the entire widget tree rather than
@@ -2356,7 +2356,7 @@ abstract class BuildContext {
   RenderObject ancestorRenderObjectOfType(TypeMatcher matcher);
 
   /// Returns the [RenderObject] object of the nearest ancestor [RenderObjectWidget] widget
-  /// that is an instance of the given type [T].
+  /// that is an instance of the given type `T`.
   ///
   /// This should not be used from build methods, because the build context will
   /// not be rebuilt if the value that would be returned by this method changes.

--- a/packages/flutter_driver/lib/src/common/find.dart
+++ b/packages/flutter_driver/lib/src/common/find.dart
@@ -174,7 +174,7 @@ class BySemanticsLabel extends SerializableFinder {
   /// Creates a semantic label finder given the [label].
   const BySemanticsLabel(this.label);
 
-  /// A [Pattern] matching the [Semantics.properties.label].
+  /// A [Pattern] matching the label of a [SemanticsNode].
   ///
   /// If this is a [String], it will be treated as an exact match.
   final Pattern label;

--- a/packages/flutter_driver/lib/src/common/geometry.dart
+++ b/packages/flutter_driver/lib/src/common/geometry.dart
@@ -52,7 +52,7 @@ class GetOffset extends CommandWithTarget {
   String get kind => 'get_offset';
 }
 
-/// The result of the [GetRect] command.
+/// The result of the [GetOffset] command.
 ///
 /// The offset is provided in logical pixels, which can be translated
 /// to device pixels via [Window.devicePixelRatio].

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -146,11 +146,11 @@ class TimelineSummary {
   /// * "frame_rasterizer_begin_times": The rasterize begin time of each frame.
   /// * "average_vsync_transitions_missed": Computes the average of the
   ///   `vsync_transitions_missed` over the lag events.
-  ///   See [sceneDisplayLagSummarizer.computeAverageVsyncTransitionsMissed].
+  ///   See [SceneDisplayLagSummarizer.computeAverageVsyncTransitionsMissed].
   /// * "90th_percentile_vsync_transitions_missed" and
   ///   "99th_percentile_vsync_transitions_missed": The 90/99-th percentile
   ///   `vsync_transitions_missed` over the lag events.
-  ///   See [sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed].
+  ///   See [SceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed].
   Map<String, dynamic> get summaryJson {
     final SceneDisplayLagSummarizer sceneDisplayLagSummarizer = _sceneDisplayLagSummarizer();
     final Map<String, dynamic> profilingSummary = _profilingSummarizer().summarize();

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -361,8 +361,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     ).replaceFirst(r'$second', _decimalFormat.format(second));
   }
 
-  /// A [LocalizationsDelegate] that uses [GlobalCupertinoLocalizations.load]
-  /// to create an instance of this class.
+  /// A [LocalizationsDelegate] for [CupertinoLocalizations].
   ///
   /// Most internationalized apps will use [GlobalCupertinoLocalizations.delegates]
   /// as the value of [CupertinoApp.localizationsDelegates] to include

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -79,7 +79,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  4. The [intl.DateFormat] for [formatMediumDate].
   ///  5. The [intl.DateFormat] for [formatFullDate].
   ///  6. The [intl.DateFormat] for [formatMonthYear].
-  ///  7. The [int.DateFormat] for [formatShortMonthDay].
+  ///  7. The [intl.DateFormat] for [formatShortMonthDay].
   ///  8. The [NumberFormat] for [formatDecimal] (also used by [formatHour] and
   ///     [formatTimeOfDay] when [timeOfDayFormat] doesn't use [HourFormat.HH]).
   ///  9. The [NumberFormat] for [formatHour] and the hour part of
@@ -667,8 +667,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   @override
   ScriptCategory get scriptCategory;
 
-  /// A [LocalizationsDelegate] that uses [GlobalMaterialLocalizations.load]
-  /// to create an instance of this class.
+  /// A [LocalizationsDelegate] for [MaterialLocalizations].
   ///
   /// Most internationalized apps will use [GlobalMaterialLocalizations.delegates]
   /// as the value of [MaterialApp.localizationsDelegates] to include

--- a/packages/flutter_localizations/lib/src/widgets_localizations.dart
+++ b/packages/flutter_localizations/lib/src/widgets_localizations.dart
@@ -59,7 +59,7 @@ class GlobalWidgetsLocalizations implements WidgetsLocalizations {
   /// A [LocalizationsDelegate] that uses [GlobalWidgetsLocalizations.load]
   /// to create an instance of this class.
   ///
-  /// [WidgetsApp] automatically adds this value to [WidgetApp.localizationsDelegates].
+  /// [WidgetsApp] automatically adds this value to [WidgetsApp.localizationsDelegates].
   static const LocalizationsDelegate<WidgetsLocalizations> delegate = _WidgetsLocalizationsDelegate();
 }
 

--- a/packages/flutter_test/lib/src/animation_sheet.dart
+++ b/packages/flutter_test/lib/src/animation_sheet.dart
@@ -29,7 +29,7 @@ import 'package:flutter_test/flutter_test.dart';
 ///    animation sheet, and can be matched against the golden test.
 ///
 /// {@tool snippet}
-/// The following example shows how to record an animation sheet of an [Inkwell]
+/// The following example shows how to record an animation sheet of an [InkWell]
 /// being pressed then released.
 ///
 /// ```dart

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -252,10 +252,10 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// This method has no effect on the timeout specified via `timeout` on
   /// [testWidgets]. That timeout is implemented by the `test` package.
   ///
-  /// By default, each [pump] and [pumpWidget] call increases the timeout by a
-  /// hundred milliseconds, and each [matchesGoldenFile] expectation increases
-  /// it by a minute. If there is no timeout in the first place, this has no
-  /// effect.
+  /// By default, each [pump] and [WidgetTester.pumpWidget] call increases the
+  /// timeout by a hundred milliseconds, and each [matchesGoldenFile]
+  /// expectation increases it by a minute. If there is no timeout in the first
+  /// place, this has no effect.
   ///
   /// The granularity of timeouts is coarse: the time is checked once per
   /// second, and only when the test is not executing. It is therefore possible

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -221,7 +221,7 @@ abstract class WebGoldenComparator {
 /// updates the files on disk to match the rendering.
 ///
 /// When using `flutter run`, the default comparator
-/// ([_TrivialWebGoldenComparator]) is used. It prints a message to the console
+/// (`_TrivialWebGoldenComparator`) is used. It prints a message to the console
 /// but otherwise does nothing. This allows tests to be developed visually on a
 /// web browser.
 ///

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -275,7 +275,7 @@ Matcher offsetMoreOrLessEquals(Offset value, { double epsilon = precisionErrorTo
 ///    with ids that match the pattern #[0-9a-f]{5}.
 ///  * [shortHash], a method that generates a 5 character long hexadecimal
 ///    [String] based on [Object.hashCode].
-///  * [TreeDiagnosticsMixin.toStringDeep], a method that returns a [String]
+///  * [DiagnosticableTree.toStringDeep], a method that returns a [String]
 ///    typically containing multiple hash codes.
 Matcher equalsIgnoringHashCodes(String value) {
   return _EqualsIgnoringHashCodes(value);
@@ -416,7 +416,7 @@ AsyncMatcher matchesReferenceImage(ui.Image image) {
 /// provided, then they are not part of the comparison.  All of the boolean
 /// flag and action fields must match, and default to false.
 ///
-/// To retrieve the semantics data of a widget, use [tester.getSemantics]
+/// To retrieve the semantics data of a widget, use [WidgetTester.getSemantics]
 /// with a [Finder] that returns a single widget. Semantics must be enabled
 /// in order to use this method.
 ///

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -180,47 +180,9 @@ void test(
 /// of any tests or sub-groups it contains. [setUp] and [tearDown] are also scoped
 /// to the containing group.
 ///
-/// If [testOn] is passed, it's parsed as a [platform selector][]; the test will
-/// only be run on matching platforms.
-///
-/// [platform selector]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors
-///
-/// If [timeout] is passed, it's used to modify or replace the default timeout
-/// of 30 seconds. Timeout modifications take precedence in suite-group-test
-/// order, so [timeout] will also modify any timeouts set on the suite, and will
-/// be modified by any timeouts set on individual tests.
-///
-/// If [skip] is a String or `true`, the group is skipped. If it's a String, it
+/// If `skip` is a String or `true`, the group is skipped. If it's a String, it
 /// should explain why the group is skipped; this reason will be printed instead
 /// of running the group's tests.
-///
-/// If [tags] is passed, it declares user-defined tags that are applied to the
-/// test. These tags can be used to select or skip the test on the command line,
-/// or to do bulk test configuration. All tags should be declared in the
-/// [package configuration file][configuring tags]. The parameter can be an
-/// [Iterable] of tag names, or a [String] representing a single tag.
-///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/44d6cb196f34a93a975ed5f3cb76afcc3a7b39b0/doc/package_config.md#configuring-tags
-///
-/// [onPlatform] allows groups to be configured on a platform-by-platform
-/// basis. It's a map from strings that are parsed as [PlatformSelector]s to
-/// annotation classes: [Timeout], [Skip], or lists of those. These
-/// annotations apply only on the given platforms. For example:
-///
-///     group('potentially slow tests', () {
-///       // ...
-///     }, onPlatform: {
-///       // These tests are especially slow on Windows.
-///       'windows': new Timeout.factor(2),
-///       'browser': [
-///         new Skip('TODO: add browser support'),
-///         // They'll be slow on browsers once it works on them.
-///         new Timeout.factor(2)
-///       ]
-///     });
-///
-/// If multiple platforms match, the annotations apply in order as through
-/// they were in nested groups.
 @isTestGroup
 void group(Object description, void Function() body, { dynamic skip }) {
   _declarer.group(description.toString(), body, skip: skip);
@@ -228,11 +190,11 @@ void group(Object description, void Function() body, { dynamic skip }) {
 
 /// Registers a function to be run before tests.
 ///
-/// This function will be called before each test is run. [callback] may be
+/// This function will be called before each test is run. The `body` may be
 /// asynchronous; if so, it must return a [Future].
 ///
 /// If this is called within a test group, it applies only to tests in that
-/// group. [callback] will be run after any set-up callbacks in parent groups or
+/// group. The `body` will be run after any set-up callbacks in parent groups or
 /// at the top level.
 ///
 /// Each callback at the top level or in a given group will be run in the order
@@ -243,11 +205,11 @@ void setUp(dynamic Function() body) {
 
 /// Registers a function to be run after tests.
 ///
-/// This function will be called after each test is run. [callback] may be
+/// This function will be called after each test is run. The `body` may be
 /// asynchronous; if so, it must return a [Future].
 ///
 /// If this is called within a test group, it applies only to tests in that
-/// group. [callback] will be run before any tear-down callbacks in parent
+/// group. The `body` will be run before any tear-down callbacks in parent
 /// groups or at the top level.
 ///
 /// Each callback at the top level or in a given group will be run in the
@@ -260,9 +222,9 @@ void tearDown(dynamic Function() body) {
 
 /// Registers a function to be run once before all tests.
 ///
-/// [callback] may be asynchronous; if so, it must return a [Future].
+/// The `body` may be asynchronous; if so, it must return a [Future].
 ///
-/// If this is called within a test group, [callback] will run before all tests
+/// If this is called within a test group, The `body` will run before all tests
 /// in that group. It will be run after any [setUpAll] callbacks in parent
 /// groups or at the top level. It won't be run if none of the tests in the
 /// group are run.
@@ -277,7 +239,7 @@ void setUpAll(dynamic Function() body) {
 
 /// Registers a function to be run once after all tests.
 ///
-/// If this is called within a test group, [callback] will run after all tests
+/// If this is called within a test group, `body` will run after all tests
 /// in that group. It will be run before any [tearDownAll] callbacks in parent
 /// groups or at the top level. It won't be run if none of the tests in the
 /// group are run.

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -64,7 +64,7 @@ class TestTextInput {
   /// Log for method calls.
   ///
   /// For all registered channels, handled calls are added to the list. Can
-  /// be cleaned using [clearLog].
+  /// be cleaned using `log.clear()`.
   final List<MethodCall> log = <MethodCall>[];
 
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].


### PR DESCRIPTION
**Reviewers**: Please ignore the first commit, it is a copy of https://github.com/flutter/flutter/pull/62317 to make cirrus happy.

## Description

* Make all warnings (except for `unresolved doc reference`) fatal
* Fix all warnings except for `unresolved doc reference`
* Fix `unresolved doc references` in:
  * painting library
  * scheduler library
  * services library
  * flutter_test
  * flutter_localizations
  * flutter_driver
  * semantics

The following packages still have `unresolved doc references` that need cleaning up:

- [ ] material
- [ ] widgets
- [x] rendering (https://github.com/flutter/flutter/pull/62443)

## Related Issues

#31931

## Tests

I added the following tests:

* doc only change, no tests

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
