### PR TITLE
Updated examples/layers to use the new button API.

### DIFF
--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -253,7 +253,8 @@ class IsolateExampleState extends State<StatefulWidget> with SingleTickerProvide
           ),
           Text(_status),
           Center(
-            child: RaisedButton(
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
               child: Text(_label),
               onPressed: _handleButtonPressed,
             ),

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -254,7 +254,6 @@ class IsolateExampleState extends State<StatefulWidget> with SingleTickerProvide
           Text(_status),
           Center(
             child: ElevatedButton(
-              style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
               child: Text(_label),
               onPressed: _handleButtonPressed,
             ),

--- a/examples/layers/widgets/sectors.dart
+++ b/examples/layers/widgets/sectors.dart
@@ -97,7 +97,6 @@ class SectorAppState extends State<SectorApp> {
           child: Row(
             children: <Widget>[
               ElevatedButton(
-                style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
                 onPressed: _enabledAdd ? addSector : null,
                 child: IntrinsicWidth(
                   child: Row(
@@ -113,7 +112,6 @@ class SectorAppState extends State<SectorApp> {
                 ),
               ),
               ElevatedButton(
-                style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
                 onPressed: _enabledRemove ? removeSector : null,
                 child: IntrinsicWidth(
                   child: Row(

--- a/examples/layers/widgets/sectors.dart
+++ b/examples/layers/widgets/sectors.dart
@@ -96,7 +96,8 @@ class SectorAppState extends State<SectorApp> {
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 25.0),
           child: Row(
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
                 onPressed: _enabledAdd ? addSector : null,
                 child: IntrinsicWidth(
                   child: Row(
@@ -111,7 +112,8 @@ class SectorAppState extends State<SectorApp> {
                   ),
                 ),
               ),
-              RaisedButton(
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(primary: Colors.grey[300], onPrimary: Colors.black),
                 onPressed: _enabledRemove ? removeSector : null,
                 child: IntrinsicWidth(
                   child: Row(


### PR DESCRIPTION
Updated the examples/layers apps to use the new button API. This is part of the transition to the new button universe (https://github.com/flutter/flutter/pull/59702).
