### PR TITLE
Fix "unresolved doc reference" in widgets layer - part 1

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -33,12 +33,12 @@ abstract class RenderSliverBoxChildManager {
   /// If no child corresponds to `index`, then do nothing.
   ///
   /// Which child is indicated by index zero depends on the [GrowthDirection]
-  /// specified in the [RenderSliverMultiBoxAdaptor.constraints]. For example
-  /// if the children are the alphabet, then if
+  /// specified in the `constraints` of the [RenderSliverMultiBoxAdaptor]. For
+  /// example if the children are the alphabet, then if
   /// [SliverConstraints.growthDirection] is [GrowthDirection.forward] then
   /// index zero is A, and index 25 is Z. On the other hand if
-  /// [SliverConstraints.growthDirection] is [GrowthDirection.reverse]
-  /// then index zero is Z, and index 25 is A.
+  /// [SliverConstraints.growthDirection] is [GrowthDirection.reverse] then
+  /// index zero is Z, and index 25 is A.
   ///
   /// During a call to [createChild] it is valid to remove other children from
   /// the [RenderSliverMultiBoxAdaptor] object if they were not created during
@@ -49,7 +49,7 @@ abstract class RenderSliverBoxChildManager {
   /// Remove the given child from the child list.
   ///
   /// Called by [RenderSliverMultiBoxAdaptor.collectGarbage], which itself is
-  /// called from [RenderSliverMultiBoxAdaptor.performLayout].
+  /// called from [RenderSliverMultiBoxAdaptor]'s `performLayout`.
   ///
   /// The index of the given child can be obtained using the
   /// [RenderSliverMultiBoxAdaptor.indexOf] method, which reads it from the

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -32,7 +32,7 @@ BuildContext _getParent(BuildContext context) {
 
 /// A class representing a particular configuration of an [Action].
 ///
-/// This class is what a key map in a [ShortcutMap] has as values, and is used
+/// This class is what the [Shortcuts.shortcuts] map has as values, and is used
 /// by an [ActionDispatcher] to look up an action and invoke it, giving it this
 /// object to extract configuration information from.
 ///

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -143,7 +143,7 @@ class WidgetsApp extends StatefulWidget {
   /// _must_ contain an entry for `'/'`.
   ///
   /// If [home] or [routes] are not null, the routing implementation needs to know how
-  /// appropriately build [PageRoutes]. This can be achieved by supplying the
+  /// appropriately build [PageRoute]s. This can be achieved by supplying the
   /// [pageRouteBuilder] parameter.  The [pageRouteBuilder] is used by [MaterialApp]
   /// and [CupertinoApp] to create [MaterialPageRoute]s and [CupertinoPageRoute],
   /// respectively.
@@ -153,10 +153,10 @@ class WidgetsApp extends StatefulWidget {
   /// rather than [builder] if you intend to only display a single route in your app.
   ///
   /// [WidgetsApp] is also possible to provide a custom implementation of routing via the
-  /// [onGeneratedRoute] and [onUnknownRoute] parameters. These parameters correspond
+  /// [onGenerateRoute] and [onUnknownRoute] parameters. These parameters correspond
   /// to [Navigator.onGenerateRoute] and [Navigator.onUnknownRoute]. If [home], [routes],
   /// and [builder] are null, or if they fail to create a requested route,
-  /// [onGeneratedRoute] will be invoked.  If that fails, [onUnknownRoute] will be invoked.
+  /// [onGenerateRoute] will be invoked.  If that fails, [onUnknownRoute] will be invoked.
   ///
   /// The [pageRouteBuilder] will create a [PageRoute] that wraps newly built routes.
   /// If the [builder] is non-null and the [onGenerateRoute] argument is null, then the

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -518,7 +518,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// a [Future].
 ///
 /// The [future] must have been obtained earlier, e.g. during [State.initState],
-/// [State.didUpdateConfig], or [State.didChangeDependencies]. It must not be
+/// [State.didUpdateWidget], or [State.didChangeDependencies]. It must not be
 /// created during the [State.build] or [StatelessWidget.build] method call when
 /// constructing the [FutureBuilder]. If the [future] is created at the same
 /// time as the [FutureBuilder], then every time the [FutureBuilder]'s parent is

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -200,8 +200,8 @@ class AutofillGroup extends StatefulWidget {
 ///
 /// The [AutofillGroupState] class also provides an [attach] method that can be
 /// called by [TextInputClient]s that support autofill, instead of
-/// [TextInputClient.attach], to create a [TextInputConnection] to interact with
-/// the platform's text input system.
+/// [TextInputConnection.attach], to create a [TextInputConnection] to interact
+/// with the platform's text input system.
 /// {@endtemplate}
 ///
 /// Typically obtained using [AutofillGroup.of].

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -982,7 +982,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
 ///
 /// See also:
 ///
-///  * [ShapeBorderClipper], which converts a [ShapeBorder] to a [CustomerClipper], as
+///  * [ShapeBorderClipper], which converts a [ShapeBorder] to a [CustomClipper], as
 ///    needed by this widget.
 class PhysicalShape extends SingleChildRenderObjectWidget {
   /// Creates a physical model with an arbitrary shape clip.
@@ -1694,8 +1694,8 @@ class Padding extends SingleChildRenderObjectWidget {
 ///
 /// {@tool snippet}
 /// The [Align] widget in this example uses one of the defined constants from
-/// [Alignment], [topRight]. This places the [FlutterLogo] in the top right corner
-/// of the parent blue [Container].
+/// [Alignment], [Alignment.topRight]. This places the [FlutterLogo] in the top
+/// right corner of the parent blue [Container].
 ///
 /// ![A blue square container with the Flutter logo in the top right corner.](https://flutter.github.io/assets-for-api-docs/assets/widgets/align_constant.png)
 ///
@@ -5587,7 +5587,7 @@ class RawImage extends LeafRenderObjectWidget {
 /// {@end-tool}
 ///
 /// Assuming that `TestWidget` uses [DefaultAssetBundle.of] to obtain its
-/// [AssetBundle], it will now see the [TestAssetBundle]'s "Hello World!" data
+/// [AssetBundle], it will now see the `TestAssetBundle`'s "Hello World!" data
 /// when requesting the "resources/test" asset.
 ///
 /// See also:
@@ -6607,8 +6607,8 @@ class MetaData extends SingleChildRenderObjectWidget {
 ///  * [ExcludeSemantics], which excludes a subtree from the semantics tree
 ///    (which might be useful if it is, e.g., totally decorative and not
 ///    important to the user).
-///  * [RenderObject.semanticsAnnotator], the rendering library API through which
-///    the [Semantics] widget is actually implemented.
+///  * [RenderObject.describeSemanticsConfiguration], the rendering library API
+///    through which the [Semantics] widget is actually implemented.
 ///  * [SemanticsNode], the object used by the rendering library to represent
 ///    semantics in the semantics tree.
 ///  * [SemanticsDebugger], an overlay to help visualize the semantics tree. Can

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1236,10 +1236,10 @@ class Transform extends SingleChildRenderObjectWidget {
   /// This is equivalent to setting an origin based on the size of the box.
   /// If it is specified at the same time as the [origin], both are applied.
   ///
-  /// An [AlignmentDirectional.start] value is the same as an [Alignment]
+  /// An [AlignmentDirectional.centerStart] value is the same as an [Alignment]
   /// whose [Alignment.x] value is `-1.0` if [textDirection] is
   /// [TextDirection.ltr], and `1.0` if [textDirection] is [TextDirection.rtl].
-  /// Similarly [AlignmentDirectional.end] is the same as an [Alignment]
+  /// Similarly [AlignmentDirectional.centerEnd] is the same as an [Alignment]
   /// whose [Alignment.x] value is `1.0` if [textDirection] is
   /// [TextDirection.ltr], and `-1.0` if [textDirection] is [TextDirection.rtl].
   final AlignmentGeometry alignment;

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -577,7 +577,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
 
   /// Called when the system locale changes.
   ///
-  /// Calls [dispatchLocaleChanged] to notify the binding observers.
+  /// Calls [dispatchLocalesChanged] to notify the binding observers.
   ///
   /// See [Window.onLocaleChanged].
   @protected
@@ -961,15 +961,16 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
 
   /// Computes the locale the current platform would resolve to.
   ///
-  /// This method is meant to be used as part of a [localeListResolutionCallback].
-  /// Since this method may return null, a Flutter/dart algorithm should still be
-  /// provided as a fallback in case a native resolved locale cannot be determined
-  /// or if the native resolved locale is undesirable.
+  /// This method is meant to be used as part of a
+  /// [WidgetsApp.localeListResolutionCallback]. Since this method may return
+  /// null, a Flutter/dart algorithm should still be provided as a fallback in
+  /// case a native resolved locale cannot be determined or if the native
+  /// resolved locale is undesirable.
   ///
   /// This method may return a null [Locale] if the platform does not support
   /// native locale resolution, or if the resolution failed.
   ///
-  /// The first [supportedLocale] is treated as the default locale and will be returned
+  /// The first `supportedLocale` is treated as the default locale and will be returned
   /// if no better match is found.
   ///
   /// Android and iOS are currently supported.
@@ -994,7 +995,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   ///
   /// Second-best (and n-best) matching locales should be obtained by calling this
   /// method again with the matched locale of the first call omitted from
-  /// [supportedLocales].
+  /// `supportedLocales`.
   Locale computePlatformResolvedLocale(List<Locale> supportedLocales) {
     return window.computePlatformResolvedLocale(supportedLocales);
   }

--- a/packages/flutter/lib/src/widgets/disposable_build_context.dart
+++ b/packages/flutter/lib/src/widgets/disposable_build_context.dart
@@ -9,9 +9,9 @@ import 'framework.dart';
 /// Provides non-leaking access to a [BuildContext].
 ///
 /// A [BuildContext] is only valid if it is pointing to an active [Element].
-/// Once the [Element.dispose] method is called, the [BuildContext] should not
-/// be accessed further. This class makes it possible for a [StatefulWidget] to
-/// share its build context safely with other objects.
+/// Once the [Element] is unmounted, the [BuildContext] should not be accessed
+/// further. This class makes it possible for a [StatefulWidget] to share its
+/// build context safely with other objects.
 ///
 /// Creators of this object must guarantee the following:
 ///

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -22,7 +22,7 @@ import 'scroll_simulation.dart';
 
 /// The signature of a method that provides a [BuildContext] and
 /// [ScrollController] for building a widget that may overflow the draggable
-/// [Axis] of the containing [DraggableScrollSheet].
+/// [Axis] of the containing [DraggableScrollableSheet].
 ///
 /// Users should apply the [scrollController] to a [ScrollView] subclass, such
 /// as a [SingleChildScrollView], [ListView] or [GridView], to have the whole

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -120,7 +120,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 ///    with a [TextEditingController].
 ///  * [EditableText], which is a raw region of editable text that can be
 ///    controlled with a [TextEditingController].
-///  * Learn how to use a [TextEditingController] in one of our [cookbook recipe]s.(https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller)
+///  * Learn how to use a [TextEditingController] in one of our [cookbook recipes](https://flutter.dev/docs/cookbook/forms/text-field-changes#2-use-a-texteditingcontroller).
 class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// Creates a controller for an editable text field.
   ///
@@ -320,7 +320,7 @@ class ToolbarOptions {
 /// action when running on an Android device will result in an error when in
 /// debug mode. In release mode, incompatible [TextInputAction]s are replaced
 /// either with "unspecified" on Android, or "default" on iOS. Appropriate
-/// [inputAction]s can be chosen by checking the current platform and then
+/// [textInputAction]s can be chosen by checking the current platform and then
 /// selecting the appropriate action.
 ///
 /// ## Lifecycle

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -184,7 +184,7 @@ enum UnfocusDisposition {
 /// a widget might need to host one if the widget subsystem is not being used,
 /// or if the [Focus] and [FocusScope] widgets provide insufficient control.
 ///
-/// [FocusNodes] are organized into _scopes_ (see [FocusScopeNode]), which form
+/// [FocusNode]s are organized into _scopes_ (see [FocusScopeNode]), which form
 /// sub-trees of nodes that restrict traversal to a group of nodes. Within a
 /// scope, the most recent nodes to have focus are remembered, and if a node is
 /// focused and then unfocused, the previous node receives focus again.
@@ -1173,7 +1173,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
 /// that manage their own [FocusScopeNode]s and [FocusNode]s, respectively. If
 /// they aren't appropriate, [FocusScopeNode]s can be managed directly._
 ///
-/// [FocusScopeNode] organizes [FocusNodes] into _scopes_. Scopes form sub-trees
+/// [FocusScopeNode] organizes [FocusNode]s into _scopes_. Scopes form sub-trees
 /// of nodes that can be traversed as a group. Within a scope, the most recent
 /// nodes to have focus are remembered, and if a node is focused and then
 /// removed, the original node receives focus again.

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -14,14 +14,14 @@ import 'inherited_notifier.dart';
 /// A widget that manages a [FocusNode] to allow keyboard focus to be given
 /// to this widget and its descendants.
 ///
-/// When the focus is gained or lost, [onFocusChanged] is called.
+/// When the focus is gained or lost, [onFocusChange] is called.
 ///
 /// For keyboard events, [onKey] is called if [FocusNode.hasFocus] is true for
 /// this widget's [focusNode], unless a focused descendant's [onKey] callback
 /// returns true when called.
 ///
 /// This widget does not provide any visual indication that the focus has
-/// changed. Any desired visual changes should be made when [onFocusChanged] is
+/// changed. Any desired visual changes should be made when [onFocusChange] is
 /// called.
 ///
 /// To access the [FocusNode] of the nearest ancestor [Focus] widget and
@@ -949,7 +949,7 @@ class _FocusMarker extends InheritedNotifier<FocusNode> {
 /// A widget that controls whether or not the descendants of this widget are
 /// focusable.
 ///
-/// Does not affect the value of [canRequestFocus] on the descendants.
+/// Does not affect the value of [Focus.canRequestFocus] on the descendants.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1136,7 +1136,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
 ///  * [FocusTraversalGroup], a widget that groups together and imposes a
 ///    traversal policy on the [Focus] nodes below it in the widget hierarchy.
 ///  * [FocusTraversalOrder], a widget that assigns an order to a widget subtree
-///    for the [OrderedFocusTraversalPolicy] to use.
+///    for the [OrderedTraversalPolicy] to use.
 ///  * [NumericFocusOrder], for a focus order that describes its order with a
 ///    `double`.
 ///  * [LexicalFocusOrder], a focus order that assigns a string-based lexical
@@ -1190,7 +1190,7 @@ abstract class FocusOrder with Diagnosticable implements Comparable<FocusOrder> 
 /// See also:
 ///
 ///  * [FocusTraversalOrder], a widget that assigns an order to a widget subtree
-///    for the [OrderedFocusTraversalPolicy] to use.
+///    for the [OrderedTraversalPolicy] to use.
 class NumericFocusOrder extends FocusOrder {
   /// Const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1228,7 +1228,7 @@ class NumericFocusOrder extends FocusOrder {
 /// See also:
 ///
 ///  * [FocusTraversalOrder], a widget that assigns an order to a widget subtree
-///    for the [OrderedFocusTraversalPolicy] to use.
+///    for the [OrderedTraversalPolicy] to use.
 class LexicalFocusOrder extends FocusOrder {
   /// Const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4506,7 +4506,7 @@ typedef TransitionBuilder = Widget Function(BuildContext context, Widget child);
 /// A builder that creates a widget given the two callbacks `onStepContinue` and
 /// `onStepCancel`.
 ///
-/// Used by [Stepper.builder].
+/// Used by [Stepper.controlsBuilder].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -75,17 +75,17 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
 /// large, or some other criteria implemented by a custom [ImageCache]
 /// implementation.
 ///
-/// The [ImageCache] holds a reference to all images passed to [putIfAbsent] as
-/// long as their [ImageStreamCompleter] has at least one listener. This method
-/// will wait until the end of the frame after its future completes before
-/// releasing its own listener. This gives callers a chance to listen to the
-/// stream if necessary. A caller can determine if the image ended up in the
-/// cache by calling [ImageProvider.obtainCacheStatus]. If it is only held as
-/// [ImageCacheStatus.live], and the caller wishes to keep the resolved
-/// image in memory, the caller should immediately call `provider.resolve` and
-/// add a listener to the returned [ImageStream]. The image will remain pinned
-/// in memory at least until the caller removes its listener from the stream,
-/// even if it would not otherwise fit into the cache.
+/// The [ImageCache] holds a reference to all images passed to
+/// [ImageCache.putIfAbsent] as long as their [ImageStreamCompleter] has at
+/// least one listener. This method will wait until the end of the frame after
+/// its future completes before releasing its own listener. This gives callers a
+/// chance to listen to the stream if necessary. A caller can determine if the
+/// image ended up in the cache by calling [ImageProvider.obtainCacheStatus]. If
+/// it is only held as [ImageCacheStatus.live], and the caller wishes to keep
+/// the resolved image in memory, the caller should immediately call
+/// `provider.resolve` and add a listener to the returned [ImageStream]. The
+/// image will remain pinned in memory at least until the caller removes its
+/// listener from the stream, even if it would not otherwise fit into the cache.
 ///
 /// Callers should be cautious about pinning large images or a large number of
 /// images in memory, as this can result in running out of memory and being
@@ -281,12 +281,12 @@ typedef ImageErrorWidgetBuilder = Widget Function(
 ///
 /// The [Image.asset], [Image.network], [Image.file], and [Image.memory]
 /// constructors allow a custom decode size to be specified through
-/// [cacheWidth] and [cacheHeight] parameters. The engine will decode the
+/// `cacheWidth` and `cacheHeight` parameters. The engine will decode the
 /// image to the specified size, which is primarily intended to reduce the
 /// memory usage of [ImageCache].
 ///
 /// In the case where a network image is used on the Web platform, the
-/// [cacheWidth] and [cacheHeight] parameters are ignored as the Web engine
+/// `cacheWidth` and `cacheHeight` parameters are ignored as the Web engine
 /// delegates image decoding of network images to the Web, which does not support
 /// custom decode sizes.
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -582,7 +582,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 /// {@tool dartpad --template=stateful_widget_scaffold}
 ///
 /// The following example (depicted above) transitions an AnimatedContainer
-/// between two states. It adjusts the [height], [width], [color], and
+/// between two states. It adjusts the `height`, `width`, `color`, and
 /// [alignment] properties when tapped.
 ///
 /// ```dart
@@ -790,7 +790,8 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 ///
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedAlign], which automatically transitions its child's
-///    position over a given duration whenever the given [alignment] changes.
+///    position over a given duration whenever the given
+///    [AnimatedAlign.alignment] changes.
 class AnimatedPadding extends ImplicitlyAnimatedWidget {
   /// Creates a widget that insets its child by a value that animates
   /// implicitly.
@@ -1535,7 +1536,7 @@ class _SliverAnimatedOpacityState extends ImplicitlyAnimatedWidgetState<SliverAn
 /// without explicit style) over a given duration whenever the given style
 /// changes.
 ///
-/// The [textAlign], [softWrap], [textOverflow], [maxLines], [textWidthBasis]
+/// The [textAlign], [softWrap], [overflow], [maxLines], [textWidthBasis]
 /// and [textHeightBehavior] properties are not animated and take effect
 /// immediately when changed.
 ///

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -300,12 +300,12 @@ class FixedExtentScrollController extends ScrollController {
 /// Metrics for a [ScrollPosition] to a scroll view with fixed item sizes.
 ///
 /// The metrics are available on [ScrollNotification]s generated from a scroll
-/// views such as [ListWheelScrollView]s with a [FixedExtentScrollController] and
-/// exposes the current [itemIndex] and the scroll view's [itemExtent].
+/// views such as [ListWheelScrollView]s with a [FixedExtentScrollController]
+/// and exposes the current [itemIndex] and the scroll view's extents.
 ///
-/// `FixedExtent` refers to the fact that the scrollable items have the same size.
-/// This is distinct from `Fixed` in the parent class name's [FixedScrollMetric]
-/// which refers to its immutability.
+/// `FixedExtent` refers to the fact that the scrollable items have the same
+/// size. This is distinct from `Fixed` in the parent class name's
+/// [FixedScrollMetrics] which refers to its immutability.
 class FixedExtentMetrics extends FixedScrollMetrics {
   /// Creates an immutable snapshot of values associated with a
   /// [ListWheelScrollView].

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -195,7 +195,7 @@ class _WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliz
 ///
 ///  * [GlobalWidgetsLocalizations], which provides widgets localizations for
 ///    many languages.
-///  * [WidgetsApp.delegates], which automatically includes
+///  * [WidgetsApp.localizationsDelegates], which automatically includes
 ///    [DefaultWidgetsLocalizations.delegate] by default.
 class DefaultWidgetsLocalizations implements WidgetsLocalizations {
   /// Construct an object that defines the localized values for the widgets

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -239,8 +239,8 @@ abstract class Route<T> {
   /// Returns whether calling [Navigator.maybePop] when this [Route] is current
   /// ([isCurrent]) should do anything.
   ///
-  /// [Navigator.maybePop] is usually used instead of [pop] to handle the system
-  /// back button.
+  /// [Navigator.maybePop] is usually used instead of [Navigator.pop] to handle
+  /// the system back button.
   ///
   /// By default, if a [Route] is the first route in the history (i.e., if
   /// [isFirst]), it reports that pops should be bubbled

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1255,7 +1255,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// root [Navigator].
 ///
 /// In practice, the nested [Navigator]s for tabbed navigation sit in the
-/// [WidgetApp] and [CupertinoTabView] widgets and do not need to be explicitly
+/// [WidgetsApp] and [CupertinoTabView] widgets and do not need to be explicitly
 /// created or managed.
 ///
 /// {@tool sample --template=freeform}
@@ -1393,7 +1393,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///
 /// [Navigator.of] operates on the nearest ancestor [Navigator] from the given
 /// [BuildContext]. Be sure to provide a [BuildContext] below the intended
-/// [Navigator], especially in large [build] methods where nested [Navigator]s
+/// [Navigator], especially in large `build` methods where nested [Navigator]s
 /// are created. The [Builder] widget can be used to access a [BuildContext] at
 /// a desired location in the widget subtree.
 class Navigator extends StatefulWidget {

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -196,7 +196,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// view. The app bar can still expand and contract as the user scrolls, but it
 /// will remain visible rather than being scrolled out of view.
 ///
-/// This works naturally in a [NestedScroll] view, as the pinned [SliverAppBar]
+/// This works naturally in a [NestedScrollView], as the pinned [SliverAppBar]
 /// is not expected to move in or out of the visible portion of the viewport.
 /// As the inner or outer [Scrollable]s are moved, the app bar persists as
 /// expected.
@@ -266,7 +266,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 ///
 /// ### Snapping [SliverAppBar]s
 ///
-/// Floating [SliverAppBars] also have the option to perform a snapping animation.
+/// Floating [SliverAppBar]s also have the option to perform a snapping animation.
 /// If [SliverAppBar.snap] is true, then a scroll that exposes the floating app
 /// bar will trigger an animation that slides the entire app bar into view.
 /// Similarly if a scroll dismisses the app bar, the animation will slide the
@@ -289,10 +289,10 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 ///
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// snapping, floating [SliverAppBar]. _Without_ setting any additional flags,
-/// e.g [NestedScrollView.floatHeaderSlivers] and [SliverAppBar.nestedSnap], the
-/// [SliverAppBar] will animate in and out without floating. The
-/// [SliverOverlapAbsorber] and [SliverOverlapInjector] maintain the proper
-/// alignment between the two separate scroll views.
+/// e.g [NestedScrollView.floatHeaderSlivers], the [SliverAppBar] will animate
+/// in and out without floating. The [SliverOverlapAbsorber] and
+/// [SliverOverlapInjector] maintain the proper alignment between the two
+/// separate scroll views.
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
@@ -1703,7 +1703,7 @@ class SliverOverlapAbsorberHandle extends ChangeNotifier {
 /// A sliver that wraps another, forcing its layout extent to be treated as
 /// overlap.
 ///
-/// The difference between the overlap requested by the child [sliver] and the
+/// The difference between the overlap requested by the child `sliver` and the
 /// overlap reported by this widget, called the _absorbed overlap_, is reported
 /// to the [SliverOverlapAbsorberHandle], which is typically passed to a
 /// [SliverOverlapInjector].
@@ -1752,7 +1752,7 @@ class SliverOverlapAbsorber extends SingleChildRenderObjectWidget {
 /// A sliver that wraps another, forcing its layout extent to be treated as
 /// overlap.
 ///
-/// The difference between the overlap requested by the child [sliver] and the
+/// The difference between the overlap requested by the child `sliver` and the
 /// overlap reported by this widget, called the _absorbed overlap_, is reported
 /// to the [SliverOverlapAbsorberHandle], which is typically passed to a
 /// [RenderSliverOverlapInjector].

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -31,7 +31,7 @@ import 'framework.dart';
 /// {@endtemplate}
 ///
 /// {@template flutter.widgets.platformViews.gestures}
-/// The widget participates in Flutter's [GestureArena]s, and dispatches touch events to the
+/// The widget participates in Flutter's gesture arenas, and dispatches touch events to the
 /// platform view iff it won the arena. Specific gestures that should be dispatched to the platform
 /// view can be specified in the `gestureRecognizers` constructor parameter. If
 /// the set of gesture recognizers is empty, a gesture will be dispatched to the platform
@@ -748,7 +748,7 @@ typedef PlatformViewSurfaceFactory = Widget Function(BuildContext context, Platf
 
 /// Constructs a [PlatformViewController].
 ///
-/// The [PlatformViewController.id] field of the created controller must match the value of the
+/// The [PlatformViewController.viewId] field of the created controller must match the value of the
 /// params [PlatformViewCreationParams.id] field.
 ///
 /// See also:
@@ -916,7 +916,7 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 /// See also:
 ///
 ///  * [AndroidView] which embeds an Android platform view in the widget hierarchy using a [TextureLayer].
-///  * [UIKitView] which embeds an iOS platform view in the widget hierarchy.
+///  * [UiKitView] which embeds an iOS platform view in the widget hierarchy.
 // TODO(amirh): Link to the embedder's system compositor documentation once available.
 class PlatformViewSurface extends LeafRenderObjectWidget {
 
@@ -1011,7 +1011,7 @@ class PlatformViewSurface extends LeafRenderObjectWidget {
 /// See also:
 ///
 ///  * [AndroidView] which embeds an Android platform view in the widget hierarchy using a [TextureLayer].
-///  * [UIKitView] which embeds an iOS platform view in the widget hierarchy.
+///  * [UiKitView] which embeds an iOS platform view in the widget hierarchy.
 class AndroidViewSurface extends PlatformViewSurface {
   /// Construct an `AndroidPlatformViewSurface`.
   const AndroidViewSurface({

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -838,12 +838,12 @@ abstract class BoxScrollView extends ScrollView {
 ///    list instead of destroying them. When scrolled back into view, the render
 ///    object is repainted as-is (if it wasn't marked dirty in the interim).
 ///
-///    This only works if [addAutomaticKeepAlives] and [addRepaintBoundaries]
+///    This only works if `addAutomaticKeepAlives` and `addRepaintBoundaries`
 ///    are false since those parameters cause the [ListView] to wrap each child
 ///    widget subtree with other widgets.
 ///
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default when
-///    [addAutomaticKeepAlives] is true). [AutomaticKeepAlive] allows descendant
+///    `addAutomaticKeepAlives` is true). [AutomaticKeepAlive] allows descendant
 ///    widgets to control whether the subtree is actually kept alive or not.
 ///    This behavior is in contrast with [KeepAlive], which will unconditionally keep
 ///    the subtree alive.
@@ -1470,7 +1470,7 @@ class ListView extends BoxScrollView {
 ///
 /// {@tool snippet}
 /// This example demonstrates how to create a [GridView] with two columns. The
-/// children are spaced apart using the [crossAxisSpacing] and [mainAxisSpacing]
+/// children are spaced apart using the `crossAxisSpacing` and `mainAxisSpacing`
 /// properties.
 ///
 /// ![The GridView displays six children with different background colors arranged in two columns](https://flutter.github.io/assets-for-api-docs/assets/widgets/grid_view.png)

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -182,7 +182,7 @@ abstract class SliverChildDelegate {
 
   /// Find index of child element with associated key.
   ///
-  /// This will be called during [performRebuild] in [SliverMultiBoxAdaptorElement]
+  /// This will be called during `performRebuild` in [SliverMultiBoxAdaptorElement]
   /// to check if a child has moved to a different position. It should return the
   /// index of the child element with associated key, null if not found.
   int findIndexByKey(Key key) => null;
@@ -605,7 +605,7 @@ class SliverChildListDelegate extends SliverChildDelegate {
   ///
   /// See also:
   ///
-  ///  * [IndexedChildSemantics], for an explanation of how to manually
+  ///  * [IndexedSemantics], for an explanation of how to manually
   ///    provide semantic indexes.
   final bool addSemanticIndexes;
 

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -191,7 +191,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// size its child to fill the maximum available extent. [SliverFillRemaining]
 /// will not constrain the scrollable area, as it could potentially have an
 /// infinite depth. This is also true for use cases such as a [ScrollView] when
-/// [ScrollView.shrinkwrap] is true.
+/// [ScrollView.shrinkWrap] is true.
 ///
 /// ### When [SliverFillRemaining] does not have a scrollable child
 ///
@@ -418,7 +418,7 @@ class SliverFillRemaining extends StatelessWidget {
   ///
   /// Setting this value to false will allow the child to fill the remainder of
   /// the viewport and not extend further. However, if the
-  /// [precedingScrollExtent] of the [SliverConstraints] and/or the [child]'s
+  /// [SliverConstraints.precedingScrollExtent] and/or the [child]'s
   /// extent exceeds the size of the viewport, the sliver will defer to the
   /// child's size rather than overriding it.
   final bool hasScrollBody;

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -54,8 +54,8 @@ class SliverFillViewport extends StatelessWidget {
   /// widget along this main axis, such as in a [CustomScrollView] with multiple
   /// children.
   ///
-  /// This option cannot be [null]. If [viewportFraction] >= 1.0, this option has no
-  /// effect. Defaults to [true].
+  /// This option cannot be null. If [viewportFraction] >= 1.0, this option has no
+  /// effect. Defaults to true.
   final bool padEnds;
 
   /// {@macro flutter.widgets.sliverMultiBoxAdaptor.delegate}

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1065,7 +1065,7 @@ class TextSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onDoubleTapDown].
   ///
-  /// By default, it selects a word through [renderEditable.selectWord] if
+  /// By default, it selects a word through [RenderEditable.selectWord] if
   /// selectionEnabled and shows toolbar if necessary.
   ///
   /// See also:
@@ -1099,7 +1099,8 @@ class TextSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onDragSelectionUpdate].
   ///
-  /// By default, it updates the selection location specified in [details].
+  /// By default, it updates the selection location specified in the provided
+  /// details objects.
   ///
   /// See also:
   ///
@@ -1196,7 +1197,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
   final GestureTapDownCallback onTapDown;
 
   /// Called when a pointer has tapped down and the force of the pointer has
-  /// just become greater than [ForcePressGestureDetector.startPressure].
+  /// just become greater than [ForcePressGestureRecognizer.startPressure].
   final GestureForcePressStartCallback onForcePressStart;
 
   /// Called when a pointer that had previously triggered [onForcePressStart] is
@@ -1204,7 +1205,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
   final GestureForcePressEndCallback onForcePressEnd;
 
   /// Called for each distinct tap except for every second tap of a double tap.
-  /// For example, if the detector was configured [onSingleTapDown] and
+  /// For example, if the detector was configured with [onTapDown] and
   /// [onDoubleTapDown], three quick taps would be recognized as a single tap
   /// down, followed by a double tap down, followed by a single tap down.
   final GestureTapUpCallback onSingleTapUp;

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -949,8 +949,9 @@ class DecoratedBoxTransition extends AnimatedWidget {
 /// Animated version of an [Align] that animates its [Align.alignment] property.
 ///
 /// Here's an illustration of the [DecoratedBoxTransition] widget, with it's
-/// [decoration] animated by a [CurvedAnimation] set to [Curves.decelerate]:
-/// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/align_transition.mp4}
+/// [DecoratedBoxTransition.decoration] animated by a [CurvedAnimation] set to
+/// [Curves.decelerate]: {@animation 300 378
+/// https://flutter.github.io/assets-for-api-docs/assets/widgets/align_transition.mp4}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -950,8 +950,9 @@ class DecoratedBoxTransition extends AnimatedWidget {
 ///
 /// Here's an illustration of the [DecoratedBoxTransition] widget, with it's
 /// [DecoratedBoxTransition.decoration] animated by a [CurvedAnimation] set to
-/// [Curves.decelerate]: {@animation 300 378
-/// https://flutter.github.io/assets-for-api-docs/assets/widgets/align_transition.mp4}
+/// [Curves.decelerate]:
+///
+/// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/align_transition.mp4}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1894,7 +1894,7 @@ mixin WidgetInspectorService {
     }
   }
 
-  /// This method is called by [WidgetBinding.performReassemble] to flush caches
+  /// This method is called by [WidgetsBinding.performReassemble] to flush caches
   /// of obsolete values after a hot reload.
   ///
   /// Do not call this method directly. Instead, use


### PR DESCRIPTION
## Description

Title says it all, see also #62367.

## Related Issues

#31931

## Tests

I added the following tests:

Doc change only.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
