### PR TITLE
Add a comment with a reference to issue 62919

### DIFF
--- a/dev/bots/test/sdk_directory_has_space_test.dart
+++ b/dev/bots/test/sdk_directory_has_space_test.dart
@@ -17,5 +17,5 @@ void main() {
     expect(expectedName, contains(' '));
     final List<String> parts = path.split(Directory.current.absolute.path);
     expect(parts.reversed.take(3), <String>['bots', 'dev', expectedName]);
-  }, skip: true);
+  }, skip: true); // https://github.com/flutter/flutter/issues/62919
 }


### PR DESCRIPTION
Add a comment with a reference to issue #62919 (LUCI should run the tests in a directory that contains a space character) to this skipped test.