### PR TITLE
Reland "Export Material curves in the Material lib"

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -49,6 +49,7 @@ export 'src/material/circle_avatar.dart';
 export 'src/material/color_scheme.dart';
 export 'src/material/colors.dart';
 export 'src/material/constants.dart';
+export 'src/material/curves.dart';
 export 'src/material/data_table.dart';
 export 'src/material/data_table_source.dart';
 export 'src/material/debug.dart';


### PR DESCRIPTION
Reverts flutter/flutter#62431

A new version 1.1.2 of the animations package has been published and this should be save to land now.