### PR TITLE
Make _isLocalCreationLocation public

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2894,6 +2894,7 @@ bool debugIsLocalCreationLocation(Object object) {
     if (location == null)
       isLocal =  false;
     isLocal = WidgetInspectorService.instance._isLocalCreationLocation(location);
+    return true;
   }());
   return isLocal;
 }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2860,7 +2860,7 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
   bool processElement(Element target) {
     // TODO(chunhtai): should print out all the widgets that are about to cross
     // package boundaries.
-    if (_isLocalCreationLocation(target)) {
+    if (debugIsLocalCreationLocation(target)) {
       nodes.add(
         DiagnosticsBlock(
           name: 'The relevant error-causing widget was',
@@ -2881,15 +2881,21 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
 
 /// Returns if an object is user created.
 ///
+/// This always returns false if it is not called in debug mode.
+///
 /// {@macro widgets.inspector.trackCreation}
 ///
 /// Currently is local creation locations are only available for
 /// [Widget] and [Element].
-bool _isLocalCreationLocation(Object object) {
-  final _Location location = _getCreationLocation(object);
-  if (location == null)
-    return false;
-  return WidgetInspectorService.instance._isLocalCreationLocation(location);
+bool debugIsLocalCreationLocation(Object object) {
+  bool isLocal = false;
+  assert(() {
+    final _Location location = _getCreationLocation(object);
+    if (location == null)
+      isLocal =  false;
+    isLocal = WidgetInspectorService.instance._isLocalCreationLocation(location);
+  }());
+  return isLocal;
 }
 
 /// Returns the creation location of an object in String format if one is available.

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2749,7 +2749,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(node.toJsonMap(emptyDelegate), node.toJsonMap(defaultDelegate));
     });
 
-
     testWidgets('debugIsLocalCreationLocation test', (WidgetTester tester) async {
 
       final GlobalKey key = GlobalKey();
@@ -2774,11 +2773,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       final Element paddingElement = paddingFinder.evaluate().first;
 
-
       expect(debugIsLocalCreationLocation(paddingElement), isFalse);
       expect(debugIsLocalCreationLocation(paddingElement.widget), isFalse);
-
-
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // Test requires --track-widget-creation flag.
 
   }

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2748,6 +2748,39 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         );
       expect(node.toJsonMap(emptyDelegate), node.toJsonMap(defaultDelegate));
     });
+
+
+    testWidgets('debugIsLocalCreationLocation test', (WidgetTester tester) async {
+
+      final GlobalKey key = GlobalKey();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            child: Text('target', key: key, textDirection: TextDirection.ltr),
+          ),
+        ),
+      );
+
+      final Element element = key.currentContext as Element;
+
+      expect(debugIsLocalCreationLocation(element), isTrue);
+      expect(debugIsLocalCreationLocation(element.widget), isTrue);
+
+      // Padding is inside container
+      final Finder paddingFinder = find.byType(Padding);
+
+      final Element paddingElement = paddingFinder.evaluate().first;
+
+
+      expect(debugIsLocalCreationLocation(paddingElement), isFalse);
+      expect(debugIsLocalCreationLocation(paddingElement.widget), isFalse);
+
+
+    });
+
   }
 }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2779,7 +2779,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(debugIsLocalCreationLocation(paddingElement.widget), isFalse);
 
 
-    });
+    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // Test requires --track-widget-creation flag.
 
   }
 }


### PR DESCRIPTION
## Description

This makes `_isLocalCreationLocation` public. Debugging tools might benefit from the ability to determine widgets/ elements which live inside the project.

## Related Issues

This closes #62187 as discussed with @jacob314 

## Tests

I added the following tests:

"debugIsLocalCreationLocation test" in `widget_inspector_test.dart`.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

