### PR TITLE
Revert "move compile/target sdk versions to 29"

### DIFF
--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "com.example.macrobenchmarks"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.stocks"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility 1.8
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -44,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.android_embedding_v2_smoke_test"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility 1.8
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/android/app/build.gradle
+++ b/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.splash_screen_kitchen_sink"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/android_splash_screens/splash_screen_load_rotate/android/app/build.gradle
+++ b/dev/integration_tests/android_splash_screens/splash_screen_load_rotate/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.splash_screen_load_rotate"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/android_splash_screens/splash_screen_trans_rotate/android/app/build.gradle
+++ b/dev/integration_tests/android_splash_screens/splash_screen_trans_rotate/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.splash_screen_trans_rotate"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/external_ui/android/app/build.gradle
+++ b/dev/integration_tests/external_ui/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.externalui"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/flutter_driver_screenshot_test/android/app/build.gradle
+++ b/dev/integration_tests/flutter_driver_screenshot_test/android/app/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -44,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.screenshot_tests"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -40,7 +40,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.demo.gallery"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/image_loading/android/app/bin/build.gradle
+++ b/dev/integration_tests/image_loading/android/app/bin/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/image_loading/android/app/build.gradle
+++ b/dev/integration_tests/image_loading/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.addtoapp"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/integration_tests/named_isolates/android/app/build.gradle
+++ b/dev/integration_tests/named_isolates/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.named_isolates"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/non_nullable/android/app/build.gradle
+++ b/dev/integration_tests/non_nullable/android/app/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -44,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.non_nullable"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
     }

--- a/dev/integration_tests/release_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.release_smoke_test"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -44,7 +44,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.manual_tests"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/catalog/android/app/build.gradle
+++ b/examples/catalog/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.catalog"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.layers"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -3,7 +3,7 @@ def flutterPluginVersion = 'managed'
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility 1.8
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "{{androidIdentifier}}.host"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -30,11 +30,11 @@ group '{{androidIdentifier}}'
 version '1.0'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -865,7 +865,7 @@ String gradleFileWithApplicationId(String id) {
   return '''
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId '$id'
@@ -882,7 +882,7 @@ version '1.0-SNAPSHOT'
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 }
 ''';
 }


### PR DESCRIPTION
Reverts flutter/flutter#62799

Multiple devicelab machines are failing to download android-29 sources:

```
2020-08-04T10:52:24.777007: stdout: [+1388 ms] Checking the license for package Android SDK Platform 29 in /usr/local/share/android-sdk/licenses
2020-08-04T10:52:24.777794: stdout: [   +1 ms] License for package Android SDK Platform 29 accepted.
stdout: [        ] Preparing "Install Android SDK Platform 29 (revision: 4)".
2020-08-04T10:52:24.778500: stdout: [        ] Warning: Failed to read or create install properties file.
2020-08-04T10:52:24.780064: stderr: [   +1 ms] FAILURE: Build failed with an exception.
2020-08-04T10:52:24.780452: stderr: [        ] * What went wrong:
2020-08-04T10:52:24.780821: stderr: [        ] Could not determine the dependencies of task ':app:compileDebugJavaWithJavac'.
2020-08-04T10:52:24.781139: stderr: [        ] > Failed to install the following SDK components:
2020-08-04T10:52:24.781452: stderr: [        ]       platforms;android-29 Android SDK Platform 29
2020-08-04T10:52:24.781884: stderr: [        ]   Install the missing components using the SDK manager in Android Studio.
2020-08-04T10:52:24.782407: stderr: [        ] * Try:
2020-08-04T10:52:24.783440: stderr: [        ] Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
stderr: [        ] * Get more help at https://help.gradle.org
2020-08-04T10:52:24.784339: stderr: [        ] BUILD FAILED in 1s
2020-08-04T10:52:25.227565: stdout: [ +443 ms] Running Gradle task 'assembleDebug'... (completed in 1.9s)
2020-08-04T10:52:25.235111: stdout: [   +7 ms] "flutter drive" took 4,801ms.
2020-08-04T10:52:25.241076: stderr: [   +6 ms] Gradle task assembleDebug failed with exit code 1
```