### PR TITLE
Temporarily disable Dart Development Service in flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -15,6 +15,9 @@ import 'logger.dart';
 class DartDevelopmentService {
   DartDevelopmentService({@required this.logger});
 
+  // TODO(bkonyi): enable once VM service can handle SSE forwarding for
+  // Devtools (https://github.com/flutter/flutter/issues/62507)
+  static const bool ddsDisabled = true;
   final Logger logger;
   dds.DartDevelopmentService _ddsInstance;
 
@@ -22,6 +25,13 @@ class DartDevelopmentService {
     Uri observatoryUri,
     bool ipv6,
   ) async {
+    if (ddsDisabled) {
+      logger.printTrace(
+          'DDS is currently disabled due to '
+          'https://github.com/flutter/flutter/issues/62507'
+        );
+      return;
+    }
     final Uri ddsUri = Uri(
       scheme: 'http',
       host: (ipv6 ?

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -27,9 +27,9 @@ class DartDevelopmentService {
   ) async {
     if (ddsDisabled) {
       logger.printTrace(
-          'DDS is currently disabled due to '
-          'https://github.com/flutter/flutter/issues/62507'
-        );
+        'DDS is currently disabled due to '
+        'https://github.com/flutter/flutter/issues/62507'
+      );
       return;
     }
     final Uri ddsUri = Uri(

--- a/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io'; // ignore: dart_io_import
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:matcher/matcher.dart';
 import 'package:vm_service/vm_service.dart';
@@ -46,7 +47,7 @@ void main() {
       for (final Protocol protocol in protocolList.protocols) {
         expect(protocol.protocolName, anyOf('VM Service', 'DDS'));
       }
-    });
+    }, skip: DartDevelopmentService.ddsDisabled);
 
     test('flutterVersion can be called', () async {
       final Response response =


### PR DESCRIPTION
Devtools doesn't currently support connections to DDS. Disable DDS temporarily while a solution is worked on. See https://github.com/flutter/flutter/issues/62507.