### PR TITLE
Revert "remove iOS folder (#61561)"

### DIFF
--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -129,10 +129,9 @@ class Template {
         return null;
       }
 
-      final bool ios = context['ios'] as bool;
-      if (relativeDestinationPath.contains('ios') && !ios) {
-        return null;
-      }
+      // TODO(cyanglaz): do not add iOS folder by default when 1.20.0 is released.
+      // Also need to update the flutter SDK min constraint in the pubspec.yaml to 1.20.0.
+      // https://github.com/flutter/flutter/issues/59787
 
       // Only build a web project if explicitly asked.
       final bool web = context['web'] as bool;

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1533,7 +1533,7 @@ void main() {
 
     // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
     // https://github.com/flutter/flutter/issues/59787
-    expect(projectDir.childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('ios').existsSync(), true);
     expect(projectDir.childDirectory('android').existsSync(), false);
     expect(projectDir.childDirectory('web').existsSync(), false);
     expect(projectDir.childDirectory('linux').existsSync(), false);
@@ -1542,7 +1542,7 @@ void main() {
 
     // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
     // https://github.com/flutter/flutter/issues/59787
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
     expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), false);
     expect(projectDir.childDirectory('example').childDirectory('web').existsSync(), false);
     expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), false);
@@ -1556,6 +1556,25 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
+
+  // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
+  // https://github.com/flutter/flutter/issues/59787
+  testUsingContext('create an empty plugin contains a no-op ios folder, but no pubspec entry.', () async {
+    Cache.flutterRoot = '../..';
+    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
+    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+
+    expect(projectDir.childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
+      'some_platform'
+    ], pluginClass: 'somePluginClass',
+    unexpectedPlatforms: <String>['ios']);
+  });
 
   testUsingContext('plugin supports ios if requested', () async {
     Cache.flutterRoot = '../..';


### PR DESCRIPTION
Reverting the "removing no-op" ios folder change.

The change was first landed on master in https://github.com/flutter/flutter/commit/004f90f8fd8a8fb93d386d55364707ef1e517948 
and cherry-picked within https://github.com/flutter/flutter/pull/62372

We plan to re-land this along with https://github.com/flutter/flutter/pull/62885 after 1.20 is released. 