### PR TITLE
Add isPartiallyHidden SemanticsFlag

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3679,9 +3679,14 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
         ..transform = geometry.transform
         ..parentSemanticsClipRect = geometry.semanticsClipRect
         ..parentPaintClipRect = geometry.paintClipRect;
-      if (!_mergeIntoParent && geometry.markAsHidden) {
+      if (!_mergeIntoParent) {
         _ensureConfigIsWritable();
-        _config.isHidden = true;
+        if (geometry.markAsHidden) {
+          _config.isHidden = true;
+        }
+        if (geometry.markAsPartiallyHidden) {
+          _config.isPartiallyHidden = true;
+        }
       }
     }
 
@@ -3832,6 +3837,7 @@ class _SemanticsGeometry {
     if (_paintClipRect != null) {
       final Rect paintRect = _paintClipRect.intersect(_rect);
       _markAsHidden = paintRect.isEmpty && !_rect.isEmpty;
+      _markAsPartiallyHidden = !markAsHidden && paintRect != _rect; // true if the intersection resulted in a smaller rect
       if (!_markAsHidden)
         _rect = paintRect;
     }
@@ -3911,6 +3917,19 @@ class _SemanticsGeometry {
   ///  * [SemanticsFlag.isHidden] for the purpose of marking a node as hidden.
   bool get markAsHidden => _markAsHidden;
   bool _markAsHidden = false;
+
+  /// Whether the [SemanticsNode] annotated with the geometric information
+  /// tracked by this object should be marked as partially hidden because
+  /// it is both partially on and off screen or otherwise obscured.
+  ///
+  /// Platforms should generally call [SemanticsAction.showOnScreen] when an
+  /// element with [SemanticsFlag.isPartiallyHidden] receives accessibility focus.
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsFlag.isPartiallyHidden] for marking a node as partially hidden.
+  bool get markAsPartiallyHidden => _markAsPartiallyHidden;
+  bool _markAsPartiallyHidden = false;
 }
 
 /// A class that creates [DiagnosticsNode] by wrapping [RenderObject.debugCreator].

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3640,7 +3640,7 @@ class SemanticsConfiguration {
     _setFlag(SemanticsFlag.isHeader, value);
   }
 
-  /// Whether the owning [RenderObject] is considered hidden.
+  /// Whether the owning [RenderObject] is considered fully hidden.
   ///
   /// Hidden elements are currently not visible on screen. They may be covered
   /// by other elements or positioned outside of the visible area of a viewport.
@@ -3656,9 +3656,39 @@ class SemanticsConfiguration {
   /// the semantics tree altogether. Hidden elements are only included in the
   /// semantics tree to work around platform limitations and they are mainly
   /// used to implement accessibility scrolling on iOS.
+  ///
+  /// See also:
+  ///
+  /// * [SemanticsFlag.isPartiallyHidden]
   bool get isHidden => _hasFlag(SemanticsFlag.isHidden);
   set isHidden(bool value) {
     _setFlag(SemanticsFlag.isHidden, value);
+  }
+
+  /// Whether the owning [RenderObject] is considered partially hidden.
+  ///
+  /// Elements with this flag are both partially hidden off screen and partially
+  /// visible on screen. They may be partially covered by other elements or
+  /// positioned partway outside of the visible area of a viewport.
+  ///
+  /// Partially hidden elements are brought fully on screen upon gaining
+  /// accessibility focus.
+  ///
+  /// This flag is different from [isHidden], since partially hidden elements
+  /// are still valid memebers of the semantics tree for all platforms.
+  ///
+  /// Platforms should generally call [SemanticsAction.showOnScreen] when an
+  /// element with [isPartiallyHidden] receives accessibility focus, although
+  /// additional platform-specific considerations may be needed to ensure
+  /// this does not interfere with other actions, such as smooth scrolling
+  /// on Android.
+  ///
+  /// See also:
+  ///
+  /// * [SemanticsFlag.isHidden]
+  bool get isPartiallyHidden => _hasFlag(SemanticsFlag.isPartiallyHidden);
+  set isPartiallyHidden(bool value) {
+    _setFlag(SemanticsFlag.isPartiallyHidden, value);
   }
 
   /// Whether the owning [RenderObject] is a text field.

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1133,6 +1133,7 @@ void main() {
             hasTapAction: true,
             isSelected: year == 2016,
             isFocusable: true,
+            isPartiallyHidden: year >= 2022, // The last row is partially hidden.
           ));
         }
 

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -434,9 +434,10 @@ void _defineTests() {
       ),
     ));
     List<SemanticsFlag> flags = SemanticsFlag.values.values.toList();
-    // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
-    // therefore it has to be removed.
-    flags.remove(SemanticsFlag.hasImplicitScrolling);
+    // These aren't a part of [SemanticsProperties] and therefore have to be removed.
+    flags
+      ..remove(SemanticsFlag.hasImplicitScrolling)
+      ..remove(SemanticsFlag.isPartiallyHidden);
     TestSemantics expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
@@ -483,9 +484,10 @@ void _defineTests() {
       ),
     ));
     flags = SemanticsFlag.values.values.toList();
-    // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
-    // therefore it has to be removed.
-    flags.remove(SemanticsFlag.hasImplicitScrolling);
+    // These aren't a part of [SemanticsProperties] and therefore have to be removed.
+    flags
+      ..remove(SemanticsFlag.hasImplicitScrolling)
+      ..remove(SemanticsFlag.isPartiallyHidden);
     expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2401,6 +2401,7 @@ void main() {
                               TestSemantics(
                                 id: 8,
                                 tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                                 label: 'N',
                                 textDirection: TextDirection.ltr,
                               ),

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -362,6 +362,7 @@ void main() {
                   textDirection: TextDirection.ltr,
                 ),
                 TestSemantics(
+                  flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                   label: r'item 1',
                   textDirection: TextDirection.ltr,
                 ),

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -494,7 +494,9 @@ void main() {
     flags
       ..remove(SemanticsFlag.hasToggledState)
       ..remove(SemanticsFlag.isToggled)
-      ..remove(SemanticsFlag.hasImplicitScrolling);
+      // These aren't a part of [SemanticsProperties] and therefore have to be removed.
+      ..remove(SemanticsFlag.hasImplicitScrolling)
+      ..remove(SemanticsFlag.isPartiallyHidden);
 
     TestSemantics expectedSemantics = TestSemantics.root(
       children: <TestSemantics>[

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -174,6 +174,7 @@ void _tests() {
                     children: <TestSemantics>[
                       TestSemantics(
                         id: 3,
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 0',
                         textDirection: TextDirection.ltr,
                       ),
@@ -262,6 +263,7 @@ void _tests() {
                       ),
                       TestSemantics(
                         id: 5,
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 2',
                         textDirection: TextDirection.ltr,
                       ),
@@ -350,10 +352,12 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 1',
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 2',
                         textDirection: TextDirection.ltr,
                       ),
@@ -532,6 +536,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 1',
                         textDirection: TextDirection.ltr,
                       ),
@@ -540,6 +545,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -643,6 +649,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 1',
                         textDirection: TextDirection.ltr,
                       ),
@@ -651,6 +658,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -749,6 +757,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -757,6 +766,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 1',
                         textDirection: TextDirection.ltr,
                       ),
@@ -863,6 +873,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -871,6 +882,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Item 1',
                         textDirection: TextDirection.ltr,
                       ),
@@ -1009,6 +1021,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Forward Item 1',
                         textDirection: TextDirection.ltr,
                       ),
@@ -1017,6 +1030,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Forward Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -1075,6 +1089,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Backward Item 3',
                         textDirection: TextDirection.ltr,
                       ),
@@ -1083,6 +1098,7 @@ void _tests() {
                         textDirection: TextDirection.ltr,
                       ),
                       TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                         label: 'Backward Item 1',
                         textDirection: TextDirection.ltr,
                       ),

--- a/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
@@ -195,6 +195,7 @@ void main() {
                     TestSemantics(
                       label: 'Tile 10',
                       textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                     ),
                     TestSemantics(
                       label: 'Tile 11',
@@ -219,6 +220,7 @@ void main() {
                     TestSemantics(
                       label: 'Tile 16',
                       textDirection: TextDirection.ltr,
+                      flags: <SemanticsFlag>[SemanticsFlag.isPartiallyHidden],
                     ),
                     TestSemantics(
                       label: 'Tile 17',

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -469,6 +469,7 @@ Matcher matchesSemantics({
   bool hasToggledState = false,
   bool isToggled = false,
   bool hasImplicitScrolling = false,
+  bool isPartiallyHidden = false,
   // Actions //
   bool hasTapAction = false,
   bool hasLongPressAction = false,
@@ -520,6 +521,7 @@ Matcher matchesSemantics({
     if (hasToggledState) SemanticsFlag.hasToggledState,
     if (isToggled) SemanticsFlag.isToggled,
     if (hasImplicitScrolling) SemanticsFlag.hasImplicitScrolling,
+    if (isPartiallyHidden) SemanticsFlag.isPartiallyHidden,
   ];
 
   final List<SemanticsAction> actions = <SemanticsAction>[


### PR DESCRIPTION
## Description

This is the framework side of changes required for [Proposal: New "isPartiallyHidden" Semantics Flag](https://github.com/flutter/flutter/issues/62931).

See related engine PR here: flutter/engine#20285. Tests will fail without this, because `SemanticsFlag.isPartiallyHidden` is defined in the engine.

Please see **"Q&A -> Open questions"** at the bottom of ([#62931](https://github.com/flutter/flutter/issues/62931)), especially the two questions most relevant to the framework:

1. **The `isHidden` flag is exposed to end users via the [Semantics widget](https://api.flutter.dev/flutter/widgets/Semantics-class.html), should we do the same for `isPartiallyHidden`?**

    1. Unsure of a use case for this, but it may prove helpful to some users.


2. **How will this affect other widgets/semantic nodes which are not in scrollable containers but still partially obscured?**
  
    1. Unsure if this situation would arise. If so, `showOnScreen` will hopefully be a no-op.

## Related Issues

Will fix issues for Android (https://github.com/flutter/flutter/issues/36307) and iOS (https://github.com/flutter/flutter/issues/61624) currently affecting `customer: money`.

## Tests

A few tests which check for `isHidden` had to be updated to support this, and now also implicitly cover `isPartiallyHidden` quite well.

**Further tests will be added, pending feedback on initial draft.**

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
