### PR TITLE
Make RawKeyboard assert when no keys are in keysPressed when sending a key down event.

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -581,6 +581,11 @@ class RawKeyboard {
     // Make sure that the modifiers reflect reality, in case a modifier key was
     // pressed/released while the app didn't have focus.
     _synchronizeModifiers(event);
+    assert(event is! RawKeyDownEvent || _keysPressed.isNotEmpty,
+        'Attempted to send a key down event when no keys are in keysPressed. '
+        "This state can occur if the key event being sent doesn't properly "
+        'set its modifier flags. This was the event: $event and its data: '
+        '${event.data}');
     // Send the event to passive listeners.
     for (final ValueChanged<RawKeyEvent> listener in List<ValueChanged<RawKeyEvent>>.from(_listeners)) {
       if (_listeners.contains(listener)) {

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -313,6 +313,8 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
         "This state can occur if the key event being sent doesn't properly "
         'set its modifier flags. This was the event: $event and its data: '
         '${event.data}');
+      // Avoid the crash in release mode, since it's easy to miss a particular
+      // bad key sequence in testing, and so shouldn't crash the app in release.
       if (RawKeyboard.instance.keysPressed.isNotEmpty) {
         keySet = LogicalKeySet.fromSet(RawKeyboard.instance.keysPressed);
       } else {

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -306,7 +306,19 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
       return false;
     }
     assert(context != null);
-    final LogicalKeySet keySet = keysPressed ?? LogicalKeySet.fromSet(RawKeyboard.instance.keysPressed);
+    LogicalKeySet keySet = keysPressed;
+    if (keySet == null) {
+      assert(RawKeyboard.instance.keysPressed.isNotEmpty,
+        'Received a key down event when no keys are in keysPressed. '
+        "This state can occur if the key event being sent doesn't properly "
+        'set its modifier flags. This was the event: $event and its data: '
+        '${event.data}');
+      if (RawKeyboard.instance.keysPressed.isNotEmpty) {
+        keySet = LogicalKeySet.fromSet(RawKeyboard.instance.keysPressed);
+      } else {
+        return false;
+      }
+    }
     Intent matchedIntent = _shortcuts[keySet];
     if (matchedIntent == null) {
       // If there's not a more specific match, We also look for any keys that


### PR DESCRIPTION
## Description

This adds an assert in `RawKeyboard` that catches the case where it tries to send a key down event, but (after synchronizing modifiers) there are no keys in `keysPressed`.  This state can occur if the modifier flags are not set properly for the platform.

Also prevents shortcuts attempting to handle a key down when no keys are pressed at the moment (which was causing a crash in release mode).

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/63353

## Tests

- Added a test that checks this case.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.