### PR TITLE
Deprecate the global imageCache getter

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -168,6 +168,6 @@ class _SystemFontsNotifier extends Listenable {
 /// Use [PaintingBinding.imageCache] instead.
 @Deprecated(
   'Use PaintingBinding.instance.imageCache instead. '
-  'This feature was deprecated after v1.21.0.'
+  'This feature was deprecated after v1.21.0-6.0.pre.'
 )
 ImageCache get imageCache => PaintingBinding.instance.imageCache;

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -167,7 +167,7 @@ class _SystemFontsNotifier extends Listenable {
 ///
 /// Use [PaintingBinding.imageCache] instead.
 @Deprecated(
-    'Use PaintingBinding.instance.imageCache instead. '
-    'This feature was deprecated after v1.21.0.'
+  'Use PaintingBinding.instance.imageCache instead. '
+  'This feature was deprecated after v1.21.0.'
 )
 ImageCache get imageCache => PaintingBinding.instance.imageCache;

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -163,11 +163,11 @@ class _SystemFontsNotifier extends Listenable {
   }
 }
 
-/// The singleton that implements the Flutter framework's image cache.
+/// Deprecated.
 ///
-/// The cache is used internally by [ImageProvider] and should generally not be
-/// accessed directly.
-///
-/// The image cache is created during startup by the [PaintingBinding]'s
-/// [PaintingBinding.createImageCache] method.
+/// Use [PaintingBinding.imageCache] instead.
+@Deprecated(
+    'Use PaintingBinding.instance.imageCache instead. '
+    'This feature was deprecated after v1.21.0-6.0.pre.149.'
+)
 ImageCache get imageCache => PaintingBinding.instance.imageCache;

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -168,6 +168,6 @@ class _SystemFontsNotifier extends Listenable {
 /// Use [PaintingBinding.imageCache] instead.
 @Deprecated(
     'Use PaintingBinding.instance.imageCache instead. '
-    'This feature was deprecated after v1.21.0-6.0.pre.149.'
+    'This feature was deprecated after v1.21.0.'
 )
 ImageCache get imageCache => PaintingBinding.instance.imageCache;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -549,7 +549,7 @@ abstract class ImageProvider<T> {
   /// ```
   /// {@end-tool}
   Future<bool> evict({ ImageCache cache, ImageConfiguration configuration = ImageConfiguration.empty }) async {
-    cache ??= imageCache;
+    cache ??= PaintingBinding.instance.imageCache;
     final T key = await obtainKey(configuration);
     return cache.evict(key);
   }

--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/painting.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
 
 void main() {
   testWidgets('didHaveMemoryPressure clears imageCache', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/image_cache_clearing_test.dart
+++ b/packages/flutter/test/painting/image_cache_clearing_test.dart
@@ -27,7 +27,7 @@ void main() {
         completer.complete();
       }
     ));
-    imageCache.clearLiveImages();
+    PaintingBinding.instance.imageCache.clearLiveImages();
     await completer.future;
   });
 }

--- a/packages/flutter/test/painting/image_cache_resize_test.dart
+++ b/packages/flutter/test/painting/image_cache_resize_test.dart
@@ -10,6 +10,8 @@ import '../flutter_test_alternative.dart';
 import '../rendering/rendering_tester.dart';
 import 'mocks_for_image_cache.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   TestRenderingFlutterBinding();
 

--- a/packages/flutter/test/painting/image_cache_test.dart
+++ b/packages/flutter/test/painting/image_cache_test.dart
@@ -10,6 +10,8 @@ import '../flutter_test_alternative.dart';
 import '../rendering/rendering_tester.dart';
 import 'mocks_for_image_cache.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   TestRenderingFlutterBinding();
 

--- a/packages/flutter/test/painting/image_provider_and_image_cache_test.dart
+++ b/packages/flutter/test/painting/image_provider_and_image_cache_test.dart
@@ -16,6 +16,8 @@ import '../rendering/rendering_tester.dart';
 import 'image_data.dart';
 import 'mocks_for_image_cache.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   TestRenderingFlutterBinding();
 

--- a/packages/flutter/test/painting/image_provider_network_image_test.dart
+++ b/packages/flutter/test/painting/image_provider_network_image_test.dart
@@ -18,6 +18,8 @@ import 'package:mockito/mockito.dart';
 import '../rendering/rendering_tester.dart';
 import 'image_data.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   TestRenderingFlutterBinding();
 

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -19,6 +19,8 @@ import '../rendering/rendering_tester.dart';
 import 'image_data.dart';
 import 'mocks_for_image_cache.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   TestRenderingFlutterBinding();
 

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -18,6 +18,8 @@ import 'package:flutter_test/flutter_test.dart';
 import '../painting/image_data.dart';
 import 'semantics_tester.dart';
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 // This must be run with [WidgetTester.runAsync] since it performs real async
 // work.
 Future<ui.Image> createTestImage([List<int> bytes = kTransparentImage]) async {

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter/widgets.dart';
 import '../painting/image_test_utils.dart';
 import '../painting/mocks_for_image_cache.dart' show TestImage;
 
+ImageCache get imageCache => PaintingBinding.instance.imageCache;
+
 void main() {
   tearDown(() {
     imageCache.clear();


### PR DESCRIPTION
## Description

Deprecate global `imageCache` in favor of `PaintingBinding.instance.imageCache`

## Related Issues

n/a

## Tests

I added the following tests:

n/a

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
