### PR TITLE
Add remaining benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -72,6 +72,18 @@ final Map<String, RecorderFactory> benchmarks = <String, RecorderFactory>{
       benchmarkName: '${_galleryBenchmarkPrefix}_studies_perf',
       shouldRunPredicate: (String demo) => typeOfDemo(demo) == DemoType.study,
     ),
+    '${_galleryBenchmarkPrefix}_unanimated_perf': () => GalleryRecorder(
+      benchmarkName: '${_galleryBenchmarkPrefix}_unanimated_perf',
+      shouldRunPredicate: (String demo) => typeOfDemo(demo) == DemoType.unanimatedWidget,
+    ),
+    '${_galleryBenchmarkPrefix}_animated_perf': () => GalleryRecorder(
+      benchmarkName: '${_galleryBenchmarkPrefix}_animated_perf',
+      shouldRunPredicate: (String demo) => typeOfDemo(demo) == DemoType.animatedWidget,
+    ),
+    '${_galleryBenchmarkPrefix}_scroll_perf': () => GalleryRecorder(
+      benchmarkName: '${_galleryBenchmarkPrefix}_scroll_perf',
+      testScrollsOnly: true,
+    ),
   },
 };
 

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -90,7 +90,8 @@ class Chrome {
         '--user-data-dir=${options.userDataDirectory}',
       if (options.url != null)
         options.url,
-      '--no-sandbox',
+      if (io.Platform.environment['CHROME_NO_SANDBOX'] == 'true')
+        '--no-sandbox',
       if (options.headless)
         '--headless',
       if (withDebugging)

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -90,8 +90,7 @@ class Chrome {
         '--user-data-dir=${options.userDataDirectory}',
       if (options.url != null)
         options.url,
-      if (io.Platform.environment['CHROME_NO_SANDBOX'] == 'true')
-        '--no-sandbox',
+      '--no-sandbox',
       if (options.headless)
         '--headless',
       if (withDebugging)


### PR DESCRIPTION
## Description

Adds the other 3 web benchmarks for Gallery.
Now that https://github.com/cirruslabs/cirrus-ci-docs/issues/688 is closed, the new benchmarks should be passing with increased `/dev/shm`.

## Related Issues

Closes https://github.com/flutter/gallery/issues/192

## Tests

I added the following benchmark tests:

* gallery_v2_unanimated_perf
* gallery_v2_animated_perf
* gallery_v2_scroll_perf

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
    * No new documentation is needed.
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
    The following error and info were raised, but they are unrelated to this PR.
<details> <summary>Logs</summary>

```
  error • A value of type 'Future<Dwds> Function({AssetReader assetReader,
         Stream<BuildResult> buildResults, Future<ChromeConnection> Function()
         chromeConnection, bool enableDebugExtension, bool enableDebugging,
         ExpressionCompiler expressionCompiler, String hostname, LoadStrategy
         loadStrategy, void Function(Level, String) logWriter, bool
         restoreBreakpoints, bool serveDevTools, Future<String> Function(String)
         urlEncoder, bool useSseForDebugProxy, bool verbose})' can't be assigned
         to a variable of type 'Future<Dwds> Function({AssetReader assetReader,
         Stream<BuildResult> buildResults, Future<ChromeConnection> Function()
         chromeConnection, bool enableDebugExtension, bool enableDebugging,
         ExpressionCompiler expressionCompiler, String hostname, LoadStrategy
         loadStrategy, void Function(Level, String) logWriter, bool
         serveDevTools, Future<String> Function(String) urlEncoder, bool
         useFileProvider, bool useSseForDebugBackend, bool useSseForDebugProxy,
         bool verbose})' •
         packages/flutter_tools/lib/src/build_runner/devfs_web.dart:152:33 •
         invalid_assignment
   info • The method doesn't override an inherited method •
          packages/flutter_tools/lib/src/build_runner/devfs_web.dart:603:18 •
          override_on_non_overriding_member
```

</details>

- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
