### PR TITLE
Fix lifecycle clean up in the material date picker tests for screen size and semantics.

### DIFF
--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -810,6 +810,7 @@ void main() {
   group('Semantics', () {
     testWidgets('calendar day mode', (WidgetTester tester) async {
       final SemanticsHandle semantics = tester.ensureSemantics();
+      addTearDown(semantics.dispose);
 
       await prepareDatePicker(tester, (Future<DateTime> date) async {
         // Header
@@ -1022,12 +1023,11 @@ void main() {
           isFocusable: true,
         ));
       });
-
-      semantics.dispose();
     });
 
     testWidgets('calendar year mode', (WidgetTester tester) async {
       final SemanticsHandle semantics = tester.ensureSemantics();
+      addTearDown(semantics.dispose);
 
       initialCalendarMode = DatePickerMode.year;
       await prepareDatePicker(tester, (Future<DateTime> date) async {
@@ -1079,14 +1079,12 @@ void main() {
           hasEnabledState: true,
           isFocusable: true,
         ));
-
       });
-
-      semantics.dispose();
     });
 
     testWidgets('input mode', (WidgetTester tester) async {
       final SemanticsHandle semantics = tester.ensureSemantics();
+      addTearDown(semantics.dispose);
 
       initialEntryMode = DatePickerEntryMode.input;
       await prepareDatePicker(tester, (Future<DateTime> date) async {
@@ -1137,10 +1135,7 @@ void main() {
           hasEnabledState: true,
           isFocusable: true,
         ));
-
       });
-
-      semantics.dispose();
     });
   });
 
@@ -1342,9 +1337,9 @@ void main() {
 
     Future<void> _showPicker(WidgetTester tester, Size size, [double textScaleFactor = 1.0]) async {
       tester.binding.window.physicalSizeTestValue = size;
+      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
       tester.binding.window.devicePixelRatioTestValue = 1.0;
-      tester.binding.window.clearPhysicalSizeTestValue();
-      tester.binding.window.clearDevicePixelRatioTestValue();
+      addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
       await prepareDatePicker(tester, (Future<DateTime> date) async {
         await tester.tap(find.text('OK'));
       });

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -232,7 +232,9 @@ void main() {
 
     Future<void> _showPicker(WidgetTester tester, Locale locale, Size size) async {
       tester.binding.window.physicalSizeTestValue = size;
+      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
       tester.binding.window.devicePixelRatioTestValue = 1.0;
+      addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(


### PR DESCRIPTION
## Description

Take advantage of the `addTearDown` feature of the testing framework to clean up some test cases for the material date picker.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
