### PR TITLE
Add integration test for plugins without ios directories

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -269,53 +269,55 @@ public class DummyPluginAClass {
         return TaskResult.failure('Failed to build plugin A example APK');
       }
 
-      section('Build plugin A example iOS app');
+      if (Platform.isMacOS) {
+        section('Build plugin A example iOS app');
 
-      await inDirectory(exampleApp, () async {
-        await evalFlutter(
+        await inDirectory(exampleApp, () async {
+          await evalFlutter(
+            'build',
+            options: <String>[
+              'ios',
+              '--no-codesign',
+            ],
+          );
+        });
+
+        final Directory appBundle = Directory(path.join(
+          pluginADirectory.path,
+          'example',
           'build',
-          options: <String>[
-            'ios',
-            '--no-codesign',
-          ],
-        );
-      });
+          'ios',
+          'iphoneos',
+          'Runner.app',
+        ));
 
-      final Directory appBundle = Directory(path.join(
-        pluginADirectory.path,
-        'example',
-        'build',
-        'ios',
-        'iphoneos',
-        'Runner.app',
-      ));
+        if (!exists(appBundle)) {
+          return TaskResult.failure('Failed to build plugin A example iOS app');
+        }
 
-      if (!exists(appBundle)) {
-        return TaskResult.failure('Failed to build plugin A example iOS app');
+        checkDirectoryExists(path.join(
+          appBundle.path,
+          'Frameworks',
+          'plugin_a.framework',
+        ));
+        checkDirectoryExists(path.join(
+          appBundle.path,
+          'Frameworks',
+          'plugin_b.framework',
+        ));
+        checkDirectoryExists(path.join(
+          appBundle.path,
+          'Frameworks',
+          'plugin_c.framework',
+        ));
+
+        // Plugin D is Android only and should not be embedded.
+        checkDirectoryNotExists(path.join(
+          appBundle.path,
+          'Frameworks',
+          'plugin_d.framework',
+        ));
       }
-
-      checkDirectoryExists(path.join(
-        appBundle.path,
-        'Frameworks',
-        'plugin_a.framework',
-      ));
-      checkDirectoryExists(path.join(
-        appBundle.path,
-        'Frameworks',
-        'plugin_b.framework',
-      ));
-      checkDirectoryExists(path.join(
-        appBundle.path,
-        'Frameworks',
-        'plugin_c.framework',
-      ));
-
-      // Plugin D is Android only and should not be embedded.
-      checkDirectoryNotExists(path.join(
-        appBundle.path,
-        'Frameworks',
-        'plugin_d.framework',
-      ));
 
       return TaskResult.success(null);
     } on TaskResult catch (taskResult) {

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -78,6 +78,11 @@ Future<void> main() async {
         );
       });
 
+      checkDirectoryNotExists(path.join(
+        pluginCDirectory.path,
+        'android',
+      ));
+
       final File pluginCpubspec = File(path.join(pluginCDirectory.path, 'pubspec.yaml'));
       await pluginCpubspec.writeAsString('''
 name: plugin_c
@@ -97,6 +102,27 @@ environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
   flutter: ">=1.5.0 <2.0.0"
 ''', flush: true);
+
+      section('Create plugin D without ios/ directory');
+
+      final Directory pluginDDirectory = Directory(path.join(tempDir.path, 'plugin_d'));
+      await inDirectory(tempDir, () async {
+        await flutter(
+          'create',
+          options: <String>[
+            '--org',
+            'io.flutter.devicelab.plugin_d',
+            '--template=plugin',
+            '--platforms=android',
+            pluginDDirectory.path,
+          ],
+        );
+      });
+
+      checkDirectoryNotExists(path.join(
+        pluginDDirectory.path,
+        'ios',
+      ));
 
       section('Write dummy Kotlin code in plugin B');
 
@@ -120,7 +146,7 @@ public class DummyPluginBClass {
 }
 ''', flush: true);
 
-      section('Make plugin A depend on plugin B and plugin C');
+      section('Make plugin A depend on plugin B, C, and D');
 
       final File pluginApubspec = File(path.join(pluginADirectory.path, 'pubspec.yaml'));
       String pluginApubspecContent = await pluginApubspec.readAsString();
@@ -130,7 +156,9 @@ public class DummyPluginBClass {
         '  plugin_b:\n'
         '    path: ${pluginBDirectory.path}\n'
         '  plugin_c:\n'
-        '    path: ${pluginCDirectory.path}\n',
+        '    path: ${pluginCDirectory.path}\n'
+        '  plugin_d:\n'
+        '    path: ${pluginDDirectory.path}\n',
       );
       await pluginApubspec.writeAsString(pluginApubspecContent, flush: true);
 
@@ -187,7 +215,7 @@ public class DummyPluginAClass {
         '['
           '{'
             '"name":"plugin_a",'
-            '"dependencies":["plugin_b","plugin_c"]'
+            '"dependencies":["plugin_b","plugin_c","plugin_d"]'
           '},'
           '{'
             '"name":"plugin_b",'
@@ -195,6 +223,10 @@ public class DummyPluginAClass {
           '},'
           '{'
             '"name":"plugin_c",'
+            '"dependencies":[]'
+          '},'
+          '{'
+            '"name":"plugin_d",'
             '"dependencies":[]'
           '}'
         ']';
@@ -206,7 +238,7 @@ public class DummyPluginAClass {
         );
       }
 
-      section('Build plugin A example app');
+      section('Build plugin A example Android app');
 
       final StringBuffer stderr = StringBuffer();
       await inDirectory(exampleApp, () async {
@@ -236,6 +268,54 @@ public class DummyPluginAClass {
       if (!pluginAExampleApk) {
         return TaskResult.failure('Failed to build plugin A example APK');
       }
+
+      section('Build plugin A example iOS app');
+
+      await inDirectory(exampleApp, () async {
+        await evalFlutter(
+          'build',
+          options: <String>[
+            'ios',
+            '--no-codesign',
+          ],
+        );
+      });
+
+      final Directory appBundle = Directory(path.join(
+        pluginADirectory.path,
+        'example',
+        'build',
+        'ios',
+        'iphoneos',
+        'Runner.app',
+      ));
+
+      if (!exists(appBundle)) {
+        return TaskResult.failure('Failed to build plugin A example iOS app');
+      }
+
+      checkDirectoryExists(path.join(
+        appBundle.path,
+        'Frameworks',
+        'plugin_a.framework',
+      ));
+      checkDirectoryExists(path.join(
+        appBundle.path,
+        'Frameworks',
+        'plugin_b.framework',
+      ));
+      checkDirectoryExists(path.join(
+        appBundle.path,
+        'Frameworks',
+        'plugin_c.framework',
+      ));
+
+      // Plugin D is Android only and should not be embedded.
+      checkDirectoryNotExists(path.join(
+        appBundle.path,
+        'Frameworks',
+        'plugin_d.framework',
+      ));
 
       return TaskResult.success(null);
     } on TaskResult catch (taskResult) {


### PR DESCRIPTION
## Description

Integration test to create an Android-only plugin with no `ios` directory, then add that dependency to another plugin.  Make sure the other plugin can build for iOS, and doesn't embed the Android-only plugin.

## Related Issues

https://github.com/flutter/flutter/pull/61561
I locally verified this integration test passes on top of https://github.com/flutter/flutter/pull/62372

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*