### PR TITLE
Feature: Add `HitTestBehavior` as an argument to `Dismissible`

### DIFF
--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -190,6 +190,8 @@ class Dismissible extends StatefulWidget {
   final DragStartBehavior dragStartBehavior;
 
   /// How to behave during hit tests.
+  ///
+  /// This defaults to [HitTestBehavior.opaque].
   final HitTestBehavior hitTestBehavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -96,9 +96,11 @@ class Dismissible extends StatefulWidget {
     this.movementDuration = const Duration(milliseconds: 200),
     this.crossAxisEndOffset = 0.0,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.hitTestBehavior = HitTestBehavior.opaque,
   }) : assert(key != null),
        assert(secondaryBackground == null || background != null),
        assert(dragStartBehavior != null),
+       assert(hitTestBehavior != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -186,6 +188,9 @@ class Dismissible extends StatefulWidget {
   ///
   ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
   final DragStartBehavior dragStartBehavior;
+
+  /// How to behave during hit tests.
+  final HitTestBehavior hitTestBehavior;
 
   @override
   _DismissibleState createState() => _DismissibleState();
@@ -579,7 +584,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       onVerticalDragStart: _directionIsXAxis ? null : _handleDragStart,
       onVerticalDragUpdate: _directionIsXAxis ? null : _handleDragUpdate,
       onVerticalDragEnd: _directionIsXAxis ? null : _handleDragEnd,
-      behavior: HitTestBehavior.opaque,
+      behavior: widget.hitTestBehavior,
       child: content,
       dragStartBehavior: widget.dragStartBehavior,
     );

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -761,7 +761,7 @@ void main() {
         ],
       ),
     ));
-    
+
     expect((tester.firstWidget(find.byKey(first)) as Dismissible).hitTestBehavior, HitTestBehavior.opaque);
     expect((tester.firstWidget(find.byKey(second)) as Dismissible).hitTestBehavior, HitTestBehavior.translucent);
     expect((tester.firstWidget(find.byKey(third)) as Dismissible).hitTestBehavior, HitTestBehavior.deferToChild);

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -735,6 +735,38 @@ void main() {
     expect(confirmDismissDirection, DismissDirection.endToStart);
   });
 
+  testWidgets('HitTestBehaviour defaults to opaque but also respects the specified behavior', (WidgetTester tester) async {
+    const ValueKey<int> first = ValueKey<int>(0);
+    const ValueKey<int> second = ValueKey<int>(1);
+    const ValueKey<int> third = ValueKey<int>(2);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView(
+        children: const <Widget>[
+          Dismissible(
+            key: first,
+            child: Text('text'),
+          ),
+          Dismissible(
+            hitTestBehavior: HitTestBehavior.translucent,
+            key: second,
+            child: Text('text'),
+          ),
+          Dismissible(
+            hitTestBehavior: HitTestBehavior.deferToChild,
+            key: third,
+            child: Text('text'),
+          ),
+        ],
+      ),
+    ));
+    
+    expect((tester.firstWidget(find.byKey(first)) as Dismissible).hitTestBehavior, HitTestBehavior.opaque);
+    expect((tester.firstWidget(find.byKey(second)) as Dismissible).hitTestBehavior, HitTestBehavior.translucent);
+    expect((tester.firstWidget(find.byKey(third)) as Dismissible).hitTestBehavior, HitTestBehavior.deferToChild);
+  });
+
   testWidgets('setState that does not remove the Dismissible from tree should throws Error', (WidgetTester tester) async {
     scrollDirection = Axis.vertical;
     dismissDirection = DismissDirection.horizontal;


### PR DESCRIPTION
## Description

Allow `Dismissible` to have `HitTestBehavior` property.

## Related Issues

Fixes #62270 

## Tests

I added the  following test:
`HitTestBehaviour defaults to opaque but also respects the specified behavior`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
