### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery ... persistent_bottom_sheet_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
@@ -62,7 +62,7 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
         return AlertDialog(
           content: const Text('You tapped the floating action button.'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               onPressed: () {
                 Navigator.pop(context);
               },
@@ -93,7 +93,7 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
         ),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: _showBottomSheetCallback,
           child: const Text('SHOW BOTTOM SHEET'),
         ),


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton and RaisedButton with ElevatedButton, per #59702.