### PR TITLE
[flutter_tools] deflake integration tests by running single isolate

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -329,6 +329,7 @@ Future<void> _runToolTests() async {
       } else {
         await _pubRunTest(
           toolsPath,
+          forceSingleCore: true,
           testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
           enableFlutterToolAsserts: true,
         );


### PR DESCRIPTION
## Description

There are  some occasional difficult to repro flakes on the tool integration tests. Try running only a single isolate to simplify the environment a bit.