### PR TITLE
Clip image of BoxDecoration to circle when shape is BoxShape.circle

### DIFF
--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -220,7 +220,10 @@ class BoxDecoration extends Decoration {
     Path clipPath;
     switch (shape) {
       case BoxShape.circle:
-        clipPath = Path()..addOval(rect);
+        final Offset center = rect.center;
+        final double radius = rect.shortestSide / 2.0;
+        final Rect square = Rect.fromCircle(center: center, radius: radius);
+        clipPath = Path()..addOval(square);
         break;
       case BoxShape.rectangle:
         if (borderRadius != null)

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -455,7 +455,11 @@ class _BoxDecorationPainter extends BoxPainter {
     Path clipPath;
     switch (_decoration.shape) {
       case BoxShape.circle:
-        clipPath = Path()..addOval(rect);
+        assert(_decoration.borderRadius == null);
+        final Offset center = rect.center;
+        final double radius = rect.shortestSide / 2.0;
+        final Rect square = Rect.fromCircle(center: center, radius: radius);
+        clipPath = Path()..addOval(square);
         break;
       case BoxShape.rectangle:
         if (_decoration.borderRadius != null)

--- a/packages/flutter/test/painting/box_decoration_test.dart
+++ b/packages/flutter/test/painting/box_decoration_test.dart
@@ -71,7 +71,7 @@ void main() {
     );
   });
 
-  test('BoxDecoration.getClipPath', () {
+  test('BoxDecoration.getClipPath with borderRadius', () {
     const double radius = 10;
     final BoxDecoration decoration = BoxDecoration(
       borderRadius: BorderRadius.circular(radius),
@@ -81,6 +81,19 @@ void main() {
     final Matcher isLookLikeExpectedPath = isPathThat(
       includes: const <Offset>[ Offset(30.0, 10.0), Offset(50.0, 10.0), ],
       excludes: const <Offset>[ Offset(1.0, 1.0), Offset(99.0, 19.0), ],
+    );
+    expect(clipPath, isLookLikeExpectedPath);
+  });
+
+  test('BoxDecoration.getClipPath with shape BoxShape.circle', () {
+    const BoxDecoration decoration = BoxDecoration(
+      shape: BoxShape.circle,
+    );
+    const Rect rect = Rect.fromLTWH(0.0, 0.0, 100.0, 20.0);
+    final Path clipPath = decoration.getClipPath(rect, TextDirection.ltr);
+    final Matcher isLookLikeExpectedPath = isPathThat(
+      includes: const <Offset>[ Offset(50.0, 0.0), Offset(40.0, 10.0), ],
+      excludes: const <Offset>[ Offset(40.0, 0.0), Offset(10.0, 10.0), ],
     );
     expect(clipPath, isLookLikeExpectedPath);
   });


### PR DESCRIPTION
## Description

Clips image of BoxDecoration to circle when `shape` is `BoxShape.circular`. <br>
Current behavior is the image is clipped to an oval. Dimensions of this oval are tightly constrained by the size of the decorated widget.

<details>
  <summary>Before</summary>
<img src="https://user-images.githubusercontent.com/24816604/89739675-60595d00-da8b-11ea-988e-4725ec6756d0.png" width=40% height=40%>
</details>


<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/24816604/89747216-5ef95600-dac6-11ea-8bae-66ddf4257839.png" width=40% height=40%>
</details>

<details>
  <summary>Source code</summary>




```dart

import 'package:flutter/material.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
        visualDensity: VisualDensity.adaptivePlatformDensity,
      ),
      home: MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatelessWidget {
  MyHomePage({Key key, this.title}) : super(key: key);

  final String title;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(title),
      ),
      body: Container(
        height: double.infinity,
        width: double.infinity,
        decoration: BoxDecoration(
          shape: BoxShape.circle,
          color: Colors.red,
          image: DecorationImage(
            fit: BoxFit.cover,
            image: AssetImage('assets/logo_flutter.png'),
          ),
        ),
      ),
    );
  }
}

```


</details>

See more in the related issue.

Also, I changed `Boxdecoration.getClipPath()` to reflect changes in clipping behavior.


## Related Issues

Fixes #63351

## Tests

I added a test for `Boxdecoration.getClipPath()` for the case when `shape` of Box decoration is `BoxShape.circle`.

https://github.com/timekone/flutter/blob/84594a2dbdfa5d1e3156c9b649c82ae5b8bdd488/packages/flutter/test/painting/box_decoration_test.dart#L88-L99

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
