### PR TITLE
migrate macrobenchmark/multi_widget_construction test to e2e

### DIFF
--- a/dev/benchmarks/macrobenchmarks/README.md
+++ b/dev/benchmarks/macrobenchmarks/README.md
@@ -45,6 +45,8 @@ The key `[test_name]` can be:
 
 - `animated_placeholder_perf`
 - `backdrop_filter_perf`
+- `color_filter_and_fade_perf`
+- `cubic_bezier_perf`
 - `cull_opacity_perf`
 - `fading_child_animation_perf`
 - `imagefiltered_transform_animation_perf`
@@ -53,7 +55,6 @@ The key `[test_name]` can be:
 - `post_backdrop_filter_perf`
 - `simple_animation_perf`
 - `textfield_perf`
-- `cubic_bezier_perf`
 
 ### E2E benchmarks
 
@@ -63,6 +64,7 @@ The key `[test_name]` can be:
 host machine. The following tests are E2E:
 
 - `cull_opacity_perf.dart`
+- `multi_widget_construction_perf`
 
 These tests should be run by:
 

--- a/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'multi_widget_construction_perf',
+    kMultiWidgetConstructionRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
+  );
+}

--- a/dev/devicelab/bin/tasks/multi_widget_construction_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/multi_widget_construction_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createsMultiWidgetConstructPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -269,6 +269,13 @@ TaskFunction createsMultiWidgetConstructPerfTest() {
   ).run;
 }
 
+TaskFunction createsMultiWidgetConstructPerfE2ETest() {
+  return E2EPerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/multi_widget_construction_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createFramePolicyIntegrationTest() {
   final String testDirectory =
       '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -172,6 +172,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
+  multi_widget_construction_perf__e2e_summary:
+    description: >
+      Measures the runtime performance of constructing and destructing widgets on Android.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+
   frame_policy_delay_test_android:
     description: >
       Tests the effect of LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -177,6 +177,7 @@ tasks:
       Measures the runtime performance of constructing and destructing widgets on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   frame_policy_delay_test_android:
     description: >


### PR DESCRIPTION
## Description

This is part of #62171, migrating `dev/benchmarks/macrobenchmarksmulti_widget_construction_perf.dart` to self-driven solution. 
This test is intended to show the overhead of a test binding. 

## Related Issues

N/A

## Tests

The PR itself is a test. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
