### PR TITLE
[flutter_tools] delete test that will start failing

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/error_handling_file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_file_system_test.dart
@@ -224,17 +224,6 @@ void main() {
     expect(identical(firstPath, fs.path), false);
   });
 
-  testWithoutContext('Throws type error if Directory type is set to curentDirectory with LocalFileSystem', () {
-    final FileSystem fs = ErrorHandlingFileSystem(
-      delegate: LocalFileSystem.instance,
-      platform: const LocalPlatform(),
-    );
-    final MockDirectory directory = MockDirectory();
-    when(directory.path).thenReturn('path');
-
-    expect(() => fs.currentDirectory = directory, throwsA(isA<TypeError>()));
-  });
-
   group('toString() gives toString() of delegate', () {
     testWithoutContext('ErrorHandlingFileSystem', () {
       final MockFileSystem mockFileSystem = MockFileSystem();


### PR DESCRIPTION
## Description

This behavior has changed in the next flutter roll, next it will throw a regular fs exception