### PR TITLE
Fix App.framework path in Podfile

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -191,6 +191,16 @@ Future<void> main() async {
       // Android-only, no embedded framework.
       checkDirectoryNotExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'android_alarm_manager.framework'));
 
+      section('Clean and pub get module');
+
+      await inDirectory(projectDir, () async {
+        await flutter('clean');
+      });
+
+      await inDirectory(projectDir, () async {
+        await flutter('pub', options: <String>['get']);
+      });
+
       section('Add to existing iOS Objective-C app');
 
       final Directory objectiveCHostApp = Directory(path.join(tempDir.path, 'hello_host_app'));
@@ -240,6 +250,23 @@ Future<void> main() async {
       if (!existingAppBuilt) {
         return TaskResult.failure('Failed to build existing Objective-C app .app');
       }
+
+      checkFileExists(path.join(
+        objectiveCBuildDirectory.path,
+        'Host.app',
+        'Frameworks',
+        'Flutter.framework',
+        'Flutter',
+      ));
+
+      checkFileExists(path.join(
+        objectiveCBuildDirectory.path,
+        'Host.app',
+        'Frameworks',
+        'App.framework',
+        'flutter_assets',
+        'isolate_snapshot_data',
+      ));
 
       final String objectiveCAnalyticsOutput = objectiveCAnalyticsOutputFile.readAsStringSync();
       if (!objectiveCAnalyticsOutput.contains('cd24: ios')

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -96,7 +96,8 @@ end
 #                                          Optional, defaults to two levels up from the directory of this script.
 #                                          MyApp/my_flutter/.ios/Flutter/../..
 def install_flutter_application_pod(flutter_application_path)
-  app_framework_dir = File.expand_path('App.framework', File.join('..', __FILE__))
+  current_directory_pathname = Pathname.new File.expand_path('..', __FILE__)
+  app_framework_dir = File.expand_path('App.framework', current_directory_pathname.to_path)
   app_framework_dylib = File.join(app_framework_dir, 'App')
   if !File.exist?(app_framework_dylib)
     # Fake an App.framework to have something to link against if the xcode backend script has not run yet.
@@ -108,7 +109,7 @@ def install_flutter_application_pod(flutter_application_path)
 
   # Keep pod and script phase paths relative so they can be checked into source control.
   # Process will be run from project directory.
-  current_directory_pathname = Pathname.new File.expand_path('..', __FILE__)
+
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
   project_directory_pathname = defined_in_file.dirname
   relative = current_directory_pathname.relative_path_from project_directory_pathname


### PR DESCRIPTION
## Description

There was a bug with the path logic in creating the Debug fake `static const int Moo = 88;` App.framework.  Fix the path.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/63176

## Tests

Add a check to make sure the App.framework is really being embedded in the host app.
Added a `flutter clean` and `flutter pub get` to the integration test.  Before, it was using the App.framework from a previous step building it from the module, which doesn't prove it can be generated from the host app without running `flutter build` in the module first.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*