### PR TITLE
Layout paragraph using the appropriate width based on its textWidthBasis

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -568,7 +568,21 @@ class TextPainter {
     _previousCaretPrototype = null;
     _paragraph.layout(ui.ParagraphConstraints(width: maxWidth));
     if (minWidth != maxWidth) {
-      final double newWidth = maxIntrinsicWidth.clamp(minWidth, maxWidth) as double;
+      double newWidth;
+      switch (textWidthBasis) {
+        case TextWidthBasis.longestLine:
+          // The parent widget expects the paragraph to be exactly
+          // `TextPainter.width` wide, if that value satisfies the constraints
+          // it gave to the TextPainter. So when `textWidthBasis` is longestLine,
+          // the paragraph's width needs to be as close to the width of its
+          // longest line as possible.
+          newWidth = _applyFloatingPointHack(_paragraph.longestLine);
+          break;
+        case TextWidthBasis.parent:
+          newWidth = maxIntrinsicWidth;
+          break;
+      }
+      newWidth = newWidth.clamp(minWidth, maxWidth) as double;
       if (newWidth != _applyFloatingPointHack(_paragraph.width)) {
         _paragraph.layout(ui.ParagraphConstraints(width: newWidth));
       }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -916,6 +916,38 @@ void main() {
     expect(tester.getSize(find.text('RIGHT ALIGNED, LONGEST LINE')).width, equals(width));
   }, skip: isBrowser);  // https://github.com/flutter/flutter/issues/44020
 
+  testWidgets(
+    'textWidthBasis.longestLine confines the width of the paragraph '
+    'when given loose constraints',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/62550.
+      await tester.pumpWidget(
+          Center(
+            child: SizedBox(
+              width: 400,
+              child: Center(
+                child: RichText(
+                  text: const TextSpan(text: 'fwefwefwewfefewfwe fwfwfwefweabcdefghijklmnopqrstuvwxyz'),
+                  textWidthBasis: TextWidthBasis.longestLine,
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        );
+
+      expect(find.byType(RichText), paints..something((Symbol method, List<dynamic> arguments) {
+        if (method != #drawParagraph)
+          return false;
+        final ui.Paragraph paragraph = arguments[0] as ui.Paragraph;
+        if (paragraph.width > paragraph.longestLine)
+          throw 'paragraph width (${paragraph.width}) greater than its longest line (${paragraph.longestLine}).';
+        if (paragraph.width >= 400)
+          throw 'paragraph.width (${paragraph.width}) >= 400';
+        return true;
+      }));
+  }, skip: isBrowser);  // https://github.com/flutter/flutter/issues/44020
+
   testWidgets('Paragraph.getBoxesForRange returns nothing when selection range is zero length', (WidgetTester tester) async {
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
     builder.addText('hello');


### PR DESCRIPTION
## Description

When a `TextPainter.textWidthBasis` is `longestLine`, the `TextPainter` should layout its paraph using the width of its longest line from the 1st layout pass. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62550

## Tests

I added the following tests:

    'textWidthBasis.longestLine confines the width of the paragraph '
    'when given loose constraints'

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
