### PR TITLE
Add daemon handler to start devtools

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -252,6 +252,12 @@ The returned `params` will contain:
 - `emulatorName` - the name of the emulator created; this will have been auto-generated if you did not supply one
 - `error` - when `success`=`false`, a message explaining why the creation of the emulator failed
 
+### devtools domain
+
+#### devtools.serve
+
+The `serve()` command starts a DevTools server if one isn't already running and prints out the host and port of the server.
+
 ## 'flutter run --machine' and 'flutter attach --machine'
 
 When running `flutter run --machine` or `flutter attach --machine` the following subset of the daemon is available:

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -895,25 +895,21 @@ class DevToolsDomain extends Domain {
     registerHandler('serve', startServer);
   }
 
-  HttpServer _devToolsServer;
-
-  void setDevToolsServer(HttpServer devToolsServer) {
-    _devToolsServer ??= devToolsServer;
-  }
+  DevtoolsLauncher _devtoolsLauncher;
 
   Future<void> startServer([ Map<String, dynamic> args ]) async {
-    _devToolsServer ??= await devtools_server.serveDevTools();
+    _devtoolsLauncher ??= DevtoolsLauncher.instance;
+    final HttpServer server = await _devtoolsLauncher.serve();
 
     sendEvent('devtools.serve', <String, dynamic>{
-      'host': _devToolsServer.address.host,
-      'port': _devToolsServer.port,
+      'host': server.address.host,
+      'port': server.port,
     });
   }
 
   @override
   Future<void> dispose() async {
-    await _devToolsServer?.close();
-    _devToolsServer = null;
+    await _devtoolsLauncher?.close();
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -897,13 +897,13 @@ class DevToolsDomain extends Domain {
 
   HttpServer _devToolsServer;
 
-  Future<Map<String, dynamic>> startServer([ Map<String, dynamic> args ]) async {
+  Future<void> startServer([ Map<String, dynamic> args ]) async {
     _devToolsServer ??= await devtools_server.serveDevTools();
 
-    return <String, dynamic>{
+    sendEvent('devtools.serve', <String, dynamic>{
       'host': _devToolsServer.address.host,
       'port': _devToolsServer.port,
-    };
+    });
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -892,12 +892,12 @@ class DeviceDomain extends Domain {
 
 class DevToolsDomain extends Domain {
   DevToolsDomain(Daemon daemon) : super(daemon, 'devtools') {
-    registerHandler('serve', startServer);
+    registerHandler('serve', serve);
   }
 
   DevtoolsLauncher _devtoolsLauncher;
 
-  Future<void> startServer([ Map<String, dynamic> args ]) async {
+  Future<void> serve([ Map<String, dynamic> args ]) async {
     _devtoolsLauncher ??= DevtoolsLauncher.instance;
     final HttpServer server = await _devtoolsLauncher.serve();
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -897,6 +897,10 @@ class DevToolsDomain extends Domain {
 
   HttpServer _devToolsServer;
 
+  void setDevToolsServer(HttpServer devToolsServer) {
+    _devToolsServer ??= devToolsServer;
+  }
+
   Future<void> startServer([ Map<String, dynamic> args ]) async {
     _devToolsServer ??= await devtools_server.serveDevTools();
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:devtools_server/devtools_server.dart' as devtools_server;
 import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -185,6 +185,7 @@ class Daemon {
   void _send(Map<String, dynamic> map) => sendCommand(map);
 
   Future<void> shutdown({ dynamic error }) async {
+    await devToolsDomain?.dispose();
     await _commandSubscription?.cancel();
     for (final Domain domain in _domainMap.values) {
       await domain.dispose();
@@ -903,6 +904,12 @@ class DevToolsDomain extends Domain {
       'host': _devToolsServer.address.host,
       'port': _devToolsServer.port,
     };
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _devToolsServer?.close();
+    _devToolsServer = null;
   }
 }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1731,9 +1731,7 @@ class DevtoolsLauncher {
   io.HttpServer _devtoolsServer;
   Future<void> launch(Uri observatoryAddress) async {
     try {
-      _devtoolsServer ??= await devtools_server.serveDevTools(
-        enableStdinCommands: false,
-      );
+      await serve();
       await devtools_server.launchDevTools(
         <String, dynamic>{
           'reuseWindows': true,
@@ -1746,6 +1744,17 @@ class DevtoolsLauncher {
     } on Exception catch (e, st) {
       globals.printTrace('Failed to launch DevTools: $e\n$st');
     }
+  }
+
+  Future<io.HttpServer> serve() async {
+    try {
+      _devtoolsServer ??= await devtools_server.serveDevTools(
+        enableStdinCommands: false,
+      );
+    } on Exception catch (e, st) {
+      globals.printTrace('Failed to serve DevTools: $e\n$st');
+    }
+    return _devtoolsServer;
   }
 
   Future<void> close() async {

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -741,6 +741,9 @@ class MockStdIn extends Mock implements IOSink {
 
 class MockStream extends Mock implements Stream<List<int>> {}
 
+class MockDevToolsServer extends Mock implements HttpServer {}
+class MockInternetAddress extends Mock implements InternetAddress {}
+
 class AlwaysTrueBotDetector implements BotDetector {
   const AlwaysTrueBotDetector();
 


### PR DESCRIPTION
## Description

This change adds a handler so that we can request to start the devtools server through the daemon API and receive the host and port.

```
helinx-macbookpro:flutter helinx$ flutter daemon
Building flutter tool...
[{"event":"daemon.connected","params":{"version":"0.6.0","pid":39909}}]
[{"event":"daemon.logMessage","params":{"level":"status","message":"Starting device daemon..."}}]
[{"id":"2","method":"devtools.serve"}]
Serving DevTools at http://127.0.0.1:55977
[{"event":"devtools.serve","params":{"host":"127.0.0.1","port":55977}}]
[{"id":"2"}]
```

## Related Issues

We would like to be able to request devtools start through the daemon API so that internal users can use an already built version of devtools instead of rebuilding when they are using an IDE.

## Tests

I added the following tests:
- Checking that event is printed with devtools server's host and port

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
