### PR TITLE
Fix Border.symmetric: phase 3

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -330,25 +330,19 @@ class Border extends BoxBorder {
 
   /// Creates a border with symmetrical vertical and horizontal sides.
   ///
-  /// All arguments default to [BorderSide.none] and must not be null.
+  /// The `vertical` argument applies to the [left] and [right] sides, and the
+  /// `horizontal` argument applies to the [top] and [bottom] sides.
   ///
-  /// If the `invertMeaningOfVerticalAndHorizontal` argument is set to true,
-  /// then the `vertical` argument will apply to the top and bottom borders, and
-  /// the `horizontal` argument will apply to the left and right borders. This
-  /// is not consistent with the use of "vertical" and "horizontal" elsewhere in
-  /// the framework, so callers are discouraged from overriding the default
-  /// value of that argument. In a future change, the argument will be removed.
+  /// All arguments default to [BorderSide.none] and must not be null.
   const Border.symmetric({
     BorderSide vertical = BorderSide.none,
     BorderSide horizontal = BorderSide.none,
-    bool invertMeaningOfVerticalAndHorizontal = false,
   }) : assert(vertical != null),
        assert(horizontal != null),
-       assert(invertMeaningOfVerticalAndHorizontal != null),
-       left = invertMeaningOfVerticalAndHorizontal ? horizontal : vertical,
-       top = invertMeaningOfVerticalAndHorizontal ? vertical : horizontal,
-       right = invertMeaningOfVerticalAndHorizontal ? horizontal : vertical,
-       bottom = invertMeaningOfVerticalAndHorizontal ? vertical : horizontal;
+       left = vertical,
+       top = horizontal,
+       right = vertical,
+       bottom = horizontal;
 
   /// A uniform border with all sides the same color and width.
   ///

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -35,15 +35,6 @@ void main() {
     expect(border.top, same(side2));
     expect(border.right, same(side1));
     expect(border.bottom, same(side2));
-    const Border border2 = Border.symmetric(
-      vertical: side1,
-      horizontal: side2,
-      invertMeaningOfVerticalAndHorizontal: true,
-    );
-    expect(border2.left, same(side2));
-    expect(border2.top, same(side1));
-    expect(border2.right, same(side2));
-    expect(border2.bottom, same(side1));
   });
 
   test('Border.merge', () {


### PR DESCRIPTION
## Description

This removes the (now unused) `invertMeaningOfVerticalAndHorizontal` flag.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61470

## Tests

* I updated the affected test

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
