### PR TITLE
Make dartdoc warnings fatal for flutter_test

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -132,9 +132,7 @@ Future<void> main(List<String> arguments) async {
     kDummyPackageName,
     kPlatformIntegrationPackageName,
     ...findPackageNames(),
-  ]..remove('flutter_test');
-  // TODO(goderbauer): Enable flutter_test when engine is rolled to include
-  //     https://github.com/flutter/engine/pull/20140.
+  ];
 
   // Generate the documentation.
   // We don't need to exclude flutter_tools in this list because it's not in the

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1245,11 +1245,15 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 /// [LiveTestWidgetsFlutterBinding.framePolicy] property.
 ///
 /// {@template flutter.flutter_test.frame_policy}
-/// The default is [fadePointers]. Setting this to anything other than
-/// [onlyPumps] results in pumping extra frames, which might involve calling
-/// builders more, or calling paint callbacks more, etc, and might interfere
-/// with the test. If you know that your test won't be affected by this, you can
-/// set the policy to [fullyLive] or [benchmarkLive] in that particular file.
+/// The default is [LiveTestWidgetsFlutterBindingFramePolicy.fadePointers].
+/// Setting this to anything other than
+/// [LiveTestWidgetsFlutterBindingFramePolicy.onlyPumps] results in pumping
+/// extra frames, which might involve calling builders more, or calling paint
+/// callbacks more, etc, and might interfere with the test. If you know that
+/// your test won't be affected by this, you can set the policy to
+/// [LiveTestWidgetsFlutterBindingFramePolicy.fullyLive] or
+/// [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] in that particular
+/// file.
 ///
 /// To set a value while still allowing the test file to work as a normal test,
 /// add the following code to your test file at the top of your
@@ -1284,7 +1288,7 @@ enum LiveTestWidgetsFlutterBindingFramePolicy {
   /// explicitly pumped.
   ///
   /// The major difference between [fullyLive] and [benchmarkLive] is the latter
-  /// ignores frame requests by [pump].
+  /// ignores frame requests by [WidgetTester.pump].
   ///
   /// This can help with orienting the developer when looking at
   /// heavily-animated situations, and will almost certainly result in
@@ -1302,7 +1306,7 @@ enum LiveTestWidgetsFlutterBindingFramePolicy {
   ///
   /// This allows all frame requests from the engine to be serviced, and allows
   /// all frame requests that are artificially triggered to be serviced, but
-  /// ignores [scheduleFrame] requests from the framework.
+  /// ignores [SchedulerBinding.scheduleFrame] requests from the framework.
   /// Therefore animation won't run for this mode because the framework
   /// generates an animation by requesting new frames.
   ///
@@ -1319,11 +1323,11 @@ enum LiveTestWidgetsFlutterBindingFramePolicy {
   /// This is used for running the test on a device, where scheduling of new
   /// frames respects what the engine and the device needed.
   ///
-  /// Compared to [fullyLive] this policy ignores the frame requests from [pump]
-  /// so that frame scheduling mimics that of the real environment, and avoids
-  /// waiting for an artificially [pump]ed frame. (For example, when driving the
-  /// test in methods like [WidgetTester.handlePointerEventRecord] or
-  /// [WidgetTester.fling].)
+  /// Compared to [fullyLive] this policy ignores the frame requests from
+  /// [WidgetTester.pump] so that frame scheduling mimics that of the real
+  /// environment, and avoids waiting for an artificially pumped frame. (For
+  /// example, when driving the test in methods like
+  /// [WidgetTester.handlePointerEventRecord] or [WidgetTester.fling].)
   ///
   /// This policy differs from [benchmark] in that it can be used for capturing
   /// animation frames requested by the framework.


### PR DESCRIPTION
To be submitted after https://github.com/flutter/engine/pull/20140 rolled into the framework.