### PR TITLE
Use OverflowBar instead of ButtonBar in DateRangePicker

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
@@ -12,7 +12,6 @@ import 'package:flutter/widgets.dart';
 
 import '../app_bar.dart';
 import '../back_button.dart';
-import '../button_bar.dart';
 import '../button_theme.dart';
 import '../color_scheme.dart';
 import '../debug.dart';
@@ -655,19 +654,23 @@ class _InputDateRangePickerDialog extends StatelessWidget {
       onIconPressed: onToggleEntryMode,
     );
 
-    final Widget actions = ButtonBar(
-      buttonTextTheme: ButtonTextTheme.primary,
-      layoutBehavior: ButtonBarLayoutBehavior.constrained,
-      children: <Widget>[
-        TextButton(
-          child: Text(cancelText ?? localizations.cancelButtonLabel),
-          onPressed: onCancel,
-        ),
-        TextButton(
-          child: Text(confirmText ?? localizations.okButtonLabel),
-          onPressed: onConfirm,
-        ),
-      ],
+    final Widget actions = Container(
+      alignment: AlignmentDirectional.centerEnd,
+      constraints: const BoxConstraints(minHeight: 52.0),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: OverflowBar(
+        spacing: 8,
+        children: <Widget>[
+          TextButton(
+            child: Text(cancelText ?? localizations.cancelButtonLabel),
+            onPressed: onCancel,
+          ),
+          TextButton(
+            child: Text(confirmText ?? localizations.okButtonLabel),
+            onPressed: onConfirm,
+          ),
+        ],
+      ),
     );
 
     switch (orientation) {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -207,6 +207,62 @@ void main() {
     });
   });
 
+  testWidgets('OK Cancel button layout', (WidgetTester tester) async {
+     Widget buildFrame(TextDirection textDirection) {
+       return MaterialApp(
+         home: Material(
+           child: Center(
+             child: Builder(
+               builder: (BuildContext context) {
+                 return ElevatedButton(
+                   child: const Text('X'),
+                   onPressed: () {
+                     showDateRangePicker(
+                       context: context,
+                       firstDate:DateTime(2001, DateTime.january, 1),
+                       lastDate: DateTime(2031, DateTime.december, 31),
+                       builder: (BuildContext context, Widget child) {
+                         return Directionality(
+                           textDirection: textDirection,
+                           child: child,
+                         );
+                       },
+                     );
+                   },
+                 );
+               },
+             ),
+           ),
+         ),
+       );
+     }
+
+    Future<void> showOkCancelDialog(TextDirection textDirection) async {
+      await tester.pumpWidget(buildFrame(textDirection));
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.edit));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> dismissOkCancelDialog() async {
+      await tester.tap(find.text('CANCEL'));
+      await tester.pumpAndSettle();
+    }
+
+    await showOkCancelDialog(TextDirection.ltr);
+    expect(tester.getBottomRight(find.text('OK')).dx, 622);
+    expect(tester.getBottomLeft(find.text('OK')).dx, 594);
+    expect(tester.getBottomRight(find.text('CANCEL')).dx, 560);
+    await dismissOkCancelDialog();
+
+    await showOkCancelDialog(TextDirection.rtl);
+    expect(tester.getBottomRight(find.text('OK')).dx, 206);
+    expect(tester.getBottomLeft(find.text('OK')).dx, 178);
+    expect(tester.getBottomRight(find.text('CANCEL')).dx, 324);
+    await dismissOkCancelDialog();
+  });
+
   group('Haptic feedback', () {
     const Duration hapticFeedbackInterval = Duration(milliseconds: 10);
     FeedbackTester feedback;


### PR DESCRIPTION
Removed DateRangePicker's dependency on ButtonBar, which has its own troublesome dependencies on ButtonTheme (now obsolete - see flutter.dev/go/material-button-system-updates) as well as a problematic implementation, see #53378.

This change is similar to #62601