### PR TITLE
After cleaning up 812 warnings: Make warnings fatal in dartdocs

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -13,24 +13,23 @@ dartdoc:
       command: ["dev/snippets/lib/main.dart", "--type=sample", "--dartpad"]
       description: "Creates full application sample code documentation output from embedded documentation samples and displays it in an embedded DartPad."
   errors:
-    # The following are always errors:
+    # Default errors of dartdoc:
     - duplicate-file
     - invalid-parameter
     - tool-error
     - unresolved-export
-    # The following are elevated from warnings because we currently don't
-    # fail on warnings:
+    # Warnings that are elevated to errors:
     - ambiguous-doc-reference
     - ambiguous-reexport
-    - ignored-canonical-for
-    - no-canonical-found
-    - not-implemented
-    - no-library-level-docs
-    - category-order-gives-missing-package-name
-    - reexported-private-api-across-packages
-    # - unresolved-doc-reference # Too many failures, needs clean-up
     - broken-link
-    - unknown-macro
-    - orphaned-file
-    - unknown-file
+    - category-order-gives-missing-package-name
+    - ignored-canonical-for
     - missing-from-search-index
+    - no-canonical-found
+    - no-library-level-docs
+    - not-implemented
+    - reexported-private-api-across-packages
+    - unknown-macro
+    - unknown-file
+    - unresolved-doc-reference
+    - orphaned-file

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -17,6 +17,9 @@ const String kDocsRoot = 'dev/docs';
 const String kPublishRoot = '$kDocsRoot/doc';
 const String kSnippetsRoot = 'dev/snippets';
 
+const String kDummyPackageName = 'Flutter';
+const String kPlatformIntegrationPackageName = 'platform_integration';
+
 /// This script expects to run with the cwd as the root of the flutter repo. It
 /// will generate documentation for the packages in `//packages/` and write the
 /// documentation to `//dev/docs/doc/api/`.
@@ -50,7 +53,7 @@ Future<void> main(List<String> arguments) async {
 
   // Create the pubspec.yaml file.
   final StringBuffer buf = StringBuffer();
-  buf.writeln('name: Flutter');
+  buf.writeln('name: $kDummyPackageName');
   buf.writeln('homepage: https://flutter.dev');
   // TODO(dnfield): Re-factor for proper versioning, https://github.com/flutter/flutter/issues/55409
   buf.writeln('version: 0.0.0');
@@ -59,10 +62,10 @@ Future<void> main(List<String> arguments) async {
     buf.writeln('  $package:');
     buf.writeln('    sdk: flutter');
   }
-  buf.writeln('  platform_integration: 0.0.1');
+  buf.writeln('  $kPlatformIntegrationPackageName: 0.0.1');
   buf.writeln('dependency_overrides:');
-  buf.writeln('  platform_integration:');
-  buf.writeln('    path: platform_integration');
+  buf.writeln('  $kPlatformIntegrationPackageName:');
+  buf.writeln('    path: $kPlatformIntegrationPackageName');
   File('$kDocsRoot/pubspec.yaml').writeAsStringSync(buf.toString());
 
   // Create the library file.
@@ -122,6 +125,14 @@ Future<void> main(List<String> arguments) async {
   );
   print('\n${result.stdout}flutter version: $version\n');
 
+  // Dartdoc warnings and errors in these packages are considered fatal.
+  // All packages owned by flutter should be in the list.
+  // TODO(goderbauer): Figure out how to add 'dart:ui'.
+  final List<String> flutterPackages = <String>[
+    kDummyPackageName,
+    kPlatfromIntegrationsPackageName,
+  ]..addAll(findPackageNames());
+
   // Generate the documentation.
   // We don't need to exclude flutter_tools in this list because it's not in the
   // recursive dependencies of the package defined at dev/docs/pubspec.yaml
@@ -142,10 +153,7 @@ Future<void> main(List<String> arguments) async {
     '--header', 'snippets.html',
     '--header', 'opensearch.html',
     '--footer-text', 'lib/footer.html',
-    '--allow-warnings-in-packages',
-    <String>[
-      'flutter',
-    ].join(','),
+    '--allow-warnings-in-packages', flutterPackages.join(','),
     '--exclude-packages',
     <String>[
       'analyzer',
@@ -189,7 +197,7 @@ Future<void> main(List<String> arguments) async {
       'package:web_socket_channel/html.dart',
     ].join(','),
     '--favicon=favicon.ico',
-    '--package-order', 'flutter,Dart,platform_integration,flutter_test,flutter_driver',
+    '--package-order', 'flutter,Dart,$kPlatformIntegrationPackageName,flutter_test,flutter_driver',
     '--auto-include-dependencies',
   ];
 
@@ -477,8 +485,8 @@ Iterable<String> libraryRefs() sync* {
   }
 
   // Add a fake package for platform integration APIs.
-  yield 'platform_integration/android.dart';
-  yield 'platform_integration/ios.dart';
+  yield '$kPlatformIntegrationPackageName/android.dart';
+  yield '$kPlatformIntegrationPackageName/ios.dart';
 }
 
 void printStream(Stream<List<int>> stream, { String prefix = '', List<Pattern> filter = const <Pattern>[] }) {

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -130,7 +130,7 @@ Future<void> main(List<String> arguments) async {
   // TODO(goderbauer): Figure out how to add 'dart:ui'.
   final List<String> flutterPackages = <String>[
     kDummyPackageName,
-    kPlatfromIntegrationsPackageName,
+    kPlatformIntegrationPackageName,
   ]..addAll(findPackageNames());
 
   // Generate the documentation.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -132,7 +132,9 @@ Future<void> main(List<String> arguments) async {
     kDummyPackageName,
     kPlatformIntegrationPackageName,
     ...findPackageNames(),
-  ];
+  ]..remove('flutter_test');
+  // TODO(goderbauer): Enable flutter_test when engine is rolled to include
+  //     https://github.com/flutter/engine/pull/20140.
 
   // Generate the documentation.
   // We don't need to exclude flutter_tools in this list because it's not in the

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -131,7 +131,8 @@ Future<void> main(List<String> arguments) async {
   final List<String> flutterPackages = <String>[
     kDummyPackageName,
     kPlatformIntegrationPackageName,
-  ]..addAll(findPackageNames());
+    ...findPackageNames(),
+  ];
 
   // Generate the documentation.
   // We don't need to exclude flutter_tools in this list because it's not in the


### PR DESCRIPTION
## Description

Ensures that our dartdocs are free of warning and errors by failing the dartdoc check when any error/warning is present. All existing 812 warnings in our docs have been cleaned up.

## Related Issues

Fixes #31931

## Tests

I added the following tests:

n/a

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
