### PR TITLE
Small documentation typo fix

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -23,7 +23,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 // Examples can assume:
 // BuildContext context;
 
-/// An immutable style in which paint text.
+/// An immutable style in which text can be formatted and painted. 
 ///
 /// ### Bold
 ///

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -23,7 +23,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 // Examples can assume:
 // BuildContext context;
 
-/// An immutable style in which text can be formatted and painted. 
+/// An immutable style describing how to format and paint text.
 ///
 /// ### Bold
 ///


### PR DESCRIPTION
## Description
This line in text_style.dart didn't really make sense, so I fixed the sentence. It can be made more verbose if desired.
