### PR TITLE
Fix the flexible space bar to still create a rendering object even if…

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -316,6 +316,8 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
             right: 0.0,
             height: height,
             child: Opacity(
+              // IOS is relying on this semantics node to correctly traverse
+              // through the app bar when it is collapsed.
               alwaysIncludeSemantics: true,
               opacity: opacity,
               child: widget.background,

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -303,42 +303,40 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
           const double fadeEnd = 1.0;
           assert(fadeStart <= fadeEnd);
           final double opacity = 1.0 - Interval(fadeStart, fadeEnd).transform(t);
-          if (opacity > 0.0) {
-            double height = settings.maxExtent;
+          double height = settings.maxExtent;
 
-            // StretchMode.zoomBackground
-            if (widget.stretchModes.contains(StretchMode.zoomBackground) &&
-              constraints.maxHeight > height) {
-              height = constraints.maxHeight;
-            }
+          // StretchMode.zoomBackground
+          if (widget.stretchModes.contains(StretchMode.zoomBackground) &&
+            constraints.maxHeight > height) {
+            height = constraints.maxHeight;
+          }
+          children.add(Positioned(
+            top: _getCollapsePadding(t, settings),
+            left: 0.0,
+            right: 0.0,
+            height: height,
+            child: Opacity(
+              alwaysIncludeSemantics: true,
+              opacity: opacity,
+              child: widget.background,
+            ),
+          ));
 
-            children.add(Positioned(
-              top: _getCollapsePadding(t, settings),
-              left: 0.0,
-              right: 0.0,
-              height: height,
-              child: Opacity(
-                opacity: opacity,
-                child: widget.background,
-              ),
-            ));
-
-            // StretchMode.blurBackground
-            if (widget.stretchModes.contains(StretchMode.blurBackground) &&
-              constraints.maxHeight > settings.maxExtent) {
-              final double blurAmount = (constraints.maxHeight - settings.maxExtent) / 10;
-              children.add(Positioned.fill(
-                child: BackdropFilter(
-                  child: Container(
-                    color: Colors.transparent,
-                  ),
-                  filter: ui.ImageFilter.blur(
-                    sigmaX: blurAmount,
-                    sigmaY: blurAmount,
-                  )
+          // StretchMode.blurBackground
+          if (widget.stretchModes.contains(StretchMode.blurBackground) &&
+            constraints.maxHeight > settings.maxExtent) {
+            final double blurAmount = (constraints.maxHeight - settings.maxExtent) / 10;
+            children.add(Positioned.fill(
+              child: BackdropFilter(
+                child: Container(
+                  color: Colors.transparent,
+                ),
+                filter: ui.ImageFilter.blur(
+                  sigmaX: blurAmount,
+                  sigmaY: blurAmount,
                 )
-              ));
-            }
+              )
+            ));
           }
         }
 

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -7,6 +7,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../widgets/semantics_tester.dart';
+
 void main() {
   testWidgets('FlexibleSpaceBar centers title on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -117,6 +119,248 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(clipRect.size.height, minExtent);
+  });
+
+  testWidgets('Collpased FlexibleSpaceBar has correct semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    const double expandedHeight = 200;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              const SliverAppBar(
+                pinned: true,
+                expandedHeight: expandedHeight,
+                title: Text('Title'),
+                flexibleSpace: FlexibleSpaceBar(
+                  background: Text('Expanded title'),
+                ),
+              ),
+              SliverList(
+                delegate: SliverChildListDelegate(
+                  <Widget>[
+                    for (int i = 0; i < 50; i++)
+                      Container(
+                        height: 200,
+                        child: Center(child: Text('Item $i')),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    TestSemantics expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
+          rect: TestSemantics.fullScreen,
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 2,
+              rect: TestSemantics.fullScreen,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 3,
+                  rect: TestSemantics.fullScreen,
+                  flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 4,
+                      rect: TestSemantics.fullScreen,
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 9,
+                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 11,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
+                              flags: <SemanticsFlag>[
+                                SemanticsFlag.isHeader,
+                                SemanticsFlag.namesRoute
+                              ],
+                              label: 'Title',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 10,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
+                              label: 'Expanded title',
+                              textDirection: TextDirection.ltr,
+                            ),
+                          ],
+                        ),
+                        TestSemantics(
+                          id: 12,
+                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                          rect: TestSemantics.fullScreen,
+                          actions: <SemanticsAction>[SemanticsAction.scrollUp],
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 5,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              label: 'Item 0',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 6,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              label: 'Item 1',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 7,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 2',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 8,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 3',
+                              textDirection: TextDirection.ltr,
+                            ),
+
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+
+    // We drag up to fully collapse the space bar.
+    await tester.drag(find.text('Item 1'), const Offset(0, -600.0));
+    await tester.pumpAndSettle();
+
+    expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 1,
+          rect: TestSemantics.fullScreen,
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 2,
+              rect: TestSemantics.fullScreen,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 3,
+                  rect: TestSemantics.fullScreen,
+                  flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 4,
+                      rect: TestSemantics.fullScreen,
+                      children: <TestSemantics>[
+                        TestSemantics(
+                          id: 9,
+                          // The app bar is collapsed.
+                          rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 11,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
+                              flags: <SemanticsFlag>[
+                                SemanticsFlag.isHeader,
+                                SemanticsFlag.namesRoute
+                              ],
+                              label: 'Title',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            // The flexible space bar still persists in the
+                            // semantic tree even if it is collapsed.
+                            TestSemantics(
+                              id: 10,
+                              rect: const Rect.fromLTRB(0.0, 36.0, 800.0, 92.0),
+                              label: 'Expanded title',
+                              textDirection: TextDirection.ltr,
+                            ),
+                          ],
+                        ),
+                        TestSemantics(
+                          id: 12,
+                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                          rect: TestSemantics.fullScreen,
+                          actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 5,
+                              rect: const Rect.fromLTRB(0.0, 150.0, 800.0, 200.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 0',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 6,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 1',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 7,
+                              rect: const Rect.fromLTRB(0.0, 56.0, 800.0, 200.0),
+                              label: 'Item 2',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 8,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              label: 'Item 3',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 13,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              label: 'Item 4',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 14,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 5',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 15,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.isHidden],
+                              label: 'Item 6',
+                              textDirection: TextDirection.ltr,
+                            ),
+
+
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true));
+
+    semantics.dispose();
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/14227


### PR DESCRIPTION
… it is collapsed

## Description

The flexible space bar removes itself from the rendering tree when it is collapse. However the ios relys on the semantics node to present in the semantics tree in order to traverse through the app bar correctly. This is not an issue in android because android will always do implicit scrolling to reveal the collapsed header again before moving the focus to the header.

This PR change the flexible space bar to always insert itself to rendering tree even if it is collapsed.

This fixes the first problem i mentioned in https://github.com/flutter/flutter/issues/62549#issuecomment-666731900

There is another pr to prevent sudden jump in accessibility focus in ios when it scrolls due to showOnScreen. https://github.com/flutter/engine/pull/20167

These two prs need to work together to fully resolve the issue

## Related Issues

https://github.com/flutter/flutter/issues/62549

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
