### PR TITLE
Attempt to reenable previously-flaky TextPainter test

### DIFF
--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -760,15 +760,6 @@ void main() {
 
     expect(lines.length, 4);
 
-    // TODO(garyq): This data dump is for debugging a test flake. This should
-    // be removed when it is no longer useful.
-    if (lines[1].hardBreak == true) {
-      print('LineMetrics called: ${lines.length}');
-      for (final ui.LineMetrics line in lines) {
-        print('${line.lineNumber}: ${line.hardBreak}');
-      }
-    }
-
     expect(lines[0].hardBreak, true);
     expect(lines[1].hardBreak, false);
     expect(lines[2].hardBreak, true);
@@ -813,12 +804,7 @@ void main() {
     expect(lines[1].lineNumber, 1);
     expect(lines[2].lineNumber, 2);
     expect(lines[3].lineNumber, 3);
-
-  // Disable this test, this is causing a large amount of flaking and
-  // does not have a clear cause. This may or may not be a dart compiler
-  // issue or similar. See https://github.com/flutter/flutter/issues/43763
-  // for more info.
-  }, skip: true);
+  });
 
   test('TextPainter caret height and line height', () {
     final TextPainter painter = TextPainter()


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/43763 for context.
