### PR TITLE
Ensure cupertino time picker positions hours and minutes correctly for RTL

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -948,9 +948,15 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       _getEstimatedColumnWidth(_PickerColumnType.hour),
       _getEstimatedColumnWidth(_PickerColumnType.minute),
     ];
+
+    // Swap the hours and minutes if RTL to ensure they are in the correct position.
+    final bool isRtl = Directionality.of(context) == TextDirection.rtl;
     final List<_ColumnBuilder> pickerBuilders = <_ColumnBuilder>[
+      if (isRtl)
+        _buildMinutePicker,
       _buildHourPicker,
-      _buildMinutePicker,
+      if (!isRtl)
+        _buildMinutePicker,
     ];
 
     // Adds am/pm column if the picker is not using 24h format.

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -950,14 +950,9 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     ];
 
     // Swap the hours and minutes if RTL to ensure they are in the correct position.
-    final bool isRtl = Directionality.of(context) == TextDirection.rtl;
-    final List<_ColumnBuilder> pickerBuilders = <_ColumnBuilder>[
-      if (isRtl)
-        _buildMinutePicker,
-      _buildHourPicker,
-      if (!isRtl)
-        _buildMinutePicker,
-    ];
+    final List<_ColumnBuilder> pickerBuilders = Directionality.of(context) == TextDirection.rtl
+      ? <_ColumnBuilder>[_buildMinutePicker, _buildHourPicker]
+      : <_ColumnBuilder>[_buildHourPicker, _buildMinutePicker];
 
     // Adds am/pm column if the picker is not using 24h format.
     if (!widget.use24hFormat) {

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1215,6 +1215,31 @@ void main() {
         matchesGoldenFile('date_picker_test.datetime.drag.png'),
       );
     });
+
+    testWidgets('DatePicker displays hours and minutes correctly in RTL', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Center(
+              child: SizedBox(
+                width: 500,
+                height: 400,
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.dateAndTime,
+                  initialDateTime: DateTime(2019, 1, 1, 4),
+                  onDateTimeChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final double hourLeft = tester.getTopLeft(find.text('4')).dx;
+      final double minuteLeft = tester.getTopLeft(find.text('00')).dx;
+      expect(hourLeft, lessThan(minuteLeft));
+    });
   });
 
   testWidgets('TimerPicker golden tests', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This change ensures that hours stays to the left of minutes even when the locale is RTL for the Cupertino time picker.

## Related Issues

Fixes #63337

## Tests

I added the following tests:

- Test to check the position of the hours relative to the minutes in RTL

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
