### PR TITLE
Incomplete app widget error

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1017,6 +1017,8 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
       if (widget.onUnknownRoute == null) {
         throw FlutterError(
           'Could not find a generator for route $settings in the $runtimeType.\n'
+          'Make sure your root app widget has provided a way to generate \n'
+          'this route.\n'
           'Generators for routes are searched for in the following order:\n'
           ' 1. For the "/" route, the "home" property, if non-null, is used.\n'
           ' 2. Otherwise, the "routes" table is used, if it has an entry for '

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -179,6 +179,8 @@ void main() {
           'FlutterError\n'
           '   Could not find a generator for route RouteSettings("/path", null)\n'
           '   in the _WidgetsAppState.\n'
+          '   Make sure your root app widget has provided a way to generate\n'
+          '   this route.\n'
           '   Generators for routes are searched for in the following order:\n'
           '    1. For the "/" route, the "home" property, if non-null, is used.\n'
           '    2. Otherwise, the "routes" table is used, if it has an entry for\n'


### PR DESCRIPTION
## Description

Users may commonly create a root app widget that is incomplete without realizing it.  Examples from the issue including subclassing the wrong class or just rendering an empty `MaterialApp()`.  The error message is very detailed for such a high-level mistake.  This PR adds a small indication of what could be causing the error to help a developer find this problem.

## Related Issues

Closes https://github.com/flutter/flutter/issues/13276

## Tests

I updated an existing test of this error message.


## Breaking Change

None.