### PR TITLE
Updated old button references in dev/integration_tests/ui

### DIFF
--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -37,7 +37,7 @@ class DriverTestAppState extends State<DriverTestApp> {
                 Expanded(
                   child: Text(present ? 'present' : 'absent'),
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text(
                     'toggle',
                     key: ValueKey<String>('togglePresent'),

--- a/dev/integration_tests/ui/lib/main.dart
+++ b/dev/integration_tests/ui/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
     home: Material(
       child: Builder(
         builder: (BuildContext context) {
-          return FlatButton(
+          return TextButton(
             child: const Text(
               'flutter drive lib/xxx.dart',
               textDirection: TextDirection.ltr,

--- a/dev/integration_tests/ui/lib/screenshot.dart
+++ b/dev/integration_tests/ui/lib/screenshot.dart
@@ -33,7 +33,7 @@ class TogglerState extends State<Toggler> {
         body: Material(
           child: Column(
             children: <Widget>[
-              FlatButton(
+              TextButton(
                 key: const ValueKey<String>('toggle'),
                 child: const Text('Toggle visibility'),
                 onPressed: () {


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, RaisedButton with ElevatedButton, per #59702.