### PR TITLE
Make modifier key side handling consistent among platforms

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -165,11 +165,26 @@ abstract class RawKeyEventData {
 
   /// Returns a map of modifier keys that were pressed at the time of this
   /// event, and the keyboard side or sides that the key was on.
-  Map<ModifierKey, KeyboardSide?> get modifiersPressed {
-    final Map<ModifierKey, KeyboardSide?> result = <ModifierKey, KeyboardSide?>{};
+  Map<ModifierKey, KeyboardSide> get modifiersPressed {
+    final Map<ModifierKey, KeyboardSide> result = <ModifierKey, KeyboardSide>{};
     for (final ModifierKey key in ModifierKey.values) {
       if (isModifierPressed(key)) {
-        result[key] = getModifierSide(key);
+        final KeyboardSide? side = getModifierSide(key);
+        if (side != null) {
+          result[key] = side;
+        }
+        assert((){
+          if (side == null) {
+            debugPrint('Raw key data is returning inconsistent information for '
+                'pressed modifiers. isModifierPressed returns true for $key '
+                'being pressed, but when getModifierSide is called, it says '
+                'that no modifiers are pressed.');
+            if (this is RawKeyEventDataAndroid) {
+              debugPrint('Android raw key metaState: ${(this as RawKeyEventDataAndroid).metaState}');
+            }
+          }
+          return true;
+        }());
       }
     }
     return result;
@@ -655,10 +670,21 @@ class RawKeyboard {
     final Map<ModifierKey, KeyboardSide?> modifiersPressed = event.data.modifiersPressed;
     final Map<PhysicalKeyboardKey, LogicalKeyboardKey> modifierKeys = <PhysicalKeyboardKey, LogicalKeyboardKey>{};
     for (final ModifierKey key in modifiersPressed.keys) {
-      final Set<PhysicalKeyboardKey> mappedKeys = _modifierKeyMap[_ModifierSidePair(key, modifiersPressed[key])]!;
-      assert(mappedKeys != null,
-        'Platform key support for ${Platform.operatingSystem} is '
-        'producing unsupported modifier combinations.');
+      final Set<PhysicalKeyboardKey>? mappedKeys = _modifierKeyMap[_ModifierSidePair(key, modifiersPressed[key])];
+      assert((){
+        if (mappedKeys == null) {
+          debugPrint('Platform key support for ${Platform.operatingSystem} is '
+              'producing unsupported modifier combinations for '
+              'modifier $key on side ${modifiersPressed[key]}.');
+          if (event.data is RawKeyEventDataAndroid) {
+            debugPrint('Android raw key metaState: ${(event.data as RawKeyEventDataAndroid).metaState}');
+          }
+        }
+        return true;
+      }());
+      if (mappedKeys == null) {
+        continue;
+      }
       for (final PhysicalKeyboardKey physicalModifier in mappedKeys) {
         modifierKeys[physicalModifier] = _allModifiers[physicalModifier]!;
       }

--- a/packages/flutter/lib/src/services/raw_keyboard_android.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_android.dart
@@ -260,7 +260,7 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
 
   @override
   KeyboardSide? getModifierSide(ModifierKey key) {
-    KeyboardSide? findSide(int leftMask, int rightMask) {
+    KeyboardSide? findSide(int anyMask, int leftMask, int rightMask) {
       final int combinedMask = leftMask | rightMask;
       final int combined = metaState & combinedMask;
       if (combined == leftMask) {
@@ -270,18 +270,24 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
       } else if (combined == combinedMask) {
         return KeyboardSide.all;
       }
+      // If the platform code sets the "any" modifier, but not a specific side,
+      // then we return "all", assuming that there is only one of that modifier
+      // key on the keyboard.
+      if (metaState & anyMask != 0) {
+        return KeyboardSide.all;
+      }
       return null;
     }
 
     switch (key) {
       case ModifierKey.controlModifier:
-        return findSide(modifierLeftControl, modifierRightControl);
+        return findSide(modifierControl, modifierLeftControl, modifierRightControl);
       case ModifierKey.shiftModifier:
-        return findSide(modifierLeftShift, modifierRightShift);
+        return findSide(modifierShift, modifierLeftShift, modifierRightShift);
       case ModifierKey.altModifier:
-        return findSide(modifierLeftAlt, modifierRightAlt);
+        return findSide(modifierAlt, modifierLeftAlt, modifierRightAlt);
       case ModifierKey.metaModifier:
-        return findSide(modifierLeftMeta, modifierRightMeta);
+        return findSide(modifierMeta, modifierLeftMeta, modifierRightMeta);
       case ModifierKey.capsLockModifier:
       case ModifierKey.numLockModifier:
       case ModifierKey.scrollLockModifier:

--- a/packages/flutter/lib/src/services/raw_keyboard_fuchsia.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_fuchsia.dart
@@ -135,13 +135,13 @@ class RawKeyEventDataFuchsia extends RawKeyEventData {
 
   @override
   KeyboardSide? getModifierSide(ModifierKey key) {
-    KeyboardSide? findSide(int leftMask, int rightMask, int combinedMask) {
-      final int combined = modifiers & combinedMask;
+    KeyboardSide? findSide(int anyMask, int leftMask, int rightMask) {
+      final int combined = modifiers & anyMask;
       if (combined == leftMask) {
         return KeyboardSide.left;
       } else if (combined == rightMask) {
         return KeyboardSide.right;
-      } else if (combined == combinedMask) {
+      } else if (combined == anyMask) {
         return KeyboardSide.all;
       }
       return null;
@@ -149,13 +149,13 @@ class RawKeyEventDataFuchsia extends RawKeyEventData {
 
     switch (key) {
       case ModifierKey.controlModifier:
-        return findSide(modifierLeftControl, modifierRightControl, modifierControl);
+        return findSide(modifierControl, modifierLeftControl, modifierRightControl, );
       case ModifierKey.shiftModifier:
-        return findSide(modifierLeftShift, modifierRightShift, modifierShift);
+        return findSide(modifierShift, modifierLeftShift, modifierRightShift);
       case ModifierKey.altModifier:
-        return findSide(modifierLeftAlt, modifierRightAlt, modifierAlt);
+        return findSide(modifierAlt, modifierLeftAlt, modifierRightAlt);
       case ModifierKey.metaModifier:
-        return findSide(modifierLeftMeta, modifierRightMeta, modifierMeta);
+        return findSide(modifierMeta, modifierLeftMeta, modifierRightMeta);
       case ModifierKey.capsLockModifier:
         return (modifiers & modifierCapsLock == 0) ? null : KeyboardSide.all;
       case ModifierKey.numLockModifier:

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -286,21 +286,10 @@ class GLFWKeyHelper with KeyHelper {
 
   @override
   KeyboardSide getModifierSide(ModifierKey key) {
-    switch (key) {
-      case ModifierKey.controlModifier:
-      case ModifierKey.shiftModifier:
-      case ModifierKey.altModifier:
-      case ModifierKey.metaModifier:
-        // Neither GLFW or X11 provide a distinction between left and right modifiers, so defaults to KeyboardSide.any.
-        // https://code.woboq.org/qt5/include/X11/X.h.html#_M/ShiftMask
-        return KeyboardSide.any;
-      case ModifierKey.capsLockModifier:
-      case ModifierKey.numLockModifier:
-      case ModifierKey.functionModifier:
-      case ModifierKey.symbolModifier:
-      case ModifierKey.scrollLockModifier:
-        return KeyboardSide.all;
-    }
+    // Neither GLFW nor X11 provide a distinction between left and right
+    // modifiers, so defaults to KeyboardSide.all.
+    // https://code.woboq.org/qt5/include/X11/X.h.html#_M/ShiftMask
+    return KeyboardSide.all;
   }
 
   @override
@@ -435,21 +424,10 @@ class GtkKeyHelper with KeyHelper {
 
   @override
   KeyboardSide getModifierSide(ModifierKey key) {
-    switch (key) {
-      case ModifierKey.controlModifier:
-      case ModifierKey.shiftModifier:
-      case ModifierKey.altModifier:
-      case ModifierKey.metaModifier:
-        // Neither GTK or X11 provide a distinction between left and right modifiers, so defaults to KeyboardSide.any.
-        // https://code.woboq.org/qt5/include/X11/X.h.html#_M/ShiftMask
-        return KeyboardSide.any;
-      case ModifierKey.capsLockModifier:
-      case ModifierKey.numLockModifier:
-      case ModifierKey.functionModifier:
-      case ModifierKey.symbolModifier:
-      case ModifierKey.scrollLockModifier:
-        return KeyboardSide.all;
-    }
+    // Neither GTK nor X11 provide a distinction between left and right
+    // modifiers, so defaults to KeyboardSide.all.
+    // https://code.woboq.org/qt5/include/X11/X.h.html#_M/ShiftMask
+    return KeyboardSide.all;
   }
 
   @override

--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -184,7 +184,7 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
 
   @override
   KeyboardSide? getModifierSide(ModifierKey key) {
-    KeyboardSide? findSide(int leftMask, int rightMask, int anyMask) {
+    KeyboardSide? findSide(int anyMask, int leftMask, int rightMask) {
       final int combinedMask = leftMask | rightMask;
       final int combined = modifiers & combinedMask;
       if (combined == leftMask) {
@@ -194,7 +194,8 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
       } else if (combined == combinedMask || modifiers & (combinedMask | anyMask) == anyMask) {
         // Handles the case where macOS supplies just the "either" modifier
         // flag, but not the left/right flag. (e.g. modifierShift but not
-        // modifierLeftShift).
+        // modifierLeftShift), or if left and right flags are provided, but not
+        // the "either" modifier flag.
         return KeyboardSide.all;
       }
       return null;
@@ -202,13 +203,13 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
 
     switch (key) {
       case ModifierKey.controlModifier:
-        return findSide(modifierLeftControl, modifierRightControl, modifierControl);
+        return findSide(modifierControl, modifierLeftControl, modifierRightControl);
       case ModifierKey.shiftModifier:
-        return findSide(modifierLeftShift, modifierRightShift, modifierShift);
+        return findSide(modifierShift, modifierLeftShift, modifierRightShift);
       case ModifierKey.altModifier:
-        return findSide(modifierLeftOption, modifierRightOption, modifierOption);
+        return findSide(modifierOption, modifierLeftOption, modifierRightOption);
       case ModifierKey.metaModifier:
-        return findSide(modifierLeftCommand, modifierRightCommand, modifierCommand);
+        return findSide(modifierCommand, modifierLeftCommand, modifierRightCommand);
       case ModifierKey.capsLockModifier:
       case ModifierKey.numLockModifier:
       case ModifierKey.scrollLockModifier:

--- a/packages/flutter/lib/src/services/raw_keyboard_windows.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_windows.dart
@@ -168,13 +168,11 @@ class RawKeyEventDataWindows extends RawKeyEventData {
         return KeyboardSide.left;
       } else if (combined == rightMask) {
         return KeyboardSide.right;
-      } else if (combined == combinedMask) {
-        return KeyboardSide.all;
-      } else if (modifiers & (combinedMask | anyMask) == anyMask) {
+      } else if (combined == combinedMask || modifiers & (combinedMask | anyMask) == anyMask) {
         // Handles the case where Windows supplies just the "either" modifier
         // flag, but not the left/right flag. (e.g. modifierShift but not
         // modifierLeftShift).
-        return KeyboardSide.any;
+        return KeyboardSide.all;
       }
       return null;
     }

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -253,7 +253,7 @@ void main() {
       );
     });
 
-    testWidgets('keysPressed modifiers are synchronized with key events on linux', (WidgetTester tester) async {
+    testWidgets('keysPressed modifiers are synchronized with key events on Linux GLFW', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
       // Generate the data for a regular key down event.
       final Map<String, dynamic> data = KeyEventSimulator.getKeyData(
@@ -274,6 +274,157 @@ void main() {
         RawKeyboard.instance.keysPressed,
         equals(
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
+        ),
+      );
+    });
+
+    testWidgets('sided modifiers without a side set return all sides on Android', (WidgetTester tester) async {
+      expect(RawKeyboard.instance.keysPressed, isEmpty);
+      // Generate the data for a regular key down event.
+      final Map<String, dynamic> data = KeyEventSimulator.getKeyData(
+        LogicalKeyboardKey.keyA,
+        platform: 'android',
+        isDown: true,
+      );
+      // Set only the generic "down" modifier, without setting a side.
+      data['metaState'] |=
+        RawKeyEventDataAndroid.modifierShift |
+        RawKeyEventDataAndroid.modifierAlt |
+        RawKeyEventDataAndroid.modifierControl |
+        RawKeyEventDataAndroid.modifierMeta;
+      // dispatch the modified data.
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.keyEvent.name,
+        SystemChannels.keyEvent.codec.encodeMessage(data),
+            (ByteData data) {},
+      );
+      expect(
+        RawKeyboard.instance.keysPressed,
+        equals(
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+            LogicalKeyboardKey.shiftRight,
+            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
+            LogicalKeyboardKey.controlLeft,
+            LogicalKeyboardKey.controlRight,
+            LogicalKeyboardKey.metaLeft,
+            LogicalKeyboardKey.metaRight,
+            LogicalKeyboardKey.keyA,
+          },
+        ),
+      );
+    });
+
+    testWidgets('sided modifiers without a side set return all sides on macOS', (WidgetTester tester) async {
+      expect(RawKeyboard.instance.keysPressed, isEmpty);
+      // Generate the data for a regular key down event.
+      final Map<String, dynamic> data = KeyEventSimulator.getKeyData(
+        LogicalKeyboardKey.keyA,
+        platform: 'macos',
+        isDown: true,
+      );
+      // Set only the generic "shift down" modifier, without setting a side.
+      data['modifiers'] |=
+          RawKeyEventDataMacOs.modifierShift |
+          RawKeyEventDataMacOs.modifierOption |
+          RawKeyEventDataMacOs.modifierCommand |
+          RawKeyEventDataMacOs.modifierControl;
+      // dispatch the modified data.
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.keyEvent.name,
+        SystemChannels.keyEvent.codec.encodeMessage(data),
+            (ByteData data) {},
+      );
+      expect(
+        RawKeyboard.instance.keysPressed,
+        equals(
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+            LogicalKeyboardKey.shiftRight,
+            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
+            LogicalKeyboardKey.controlLeft,
+            LogicalKeyboardKey.controlRight,
+            LogicalKeyboardKey.metaLeft,
+            LogicalKeyboardKey.metaRight,
+            LogicalKeyboardKey.keyA,
+          },
+        ),
+      );
+    });
+
+    testWidgets('sided modifiers without a side set return all sides on Windows', (WidgetTester tester) async {
+      expect(RawKeyboard.instance.keysPressed, isEmpty);
+      // Generate the data for a regular key down event.
+      final Map<String, dynamic> data = KeyEventSimulator.getKeyData(
+        LogicalKeyboardKey.keyA,
+        platform: 'windows',
+        isDown: true,
+      );
+      // Set only the generic "shift down" modifier, without setting a side.
+      // Windows doesn't have a concept of "either" for the Windows (meta) key.
+      data['modifiers'] |=
+          RawKeyEventDataWindows.modifierShift |
+          RawKeyEventDataWindows.modifierAlt |
+          RawKeyEventDataWindows.modifierControl;
+      // dispatch the modified data.
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.keyEvent.name,
+        SystemChannels.keyEvent.codec.encodeMessage(data),
+            (ByteData data) {},
+      );
+      expect(
+        RawKeyboard.instance.keysPressed,
+        equals(
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+            LogicalKeyboardKey.shiftRight,
+            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
+            LogicalKeyboardKey.controlLeft,
+            LogicalKeyboardKey.controlRight,
+            LogicalKeyboardKey.keyA,
+          },
+        ),
+      );
+    });
+
+    testWidgets('sided modifiers without a side set return all sides on Linux GLFW', (WidgetTester tester) async {
+      expect(RawKeyboard.instance.keysPressed, isEmpty);
+      // Generate the data for a regular key down event.
+      final Map<String, dynamic> data = KeyEventSimulator.getKeyData(
+        LogicalKeyboardKey.keyA,
+        platform: 'linux',
+        isDown: true,
+      );
+      // Set only the generic "shift down" modifier, without setting a side.
+      // Windows doesn't have a concept of "either" for the Windows (meta) key.
+      data['modifiers'] |=
+        GLFWKeyHelper.modifierShift |
+        GLFWKeyHelper.modifierAlt |
+        GLFWKeyHelper.modifierControl |
+        GLFWKeyHelper.modifierMeta;
+      // dispatch the modified data.
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.keyEvent.name,
+        SystemChannels.keyEvent.codec.encodeMessage(data),
+            (ByteData data) {},
+      );
+      expect(
+        RawKeyboard.instance.keysPressed,
+        equals(
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+            LogicalKeyboardKey.shiftRight,
+            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
+            LogicalKeyboardKey.controlLeft,
+            LogicalKeyboardKey.controlRight,
+            LogicalKeyboardKey.metaLeft,
+            LogicalKeyboardKey.metaRight,
+            LogicalKeyboardKey.keyA,
+          },
         ),
       );
     });

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -24,8 +24,12 @@ void main() {
         expect(
           RawKeyboard.instance.keysPressed,
           equals(
-            <LogicalKeyboardKey>{ LogicalKeyboardKey.shiftLeft },
-          ),
+            <LogicalKeyboardKey>{ LogicalKeyboardKey.shiftLeft,
+            // Linux doesn't have a concept of left/right keys, so they're all
+            // shown as down when either is pressed.
+            if (platform == 'linux') LogicalKeyboardKey.shiftRight,
+          },
+        ),
           reason: 'on $platform',
         );
         await simulateKeyDownEvent(LogicalKeyboardKey.controlLeft, platform: platform);
@@ -34,7 +38,9 @@ void main() {
           equals(
             <LogicalKeyboardKey>{
               LogicalKeyboardKey.shiftLeft,
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
               LogicalKeyboardKey.controlLeft,
+              if (platform == 'linux') LogicalKeyboardKey.controlRight,
             },
           ),
           reason: 'on $platform',
@@ -45,7 +51,9 @@ void main() {
           equals(
             <LogicalKeyboardKey>{
               LogicalKeyboardKey.shiftLeft,
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
               LogicalKeyboardKey.controlLeft,
+              if (platform == 'linux') LogicalKeyboardKey.controlRight,
               LogicalKeyboardKey.keyA,
             },
           ),
@@ -57,7 +65,9 @@ void main() {
           equals(
             <LogicalKeyboardKey>{
               LogicalKeyboardKey.shiftLeft,
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
               LogicalKeyboardKey.controlLeft,
+              if (platform == 'linux') LogicalKeyboardKey.controlRight,
             },
           ),
           reason: 'on $platform',
@@ -66,7 +76,10 @@ void main() {
         expect(
           RawKeyboard.instance.keysPressed,
           equals(
-            <LogicalKeyboardKey>{ LogicalKeyboardKey.shiftLeft },
+            <LogicalKeyboardKey>{
+              LogicalKeyboardKey.shiftLeft,
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
+            },
           ),
           reason: 'on $platform',
         );
@@ -116,7 +129,12 @@ void main() {
         expect(
           RawKeyboard.instance.keysPressed,
           equals(
-            <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft},
+            <LogicalKeyboardKey>{
+              LogicalKeyboardKey.shiftLeft,
+              // Linux doesn't have a concept of left/right keys, so they're all
+              // shown as down when either is pressed.
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
+            },
           ),
           reason: 'on $platform',
         );
@@ -133,6 +151,7 @@ void main() {
           equals(
             <LogicalKeyboardKey>{
               LogicalKeyboardKey.shiftLeft,
+              if (platform == 'linux') LogicalKeyboardKey.shiftRight,
               LogicalKeyboardKey.keyA,
             },
           ),
@@ -273,7 +292,13 @@ void main() {
       expect(
         RawKeyboard.instance.keysPressed,
         equals(
-          <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.shiftLeft,
+            // Linux doesn't have a concept of left/right keys, so they're all
+            // shown as down when either is pressed.
+            LogicalKeyboardKey.shiftRight,
+            LogicalKeyboardKey.keyA,
+          },
         ),
       );
     });
@@ -981,9 +1006,9 @@ void main() {
       RawKeyEventDataWindows.modifierRightControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.right),
       RawKeyEventDataWindows.modifierLeftMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.left),
       RawKeyEventDataWindows.modifierRightMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.right),
-      RawKeyEventDataWindows.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.any),
-      RawKeyEventDataWindows.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.any),
-      RawKeyEventDataWindows.modifierAlt: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.any),
+      RawKeyEventDataWindows.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.all),
+      RawKeyEventDataWindows.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.all),
+      RawKeyEventDataWindows.modifierAlt: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.all),
       RawKeyEventDataWindows.modifierCaps: _ModifierCheck(ModifierKey.capsLockModifier, KeyboardSide.all),
       RawKeyEventDataWindows.modifierNumLock: _ModifierCheck(ModifierKey.numLockModifier, KeyboardSide.all),
       RawKeyEventDataWindows.modifierScrollLock: _ModifierCheck(ModifierKey.scrollLockModifier, KeyboardSide.all),
@@ -1118,10 +1143,10 @@ void main() {
 
   group('RawKeyEventDataLinux-GFLW', () {
     const Map<int, _ModifierCheck> modifierTests = <int, _ModifierCheck>{
-      GLFWKeyHelper.modifierAlt: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.any),
-      GLFWKeyHelper.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.any),
-      GLFWKeyHelper.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.any),
-      GLFWKeyHelper.modifierMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.any),
+      GLFWKeyHelper.modifierAlt: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.all),
+      GLFWKeyHelper.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.all),
+      GLFWKeyHelper.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.all),
+      GLFWKeyHelper.modifierMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.all),
       GLFWKeyHelper.modifierNumericPad: _ModifierCheck(ModifierKey.numLockModifier, KeyboardSide.all),
       GLFWKeyHelper.modifierCapsLock: _ModifierCheck(ModifierKey.capsLockModifier, KeyboardSide.all),
     };
@@ -1208,7 +1233,7 @@ void main() {
             if (key != ModifierKey.controlModifier) {
               expect(data.getModifierSide(key), equals(modifierTests[modifier].side));
             } else {
-              expect(data.getModifierSide(key), equals(KeyboardSide.any));
+              expect(data.getModifierSide(key), equals(KeyboardSide.all));
             }
           } else {
             expect(
@@ -1302,10 +1327,10 @@ void main() {
 
   group('RawKeyEventDataLinux-GTK', () {
     const Map<int, _ModifierCheck> modifierTests = <int, _ModifierCheck>{
-      GtkKeyHelper.modifierMod1: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.any),
-      GtkKeyHelper.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.any),
-      GtkKeyHelper.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.any),
-      GtkKeyHelper.modifierMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.any),
+      GtkKeyHelper.modifierMod1: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.all),
+      GtkKeyHelper.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.all),
+      GtkKeyHelper.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.all),
+      GtkKeyHelper.modifierMeta: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.all),
       GtkKeyHelper.modifierMod2: _ModifierCheck(ModifierKey.numLockModifier, KeyboardSide.all),
       GtkKeyHelper.modifierCapsLock: _ModifierCheck(ModifierKey.capsLockModifier, KeyboardSide.all),
     };
@@ -1392,7 +1417,7 @@ void main() {
             if (key != ModifierKey.controlModifier) {
               expect(data.getModifierSide(key), equals(modifierTests[modifier].side));
             } else {
-              expect(data.getModifierSide(key), equals(KeyboardSide.any));
+              expect(data.getModifierSide(key), equals(KeyboardSide.all));
             }
           } else {
             expect(


### PR DESCRIPTION
## Description

This makes the processing of `RawKeyboardEventData.getModifierSide` consistent among the platforms.

Before this change, some platforms (Android) didn't handle the case where the "either" flag was set, but no side flag was set (e.g. "shift" was set, but not "shift left"), and instead said that no keys were down by returning null (which was wrong).

Some platforms (Linux, Windows) also returned `KeyboardSide.any` from `getModifierSide`, when the contract says that it will never return `KeyboardSide.any`. Those methods now return `KeyboardSide.all` in the case where no side is specified, as macOS and Fuchsia already did.

Now, all platforms will return `KeyboardSide.all` from `getModifierSide` when it's not clear which side the key was on.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/62663

## Tests

- Added tests for all the platforms that handle key events to make sure that if a modifier is indicated, but no side is specified, that it returns `KeyboardSide.all`.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.