### PR TITLE
WidgetTester.drag with time duration

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
@@ -19,10 +19,10 @@ void main() {
       final Finder nestedScroll = find.byKey(const ValueKey<String>('tabbar_view'));
       expect(nestedScroll, findsOneWidget);
       Future<void> _scrollOnce(double offset) async {
-        await controller.drag(
+        await controller.slowDrag(
           nestedScroll,
           Offset(-offset, 0.0),
-          duration: const Duration(milliseconds: 300)
+          const Duration(milliseconds: 300),
         );
         await Future<void>.delayed(const Duration(milliseconds: 500));
       }

--- a/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
@@ -19,7 +19,7 @@ void main() {
       final Finder nestedScroll = find.byKey(const ValueKey<String>('tabbar_view'));
       expect(nestedScroll, findsOneWidget);
       Future<void> _scrollOnce(double offset) async {
-        await controller.slowDrag(
+        await controller.timedDrag(
           nestedScroll,
           Offset(-offset, 0.0),
           const Duration(milliseconds: 300),

--- a/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
@@ -1,0 +1,37 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'picture_cache_perf',
+    kPictureCacheRouteName,
+    pageDelay: const Duration(seconds: 1),
+    body: (WidgetController controller) async {
+      final Finder nestedScroll = find.byKey(const ValueKey<String>('tabbar_view'));
+      expect(nestedScroll, findsOneWidget);
+      Future<void> _scrollOnce(double offset) async {
+        await controller.drag(
+          nestedScroll,
+          Offset(-offset, 0.0),
+          duration: const Duration(milliseconds: 300)
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      }
+      for (int i = 0; i < 3; i += 1) {
+        await _scrollOnce(-300.0);
+        await _scrollOnce(-300.0);
+        await _scrollOnce(300.0);
+        await _scrollOnce(300.0);
+      }
+    },
+  );
+}

--- a/dev/devicelab/bin/tasks/picture_cache_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/picture_cache_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createPictureCachePerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -158,6 +158,13 @@ TaskFunction createPictureCachePerfTest() {
   ).run;
 }
 
+TaskFunction createPictureCachePerfE2ETest() {
+  return E2EPerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/picture_cache_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createFlutterGalleryStartupTest() {
   return StartupTest(
     '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -190,6 +190,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  picture_cache_perf__e2e_summary:
+    description: >
+      Measures the runtime performance of raster caching many pictures on Android.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
   cubic_bezier_perf__timeline_summary:
     description: >
       Measures the runtime performance of cubic bezier animations on Android.

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -477,6 +477,14 @@ abstract class WidgetController {
   /// system identifies the gesture as a fling, consider using [fling] instead.
   ///
   /// {@template flutter.flutter_test.drag}
+  /// If `duration` is not `null`, this is a convenience wrap of
+  /// [handlePointerEventRecord], with the input lasts for `duration` at the
+  /// given `frequency` (Hz).
+  /// See [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] for more
+  /// accurate time control.
+  /// Otherwise the input events are assumed to happen at once, and `frequency`
+  /// is ignored.
+  ///
   /// By default, if the x or y component of offset is greater than
   /// [kDragSlopDefault], the gesture is broken up into two separate moves
   /// calls. Changing `touchSlopX` or `touchSlopY` will change the minimum

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -477,13 +477,15 @@ abstract class WidgetController {
   /// system identifies the gesture as a fling, consider using [fling] instead.
   ///
   /// {@template flutter.flutter_test.drag}
-  /// If `duration` is not `null`, this is a convenience wrap of
-  /// [handlePointerEventRecord], with the input lasts for `duration` at the
-  /// given `frequency` (Hz).
-  /// See [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] for more
-  /// accurate time control.
-  /// Otherwise the input events are assumed to happen at once, and `frequency`
-  /// is ignored.
+  /// [duration] specifies the length of the action. The move events are
+  /// sent at a given [frequency] in Hz (or events per second). It defaults to
+  /// 60Hz.
+  ///
+  /// See also [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] for
+  /// more accurate time control.
+  ///
+  /// If [duration] is null, input events are assumed to happen at once, and
+  /// [frequency] is ignored.
   ///
   /// By default, if the x or y component of offset is greater than
   /// [kDragSlopDefault], the gesture is broken up into two separate moves

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -722,7 +722,10 @@ abstract class WidgetController {
           timeStamp: duration,
           position: offsets.last,
           pointer: pointer,
-          buttons: buttons,
+          // The PointerData recieved from the engine with
+          // chagne = PointerChnage.up, which translates to PointerUpEvent,
+          // doesn't provide the button field.
+          // buttons: buttons,
         )
       ]),
     ];

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -477,7 +477,7 @@ abstract class WidgetController {
   /// system identifies the gesture as a fling, consider using [fling] instead.
   ///
   /// The operation happens at once. If you want the drag to last for a period
-  /// of time, consider using [slowDrag].
+  /// of time, consider using [timedDrag].
   ///
   /// {@template flutter.flutter_test.drag}
   /// By default, if the x or y component of offset is greater than
@@ -522,7 +522,7 @@ abstract class WidgetController {
   /// instead.
   ///
   /// The operation happens at once. If you want the drag to last for a period
-  /// of time, consider using [slowDragFrom].
+  /// of time, consider using [timedDragFrom].
   ///
   /// {@macro flutter.flutter_test.drag}
   Future<void> dragFrom(
@@ -626,7 +626,9 @@ abstract class WidgetController {
   /// If the middle of the widget is not exposed, this might send
   /// events to another object.
   ///
-  /// This is the timed version of [drag].
+  /// This is the timed version of [drag]. This may or may not result in a
+  /// [fling] or ballistic animation, depending on the speed from
+  /// `offset/duration`.
   ///
   /// The move events are sent at a given `frequency` in Hz (or events per
   /// second). It defaults to 60Hz.
@@ -635,7 +637,7 @@ abstract class WidgetController {
   ///
   /// See also [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] for
   /// more accurate time control.
-  Future<void> slowDrag(
+  Future<void> timedDrag(
     Finder finder,
     Offset offset,
     Duration duration, {
@@ -643,7 +645,7 @@ abstract class WidgetController {
     int buttons = kPrimaryButton,
     double frequency = 60.0,
   }) {
-    return slowDragFrom(
+    return timedDragFrom(
       getCenter(finder),
       offset,
       duration,
@@ -659,7 +661,9 @@ abstract class WidgetController {
   /// If the middle of the widget is not exposed, this might send
   /// events to another object.
   ///
-  /// This is the timed version of [drag].
+  /// This is the timed version of [drag]. This may or may not result in a
+  /// [fling] or ballistic animation, depending on the speed from
+  /// `offset/duration`.
   ///
   /// The move events are sent at a given `frequency` in Hz (or events per
   /// second). It defaults to 60Hz.
@@ -668,7 +672,7 @@ abstract class WidgetController {
   ///
   /// See also [LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive] for
   /// more accurate time control.
-  Future<void> slowDragFrom(
+  Future<void> timedDragFrom(
     Offset startLocation,
     Offset offset,
     Duration duration, {

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -541,8 +541,7 @@ abstract class WidgetController {
     Duration duration,
     double frequency = 60.0,
   }) {
-    assert(touchSlopX > kTouchSlop);
-    assert(touchSlopY > kTouchSlop);
+    assert(kDragSlopDefault > kTouchSlop);
     if (duration == null) {
       return TestAsyncUtils.guard<void>(() async {
         final TestGesture gesture = await startGesture(

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -503,7 +503,6 @@ abstract class WidgetController {
     Duration duration,
     double frequency = 60.0,
   }) {
-    assert(kDragSlopDefault > kTouchSlop);
     return dragFrom(
       getCenter(finder),
       offset,
@@ -532,7 +531,6 @@ abstract class WidgetController {
     Duration duration,
     double frequency = 60.0,
   }) {
-    assert(kDragSlopDefault > kTouchSlop);
     if (duration != null) {
       return TestAsyncUtils.guard<void>(() async {
         return handlePointerEventRecord(_separateDragEvents(
@@ -543,6 +541,8 @@ abstract class WidgetController {
         ));
       });
     }
+    assert(touchSlopX > kTouchSlop);
+    assert(touchSlopY > kTouchSlop);
     return TestAsyncUtils.guard<void>(() async {
       final TestGesture gesture = await startGesture(startLocation, pointer: pointer, buttons: buttons);
       assert(gesture != null);

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -577,6 +577,43 @@ void main() {
       }
   });
 
+   testWidgets(
+    'WidgetTester.timedDrag must respect buttons',
+    (WidgetTester tester) async {
+      final List<String> logs = <String>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Listener(
+            onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
+            onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
+            onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
+            child: const Text('test'),
+          ),
+        ),
+      );
+
+      await tester.timedDrag(
+        find.text('test'),
+        const Offset(-200.0, 0.0),
+        const Duration(seconds: 1),
+        buttons: kSecondaryMouseButton,
+      );
+      await tester.pumpAndSettle();
+
+      const String b = '$kSecondaryMouseButton';
+      for(int i = 0; i < logs.length; i++) {
+        if (i == 0)
+          expect(logs[i], 'down $b');
+        else if (i != logs.length - 1)
+          expect(logs[i], 'move $b');
+        else
+          expect(logs[i], 'up 0');
+      }
+    },
+  );
+
   testWidgets(
     'ensureVisible: scrolls to make widget visible',
     (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Add `duration` and `frequency` optional argument to implement operation that lasts for a period of time, used for performance test purposes to capture animation during an operation. 
Documents will be updated after #63390 lands. 

## Related Issues

#38329

## Tests

I added the following tests:

`picture_cache_perf__e2e_summary` in devicelab, as part of #62171 to test the new feature as well as to test the related performance. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
