### PR TITLE
Updated old button references in packages/flutter_test

### DIFF
--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -583,9 +583,11 @@ void main() {
         theme: ThemeData.light(),
         home: Scaffold(
           backgroundColor: Colors.white,
-          body: RaisedButton(
-            color: const Color(0xFFFBBC04),
-            elevation: 0,
+          body: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              primary: const Color(0xFFFBBC04),
+              elevation: 0,
+            ),
             onPressed: () {},
             child: const Text('Button', style: TextStyle(color: Colors.black)),
         ),

--- a/packages/flutter_test/test/accessibility_window_test.dart
+++ b/packages/flutter_test/test/accessibility_window_test.dart
@@ -10,11 +10,13 @@ void main() {
     tester.binding.window.devicePixelRatioTestValue = 1.2;
     tester.binding.window.physicalSizeTestValue = const Size(250, 300);
 
-    final RaisedButton invalidButton = RaisedButton(
+    final Widget invalidButton = ElevatedButton(
       onPressed: () {},
+      style: ElevatedButton.styleFrom(
+        primary: Colors.orangeAccent, // background fill color
+        onPrimary: Colors.orange, // text foreground color
+      ),
       child: const Text('Button'),
-      textColor: Colors.orange,
-      color: Colors.orangeAccent,
     );
     await tester.pumpWidget(MaterialApp(home: Scaffold(body: invalidButton)));
 
@@ -26,11 +28,13 @@ void main() {
     tester.binding.window.devicePixelRatioTestValue = 4.2;
     tester.binding.window.physicalSizeTestValue = const Size(2500, 3000);
 
-    final RaisedButton invalidButton = RaisedButton(
+    final Widget invalidButton = ElevatedButton(
       onPressed: () {},
+      style: ElevatedButton.styleFrom(
+        primary: Colors.orangeAccent, // background fill color
+        onPrimary: Colors.orange, // text foreground color
+      ),
       child: const Text('Button'),
-      textColor: Colors.orange,
-      color: Colors.orangeAccent,
     );
     await tester.pumpWidget(MaterialApp(home: Scaffold(body: invalidButton)));
 

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -63,7 +63,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Container(
-              child: OutlineButton(
+              child: OutlinedButton(
                   onPressed: () { },
                   child: const Text('hello'),
               ),

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -85,7 +85,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Container(
-              child: OutlineButton(
+              child: OutlinedButton(
                   onPressed: () { },
                   child: const Text('hello'),
               ),

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -41,7 +41,7 @@ void main() {
         Semantics(
           label: 'Add',
           button: true,
-          child: const FlatButton(
+          child: const TextButton(
             child: Text('+'),
             onPressed: null,
           ),

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -18,7 +18,7 @@ class _CountButtonState extends State<CountButton> {
   int counter = 0;
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       child: Text('Counter $counter'),
       onPressed: () {
         setState(() {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -375,7 +375,7 @@ void main() {
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
-                return RaisedButton(
+                return ElevatedButton(
                   child: const Text('Next'),
                   onPressed: () {
                     Navigator.push<void>(context, MaterialPageRoute<void>(


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, RaisedButton with ElevatedButton, OutlineButton with OutlinedButton, per #59702.