### PR TITLE
Return devtools serve response instead of printing

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -256,7 +256,7 @@ The returned `params` will contain:
 
 #### devtools.serve
 
-The `serve()` command starts a DevTools server if one isn't already running and prints out the host and port of the server.
+The `serve()` command starts a DevTools server if one isn't already running and returns the host and port of the server.
 
 ## 'flutter run --machine' and 'flutter attach --machine'
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -896,14 +896,14 @@ class DevToolsDomain extends Domain {
 
   DevtoolsLauncher _devtoolsLauncher;
 
-  Future<void> serve([ Map<String, dynamic> args ]) async {
+  Future<Map<String, dynamic>> serve([ Map<String, dynamic> args ]) async {
     _devtoolsLauncher ??= DevtoolsLauncher.instance;
     final HttpServer server = await _devtoolsLauncher.serve();
 
-    sendEvent('devtools.serve', <String, dynamic>{
+    return<String, dynamic>{
       'host': server.address.host,
       'port': server.port,
-    });
+    };
   }
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -321,10 +321,10 @@ void main() {
       when(mockDevToolsLauncher.serve()).thenAnswer((_) async => mockDevToolsServer);
 
       commands.add(<String, dynamic>{'id': 0, 'method': 'devtools.serve'});
-      final Map<String, dynamic> response = await responses.stream.firstWhere(_isDevToolsEvent);
-      expect(response['params'], isNotEmpty);
-      expect(response['params']['host'], equals('127.0.0.1'));
-      expect(response['params']['port'], equals(1234));
+      final Map<String, dynamic> response = await responses.stream.firstWhere((Map<String, dynamic> response) => response['id'] == 0);
+      expect(response['result'], isNotEmpty);
+      expect(response['result']['host'], equals('127.0.0.1'));
+      expect(response['result']['port'], equals(1234));
       await responses.close();
       await commands.close();
     }, overrides: <Type, Generator>{
@@ -465,8 +465,6 @@ void main() {
 bool _notEvent(Map<String, dynamic> map) => map['event'] == null;
 
 bool _isConnectedEvent(Map<String, dynamic> map) => map['event'] == 'daemon.connected';
-
-bool _isDevToolsEvent(Map<String, dynamic> map) => map['event'] == 'devtools.serve';
 
 class MockFuchsiaWorkflow extends FuchsiaWorkflow {
   MockFuchsiaWorkflow({ this.canListDevices = true });


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/flutter/flutter/pull/62608. Initially I thought I needed output to match another format to minimize changes in the IntelliJ plugin but it would be better to parse a result value.

## Related Issues

See [previous PR](https://github.com/flutter/flutter/pull/62608)

## Tests

I modified the test for calling `devtools.serve`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
