### PR TITLE
Revert "Add padding around flutter api docs search input"

### DIFF
--- a/dev/docs/assets/overrides.css
+++ b/dev/docs/assets/overrides.css
@@ -107,7 +107,7 @@ code {
   background-image: none;
   border: 1px solid #ccc;
   border-radius: 2px;
-  padding: 14px 6px;
+  padding: 4px 6px;
   font-size: 15px;
 }
 


### PR DESCRIPTION
Reverts flutter/flutter#44980

Causes some misalignment between entered text and the suggested text:

![Screen Shot 2020-08-06 at 11 30 39 AM](https://user-images.githubusercontent.com/1227763/89568766-a3d87080-d7d8-11ea-8753-59e8fe7cc79b.png)

/cc @xrr2016 @gspencergoog 

Compare https://api.flutter.dev/ (doesn't have #44980 yet) with https://master-api.flutter.dev/ (includes #44980).