### PR TITLE
non-nullable LicenseEntry.packages

### DIFF
--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -47,7 +47,7 @@ abstract class LicenseEntry {
   const LicenseEntry();
 
   /// The names of the packages that this license entry applies to.
-  Iterable<String>? get packages;
+  Iterable<String> get packages;
 
   /// The paragraphs of the license, each as a [LicenseParagraph] consisting of
   /// a string and some formatting information. Paragraphs can include newline
@@ -123,7 +123,7 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
   const LicenseEntryWithLineBreaks(this.packages, this.text);
 
   @override
-  final List<String>? packages;
+  final List<String> packages;
 
   /// The text of the license.
   ///


### PR DESCRIPTION
## Description

LicenseEntry.packages should be non-nullable.

## Related Issues

* dart-lang/sdk#40146

## Tests

I added the following tests:

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
