### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery … drawer_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -254,7 +254,7 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
         return AlertDialog(
           title: const Text('Account switching not implemented.'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('OK'),
               onPressed: () {
                 Navigator.pop(context);


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, per #59702.