### PR TITLE
separate scroll until visible implementation for lower level accessibility 

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -817,26 +817,32 @@ abstract class WidgetController {
   /// Shorthand for `Scrollable.ensureVisible(element(finder))`
   Future<void> ensureVisible(Finder finder) => Scrollable.ensureVisible(element(finder));
 
-  /// Repeatedly scrolls the `scrollable` by `delta` in the
-  /// [Scrollable.axisDirection] until `finder` is visible.
+  /// Repeatedly scrolls a [Scrollable] by `delta` in the
+  /// [Scrpllable.axisDirection] until `finder` is visible.
   ///
   /// Between each scroll, wait for `duration` time for settling.
+  ///
+  /// If `scrollable` is `null`, this will find a [Scrollable].
   ///
   /// Throws a [StateError] if `finder` is not found for maximum `maxScrolls`
   /// times.
   ///
   /// This is different from [ensureVisible] in that this allows looking for
   /// `finder` that is not built yet, but the caller must specify the scrollable
-  /// that will build child specified by `finder`.
+  /// that will build child specified by `finder` when there are multiple
+  ///[Scrollable]s.
+  ///
+  /// See [dragUntilVisible].
   Future<void> scrollUntilVisible(
     Finder finder,
-    Finder scrollable,
     double delta, {
+      Finder scrollable,
       int maxScrolls = 50,
       Duration duration = const Duration(milliseconds: 50),
     }
   ) {
     assert(maxScrolls > 0);
+    scrollable ??= find.byType(Scrollable);
     return TestAsyncUtils.guard<void>(() async {
       Offset moveStep;
       switch(widget<Scrollable>(scrollable).axisDirection) {
@@ -853,10 +859,33 @@ abstract class WidgetController {
           moveStep = Offset(-delta, 0);
           break;
       }
-      while(maxScrolls > 0 && finder.evaluate().isEmpty) {
-        await drag(scrollable, moveStep);
+      await dragUntilVisible(
+        finder,
+        scrollable,
+        moveStep,
+        maxIteration: maxScrolls,
+        duration: duration);
+    });
+  }
+
+  /// Repeatedly drags the `view` by `moveStep` until `finder` is visible.
+  ///
+  /// Between each operation, wait for `duration` time for settling.
+  ///
+  /// Throws a [StateError] if `finder` is not found for maximum `maxIteration`
+  /// times.
+  Future<void> dragUntilVisible(
+    Finder finder,
+    Finder view,
+    Offset moveStep, {
+      int maxIteration = 50,
+      Duration duration = const Duration(milliseconds: 50),
+  }) {
+    return TestAsyncUtils.guard<void>(() async {
+      while(maxIteration > 0 && finder.evaluate().isEmpty) {
+        await drag(view, moveStep);
         await pump(duration);
-        maxScrolls -= 1;
+        maxIteration-= 1;
       }
       await Scrollable.ensureVisible(element(finder));
     });

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -832,7 +832,7 @@ abstract class WidgetController {
   /// that will build child specified by `finder` when there are multiple
   ///[Scrollable]s.
   ///
-  /// See [dragUntilVisible].
+  /// See also [dragUntilVisible].
   Future<void> scrollUntilVisible(
     Finder finder,
     double delta, {

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -818,7 +818,7 @@ abstract class WidgetController {
   Future<void> ensureVisible(Finder finder) => Scrollable.ensureVisible(element(finder));
 
   /// Repeatedly scrolls a [Scrollable] by `delta` in the
-  /// [Scrpllable.axisDirection] until `finder` is visible.
+  /// [Scrollable.axisDirection] until `finder` is visible.
   ///
   /// Between each scroll, wait for `duration` time for settling.
   ///

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/semantics.dart';

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -596,7 +596,6 @@ void main() {
 
         await tester.scrollUntilVisible(
           find.text('Item 45', skipOffstage: false),
-          find.byType(Scrollable),
           100,
         );
         await tester.pumpAndSettle();
@@ -628,7 +627,6 @@ void main() {
 
         await tester.scrollUntilVisible(
           find.text('Item 45', skipOffstage: false),
-          find.byType(Scrollable),
           100,
         );
         await tester.pumpAndSettle();
@@ -656,7 +654,6 @@ void main() {
         try {
           await tester.scrollUntilVisible(
             find.text('Item 55', skipOffstage: false),
-            find.byType(Scrollable),
             100,
           );
         } on StateError catch (e) {


### PR DESCRIPTION
## Description

This is a follow up of #62097, where in many use cases the `Scrollable` is not exposed: e.g. it's within `ListView`. so having separate API at lower level is useful. 

## Related Issues

#61458

## Tests

I modified `'scrollUntilVisible: scrolls to make unbuilt widget visible'` group in `packages/flutter_test/test/controller_test.dart` and added `'Drag Until Visible'` test.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
