### PR TITLE
Add punctuation for unterminated sentences in doc comments

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -10,18 +10,18 @@ import 'tween.dart';
 // Examples can assume:
 // AnimationController _controller;
 
-/// The status of an animation
+/// The status of an animation.
 enum AnimationStatus {
-  /// The animation is stopped at the beginning
+  /// The animation is stopped at the beginning.
   dismissed,
 
-  /// The animation is running from beginning to end
+  /// The animation is running from beginning to end.
   forward,
 
-  /// The animation is running backwards, from end to beginning
+  /// The animation is running backwards, from end to beginning.
   reverse,
 
-  /// The animation is stopped at the end
+  /// The animation is stopped at the end.
   completed,
 }
 

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -36,19 +36,19 @@ enum DatePickerDateTimeOrder {
 enum DatePickerDateOrder {
   /// Order of the columns, from left to right: day, month, year.
   ///
-  /// Example: 12 | March | 1996
+  /// Example: 12 | March | 1996.
   dmy,
   /// Order of the columns, from left to right: month, day, year.
   ///
-  /// Example: March | 12 | 1996
+  /// Example: March | 12 | 1996.
   mdy,
   /// Order of the columns, from left to right: year, month, day.
   ///
-  /// Example: 1996 | March | 12
+  /// Example: 1996 | March | 12.
   ymd,
   /// Order of the columns, from left to right: year, day, month.
   ///
-  /// Example: 1996 | 12 | March
+  /// Example: 1996 | 12 | March.
   ydm,
 }
 
@@ -208,19 +208,19 @@ abstract class CupertinoLocalizations {
   // The global version uses the translated string from the arb file.
   String timerPickerSecondLabel(int second);
 
-  /// The term used for cutting
+  /// The term used for cutting.
   // The global version uses the translated string from the arb file.
   String get cutButtonLabel;
 
-  /// The term used for copying
+  /// The term used for copying.
   // The global version uses the translated string from the arb file.
   String get copyButtonLabel;
 
-  /// The term used for pasting
+  /// The term used for pasting.
   // The global version uses the translated string from the arb file.
   String get pasteButtonLabel;
 
-  /// The term used for selecting everything
+  /// The term used for selecting everything.
   // The global version uses the translated string from the arb file.
   String get selectAllButtonLabel;
 

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -184,7 +184,7 @@ class CupertinoSegmentedControl<T> extends StatefulWidget {
   /// Defaults to the selectedColor at 20% opacity if null.
   final Color pressedColor;
 
-  /// The CupertinoSegmentedControl will be placed inside this padding
+  /// The CupertinoSegmentedControl will be placed inside this padding.
   ///
   /// Defaults to EdgeInsets.symmetric(horizontal: 16.0)
   final EdgeInsetsGeometry padding;

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -99,7 +99,7 @@ abstract class StackFilter {
   /// Filters the list of [StackFrame]s by updating corresponding indices in
   /// `reasons`.
   ///
-  /// To elide a frame or number of frames, set the string
+  /// To elide a frame or number of frames, set the string.
   void filter(List<StackFrame> stackFrames, List<String?> reasons);
 }
 

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -258,7 +258,7 @@ class TextTreeConfiguration {
   /// Prefix to add to other lines to display a child with this style.
   ///
   /// [prefixOtherLines] should typically be one character shorter than
-  /// [prefixLineOne] as
+  /// [prefixLineOne] is.
   final String prefixOtherLines;
 
   /// Prefix to add to the first line to display the last child of a node with
@@ -1511,7 +1511,7 @@ abstract class DiagnosticsNode {
   /// will make the name self-evident.
   final bool showName;
 
-  /// Prefix to include at the start of each line
+  /// Prefix to include at the start of each line.
   final String? linePrefix;
 
   /// Description to show if the node has no displayed properties or children.

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -15,26 +15,26 @@ class Unicode {
   // prevents instantiation and extension.
   // ignore: unused_element
   Unicode._();
-  /// U+202A LEFT-TO-RIGHT EMBEDDING
+  /// `U+202A LEFT-TO-RIGHT EMBEDDING`
   ///
   /// Treat the following text as embedded left-to-right.
   ///
   /// Use [PDF] to end the embedding.
   static const String LRE = '\u202A';
 
-  /// U+202B RIGHT-TO-LEFT EMBEDDING
+  /// `U+202B RIGHT-TO-LEFT EMBEDDING`
   ///
   /// Treat the following text as embedded right-to-left.
   ///
   /// Use [PDF] to end the embedding.
   static const String RLE = '\u202B';
 
-  /// U+202C POP DIRECTIONAL FORMATTING
+  /// `U+202C POP DIRECTIONAL FORMATTING`
   ///
   /// End the scope of the last [LRE], [RLE], [RLO], or [LRO].
   static const String PDF = '\u202C';
 
-  /// U+202A LEFT-TO-RIGHT OVERRIDE
+  /// `U+202A LEFT-TO-RIGHT OVERRIDE`
   ///
   /// Force following characters to be treated as strong left-to-right characters.
   ///
@@ -43,7 +43,7 @@ class Unicode {
   /// Use [PDF] to end the override.
   static const String LRO = '\u202D';
 
-  /// U+202B RIGHT-TO-LEFT OVERRIDE
+  /// `U+202B RIGHT-TO-LEFT OVERRIDE`
   ///
   /// Force following characters to be treated as strong right-to-left characters.
   ///
@@ -52,21 +52,21 @@ class Unicode {
   /// Use [PDF] to end the override.
   static const String RLO = '\u202E';
 
-  /// U+2066 LEFT-TO-RIGHT ISOLATE
+  /// `U+2066 LEFT-TO-RIGHT ISOLATE`
   ///
   /// Treat the following text as isolated and left-to-right.
   ///
   /// Use [PDI] to end the isolated scope.
   static const String LRI = '\u2066';
 
-  /// U+2067 RIGHT-TO-LEFT ISOLATE
+  /// `U+2067 RIGHT-TO-LEFT ISOLATE`
   ///
   /// Treat the following text as isolated and right-to-left.
   ///
   /// Use [PDI] to end the isolated scope.
   static const String RLI = '\u2067';
 
-  /// U+2068 FIRST STRONG ISOLATE
+  /// `U+2068 FIRST STRONG ISOLATE`
   ///
   /// Treat the following text as isolated and in the direction of its first
   /// strong directional character that is not inside a nested isolate.
@@ -79,22 +79,22 @@ class Unicode {
   /// Use [PDI] to end the isolated scope.
   static const String FSI = '\u2068';
 
-  /// U+2069 POP DIRECTIONAL ISOLATE
+  /// `U+2069 POP DIRECTIONAL ISOLATE`
   ///
   /// End the scope of the last [LRI], [RLI], or [FSI].
   static const String PDI = '\u2069';
 
-  /// U+200E LEFT-TO-RIGHT MARK
+  /// `U+200E LEFT-TO-RIGHT MARK`
   ///
   /// Left-to-right zero-width character.
   static const String LRM = '\u200E';
 
-  /// U+200F RIGHT-TO-LEFT MARK
+  /// `U+200F RIGHT-TO-LEFT MARK`
   ///
   /// Right-to-left zero-width non-Arabic character.
   static const String RLM = '\u200F';
 
-  /// U+061C ARABIC LETTER MARK
+  /// `U+061C ARABIC LETTER MARK`
   ///
   /// Right-to-left zero-width Arabic character.
   static const String ALM = '\u061C';

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -388,7 +388,7 @@ abstract class PointerEvent with Diagnosticable {
   ///
   /// The angle of the contact ellipse, in radians in the range:
   ///
-  ///    -pi/2 < orientation <= pi/2
+  ///     -pi/2 < orientation <= pi/2
   ///
   /// ...giving the angle of the major axis of the ellipse with the y-axis
   /// (negative angles indicating an orientation along the top-left /
@@ -400,7 +400,7 @@ abstract class PointerEvent with Diagnosticable {
   ///
   /// The angle of the stylus, in radians in the range:
   ///
-  ///    -pi < orientation <= pi
+  ///     -pi < orientation <= pi
   ///
   /// ...giving the angle of the axis of the stylus projected onto the input
   /// surface, relative to the positive y-axis of that surface (thus 0.0
@@ -417,7 +417,7 @@ abstract class PointerEvent with Diagnosticable {
   ///
   /// The angle of the stylus, in radians in the range:
   ///
-  ///    0 <= tilt <= pi/2
+  ///     0 <= tilt <= pi/2
   ///
   /// ...giving the angle of the axis of the stylus, relative to the axis
   /// perpendicular to the input surface (thus 0.0 indicates the stylus is

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -359,7 +359,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   /// Updates [_initialLine] and [_currentLine] accordingly to the situation of
-  /// the registered pointers
+  /// the registered pointers.
   void _updateLines() {
     final int count = _pointerLocations.keys.length;
     assert(_pointerQueue.length >= count);

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -11,7 +11,7 @@ import 'constants.dart';
 import 'events.dart';
 import 'recognizer.dart';
 
-/// Details for [GestureTapDownCallback], such as position
+/// Details for [GestureTapDownCallback], such as position.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -279,7 +279,7 @@ class BottomNavigationBar extends StatefulWidget {
   final IconThemeData selectedIconTheme;
 
   /// The size, opacity, and color of the icon in the currently unselected
-  /// [BottomNavigationBarItem.icon]s
+  /// [BottomNavigationBarItem.icon]s.
   ///
   /// If this is not provided, the size will default to [iconSize], the color
   /// will default to [unselectedItemColor].

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1430,7 +1430,7 @@ class RawChip extends StatefulWidget
         CheckmarkableChipAttributes,
         DisabledChipAttributes,
         TappableChipAttributes {
-  /// Creates a RawChip
+  /// Creates a RawChip.
   ///
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
   /// the same time.

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -18,7 +18,7 @@ import 'theme_data.dart';
 /// [InputChip], [ChoiceChip], [FilterChip], and [ActionChip].
 ///
 /// A chip theme describes the color, shape and text styles for the chips it is
-/// applied to
+/// applied to.
 ///
 /// Descendant widgets obtain the current theme's [ChipThemeData] object using
 /// [ChipTheme.of]. When a widget uses [ChipTheme.of], it is automatically

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -179,7 +179,7 @@ class FlexibleSpaceBar extends StatefulWidget {
   /// Defaults to [CollapseMode.parallax].
   final CollapseMode collapseMode;
 
-  /// Stretch effect while over-scrolling,
+  /// Stretch effect while over-scrolling.
   ///
   /// Defaults to include [StretchMode.zoomBackground].
   final List<StretchMode> stretchModes;

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -85,7 +85,7 @@ abstract class InteractiveInkFeature extends InkFeature {
   /// [clipCallback] is the callback used to obtain the [Rect] used for clipping the ink effect.
   /// If [clipCallback] is null, no clipping is performed on the ink circle.
   ///
-  /// Clipping can happen in 3 different ways -
+  /// Clipping can happen in 3 different ways:
   ///  1. If [customBorder] is provided, it is used to determine the path
   ///     for clipping.
   ///  2. If [customBorder] is null, and [borderRadius] is provided, the canvas

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -468,7 +468,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
   }
 }
 
-/// Defines the behavior of the floating label
+/// Defines the behavior of the floating label.
 enum FloatingLabelBehavior {
   /// The label will always be positioned within the content, or hidden.
   never,

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -118,7 +118,7 @@ class MergeableMaterial extends StatefulWidget {
 
   /// The z-coordinate at which to place all the [Material] slices.
   ///
-  /// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24
+  /// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24.
   ///
   /// Defaults to 2, the appropriate elevation for cards.
   ///

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -58,7 +58,7 @@ const double _monthNavButtonsWidth = 108.0;
 ///    time picker.
 ///
 class CalendarDatePicker extends StatefulWidget {
-  /// Creates a calender date picker
+  /// Creates a calender date picker.
   ///
   /// It will display a grid of days for the [initialDate]'s month. The day
   /// indicated by [initialDate] will be selected.
@@ -437,7 +437,7 @@ class _MonthPicker extends StatefulWidget {
        assert(!selectedDate.isAfter(lastDate)),
        super(key: key);
 
-  /// The initial month to display
+  /// The initial month to display.
   final DateTime initialMonth;
 
   /// The current date.
@@ -463,7 +463,7 @@ class _MonthPicker extends StatefulWidget {
   /// Called when the user picks a day.
   final ValueChanged<DateTime> onChanged;
 
-  /// Called when the user navigates to a new month
+  /// Called when the user navigates to a new month.
   final ValueChanged<DateTime> onDisplayedMonthChanged;
 
   /// Optional user supplied predicate function to customize selectable days.

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -175,7 +175,7 @@ abstract class SearchDelegate<T> {
   /// clear the query and show the suggestions again (via [showSuggestions]) if
   /// the results are currently shown.
   ///
-  /// Returns null if no widget should be shown
+  /// Returns null if no widget should be shown.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/shadows.dart
+++ b/packages/flutter/lib/src/material/shadows.dart
@@ -14,7 +14,7 @@ import 'package:flutter/painting.dart';
 
 /// Map of elevation offsets used by material design to [BoxShadow] definitions.
 ///
-/// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24
+/// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24.
 ///
 /// Each entry has three shadows which must be combined to obtain the defined
 /// effect for that elevation.

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -27,7 +27,7 @@ import 'theme_data.dart';
 /// The slider is as big as the largest of
 /// the [SliderComponentShape.getPreferredSize] of the thumb shape,
 /// the [SliderComponentShape.getPreferredSize] of the overlay shape,
-/// and the [SliderTickMarkShape.getPreferredSize] of the tick mark shape
+/// and the [SliderTickMarkShape.getPreferredSize] of the tick mark shape.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -734,7 +734,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// If this property is null, then kTabLabelPadding is used.
   final EdgeInsetsGeometry labelPadding;
 
-  /// The text style of the unselected tab labels
+  /// The text style of the unselected tab labels.
   ///
   /// If this property is null, then the [labelStyle] value is used. If [labelStyle]
   /// is null, then the text style of the [ThemeData.primaryTextTheme]'s

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -28,7 +28,7 @@ export 'package:flutter/services.dart' show TextInputType, TextInputAction, Text
 
 /// Signature for the [TextField.buildCounter] callback.
 typedef InputCounterWidgetBuilder = Widget Function(
-  /// The build context for the TextField
+  /// The build context for the TextField.
   BuildContext context, {
   /// The length of the string currently in the input.
   @required int currentLength,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1085,7 +1085,7 @@ class ThemeData with Diagnosticable {
   final TextButtonThemeData textButtonTheme;
 
   /// A theme for customizing the appearance and internal layout of
-  /// [ElevatedButton]s
+  /// [ElevatedButton]s.
   final ElevatedButtonThemeData elevatedButtonTheme;
 
   /// A theme for customizing the appearance and internal layout of

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -134,7 +134,7 @@ class TimePickerThemeData with Diagnosticable {
 
   /// The color of the entry mode [IconButton].
   ///
-  /// If this is null, the time picker defaults to
+  /// If this is null, the time picker defaults to:
   /// ```
   /// Theme.of(context).colorScheme.onSurface.withOpacity(
   ///   Theme.of(context).colorScheme.brightness == Brightness.dark ? 1.0 : 0.6,

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -171,27 +171,27 @@ enum VerticalDirection {
 
 /// A direction along either the horizontal or vertical [Axis].
 enum AxisDirection {
-  /// Zero is at the bottom and positive values are above it: ⇈
+  /// Zero is at the bottom and positive values are above it: `⇈`
   ///
   /// Alphabetical content with a [GrowthDirection.forward] would have the A at
   /// the bottom and the Z at the top. This is an unusual configuration.
   up,
 
-  /// Zero is on the left and positive values are to the right of it: ⇉
+  /// Zero is on the left and positive values are to the right of it: `⇉`
   ///
   /// Alphabetical content with a [GrowthDirection.forward] would have the A on
   /// the left and the Z on the right. This is the ordinary reading order for a
   /// horizontal set of tabs in an English application, for example.
   right,
 
-  /// Zero is at the top and positive values are below it: ⇊
+  /// Zero is at the top and positive values are below it: `⇊`
   ///
   /// Alphabetical content with a [GrowthDirection.forward] would have the A at
   /// the top and the Z at the bottom. This is the ordinary reading order for a
   /// vertical list.
   down,
 
-  /// Zero is to the right and positive values are to the left of it: ⇇
+  /// Zero is to the right and positive values are to the left of it: `⇇`
   ///
   /// Alphabetical content with a [GrowthDirection.forward] would have the A at
   /// the right and the Z at the left. This is the ordinary reading order for a

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -471,7 +471,7 @@ class _BoxDecorationPainter extends BoxPainter {
     super.dispose();
   }
 
-  /// Paint the box decoration into the given location on the given canvas
+  /// Paint the box decoration into the given location on the given canvas.
   @override
   void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
     assert(configuration != null);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -989,7 +989,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 ///     - icons/heart.png
 /// ```
 ///
-/// Then, to fetch the image and associate it with scale `1.5`, use
+/// Then, to fetch the image and associate it with scale `1.5`, use:
 ///
 /// ```dart
 /// AssetImage('icons/heart.png', scale: 1.5)

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -75,7 +75,7 @@ const String _kAssetManifestFileName = 'AssetManifest.json';
 ///     - icons/heart.png
 /// ```
 ///
-/// Then, to fetch the image, use
+/// Then, to fetch the image, use:
 /// ```dart
 /// AssetImage('icons/heart.png')
 /// ```

--- a/packages/flutter/lib/src/painting/placeholder_span.dart
+++ b/packages/flutter/lib/src/painting/placeholder_span.dart
@@ -68,7 +68,7 @@ abstract class PlaceholderSpan extends InlineSpan {
   }
 
   // TODO(garyq): Remove this after next stable release.
-  /// The [visitTextSpan] method is invalid on [PlaceholderSpan]s
+  /// The [visitTextSpan] method is invalid on [PlaceholderSpan]s.
   @override
   @Deprecated(
     'Use to visitChildren instead. '

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -156,7 +156,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   MouseTracker _mouseTracker;
 
   /// The render tree's owner, which maintains dirty state for layout,
-  /// composite, paint, and accessibility semantics
+  /// composite, paint, and accessibility semantics.
   PipelineOwner get pipelineOwner => _pipelineOwner;
   PipelineOwner _pipelineOwner;
 

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -249,7 +249,7 @@ class BoxConstraints extends Constraints {
   BoxConstraints widthConstraints() => BoxConstraints(minWidth: minWidth, maxWidth: maxWidth);
 
   /// Returns box constraints with the same height constraints but with
-  /// unconstrained width
+  /// unconstrained width.
   BoxConstraints heightConstraints() => BoxConstraints(minHeight: minHeight, maxHeight: maxHeight);
 
   /// Returns the width that both satisfies the constraints and is as close as

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -316,7 +316,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// [handleDoubleTap], and [handleLongPress].
   ///
   /// If there are any gesture recognizers in the text span, the [handleEvent]
-  /// will still propagate pointer events to those recognizers
+  /// will still propagate pointer events to those recognizers.
   ///
   /// The default value of this property is false.
   bool ignorePointer;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -35,7 +35,7 @@ enum FlexFit {
 
 /// Parent data for use with [RenderFlex].
 class FlexParentData extends ContainerBoxParentData<RenderBox> {
-  /// The flex factor to use for this child
+  /// The flex factor to use for this child.
   ///
   /// If null or zero, the child is inflexible and determines its own size. If
   /// non-zero, the amount of space the child's can occupy in the main axis is

--- a/packages/flutter/lib/src/rendering/mouse_tracking.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracking.dart
@@ -440,7 +440,7 @@ class BaseMouseTracker extends ChangeNotifier {
   /// Override this method to receive updates when the relationship between a
   /// device and annotations have changed. Subclasses should override this method
   /// to first call to their inherited [handleDeviceUpdate] method, and then
-  /// process the update as desired,
+  /// process the update as desired.
   ///
   /// The update can be caused by two kinds of triggers:
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -676,7 +676,7 @@ abstract class Constraints {
   /// const constructors so that they can be used in const expressions.
   const Constraints();
 
-  /// Whether there is exactly one size possible given these constraints
+  /// Whether there is exactly one size possible given these constraints.
   bool get isTight;
 
   /// Whether the constraint is expressed in a consistent manner.
@@ -2987,7 +2987,7 @@ mixin RenderObjectWithChildMixin<ChildType extends RenderObject> on RenderObject
   }
 
   ChildType _child;
-  /// The render object's unique child
+  /// The render object's unique child.
   ChildType get child => _child;
   set child(ChildType value) {
     if (_child != null)

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -207,7 +207,7 @@ class RenderConstrainedBox extends RenderProxyBox {
        _additionalConstraints = additionalConstraints,
        super(child);
 
-  /// Additional constraints to apply to [child] during layout
+  /// Additional constraints to apply to [child] during layout.
   BoxConstraints get additionalConstraints => _additionalConstraints;
   BoxConstraints _additionalConstraints;
   set additionalConstraints(BoxConstraints value) {
@@ -3403,7 +3403,7 @@ class RenderMetaData extends RenderProxyBoxWithHitTestBehavior {
     RenderBox child,
   }) : super(behavior: behavior, child: child);
 
-  /// Opaque meta data ignored by the render tree
+  /// Opaque meta data ignored by the render tree.
   dynamic metaData;
 
   @override

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -284,7 +284,7 @@ enum Overflow {
   clip,
 }
 
-/// Implements the stack layout algorithm
+/// Implements the stack layout algorithm.
 ///
 /// In a stack layout, the children are positioned on top of each other in the
 /// order in which they appear in the child list. First, the non-positioned

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -694,7 +694,7 @@ class SemanticsProperties extends DiagnosticableTree {
 
   /// If non-null, indicates that this subtree is read only.
   ///
-  /// Only applicable when [textField] is true
+  /// Only applicable when [textField] is true.
   ///
   /// TalkBack/VoiceOver will treat it as non-editable text field.
   final bool readOnly;

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -712,7 +712,7 @@ class AutofillConfiguration {
 abstract class AutofillClient {
   /// The unique identifier of this [AutofillClient].
   ///
-  /// Must not be null;
+  /// Must not be null.
   String get autofillId;
 
   /// The [TextInputConfiguration] that describes this [AutofillClient].

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -53,7 +53,7 @@ abstract class TextInputFormatter {
 }
 
 /// Function signature expected for creating custom [TextInputFormatter]
-/// shorthands via [TextInputFormatter.withFunction];
+/// shorthands via [TextInputFormatter.withFunction].
 typedef TextInputFormatFunction = TextEditingValue Function(
   TextEditingValue oldValue,
   TextEditingValue newValue,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -402,7 +402,7 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
   /// The image filter to apply to the existing painted content before painting the child.
   ///
   /// For example, consider using [ImageFilter.blur] to create a backdrop
-  /// blur effect
+  /// blur effect.
   final ui.ImageFilter filter;
 
   @override
@@ -4496,7 +4496,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
     @required Widget child,
   }) : super(key: key, child: child);
 
-  /// The flex factor to use for this child
+  /// The flex factor to use for this child.
   ///
   /// If null or zero, the child is inflexible and determines its own size. If
   /// non-zero, the amount of space the child's can occupy in the main axis is
@@ -6493,7 +6493,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 class AbsorbPointer extends SingleChildRenderObjectWidget {
   /// Creates a widget that absorbs pointers during hit testing.
   ///
-  /// The [absorbing] argument must not be null
+  /// The [absorbing] argument must not be null.
   const AbsorbPointer({
     Key key,
     this.absorbing = true,
@@ -6557,7 +6557,7 @@ class MetaData extends SingleChildRenderObjectWidget {
     Widget child,
   }) : super(key: key, child: child);
 
-  /// Opaque meta data ignored by the render tree
+  /// Opaque meta data ignored by the render tree.
   final dynamic metaData;
 
   /// How to behave during hit testing.

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1006,7 +1006,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
 /// The widget is given constraints during layout that force it to fill the
 /// entire screen. If you wish to align your widget to one side of the screen
 /// (e.g., the top), consider using the [Align] widget. If you wish to center
-/// your widget, you can also use the [Center] widget
+/// your widget, you can also use the [Center] widget.
 ///
 /// Calling [runApp] again will detach the previous root widget from the screen
 /// and attach the given widget in its place. The new widget tree is compared

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -515,7 +515,7 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   final bool obscureText;
 
-  /// {@macro flutter.dart:ui.textHeightBehavior},
+  /// {@macro flutter.dart:ui.textHeightBehavior}
   final TextHeightBehavior textHeightBehavior;
 
   /// {@macro flutter.painting.textPainter.textWidthBasis}
@@ -814,7 +814,7 @@ class EditableText extends StatefulWidget {
   /// See the examples in [maxLines] for the complete picture of how [maxLines],
   /// [minLines], and [expands] interact to produce various behaviors.
   ///
-  /// Input that matches the height of its parent
+  /// Input that matches the height of its parent:
   /// ```dart
   /// Expanded(
   ///   child: TextField(maxLines: null, expands: true),
@@ -1064,7 +1064,7 @@ class EditableText extends StatefulWidget {
   /// {@template flutter.widgets.editableText.cursorWidth}
   /// How thick the cursor will be.
   ///
-  /// Defaults to 2.0
+  /// Defaults to 2.0.
   ///
   /// The cursor will draw under the text. The cursor width will extend
   /// to the right of the boundary between characters for left-to-right text

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -563,7 +563,7 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
 ///
 /// When the list is at the zero scroll offset, the first child is aligned with
 /// the middle of the viewport. When the list is at the final scroll offset,
-/// the last child is aligned with the middle of the viewport
+/// the last child is aligned with the middle of the viewport.
 ///
 /// The children are rendered as if rotating on a wheel instead of scrolling on
 /// a plane.

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -870,7 +870,7 @@ class MediaQuery extends InheritedWidget {
   }
 }
 
-/// Describes the navigation mode to be set by a [MediaQuery] widget
+/// Describes the navigation mode to be set by a [MediaQuery] widget.
 ///
 /// The different modes indicate the type of navigation to be used in a widget
 /// subtree for those widgets sensitive to it.

--- a/packages/flutter/lib/src/widgets/performance_overlay.dart
+++ b/packages/flutter/lib/src/widgets/performance_overlay.dart
@@ -38,7 +38,7 @@ class PerformanceOverlay extends LeafRenderObjectWidget {
     this.checkerboardOffscreenLayers = false,
   }) : super(key: key);
 
-  /// Create a performance overlay that displays all available statistics
+  /// Create a performance overlay that displays all available statistics.
   PerformanceOverlay.allEnabled({
     Key key,
     this.rasterizerThreshold = 0,

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -26,7 +26,7 @@ abstract class PreferredSizeWidget implements Widget {
   /// In many cases it's only necessary to define one preferred dimension.
   /// For example the [Scaffold] only depends on its app bar's preferred
   /// height. In that case implementations of this method can just return
-  /// `new Size.fromHeight(myAppBarHeight)`;
+  /// `new Size.fromHeight(myAppBarHeight)`.
   Size get preferredSize;
 }
 

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -407,7 +407,9 @@ class SliverFillRemaining extends StatelessWidget {
        assert(fillOverscroll != null),
        super(key: key);
 
-  /// Doc
+  /// Box child widget that fills the remaining space in the viewport.
+  ///
+  /// The main [SliverFillRemaining] documentation contains more details.
   final Widget child;
 
   /// Indicates whether the child has a scrollable body, this value cannot be

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -25,7 +25,7 @@ class SimpleExpansionPanelListTestWidget extends StatefulWidget {
   /// If null, the default [ExpansionPanelList]'s expanded header padding value is applied via [defaultExpandedHeaderPadding]
   final EdgeInsets expandedHeaderPadding;
 
-  /// Mirrors the default expanded header padding as its source constants are private
+  /// Mirrors the default expanded header padding as its source constants are private.
   static EdgeInsets defaultExpandedHeaderPadding()
   {
     return const ExpansionPanelList().expandedHeaderPadding;

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -50,7 +50,7 @@ Matcher get paintsNothing => _TestRecordingCanvasPaintsNothingMatcher();
 /// Matches objects or functions that assert when they try to paint.
 Matcher get paintsAssertion => _TestRecordingCanvasPaintsAssertionMatcher();
 
-/// Matches objects or functions that draw `methodName` exactly `count` number of times
+/// Matches objects or functions that draw `methodName` exactly `count` number of times.
 Matcher paintsExactlyCountTimes(Symbol methodName, int count) {
   return _TestRecordingCanvasPaintsCountMatcher(methodName, count);
 }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -22,7 +22,7 @@ class FakePlatformViewController extends PlatformViewController {
   bool disposed = false;
   bool focusCleared = false;
 
-  /// Events that are dispatched;
+  /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];
 
   int _id;
@@ -59,7 +59,7 @@ class FakeAndroidViewController implements AndroidViewController {
   bool focusCleared = false;
   bool created = false;
 
-  /// Events that are dispatched;
+  /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];
 
   @override

--- a/packages/flutter_driver/lib/src/common/find.dart
+++ b/packages/flutter_driver/lib/src/common/find.dart
@@ -449,7 +449,7 @@ class GetSemanticsIdResult extends Result {
   /// Creates a new [GetSemanticsId] result.
   const GetSemanticsIdResult(this.id);
 
-  /// The semantics id of the node;
+  /// The semantics id of the node.
   final int id;
 
   /// Deserializes this result from JSON.

--- a/packages/flutter_driver/lib/src/common/gesture.dart
+++ b/packages/flutter_driver/lib/src/common/gesture.dart
@@ -59,7 +59,7 @@ class Scroll extends CommandWithTarget {
   /// Delta Y offset per move event.
   final double dy;
 
-  /// The duration of the scrolling action
+  /// The duration of the scrolling action.
   final Duration duration;
 
   /// The frequency in Hz of the generated move events.

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -160,10 +160,10 @@ abstract class FlutterDriver {
     );
   }
 
-  /// Getter of appIsolate
+  /// Getter of appIsolate.
   VMIsolate get appIsolate => throw UnimplementedError();
 
-  /// Getter of serviceClient
+  /// Getter of serviceClient.
   VMServiceClient get serviceClient => throw UnimplementedError();
 
   /// Sends [command] to the Flutter Driver extensions.

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -266,7 +266,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
   /// The unique ID of this driver instance.
   final int _driverId;
 
-  /// Client connected to the Dart VM running the Flutter application
+  /// Client connected to the Dart VM running the Flutter application.
   ///
   /// You can use [VMServiceClient] to check VM version, flags and get
   /// notified when a new isolate has been instantiated. That could be

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -31,7 +31,7 @@ class WebFlutterDriver extends FlutterDriver {
   final FlutterWebConnection _connection;
   DateTime _startTime;
 
-  /// Start time for tracing
+  /// Start time for tracing.
   @visibleForTesting
   DateTime get startTime => _startTime;
 
@@ -152,7 +152,7 @@ class WebFlutterDriver extends FlutterDriver {
     _startTime = DateTime.now();
   }
 
-  /// Checks whether browser supports Timeline related operations
+  /// Checks whether browser supports Timeline related operations.
   void _checkBrowserSupportsTimeline() {
     if (!_connection.supportsTimelineAction) {
       throw UnsupportedError('Timeline action is not supported by current testing browser');
@@ -163,12 +163,12 @@ class WebFlutterDriver extends FlutterDriver {
 /// Encapsulates connection information to an instance of a Flutter Web application.
 class FlutterWebConnection {
   /// Creates a FlutterWebConnection with WebDriver
-  /// and whether the WebDriver supports timeline action
+  /// and whether the WebDriver supports timeline action.
   FlutterWebConnection(this._driver, this.supportsTimelineAction);
 
   final async_io.WebDriver _driver;
 
-  /// Whether the connected WebDriver supports timeline action for Flutter Web Driver
+  /// Whether the connected WebDriver supports timeline action for Flutter Web Driver.
   bool supportsTimelineAction;
 
   /// Starts WebDriver with the given [settings] and
@@ -196,7 +196,7 @@ class FlutterWebConnection {
     return FlutterWebConnection(driver, settings['support-timeline-action'] as bool);
   }
 
-  /// Sends command via WebDriver to Flutter web application
+  /// Sends command via WebDriver to Flutter web application.
   Future<dynamic> sendCommand(String script, Duration duration) async {
     dynamic result;
     try {

--- a/packages/flutter_localizations/lib/flutter_localizations.dart
+++ b/packages/flutter_localizations/lib/flutter_localizations.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Localizations for the Flutter library
+/// Localizations for the Flutter library.
 library flutter_localizations;
 
 export 'src/cupertino_localizations.dart';

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -855,6 +855,7 @@ Map<String, String> parseAdbDeviceProperties(String str) {
 ///
 /// Example output:
 ///
+/// ```
 /// Applications Memory Usage (in Kilobytes):
 /// Uptime: 441088659 Realtime: 521464097
 ///
@@ -906,6 +907,7 @@ Map<String, String> parseAdbDeviceProperties(String str) {
 ///          MEMORY_USED:        0
 ///   PAGECACHE_OVERFLOW:        0          MALLOC_SIZE:        0
 /// ...
+/// ```
 ///
 /// For more information, see https://developer.android.com/studio/command-line/dumpsys.
 @visibleForTesting

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -18,7 +18,7 @@ import 'android_device.dart';
 import 'android_sdk.dart';
 import 'android_workflow.dart' hide androidWorkflow;
 
-/// Device discovery for Android physical devices and emulators.s
+/// Device discovery for Android physical devices and emulators.
 class AndroidDevices extends PollingDeviceDiscovery {
   AndroidDevices({
     @required AndroidWorkflow androidWorkflow,

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -851,7 +851,7 @@ Iterable<String> findApkFilesModule(
 /// Returns the APK files for a given [FlutterProject] and [AndroidBuildInfo].
 ///
 /// The flutter.gradle plugin will copy APK outputs into:
-/// $buildDir/app/outputs/flutter-apk/app-<abi>-<flavor-flag>-<build-mode-flag>.apk
+/// `$buildDir/app/outputs/flutter-apk/app-<abi>-<flavor-flag>-<build-mode-flag>.apk`
 @visibleForTesting
 Iterable<String> listApkPaths(
   AndroidBuildInfo androidBuildInfo,

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -262,7 +262,7 @@ class AndroidApk extends ApplicationPackage {
   String get name => file.basename;
 }
 
-/// Tests whether a [Directory] is an iOS bundle directory
+/// Tests whether a [Directory] is an iOS bundle directory.
 bool _isBundleDirectory(Directory dir) => dir.path.endsWith('.app');
 
 abstract class IOSApp extends ApplicationPackage {

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -67,7 +67,7 @@ enum Artifact {
   windowsDesktopPath,
   /// The root of the cpp client code for Windows desktop.
   windowsCppClientWrapper,
-  /// The root of the sky_engine package
+  /// The root of the sky_engine package.
   skyEnginePath,
   /// The location of the macOS engine podspec file.
   flutterMacOSPodspec,

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -65,7 +65,7 @@ class _ManifestAssetBundleFactory implements AssetBundleFactory {
   AssetBundle createBundle() => ManifestAssetBundle();
 }
 
-/// An asset bundle based on a pubspec.yaml
+/// An asset bundle based on a pubspec.yaml file.
 class ManifestAssetBundle implements AssetBundle {
   /// Constructs an [ManifestAssetBundle] that gathers the set of assets from the
   /// pubspec.yaml manifest.
@@ -652,12 +652,13 @@ class _AssetDirectoryCache {
 ///
 /// Given package: 'test_package' and an assets directory like this:
 ///
-/// assets/foo
-/// assets/var1/foo
-/// assets/var2/foo
-/// assets/bar
+/// - assets/foo
+/// - assets/var1/foo
+/// - assets/var2/foo
+/// - assets/bar
 ///
-/// returns
+/// This will return:
+/// ```
 /// {
 ///   asset: packages/test_package/assets/foo: [
 ///     asset: packages/test_package/assets/foo,
@@ -668,7 +669,7 @@ class _AssetDirectoryCache {
 ///     asset: packages/test_package/assets/bar,
 ///   ],
 /// }
-///
+/// ```
 
 Map<_Asset, List<_Asset>> _parseAssets(
   PackageConfig packageConfig,

--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -230,11 +230,11 @@ class CommandHelpOption {
 
   final OutputPreferences _outputPreferences;
 
-  /// The key associated with this command
+  /// The key associated with this command.
   final String key;
-  /// A description of what this command does
+  /// A description of what this command does.
   final String description;
-  /// Text shown in parenthesis to give the context
+  /// Text shown in parenthesis to give the context.
   final String inParenthesis;
 
   bool get _hasTextInParenthesis => inParenthesis != null && inParenthesis.isNotEmpty;

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -9,7 +9,7 @@ bool isRunningFromDaemon = false;
 /// Throw a specialized exception for expected situations
 /// where the tool should exit with a clear message to the user
 /// and no stack trace unless the --verbose option is specified.
-/// For example: network errors
+/// For example: network errors.
 void throwToolExit(String message, { int exitCode }) {
   throw ToolExit(message, exitCode: exitCode);
 }
@@ -17,7 +17,7 @@ void throwToolExit(String message, { int exitCode }) {
 /// Specialized exception for expected situations
 /// where the tool should exit with a clear message to the user
 /// and no stack trace unless the --verbose option is specified.
-/// For example: network errors
+/// For example: network errors.
 class ToolExit implements Exception {
   ToolExit(this.message, { this.exitCode });
 

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -139,7 +139,7 @@ class FileSystemUtils {
         && referenceFile.statSync().modified.isAfter(entity.statSync().modified);
   }
 
-  /// Return the absolute path of the user's home directory
+  /// Return the absolute path of the user's home directory.
   String get homeDirPath {
     String path = _platform.isWindows
       ? _platform.environment['USERPROFILE']

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -182,9 +182,9 @@ final RegExp _escapeExpr = RegExp(r'\\(.)');
 ///
 /// Snapshot dependency files are a single line mapping the output snapshot to a
 /// space-separated list of input files used to generate that output. Spaces and
-/// backslashes are escaped with a backslash. e.g,
+/// backslashes are escaped with a backslash. For example:
 ///
-/// outfile : file1.dart fil\\e2.dart fil\ e3.dart
+///     outfile : file1.dart fil\\e2.dart fil\ e3.dart
 ///
 /// will return a set containing: 'file1.dart', 'fil\e2.dart', 'fil e3.dart'.
 Set<String> readDepfile(String depfilePath) {

--- a/packages/flutter_tools/lib/src/base/platform.dart
+++ b/packages/flutter_tools/lib/src/base/platform.dart
@@ -43,7 +43,7 @@ abstract class Platform {
   /// True if the operating system is iOS.
   bool get isIOS => operatingSystem == 'ios';
 
-  /// True if the operating system is Fuchsia
+  /// True if the operating system is Fuchsia.
   bool get isFuchsia => operatingSystem == 'fuchsia';
 
   /// The environment for this process.

--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -11,7 +11,7 @@ import 'io.dart';
 
 typedef SignalHandler = FutureOr<void> Function(ProcessSignal signal);
 
-/// A class that manages signal handlers
+/// A class that manages signal handlers.
 ///
 /// Signal handlers are run in the order that they were added.
 abstract class Signals {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -81,7 +81,7 @@ class BuildInfo {
   /// A "x.y.z" string used as the version number shown to users.
   /// For each new version of your app, you will provide a version number to differentiate it from previous versions.
   /// On Android it is used as versionName.
-  /// On Xcode builds it is used as CFBundleShortVersionString,
+  /// On Xcode builds it is used as CFBundleShortVersionString.
   final String buildName;
 
   /// An optional directory path to save debugging information from dwarf stack
@@ -92,7 +92,7 @@ class BuildInfo {
   /// Whether to apply dart source code obfuscation.
   final bool dartObfuscation;
 
-  /// An optional path to a JSON containing object SkSL shaders
+  /// An optional path to a JSON containing object SkSL shaders.
   ///
   /// Currently this is only supported for Android builds.
   final String bundleSkSLPath;

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -60,9 +60,9 @@ const String _kDefaultIndex = '''
 </html>
 ''';
 
-/// An expression compiler connecting to FrontendServer
+/// An expression compiler connecting to FrontendServer.
 ///
-/// This is only used in development mode
+/// This is only used in development mode.
 class WebExpressionCompiler implements ExpressionCompiler {
   WebExpressionCompiler(this._generator);
 

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -159,7 +159,7 @@ abstract class Target {
     );
   }
 
-  /// Invoke to remove the stamp file if the [buildAction] threw an exception;
+  /// Invoke to remove the stamp file if the [buildAction] threw an exception.
   void clearStamp(Environment environment) {
     final File stamp = _findStampFile(environment);
     if (stamp.existsSync()) {
@@ -260,18 +260,22 @@ abstract class Target {
 ///
 /// Use the environment to determine where to write an output file.
 ///
+/// ```dart
 ///    environment.buildDir.childFile('output')
 ///      ..createSync()
 ///      ..writeAsStringSync('output data');
+/// ```
 ///
 /// Example (Bad):
 ///
 /// Use a hard-coded path or directory relative to the current working
 /// directory to write an output file.
 ///
+/// ```dart
 ///   globals.fs.file('build/linux/out')
 ///     ..createSync()
 ///     ..writeAsStringSync('output data');
+/// ```
 ///
 /// Example (Good):
 ///
@@ -279,6 +283,7 @@ abstract class Target {
 /// is still responsible for outputting a different file, as defined by the
 /// corresponding output [Source].
 ///
+/// ```dart
 ///    final BuildMode buildMode = getBuildModeFromDefines(environment.defines);
 ///    if (buildMode == BuildMode.debug) {
 ///      environment.buildDir.childFile('debug.output')
@@ -289,6 +294,7 @@ abstract class Target {
 ///        ..createSync()
 ///        ..writeAsStringSync('non_debug');
 ///    }
+/// ```
 class Environment {
   /// Create a new [Environment] object.
   ///

--- a/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
@@ -179,7 +179,7 @@ class LocalizationOptions {
 
   /// The `--header` argument.
   ///
-  /// The header to prepend to the generated Dart localizations
+  /// The header to prepend to the generated Dart localizations.
   final String header;
 
   /// The `--output-class` argument.

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -221,7 +221,7 @@ class Dart2JSTarget extends Target {
   }
 }
 
-/// Unpacks the dart2js compilation and resources to a given output directory
+/// Unpacks the dart2js compilation and resources to a given output directory.
 class WebReleaseBundle extends Target {
   const WebReleaseBundle();
 

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -25,7 +25,7 @@ class DevelopmentArtifact {
 
   /// The name of the artifact.
   ///
-  /// This should match the flag name in precache.dart
+  /// This should match the flag name in precache.dart.
   final String name;
 
   /// A feature to control the visibility of this artifact.

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -541,7 +541,7 @@ Future<bool> _stopApp(DriveCommand command) async {
   return stopped;
 }
 
-/// A list of supported browsers
+/// A list of supported browsers.
 @visibleForTesting
 enum Browser {
   /// Chrome on Android: https://developer.chrome.com/multidevice/android/overview

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -72,13 +72,13 @@ class TargetModel {
 
   const TargetModel._(this._value);
 
-  /// The flutter patched dart SDK.
+  /// The Flutter patched Dart SDK.
   static const TargetModel flutter = TargetModel._('flutter');
 
-  /// The fuchsia patched SDK.
+  /// The Fuchsia patched SDK.
   static const TargetModel flutterRunner = TargetModel._('flutter_runner');
 
-  /// The Dart vm.
+  /// The Dart VM.
   static const TargetModel vm = TargetModel._('vm');
 
   /// The development compiler for JavaScript.

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -72,7 +72,7 @@ class TargetModel {
 
   const TargetModel._(this._value);
 
-  /// The flutter patched dart SDK
+  /// The flutter patched dart SDK.
   static const TargetModel flutter = TargetModel._('flutter');
 
   /// The fuchsia patched SDK.
@@ -488,7 +488,7 @@ abstract class ResidentCompiler {
   /// module object, for example:
   /// { 'dart':'dart_sdk', 'main': '/packages/hello_world_main.dart' }
   /// Returns a [CompilerOutput] including the name of the file containing the
-  /// compilation result and a number of errors
+  /// compilation result and a number of errors.
   Future<CompilerOutput> compileExpressionToJs(
     String libraryUri,
     int line,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -557,7 +557,7 @@ abstract class Device {
     String userIdentifier,
   });
 
-  /// Check if the device is supported by Flutter
+  /// Check if the device is supported by Flutter.
   bool isSupported();
 
   // String meant to be displayed to the user indicating if the device is
@@ -734,7 +734,7 @@ abstract class Device {
     };
   }
 
-  /// Clean up resources allocated by device
+  /// Clean up resources allocated by device.
   ///
   /// For example log readers or port forwarders.
   Future<void> dispose();
@@ -861,7 +861,7 @@ class DebuggingOptions {
   /// The port the browser should use for its debugging protocol.
   final int webBrowserDebugPort;
 
-  /// Enable expression evaluation for web target
+  /// Enable expression evaluation for web target.
   final bool webEnableExpressionEvaluation;
 
   /// A file where the vmservice URL should be written after the application is started.
@@ -925,7 +925,7 @@ abstract class DevicePortForwarder {
   /// Stops forwarding [forwardedPort].
   Future<void> unforward(ForwardedPort forwardedPort);
 
-  /// Cleanup allocated resources, like forwardedPorts
+  /// Cleanup allocated resources, like [forwardedPorts].
   Future<void> dispose();
 }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -37,7 +37,7 @@ class FlutterManifest {
     return FlutterManifest.createFromString(manifest, logger: logger);
   }
 
-  /// Returns null on missing or invalid manifest
+  /// Returns null on missing or invalid manifest.
   @visibleForTesting
   static FlutterManifest createFromString(String manifest, { @required Logger logger }) {
     return _createFromYaml(manifest != null ? loadYaml(manifest) : null, logger);

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
@@ -38,7 +38,8 @@ class FuchsiaDevFinder {
 
   /// Returns a list of attached devices as a list of strings with entries
   /// formatted as follows:
-  /// 192.168.42.172 scare-cable-skip-joy
+  ///
+  ///     192.168.42.172 scare-cable-skip-joy
   Future<List<String>> list({ Duration timeout }) async {
     if (_fuchsiaArtifacts.devFinder == null ||
         !_fuchsiaArtifacts.devFinder.existsSync()) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -199,7 +199,7 @@ class FuchsiaPackageServer {
   String get url => Uri(scheme: 'http', host: _host, port: _port).toString();
 
   /// The URL that is stripped of interface name if it is an ipv6 address,
-  /// which should be supplied to amber_ctl to configure access to host
+  /// which should be supplied to amber_ctl to configure access to host.
   String get interfaceStrippedUrl => Uri(
     scheme: 'http',
     host: (isIPv6Address(_host.split('%').first)) ? '[${_host.split('%').first}]' : _host,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -49,8 +49,9 @@ class FuchsiaSdk {
   /// Returns any attached devices is a newline-denominated String.
   ///
   /// Example output:
-  ///    $ device-finder list -full
-  ///    > 192.168.42.56 paper-pulp-bush-angel
+  ///
+  ///     $ device-finder list -full
+  ///     > 192.168.42.56 paper-pulp-bush-angel
   Future<String> listDevices({ Duration timeout }) async {
     if (globals.fuchsiaArtifacts.devFinder == null ||
         !globals.fuchsiaArtifacts.devFinder.existsSync()) {

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -191,5 +191,5 @@ PlistParser get plistParser => context.get<PlistParser>() ?? (
 ));
 PlistParser _plistInstance;
 
-/// The global template renderer
+/// The global template renderer.
 TemplateRenderer get templateRenderer => context.get<TemplateRenderer>();

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -866,11 +866,12 @@ int compareIosVersions(String v1, String v2) {
 /// Matches on device type given an identifier.
 ///
 /// Example device type identifiers:
-///   ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-5
-///   ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-6
-///   ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-6s-Plus
-///   ✗ com.apple.CoreSimulator.SimDeviceType.iPad-2
-///   ✗ com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm
+///
+/// - ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-5
+/// - ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-6
+/// - ✓ com.apple.CoreSimulator.SimDeviceType.iPhone-6s-Plus
+/// - ✗ com.apple.CoreSimulator.SimDeviceType.iPad-2
+/// - ✗ com.apple.CoreSimulator.SimDeviceType.Apple-Watch-38mm
 final RegExp _iosDeviceTypePattern =
     RegExp(r'com.apple.CoreSimulator.SimDeviceType.iPhone-(\d+)(.*)');
 

--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -28,7 +28,7 @@ class _VersionInfo {
   Version number;
 }
 
-/// A validator that checks for Clang and Make build dependencies
+/// A validator that checks for Clang and Make build dependencies.
 class LinuxDoctorValidator extends DoctorValidator {
   LinuxDoctorValidator({
     @required ProcessManager processManager,

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -12,7 +12,7 @@ import '../globals.dart' as globals;
 import '../ios/plist_parser.dart';
 import '../project.dart';
 
-/// Tests whether a [FileSystemEntity] is an macOS bundle directory
+/// Tests whether a [FileSystemEntity] is an macOS bundle directory.
 bool _isBundleDirectory(FileSystemEntity entity) =>
     entity is Directory && entity.path.endsWith('.app');
 

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -41,7 +41,7 @@ enum SdkType {
 ///
 /// Usage: xcrun [options] <tool name> ... arguments ...
 /// ...
-/// --sdk <sdk name>            find the tool for the given SDK name
+/// --sdk <sdk name>            find the tool for the given SDK name.
 String getNameForSdk(SdkType sdk) {
   switch (sdk) {
     case SdkType.iPhone:

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -176,11 +176,12 @@ class Plugin {
   /// Create a YamlMap that represents the supported platforms.
   ///
   /// For example, if the `platforms` contains 'ios' and 'android', the return map looks like:
-  ///    android:
-  ///      package: io.flutter.plugins.sample
-  ///      pluginClass: SamplePlugin
-  ///    ios:
-  ///      pluginClass: SamplePlugin
+  ///
+  ///     android:
+  ///       package: io.flutter.plugins.sample
+  ///       pluginClass: SamplePlugin
+  ///     ios:
+  ///       pluginClass: SamplePlugin
   static YamlMap createPlatformsYamlMap(List<String> platforms, String pluginClass, String androidPackage) {
     final Map<String, dynamic> map = <String, dynamic>{};
     for (final String platform in platforms) {

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -194,7 +194,7 @@ class FlutterProject {
   /// True if this project is a Flutter module project.
   bool get isModule => manifest.isModule;
 
-  /// True if the Flutter project is using the AndroidX support library
+  /// True if the Flutter project is using the AndroidX support library.
   bool get usesAndroidX => manifest.usesAndroidX;
 
   /// True if this project has an example application.
@@ -709,7 +709,7 @@ class AndroidProject extends FlutterProjectPlatform {
   /// True if the parent Flutter project is a module.
   bool get isModule => parent.isModule;
 
-  /// True if the Flutter project is using the AndroidX support library
+  /// True if the Flutter project is using the AndroidX support library.
   bool get usesAndroidX => parent.usesAndroidX;
 
   /// True, if the app project is using Kotlin.
@@ -989,7 +989,7 @@ class MacOSProject extends FlutterProjectPlatform implements XcodeBasedProject {
   }
 }
 
-/// The Windows sub project
+/// The Windows sub project.
 class WindowsProject extends FlutterProjectPlatform implements CmakeBasedProject {
   WindowsProject._(this.parent);
 
@@ -1075,7 +1075,7 @@ class LinuxProject extends FlutterProjectPlatform implements CmakeBasedProject {
   }
 }
 
-/// The Fuchsia sub project
+/// The Fuchsia sub project.
 class FuchsiaProject {
   FuchsiaProject._(this.project);
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1707,7 +1707,7 @@ class DebugConnectionInfo {
 /// Returns the next platform value for the switcher.
 ///
 /// These values must match what is available in
-/// packages/flutter/lib/src/foundation/binding.dart
+/// `packages/flutter/lib/src/foundation/binding.dart`.
 String nextPlatform(String currentPlatform, FeatureFlags featureFlags) {
   switch (currentPlatform) {
     case 'android':

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -699,7 +699,7 @@ String _shortGitRevision(String revision) {
   return revision.length > 10 ? revision.substring(0, 10) : revision;
 }
 
-/// Version of Flutter SDK parsed from git
+/// Version of Flutter SDK parsed from Git.
 class GitTagVersion {
   const GitTagVersion({
     this.x,
@@ -732,7 +732,7 @@ class GitTagVersion {
   /// The Z in vX.Y.Z.
   final int z;
 
-  /// the F in vX.Y.Z+hotfix.F
+  /// the F in vX.Y.Z+hotfix.F.
   final int hotfix;
 
   /// Number of commits since the vX.Y.Z tag.
@@ -741,10 +741,10 @@ class GitTagVersion {
   /// The git hash (or an abbreviation thereof) for this commit.
   final String hash;
 
-  /// The N in X.Y.Z-dev.N.M
+  /// The N in X.Y.Z-dev.N.M.
   final int devVersion;
 
-  /// The M in X.Y.Z-dev.N.M
+  /// The M in X.Y.Z-dev.N.M.
   final int devPatch;
 
   /// The git tag that is this version's closest ancestor.

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -811,7 +811,7 @@ extension FlutterVmService on vm_service.VmService {
     return callServiceExtension(kScreenshotSkpMethod);
   }
 
-  /// Set the VM timeline flags
+  /// Set the VM timeline flags.
   Future<vm_service.Response> setVMTimelineFlags(List<String> recordedStreams) {
     assert(recordedStreams != null);
     return callServiceExtension(

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -103,7 +103,7 @@ class VisualStudio {
   /// Returns the highest installed Windows 10 SDK version, or null if none is
   /// found.
   ///
-  /// For instance: 10.0.18362.0
+  /// For instance: 10.0.18362.0.
   String getWindows10SDKVersion() {
     final String sdkLocation = _getWindows10SdkLocation();
     if (sdkLocation == null) {

--- a/packages/flutter_tools/test/integration.shard/lifetime_test.dart
+++ b/packages/flutter_tools/test/integration.shard/lifetime_test.dart
@@ -13,8 +13,8 @@ import 'test_driver.dart';
 import 'test_utils.dart';
 
 /// This duration is arbitrary but is ideally:
-/// a) long enough to ensure that if the app is crashing at startup, we notice
-/// b) as short as possible, to avoid inflating build times
+/// a) Long enough to ensure that if the app is crashing at startup, we notice.
+/// b) As short as possible, to avoid inflating build times.
 const Duration requiredLifespan = Duration(seconds: 5);
 
 void main() {

--- a/packages/flutter_tools/test/integration.shard/template_manifest_test.dart
+++ b/packages/flutter_tools/test/integration.shard/template_manifest_test.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as path; // ignore: package_path_import
 import 'package:flutter_tools/src/convert.dart';
 import '../src/common.dart';
 
-/// Checks that all active template files are defined in the template_manifest.json
+/// Checks that all active template files are defined in the template_manifest.json file.
 void main() {
   test('Check template manifest is up to date', () {
     final Map<String, Object> manifest = json.decode(

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -54,7 +54,7 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
   ),
 ];
 
-/// Fake device to test `devices` command
+/// Fake device to test `devices` command.
 class FakeDevice extends Device {
   FakeDevice(this.name, String id, [bool ephemeral = true, this._isSupported = true, PlatformType type = PlatformType.web]) : super(
       id,
@@ -87,7 +87,7 @@ class FakeDevice extends Device {
   Future<String> sdkNameAndVersion = Future<String>.value('Test SDK (1.2.3)');
 }
 
-/// Combines fake device with its canonical JSON representation
+/// Combines fake device with its canonical JSON representation.
 class FakeDeviceJsonData {
   FakeDeviceJsonData(this.dev, this.json);
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -622,7 +622,7 @@ void applyMocksToCommand(FlutterCommand command) {
   command.applicationPackages = MockApplicationPackageStore();
 }
 
-/// Common functionality for tracking mock interaction
+/// Common functionality for tracking mock interaction.
 class BasicMock {
   final List<String> messages = <String>[];
 

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -58,7 +58,7 @@ final Map<Type, Generator> _testbedDefaults = <Type, Generator>{
 ///
 /// Example:
 ///
-/// Testing that a filesystem operation works as expected
+/// Testing that a filesystem operation works as expected:
 ///
 ///     void main() {
 ///       group('Example', () {

--- a/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
+++ b/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
@@ -20,8 +20,8 @@ import 'package:fuchsia_remote_debug_protocol/logging.dart';
 ///
 /// Example usage:
 ///
-/// $ dart examples/driver_todo_list_scroll.dart \
-///     fe80::8eae:4cff:fef4:9247 eno1
+///     $ dart examples/driver_todo_list_scroll.dart \
+///         fe80::8eae:4cff:fef4:9247 eno1
 Future<void> main(List<String> args) async {
   // Log only at info level within the library. If issues arise, this can be
   // changed to [LoggingLevel.all] or [LoggingLevel.fine] to see more

--- a/packages/fuchsia_remote_debug_protocol/examples/list_vms_and_flutter_views.dart
+++ b/packages/fuchsia_remote_debug_protocol/examples/list_vms_and_flutter_views.dart
@@ -16,8 +16,8 @@ import 'package:fuchsia_remote_debug_protocol/logging.dart';
 ///
 /// Example usage:
 ///
-/// $ dart examples/list_vms_and_flutter_views.dart \
-///     fe80::8eae:4cff:fef4:9247 eno1
+///     $ dart examples/list_vms_and_flutter_views.dart \
+///         fe80::8eae:4cff:fef4:9247 eno1
 Future<void> main(List<String> args) async {
   // Log only at info level within the library. If issues arise, this can be
   // changed to [LoggingLevel.all] or [LoggingLevel.fine] to see more


### PR DESCRIPTION
## Description

Minor punctuation fixes for many documentation comments. Generally added terminating punctuation (such as `.`) to unterminated sentences (ex: "Some words without a period").

These minor issues were found while developing an [experimental lint rule](https://github.com/dart-lang/linter/pull/2148).

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
