### PR TITLE
revert WidgetTester.pumpAndSettle breaking change

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -608,9 +608,12 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   Future<int> pumpAndSettle([
     Duration duration = const Duration(milliseconds: 100),
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
+    Duration timeout = const Duration(minutes: 10),
   ]) {
     assert(duration != null);
     assert(duration > Duration.zero);
+    assert(timeout != null);
+    assert(timeout > Duration.zero);
     assert(() {
       final WidgetsBinding binding = this.binding;
       if (binding is LiveTestWidgetsFlutterBinding &&
@@ -623,8 +626,11 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
       return true;
     }());
     return TestAsyncUtils.guard<int>(() async {
+      final DateTime endTime = binding.clock.fromNowBy(timeout);
       int count = 0;
       do {
+        if (binding.clock.now().isAfter(endTime))
+          throw FlutterError('pumpAndSettle timed out');
         await binding.pump(duration, phase);
         count += 1;
       } while (binding.hasScheduledFrame);

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -465,10 +465,20 @@ void main() {
 
   testWidgets('pumpAndSettle control test', (WidgetTester tester) async {
     final AnimationController controller = AnimationController(
-      duration: const Duration(seconds: 1),
+      duration: const Duration(minutes: 525600),
       vsync: const TestVSync(),
     );
     expect(await tester.pumpAndSettle(), 1);
+    controller.forward();
+    try {
+      await tester.pumpAndSettle();
+      expect(true, isFalse);
+    } catch (e) {
+      expect(e, isFlutterError);
+    }
+    controller.stop();
+    expect(await tester.pumpAndSettle(), 1);
+    controller.duration = const Duration(seconds: 1);
     controller.forward();
     expect(await tester.pumpAndSettle(const Duration(milliseconds: 300)), 5); // 0, 300, 600, 900, 1200ms
   });


### PR DESCRIPTION
## Description

This is to revert part of #62640 to fix b/162875258

## Related Issues

b/162875258

## Tests

I added the following tests:

Restored the related unit test for timeout. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
