### PR TITLE
Bump Cirrus image Xcode version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -333,7 +333,7 @@ task:
 # than just fetching the data in the first place.
 task:
   osx_instance:
-    image: catalina-xcode-11.3.1-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
+    image: catalina-xcode-12.0-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
     # cpu is always 2
     # memory is always 8G
   environment:

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -50,6 +50,8 @@ Future<void> main() async {
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
+          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
+          canFail: true,
         );
       });
 
@@ -69,6 +71,8 @@ Future<void> main() async {
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
+          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
+          canFail: true,
         );
       });
 


### PR DESCRIPTION
## Description

Update Cirrus macOS image to catalina-xcode-12.0-flutter.

## Related Issues

https://github.com/flutter/flutter/issues/60133
