### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery ... transformation_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -104,7 +104,7 @@ class _TransformationsDemoState extends State<TransformationsDemo> {
         ],
       ),
       actions: <Widget>[
-        FlatButton(
+        TextButton(
           child: const Text('OK'),
           onPressed: () {
             Navigator.of(context).pop();


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, per #59702.
