### PR TITLE
Updated use of OutlineButton in FocusTraversalPolicy API doc

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1528,15 +1528,34 @@ class FocusTraversalOrder extends InheritedWidget {
 ///       order = LexicalFocusOrder(widget.order.toString());
 ///     }
 ///
+///     Color overlayColor(Set<MaterialState> states) {
+///       if (states.contains(MaterialState.focused)) {
+///         return Colors.red;
+///       }
+///       if (states.contains(MaterialState.hovered)) {
+///         return Colors.blue;
+///       }
+///       return null;  // defer to the default overlayColor
+///     }
+///
+///     Color foregroundColor(Set<MaterialState> states) {
+///       if (states.contains(MaterialState.focused) || states.contains(MaterialState.hovered)) {
+///         return Colors.white;
+///       }
+///       return null;  // defer to the default foregroundColor
+///     }
+///
 ///     return FocusTraversalOrder(
 ///       order: order,
 ///       child: Padding(
 ///         padding: const EdgeInsets.all(8.0),
-///         child: OutlineButton(
+///         child: OutlinedButton(
 ///           focusNode: focusNode,
 ///           autofocus: widget.autofocus,
-///           focusColor: Colors.red,
-///           hoverColor: Colors.blue,
+///           style: ButtonStyle(
+///             overlayColor: MaterialStateProperty.resolveWith<Color>(overlayColor),
+///             foregroundColor: MaterialStateProperty.resolveWith<Color>(foregroundColor),
+///           ),
 ///           onPressed: () => _handleOnPressed(),
 ///           child: Text(widget.name),
 ///         ),


### PR DESCRIPTION
Replaced the use of OutlinedButton with OutlinedButton the  FocusTraversalPolicy API doc per #59702. Changed the demo's appearance slightly. Original version (button num0 is focused, num1 is hovered):

![Screen Shot 2020-08-07 at 2 53 10 PM](https://user-images.githubusercontent.com/1377460/89691862-ec6a5980-d8be-11ea-8050-760cab2eb7c9.png)

Updated version:

![Screen Shot 2020-08-07 at 2 50 46 PM](https://user-images.githubusercontent.com/1377460/89691868-f2603a80-d8be-11ea-8509-df1ab585221e.png)
