### PR TITLE
Add optional border to CupertinoSwitch

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -115,7 +115,7 @@ class CupertinoSwitch extends StatefulWidget {
 
   /// The width to use for the border.
   ///
-  /// Defaults to 0.0 and is disabled when null.
+  /// Defaults to 0.0 when null.
   final double? borderWidth;
 
   /// {@template flutter.cupertino.switch.dragStartBehavior}

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -528,6 +528,68 @@ void main() {
     expect(find.byType(CupertinoSwitch), paints..rrect(color: trackColor));
   });
 
+  testWidgets('Switch is using border color when set', (WidgetTester tester) async {
+    const Color borderColor = Color(0xFF00FF00);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            borderColor: borderColor,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CupertinoSwitch), findsOneWidget);
+    expect(tester.widget<CupertinoSwitch>(find.byType(CupertinoSwitch)).borderColor, borderColor);
+  });
+
+  testWidgets('Switch is using border width when set', (WidgetTester tester) async {
+    const double borderWidth = 2;
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            borderWidth: borderWidth,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CupertinoSwitch), findsOneWidget);
+    expect(tester.widget<CupertinoSwitch>(find.byType(CupertinoSwitch)).borderWidth, borderWidth);
+  });
+
+  testWidgets('Switch does not cause exception when negative borderWidth is used', (WidgetTester tester) async {
+    const double borderWidth = -1;
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: CupertinoSwitch(
+            value: false,
+            borderWidth: borderWidth,
+            dragStartBehavior: DragStartBehavior.down,
+            onChanged: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CupertinoSwitch), findsOneWidget);
+  });
+
   testWidgets('Switch is opaque when enabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(


### PR DESCRIPTION
## Description

Adds the ability to show a border around a `CupertinoSwitch`. The border width and color can be adjusted.

![preview](https://i.imgur.com/XNYuzhm.png)

## Related Issues

Addresses the issue posted: https://github.com/flutter/flutter/issues/63407

## Tests

I added the following tests:
`switch_test.dart`
- Checks if `borderColor` gets property set
- Checks if `borderWidth` gets property set
- Checks if negative `borderWidth` doesn't cause exceptions
- Pre-existing tests handle the cases of `borderColor` and `borderWidth` potentially being null

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
