### PR TITLE
Add gaplessPlayback docs default discussion

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1028,7 +1028,7 @@ class Image extends StatefulWidget {
   /// image provider you're not just changing the image, you're removing the
   /// old widget and adding a new one and not expecting them to have any
   /// relationship. With [gaplessPlayback] on you might accidentally break this
-  /// expectation. .
+  /// expectation.
   final bool gaplessPlayback;
 
   /// A Semantic description of the image.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1028,7 +1028,7 @@ class Image extends StatefulWidget {
   /// image provider you're not just changing the image, you're removing the
   /// old widget and adding a new one and not expecting them to have any
   /// relationship. With [gaplessPlayback] on you might accidentally break this
-  /// expectation.
+  /// expectation. .
   final bool gaplessPlayback;
 
   /// A Semantic description of the image.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1002,7 +1002,33 @@ class Image extends StatefulWidget {
   final bool matchTextDirection;
 
   /// Whether to continue showing the old image (true), or briefly show nothing
-  /// (false), when the image provider changes.
+  /// (false), when the image provider changes. The default value is false.
+  ///
+  /// ## Design discussion
+  ///
+  /// ### Why is the default value of [gaplessPlayback] false?
+  ///
+  /// Having the default value of [gaplessPlayback] be false helps prevent
+  /// situations where stale or misleading information might be presented.
+  /// Consider the following case:
+  ///
+  /// We have constructed a 'Person' widget that displays an avatar [Image] of
+  /// the currently loaded person along with their name. We could request for a
+  /// new person to be loaded into the widget at any time. Suppose we have a
+  /// person currently loaded and the widget loads a new person. What happens
+  /// if the [Image] fails to load?
+  ///
+  /// * Option A ([gaplessPlayback] = false): The new person's name is coupled
+  /// with a blank image.
+  ///
+  /// * Option B ([gaplessPlayback] = true): The widget displays the avatar of
+  /// the previous person and the name of the newly loaded person.
+  ///
+  /// This is why the default value is false. Most of the time you change the
+  /// image provider you're not just changing the image, you're removing the
+  /// old widget and adding a new one and not expecting them to have any
+  /// relationship. With [gaplessPlayback] on you might accidentally break this
+  /// expectation.
   final bool gaplessPlayback;
 
   /// A Semantic description of the image.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1024,7 +1024,7 @@ class Image extends StatefulWidget {
   /// * Option B ([gaplessPlayback] = true): The widget displays the avatar of
   /// the previous person and the name of the newly loaded person.
   ///
-  /// This is why the default value is false. Most of the time, when you change 
+  /// This is why the default value is false. Most of the time, when you change
   /// the image provider you're not just changing the image, you're removing the
   /// old widget and adding a new one and not expecting them to have any
   /// relationship. With [gaplessPlayback] on you might accidentally break this

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1024,11 +1024,11 @@ class Image extends StatefulWidget {
   /// * Option B ([gaplessPlayback] = true): The widget displays the avatar of
   /// the previous person and the name of the newly loaded person.
   ///
-  /// This is why the default value is false. Most of the time you change the
-  /// image provider you're not just changing the image, you're removing the
+  /// This is why the default value is false. Most of the time, when you change 
+  /// the image provider you're not just changing the image, you're removing the
   /// old widget and adding a new one and not expecting them to have any
   /// relationship. With [gaplessPlayback] on you might accidentally break this
-  /// expectation.
+  /// expectation and re-use the old widget.
   final bool gaplessPlayback;
 
   /// A Semantic description of the image.


### PR DESCRIPTION
## Description

This PR will add a discussion section to explain why [Image.gaplessPlayback](https://api.flutter.dev/flutter/widgets/Image/gaplessPlayback.html) is off by default

## Related Issues

Fixes #8911

## Tests

This does not need tests, as it is purely a documentation PR.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes