### PR TITLE
Pin iOS module test plugin versions

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1223,8 +1223,7 @@ Future<void> _runHostOnlyDeviceLabTests() async {
     () => _runDevicelabTest('module_test', environment: gradleEnvironment, testEmbeddingV2: true),
     () => _runDevicelabTest('plugin_dependencies_test', environment: gradleEnvironment),
 
-    // TODO(magder): https://github.com/flutter/flutter/issues/63447
-//    if (Platform.isMacOS) () => _runDevicelabTest('module_test_ios'),
+    if (Platform.isMacOS) () => _runDevicelabTest('module_test_ios'),
     if (Platform.isMacOS) () => _runDevicelabTest('build_ios_framework_module_test'),
     if (Platform.isMacOS) () => _runDevicelabTest('plugin_lint_mac'),
     () => _runDevicelabTest('plugin_test', environment: gradleEnvironment),

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -148,7 +148,7 @@ Future<void> main() async {
       content = content.replaceFirst(
         '\ndependencies:\n',
         // One dynamic framework, one static framework, and one that does not support iOS.
-        '\ndependencies:\n  device_info:\n  google_maps_flutter:\n  android_alarm_manager:\n',
+        '\ndependencies:\n  device_info: 0.4.2+4\n  google_maps_flutter: 0.5.29\n  android_alarm_manager: 0.4.5+11\n',
       );
       await pubspec.writeAsString(content, flush: true);
       await inDirectory(projectDir, () async {

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -148,7 +148,7 @@ Future<void> main() async {
       content = content.replaceFirst(
         '\ndependencies:\n',
         // One dynamic framework, one static framework, and one that does not support iOS.
-        '\ndependencies:\n  device_info: 0.4.2+4\n  google_maps_flutter: 0.5.29\n  android_alarm_manager: 0.4.5+11\n',
+        '\ndependencies:\n  device_info: 0.4.2+4\n  google_sign_in: 4.5.1\n  android_alarm_manager: 0.4.5+11\n',
       );
       await pubspec.writeAsString(content, flush: true);
       await inDirectory(projectDir, () async {
@@ -164,16 +164,8 @@ Future<void> main() async {
         await flutter(
           'build',
           options: <String>['ios', '--no-codesign', '-v'],
-          canFail: true,
         );
       });
-
-      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
-      final String podfileLockOutput = podfileLockFile.readAsStringSync();
-      print(podfileLockOutput);
-
-      final File pubspecLock = File(path.join(projectDir.path, 'pubspec.lock'));
-      print(pubspecLock.readAsStringSync());
 
       final bool ephemeralHostAppWithCocoaPodsBuilt = exists(ephemeralIOSHostApp);
 
@@ -181,12 +173,12 @@ Future<void> main() async {
         return TaskResult.failure('Failed to build ephemeral host .app with CocoaPods');
       }
 
-//      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
-//      final String podfileLockOutput = podfileLockFile.readAsStringSync();
+      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
+      final String podfileLockOutput = podfileLockFile.readAsStringSync();
       if (!podfileLockOutput.contains(':path: Flutter/engine')
         || !podfileLockOutput.contains(':path: Flutter/FlutterPluginRegistrant')
         || !podfileLockOutput.contains(':path: Flutter/.symlinks/device_info/ios')
-        || !podfileLockOutput.contains(':path: Flutter/.symlinks/google_maps_flutter/ios')
+        || !podfileLockOutput.contains(':path: Flutter/.symlinks/google_sign_in/ios')
         || podfileLockOutput.contains('android_alarm_manager')) {
         return TaskResult.failure('Building ephemeral host app Podfile.lock does not contain expected pods');
       }
@@ -194,7 +186,7 @@ Future<void> main() async {
       checkFileExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'device_info.framework', 'device_info'));
 
       // Static, no embedded framework.
-      checkDirectoryNotExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'google_maps_flutter.framework'));
+      checkDirectoryNotExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'google_sign_in.framework'));
 
       // Android-only, no embedded framework.
       checkDirectoryNotExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'android_alarm_manager.framework'));

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -163,9 +163,17 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['ios', '--no-codesign'],
+          options: <String>['ios', '--no-codesign', '-v'],
+          canFail: true,
         );
       });
+
+      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
+      final String podfileLockOutput = podfileLockFile.readAsStringSync();
+      print(podfileLockOutput);
+
+      final File pubspecLock = File(path.join(projectDir.path, 'pubspec.lock'));
+      print(pubspecLock.readAsStringSync());
 
       final bool ephemeralHostAppWithCocoaPodsBuilt = exists(ephemeralIOSHostApp);
 
@@ -173,8 +181,8 @@ Future<void> main() async {
         return TaskResult.failure('Failed to build ephemeral host .app with CocoaPods');
       }
 
-      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
-      final String podfileLockOutput = podfileLockFile.readAsStringSync();
+//      final File podfileLockFile = File(path.join(projectDir.path, '.ios', 'Podfile.lock'));
+//      final String podfileLockOutput = podfileLockFile.readAsStringSync();
       if (!podfileLockOutput.contains(':path: Flutter/engine')
         || !podfileLockOutput.contains(':path: Flutter/FlutterPluginRegistrant')
         || !podfileLockOutput.contains(':path: Flutter/.symlinks/device_info/ios')


### PR DESCRIPTION
## Description

Pin iOS module test plugin versions to get consistent behavior.
Switch example plugin from `google_maps_flutter` to `google_sign_in` since there seems to be an issue with GoogleMaps 3.10.0, and `google_maps_flutter` doesn't declare a dependency range.

## Related issues
https://github.com/flutter/flutter/issues/63447