### PR TITLE
[null-safety] remove some usages of mockito

### DIFF
--- a/packages/flutter/test/flutter_test_alternative.dart
+++ b/packages/flutter/test/flutter_test_alternative.dart
@@ -11,6 +11,7 @@ import 'package:test_api/test_api.dart' hide TypeMatcher, isInstanceOf; // ignor
 import 'package:test_api/test_api.dart' as test_package show TypeMatcher; // ignore: deprecated_member_use
 
 export 'package:test_api/test_api.dart' hide TypeMatcher, isInstanceOf; // ignore: deprecated_member_use
+export 'package:test_api/fake.dart'; // ignore: deprecated_member_use
 
 /// A matcher that compares the type of the actual value to the type argument T.
 test_package.TypeMatcher<T> isInstanceOf<T>() => isA<T>();

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 
 void main() {
   setUp(() => _GestureBindingSpy());
@@ -58,7 +57,7 @@ class _GestureBindingSpy extends AutomatedTestWidgetsFlutterBinding {
   PointerRouter get pointerRouter => _testPointerRouter;
 }
 
-class FakeEditableTextState extends TextSelectionDelegate with Mock { }
+class FakeEditableTextState extends TextSelectionDelegate with Fake { }
 
 class _PointerRouterSpy extends PointerRouter {
   int routeCount = 0;

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
-import 'package:mockito/mockito.dart';
 
 void main() {
   group('PhysicalShape', () {
@@ -353,8 +352,7 @@ void main() {
 
     setUp(() {
       mockContext = _MockPaintingContext();
-      mockCanvas = _MockCanvas();
-      when(mockContext.canvas).thenReturn(mockCanvas);
+      mockCanvas = mockContext.canvas;
     });
 
     testWidgets('ColoredBox - no size, no child', (WidgetTester tester) async {
@@ -372,8 +370,10 @@ void main() {
 
       renderColoredBox.paint(mockContext, Offset.zero);
 
-      verifyNever(mockCanvas.drawRect(any, any));
-      verifyNever(mockContext.paintChild(any, any));
+      expect(mockCanvas.rects, isEmpty);
+      expect(mockCanvas.paints, isEmpty);
+      expect(mockContext.children, isEmpty);
+      expect(mockContext.offets, isEmpty);
     });
 
     testWidgets('ColoredBox - no size, child', (WidgetTester tester) async {
@@ -394,8 +394,10 @@ void main() {
 
       renderColoredBox.paint(mockContext, Offset.zero);
 
-      verifyNever(mockCanvas.drawRect(any, any));
-      verify(mockContext.paintChild(renderSizedBox, Offset.zero)).called(1);
+      expect(mockCanvas.rects, isEmpty);
+      expect(mockCanvas.paints, isEmpty);
+      expect(mockContext.children.single, renderSizedBox);
+      expect(mockContext.offets.single, Offset.zero);
     });
 
     testWidgets('ColoredBox - size, no child', (WidgetTester tester) async {
@@ -405,11 +407,10 @@ void main() {
 
       renderColoredBox.paint(mockContext, Offset.zero);
 
-      final List<dynamic> drawRect = verify(mockCanvas.drawRect(captureAny, captureAny)).captured;
-      expect(drawRect.length, 2);
-      expect(drawRect[0], const Rect.fromLTWH(0, 0, 800, 600));
-      expect(drawRect[1].color, colorToPaint);
-      verifyNever(mockContext.paintChild(any, any));
+      expect(mockCanvas.rects.single, const Rect.fromLTWH(0, 0, 800, 600));
+      expect(mockCanvas.paints.single.color, colorToPaint);
+      expect(mockContext.children, isEmpty);
+      expect(mockContext.offets, isEmpty);
     });
 
     testWidgets('ColoredBox - size, child', (WidgetTester tester) async {
@@ -422,11 +423,10 @@ void main() {
 
       renderColoredBox.paint(mockContext, Offset.zero);
 
-      final List<dynamic> drawRect = verify(mockCanvas.drawRect(captureAny, captureAny)).captured;
-      expect(drawRect.length, 2);
-      expect(drawRect[0], const Rect.fromLTWH(0, 0, 800, 600));
-      expect(drawRect[1].color, colorToPaint);
-      verify(mockContext.paintChild(renderSizedBox, Offset.zero)).called(1);
+      expect(mockCanvas.rects.single, const Rect.fromLTWH(0, 0, 800, 600));
+      expect(mockCanvas.paints.single.color, colorToPaint);
+      expect(mockContext.children.single, renderSizedBox);
+      expect(mockContext.offets.single, Offset.zero);
     });
 
     testWidgets('ColoredBox - properties', (WidgetTester tester) async {
@@ -650,5 +650,29 @@ class DoesNotHitRenderBox extends Matcher {
   }
 }
 
-class _MockPaintingContext extends Mock implements PaintingContext {}
-class _MockCanvas extends Mock implements Canvas {}
+class _MockPaintingContext extends Fake implements PaintingContext {
+  final List<RenderObject> children = <RenderObject>[];
+  final List<Offset> offets = <Offset>[];
+
+  @override
+  final _MockCanvas canvas = _MockCanvas();
+
+  @override
+  void paintChild(RenderObject child, Offset offset) {
+    children.add(child);
+    offets.add(offset);
+  }
+}
+
+class _MockCanvas extends Fake implements Canvas {
+  final List<Rect> rects = <Rect>[];
+  final List<Paint> paints = <Paint>[];
+  bool didPaint = false;
+
+  @override
+  void drawRect(Rect rect, Paint paint) {
+    rects.add(rect);
+    paints.add(paint);
+  }
+
+}

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -674,5 +674,4 @@ class _MockCanvas extends Fake implements Canvas {
     rects.add(rect);
     paints.add(paint);
   }
-
 }

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -7,7 +7,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
-import 'package:mockito/mockito.dart';
 
 import '../rendering/mock_canvas.dart';
 
@@ -440,10 +439,6 @@ void main() {
 
     final RenderBox decoratedBox = tester.renderObject(find.byType(DecoratedBox).last);
     final PaintingContext context = _MockPaintingContext();
-    final Canvas canvas = _MockCanvas();
-    int saveCount = 0;
-    when(canvas.getSaveCount()).thenAnswer((_) => saveCount++);
-    when(context.canvas).thenReturn(canvas);
     FlutterError error;
     try {
       decoratedBox.paint(context, const Offset(0, 0));
@@ -561,5 +556,19 @@ void main() {
   });
 }
 
-class _MockPaintingContext extends Mock implements PaintingContext {}
-class _MockCanvas extends Mock implements Canvas {}
+class _MockPaintingContext extends Fake implements PaintingContext {
+  @override
+  final Canvas canvas = _MockCanvas();
+}
+
+class _MockCanvas extends Fake implements Canvas {
+  int saveCount = 0;
+
+  @override
+  int getSaveCount() {
+    return saveCount++;
+  }
+
+  @override
+  void drawRect(Rect rect, Paint paint) { }
+}

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -21,6 +21,9 @@ import 'package:test_api/src/backend/state.dart'; // ignore: implementation_impo
 // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart';
 
+// ignore: deprecated_member_use
+export 'package:test_api/fake.dart' show Fake;
+
 Declarer _localDeclarer;
 Declarer get _declarer {
   final Declarer declarer = Zone.current[#test.declarer] as Declarer;


### PR DESCRIPTION
## Description

To enable the flutter framework tests to eventually run in sound null-safety mode, start removing usage of mockito.