### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery leave_behind_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -124,7 +124,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
     Widget body;
     if (leaveBehindItems.isEmpty) {
       body = Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () => handleDemoAction(LeaveBehindDemoAction.reset),
           child: const Text('Reset the list'),
         ),
@@ -282,13 +282,13 @@ class _LeaveBehindListItem extends StatelessWidget {
         return AlertDialog(
           title: Text('Do you want to $action this item?'),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('Yes'),
               onPressed: () {
                 Navigator.pop(context, true); // showDialog() returns true
               },
             ),
-            FlatButton(
+            TextButton(
               child: const Text('No'),
               onPressed: () {
                 Navigator.pop(context, false); // showDialog() returns false


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, per #59702.