### PR TITLE
Updated old button references in dev/integration_tests/hybrid_android_views

### DIFF
--- a/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
@@ -64,13 +64,13 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
         Row(
           children: <Widget>[
             Expanded(
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('RECORD'),
                 onPressed: listenToFlutterViewEvents,
               ),
             ),
             Expanded(
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('CLEAR'),
                 onPressed: () {
                   setState(() {
@@ -81,7 +81,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
               ),
             ),
             Expanded(
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('SAVE'),
                 onPressed: () {
                   const StandardMessageCodec codec = StandardMessageCodec();
@@ -91,14 +91,14 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
               ),
             ),
             Expanded(
-              child: RaisedButton(
+              child: ElevatedButton(
                 key: const ValueKey<String>('play'),
                 child: const Text('PLAY FILE'),
                 onPressed: () { playEventsFile(); },
               ),
             ),
             Expanded(
-              child: RaisedButton(
+              child: ElevatedButton(
                 key: const ValueKey<String>('back'),
                 child: const Text('BACK'),
                 onPressed: () { Navigator.pop(context); },

--- a/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
@@ -60,24 +60,24 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
           ),
           if (lastTestStatus != _LastTestStatus.pending) _statusWidget(),
           if (viewChannel != null) ... <Widget>[
-            RaisedButton(
+            ElevatedButton(
               key: const ValueKey<String>('ShowAlertDialog'),
               child: const Text('SHOW ALERT DIALOG'),
               onPressed: onShowAlertDialogPressed,
             ),
-            RaisedButton(
+            ElevatedButton(
               key: const ValueKey<String>('TogglePlatformView'),
               child: const Text('TOGGLE PLATFORM VIEW'),
               onPressed: onTogglePlatformView,
             ),
             Row(
               children: <Widget>[
-                RaisedButton(
+                ElevatedButton(
                   key: const ValueKey<String>('AddChildView'),
                   child: const Text('ADD CHILD VIEW'),
                   onPressed: onChildViewPressed,
                 ),
-                RaisedButton(
+                ElevatedButton(
                   key: const ValueKey<String>('TapChildView'),
                   child: const Text('TAP CHILD VIEW'),
                   onPressed: onTapChildViewPressed,


### PR DESCRIPTION
Replaced uses of RaisedButton with ElevatedButton, per #59702.