### PR TITLE
Enable InkWell to sync its hovered state when its enabled or disabled

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -774,7 +774,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     super.didUpdateWidget(oldWidget);
     if (_isWidgetEnabled(widget) != _isWidgetEnabled(oldWidget)) {
       if (enabled) {
-        _handleHoverChange();
+        // Don't call wigdet.onHover because many wigets, including the button
+        // widgets, apply setState to an ancestor context from onHover.
+        updateHighlight(_HighlightType.hover, value: _hovering, callOnHover: false);
       }
       _updateFocusHighlights();
     }
@@ -820,7 +822,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     return null;
   }
 
-  void updateHighlight(_HighlightType type, { @required bool value }) {
+  void updateHighlight(_HighlightType type, { @required bool value, bool callOnHover = true }) {
     final InkHighlight highlight = _highlights[type];
     void handleInkRemoval() {
       assert(_highlights[type] != null);
@@ -864,7 +866,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
           widget.onHighlightChanged(value);
         break;
       case _HighlightType.hover:
-        if (widget.onHover != null)
+        if (callOnHover && widget.onHover != null)
           widget.onHover(value);
         break;
       case _HighlightType.focus:

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -733,7 +733,6 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   Set<InteractiveInkFeature> _splashes;
   InteractiveInkFeature _currentSplash;
   bool _hovering = false;
-  bool _containsMouse = false;
   final Map<_HighlightType, InkHighlight> _highlights = <_HighlightType, InkHighlight>{};
   Map<Type, Action<Intent>> _actionMap;
 
@@ -774,10 +773,8 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   void didUpdateWidget(_InkResponseStateWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (_isWidgetEnabled(widget) != _isWidgetEnabled(oldWidget)) {
-      // The value of _hovering and _containsMouse maybe not match when
-      // the widget's enabled flag changes. We sync them up here, at
-      // _build_ time.
-      _handleHoverChange(_containsMouse);
+      if (enabled)
+        _handleHoverChange();
       _updateFocusHighlights();
     }
   }
@@ -822,7 +819,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     return null;
   }
 
-  void updateHighlight(_HighlightType type, {@required bool value}) {
+  void updateHighlight(_HighlightType type, { @required bool value }) {
     final InkHighlight highlight = _highlights[type];
     void handleInkRemoval() {
       assert(_highlights[type] != null);
@@ -1045,24 +1042,20 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   bool get enabled => _isWidgetEnabled(widget);
 
   void _handleMouseEnter(PointerEnterEvent event) {
-    _containsMouse = true;
+    _hovering = true;
     if (enabled)
-      _handleHoverChange(true);
+      _handleHoverChange();
   }
 
   void _handleMouseExit(PointerExitEvent event) {
-    _containsMouse = false;
+    _hovering = false;
     // If the exit occurs after we've been disabled, we still
     // want to take down the highlights and run widget.onHover.
-    if (enabled || (!enabled && _hovering))
-      _handleHoverChange(false);
+    _handleHoverChange();
   }
 
-  void _handleHoverChange(bool hovering) {
-    if (_hovering != hovering) {
-      _hovering = hovering;
-      updateHighlight(_HighlightType.hover, value: enabled && _hovering);
-    }
+  void _handleHoverChange() {
+    updateHighlight(_HighlightType.hover, value: _hovering);
   }
 
   bool get _canRequestFocus {
@@ -1092,7 +1085,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
       widget.mouseCursor ?? MaterialStateMouseCursor.clickable,
       <MaterialState>{
         if (!enabled) MaterialState.disabled,
-        if (_hovering) MaterialState.hovered,
+        if (_hovering && enabled) MaterialState.hovered,
         if (_hasFocus) MaterialState.focused,
       },
     );

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -773,8 +773,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   void didUpdateWidget(_InkResponseStateWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (_isWidgetEnabled(widget) != _isWidgetEnabled(oldWidget)) {
-      if (enabled)
+      if (enabled) {
         _handleHoverChange();
+      }
       _updateFocusHighlights();
     }
   }
@@ -1043,8 +1044,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 
   void _handleMouseEnter(PointerEnterEvent event) {
     _hovering = true;
-    if (enabled)
+    if (enabled) {
       _handleHoverChange();
+    }
   }
 
   void _handleMouseExit(PointerExitEvent event) {

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -1191,4 +1191,68 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     expect(material, paintsExactlyCountTimes(#drawCircle, 1));
   });
+
+  testWidgets('disabled and hovered inkwell responds to mouse-exit', (WidgetTester tester) async {
+    int onHoverCount = 0;
+    bool hover;
+
+    Widget buildFrame({ bool enabled }) {
+      return Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 100,
+              height: 100,
+              child: InkWell(
+                onTap: enabled ? () { } : null,
+                onHover: (bool value) {
+                  onHoverCount += 1;
+                  hover = value;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(enabled: true));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+
+    await gesture.moveTo(tester.getCenter(find.byType(InkWell)));
+    await tester.pumpAndSettle();
+    expect(onHoverCount, 1);
+    expect(hover, true);
+
+    await tester.pumpWidget(buildFrame(enabled: false));
+    await tester.pumpAndSettle();
+    await gesture.moveTo(Offset.zero);
+    // Even though the InkWell has been disabled, the mouse-exit still
+    // causes onHover(false) to be called.
+    expect(onHoverCount, 2);
+    expect(hover, false);
+
+    await gesture.moveTo(tester.getCenter(find.byType(InkWell)));
+    await tester.pumpAndSettle();
+    // We no longer see hover events because the InkWell is disabled
+    // and it's no longer in the "hovering" state.
+    expect(onHoverCount, 2);
+    expect(hover, false);
+
+    await tester.pumpWidget(buildFrame(enabled: true));
+    await tester.pumpAndSettle();
+    // The InkWell was enabled while it contained the mouse, so its
+    // state changes to hovered.
+    expect(onHoverCount, 3);
+    expect(hover, true);
+
+    await gesture.moveTo(tester.getCenter(find.byType(InkWell)) - const Offset(1, 1));
+    await tester.pumpAndSettle();
+    // Moving the mouse a little within the InkWell doesn't change anything.
+    expect(onHoverCount, 3);
+    expect(hover, true);
+  });
 }


### PR DESCRIPTION
Currently, if an InkWell is disabled while it contains the mouse-pointer it remains stuck in the hovered state. Similarly, if a disabled InkWell contains the mouse when it is enabled, it will not enter the hovered state.

Changed InkWell to allow a mouse-exit event to clear the hovered state, even if the InkWell is disabled.  When the widget's disabled state changes, `didUpdateWidget()` now sets the hovered state to true if the InkWell contains the mouse-pointer, false otherwise.
