### PR TITLE
Use in-memory disk for docs shards

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -281,7 +281,7 @@ task:
         # Empirically, as of October 2019, the docs-linux shard took about 30 minutes when run with
         # 1 CPU and 4G of RAM. 2 CPUs reduced that to 20 minutes, more CPUs did not improve matters.
         CPU: 2
-	USE_IN_MEMORY_DISK: true
+        USE_IN_MEMORY_DISK: true
       docs_cache:
         folder: dev/docs
         fingerprint_script:
@@ -297,7 +297,7 @@ task:
         - docs-linux
       environment:
         CPU: 2
-	USE_IN_MEMORY_DISK: true
+        USE_IN_MEMORY_DISK: true
       docs_cache:
         folder: dev/docs
         reupload_on_changes: true
@@ -313,7 +313,7 @@ task:
         - docs-linux
         - docs_docset-linux
       environment:
-	USE_IN_MEMORY_DISK: true
+        USE_IN_MEMORY_DISK: true
         # For uploading master docs to Firebase master branch staging site
         FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
         # For uploading stable docs to Firebase public live site

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,6 +74,7 @@ task:
     dockerfile: "dev/ci/docker_linux/Dockerfile"
     cpu: $CPU
     memory: $MEMORY
+    use_in_memory_disk: $USE_IN_MEMORY_DISK
   environment:
     # We shrink our default resource requirement as much as possible because that way we are more
     # likely to get scheduled. We require 4G of RAM because most of the shards (all but one as of
@@ -86,6 +87,7 @@ task:
     CIRRUS_DOCKER_CONTEXT: "dev/"
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
     ANDROID_SDK_ROOT: "/opt/android_sdk"
+    USE_IN_MEMORY_DISK: false
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
@@ -279,6 +281,7 @@ task:
         # Empirically, as of October 2019, the docs-linux shard took about 30 minutes when run with
         # 1 CPU and 4G of RAM. 2 CPUs reduced that to 20 minutes, more CPUs did not improve matters.
         CPU: 2
+	USE_IN_MEMORY_DISK: true
       docs_cache:
         folder: dev/docs
         fingerprint_script:
@@ -294,6 +297,7 @@ task:
         - docs-linux
       environment:
         CPU: 2
+	USE_IN_MEMORY_DISK: true
       docs_cache:
         folder: dev/docs
         reupload_on_changes: true
@@ -309,6 +313,7 @@ task:
         - docs-linux
         - docs_docset-linux
       environment:
+	USE_IN_MEMORY_DISK: true
         # For uploading master docs to Firebase master branch staging site
         FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
         # For uploading stable docs to Firebase public live site

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -296,7 +296,9 @@ task:
       depends_on:
         - docs-linux
       environment:
+        # TODO(tvolkert): optimize CPU and MEMORY settings once #60646 is resolved.
         CPU: 2
+        MEMORY: 8G
         USE_IN_MEMORY_DISK: true
       docs_cache:
         folder: dev/docs

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -75,15 +75,17 @@ function create_docset() {
   # If dashing gets stuck, Cirrus will time out the build after an hour, and we
   # never get to see the logs. Thus, we run it in the background and tail the logs
   # while we wait for it to complete.
-  dashing build --source ./doc --config ./dashing.json > /tmp/dashing.log 2>&1 &
+  dashing_log=/tmp/dashing.log
+  dashing build --source ./doc --config ./dashing.json > $dashing_log 2>&1 &
   dashing_pid=$!
-  tail -f /tmp/dashing.log &
-  tail_pid=$!
   wait $dashing_pid && \
   cp ./doc/flutter/static-assets/favicon.png ./flutter.docset/icon.png && \
   "$DART" --disable-dart-dev ./dashing_postprocess.dart && \
-  tar cf flutter.docset.tar.gz --use-compress-program="gzip --best" flutter.docset && \
-  kill $tail_pid &> /dev/null
+  tar cf flutter.docset.tar.gz --use-compress-program="gzip --best" flutter.docset
+  if [[ $? -ne 0 ]]; then
+      tail -200 $dashing_log
+      exit 1
+  fi
 }
 
 function deploy_docs() {

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -83,6 +83,7 @@ function create_docset() {
   "$DART" --disable-dart-dev ./dashing_postprocess.dart && \
   tar cf flutter.docset.tar.gz --use-compress-program="gzip --best" flutter.docset
   if [[ $? -ne 0 ]]; then
+      >&2 echo "Dashing docset generation failed"
       tail -200 $dashing_log
       exit 1
   fi


### PR DESCRIPTION
## Description

There are indications that the `docs-linux` and `docs_docset-linux` Cirrus shards are taking excessively long due to I/O bottlenecks.  This enables in-memory disk usage to attempt to speed them up.

## Related Issues

https://github.com/flutter/flutter/issues/60646

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
