### PR TITLE
Pin gallery version

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/versions/gallery.dart';
 
 Future<void> main() async {
   await task(const NewGalleryChromeRunTest().run);
@@ -36,7 +37,8 @@ class NewGalleryChromeRunTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await gitClone(path: 'temp', repo: galleryRepo);
+    await Directory('temp').create(recursive: true);
+    await getNewGallery(galleryVersion, Directory('temp/gallery'));
 
     final TaskResult result = await inDirectory<TaskResult>('temp/gallery', () async {
       await flutter('doctor');

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -10,7 +10,6 @@ import 'package:path/path.dart' as path;
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/versions/gallery.dart';
 
 Future<void> main() async {
   await task(const NewGalleryChromeRunTest().run);
@@ -37,8 +36,7 @@ class NewGalleryChromeRunTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await Directory('temp').create(recursive: true);
-    await getNewGallery(galleryVersion, Directory('temp/gallery'));
+    await gitClone(path: 'temp', repo: galleryRepo);
 
     final TaskResult result = await inDirectory<TaskResult>('temp/gallery', () async {
       await flutter('doctor');

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/versions/gallery.dart';
 
 Future<void> main() async {
   await task(const NewGalleryChromeRunTest().run);
@@ -36,9 +37,14 @@ class NewGalleryChromeRunTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await gitClone(path: 'temp', repo: galleryRepo);
+    final Directory galleryParentDir =
+        Directory.systemTemp.createTempSync('temp');
+    final Directory galleryDir =
+        Directory(path.join(galleryParentDir.path, 'gallery'));
 
-    final TaskResult result = await inDirectory<TaskResult>('temp/gallery', () async {
+    await getNewGallery(galleryVersion, galleryDir);
+
+    final TaskResult result = await inDirectory<TaskResult>(galleryDir, () async {
       await flutter('doctor');
       await flutter('packages', options: <String>['get']);
 
@@ -102,7 +108,7 @@ class NewGalleryChromeRunTest {
       }
     });
 
-    rmTree(Directory('temp'));
+    rmTree(galleryParentDir);
 
     return result;
   }

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/versions/gallery.dart';
+import 'package:flutter_devicelab/versions/gallery.dart' show galleryVersion;
 
 Future<void> main() async {
   await task(const NewGalleryChromeRunTest().run);

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/versions/gallery.dart';
 
 import 'package:flutter_devicelab/tasks/perf_tests.dart' show WebCompileTest;
 
@@ -22,7 +23,8 @@ class NewGalleryWebCompileTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await gitClone(path: 'temp', repo: 'https://github.com/flutter/gallery.git');
+    await Directory('temp').create(recursive: true);
+    await getNewGallery(galleryVersion, Directory('temp/gallery'));
 
     final Map<String, Object> metrics = await inDirectory<Map<String, int>>(
       'temp/gallery',

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -38,7 +38,7 @@ class NewGalleryWebCompileTest {
         await flutter('doctor');
 
         return await WebCompileTest.runSingleBuildTest(
-          directory: 'temp/gallery',
+          directory: galleryDir.path,
           metric: metricKeyPrefix,
           measureBuildTime: true,
         );

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/versions/gallery.dart';
 
 import 'package:flutter_devicelab/tasks/perf_tests.dart' show WebCompileTest;
 
@@ -23,8 +22,7 @@ class NewGalleryWebCompileTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await Directory('temp').create(recursive: true);
-    await getNewGallery(galleryVersion, Directory('temp/gallery'));
+    await gitClone(path: 'temp', repo: 'https://github.com/flutter/gallery.git');
 
     final Map<String, Object> metrics = await inDirectory<Map<String, int>>(
       'temp/gallery',

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -4,8 +4,11 @@
 
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/versions/gallery.dart';
 
 import 'package:flutter_devicelab/tasks/perf_tests.dart' show WebCompileTest;
 
@@ -22,10 +25,15 @@ class NewGalleryWebCompileTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    await gitClone(path: 'temp', repo: 'https://github.com/flutter/gallery.git');
+    final Directory galleryParentDir =
+        Directory.systemTemp.createTempSync('temp');
+    final Directory galleryDir =
+        Directory(path.join(galleryParentDir.path, 'gallery'));
+
+    await getNewGallery(galleryVersion, galleryDir);
 
     final Map<String, Object> metrics = await inDirectory<Map<String, int>>(
-      'temp/gallery',
+      galleryDir,
       () async {
         await flutter('doctor');
 
@@ -37,7 +45,7 @@ class NewGalleryWebCompileTest {
       },
     );
 
-    rmTree(Directory('temp'));
+    rmTree(galleryParentDir);
 
     return TaskResult.success(metrics, benchmarkScoreKeys: metrics.keys.toList());
   }

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/versions/gallery.dart';
+import 'package:flutter_devicelab/versions/gallery.dart' show galleryVersion;
 
 import 'package:flutter_devicelab/tasks/perf_tests.dart' show WebCompileTest;
 

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -10,7 +10,7 @@ import 'package:flutter_devicelab/tasks/perf_tests.dart';
 
 import '../framework/framework.dart';
 import '../framework/utils.dart';
-import '../versions/gallery.dart';
+import '../versions/gallery.dart' show galleryVersion;
 
 class NewGalleryPerfTest extends PerfTest {
   NewGalleryPerfTest(

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -10,6 +10,7 @@ import 'package:flutter_devicelab/tasks/perf_tests.dart';
 
 import '../framework/framework.dart';
 import '../framework/utils.dart';
+import '../versions/gallery.dart';
 
 class NewGalleryPerfTest extends PerfTest {
   NewGalleryPerfTest(
@@ -28,7 +29,7 @@ class NewGalleryPerfTest extends PerfTest {
     // Manually roll the new gallery version for now. If the new gallery repo
     // turns out to be updated frequently in the future, we can set up an auto
     // roller to update this version.
-    await getNewGallery('a208eac6e6e8336ae9820e54c572c099231f1da2', galleryDir);
+    await getNewGallery(galleryVersion, galleryDir);
     return await super.run();
   }
 

--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -4,4 +4,3 @@
 
 /// The pinned version of flutter gallery, used for devicelab tests.
 const String galleryVersion = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
-

--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String gallery_version = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
+const String galleryVersion = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
 

--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -1,0 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The pinned version of flutter gallery, used for devicelab tests.
+const String gallery_version = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
+


### PR DESCRIPTION
## Description

Pin the version of `flutter/gallery` in devicelab tests in `flutter/flutter`.

## Related Issues

Closes https://github.com/flutter/flutter/issues/62983

## Tests

No tests were added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
    * I only ran the tests `flutter_gallery_v2_chrome_run_test` and `flutter_gallery_v2_web_compile_test`, and they are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
    * The following error and info were raised, but they are unrelated to the changes in this PR.
```

  error • A value of type 'Future<Dwds> Function({AssetReader assetReader, Stream<BuildResult> buildResults, Future<ChromeConnection> Function() chromeConnection,
         bool enableDebugExtension, bool enableDebugging, ExpressionCompiler expressionCompiler, String hostname, LoadStrategy loadStrategy, void Function(Level,
         String) logWriter, bool restoreBreakpoints, bool serveDevTools, Future<String> Function(String) urlEncoder, bool useSseForDebugProxy, bool verbose})' can't
         be assigned to a variable of type 'Future<Dwds> Function({AssetReader assetReader, Stream<BuildResult> buildResults, Future<ChromeConnection> Function()
         chromeConnection, bool enableDebugExtension, bool enableDebugging, ExpressionCompiler expressionCompiler, String hostname, LoadStrategy loadStrategy, void
         Function(Level, String) logWriter, bool serveDevTools, Future<String> Function(String) urlEncoder, bool useFileProvider, bool useSseForDebugBackend, bool
         useSseForDebugProxy, bool verbose})' • ../../packages/flutter_tools/lib/src/build_runner/devfs_web.dart:152:33 • invalid_assignment
   info • The method doesn't override an inherited method • ../../packages/flutter_tools/lib/src/build_runner/devfs_web.dart:603:18 •
          override_on_non_overriding_member

2 issues found. (ran in 58.2s)
```
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
    * I only ran the tests `flutter_gallery_v2_chrome_run_test` and `flutter_gallery_v2_web_compile_test`, and they are passing.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
