### PR TITLE
[flutter_tools] remove reference to flutter tool test from user generated gitignore

### DIFF
--- a/packages/flutter_tools/templates/app/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/app/.gitignore.tmpl
@@ -39,6 +39,3 @@ app.*.symbols
 
 # Obfuscation related
 app.*.map.json
-
-# Exceptions to above rules.
-!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -72,4 +72,3 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
-!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages


### PR DESCRIPTION
## Description

These are user-generated files, they should not gitignore flutter_tools test dependencies.

This was added in https://github.com/flutter/flutter/pull/21192 (according to gblame) but I think that was a mistake that took some flutter tool specific ignores