### PR TITLE
[null-safety] revert export of Fake from test_api

### DIFF
--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../flutter_test_alternative.dart' show Fake;
+
 void main() {
   setUp(() => _GestureBindingSpy());
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
+import '../flutter_test_alternative.dart' show Fake;
 
 void main() {
   group('PhysicalShape', () {

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
+import '../flutter_test_alternative.dart' show Fake;
 import '../rendering/mock_canvas.dart';
 
 void main() {

--- a/packages/flutter/test/widgets/image_headers_test.dart
+++ b/packages/flutter/test/widgets/image_headers_test.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../flutter_test_alternative.dart' show Fake;
 import '../painting/image_data.dart';
 
 void main() {

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -21,9 +21,6 @@ import 'package:test_api/src/backend/state.dart'; // ignore: implementation_impo
 // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart';
 
-// ignore: deprecated_member_use
-export 'package:test_api/fake.dart' show Fake;
-
 Declarer _localDeclarer;
 Declarer get _declarer {
   final Declarer declarer = Zone.current[#test.declarer] as Declarer;


### PR DESCRIPTION
## Description

b/162839394

The export of Fake conflicts with many tests in google3. Do a partial revert and only export from our own test alternative.