### PR TITLE
Updated old button references in dev/integration_tests/android_semantics

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
@@ -84,7 +84,7 @@ class _PopupControlsPageState extends State<PopupControlsPage> {
                           ),
                         ),
                         actions: <Widget>[
-                          FlatButton(
+                          TextButton(
                             child: const Text('OK', key: ValueKey<String>('$alertKeyValue.OK')),
                             onPressed: () {
                               Navigator.of(context).pop();


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, per #59702.