### PR TITLE
[flutter_tools] add more error context to tree shaker failure

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -66,7 +66,7 @@ class IconTreeShaker {
     }
   }
 
-  /// The MIME type for ttf fonts.
+  /// The MIME types for supported font sets.
   static const Set<String> kTtfMimeTypes = <String>{
     'font/ttf', // based on internet search
     'font/opentype',
@@ -383,5 +383,7 @@ class IconTreeShakerException implements Exception {
   final String message;
 
   @override
-  String toString() => 'FontSubset error: $message';
+  String toString() => 'IconTreeShakerException: $message\n\n'
+    'To disable icon tree shaking, pass --no-tree-shake-icons to the requested '
+    'flutter build command';
 }


### PR DESCRIPTION
## Description

Since --tree-shake-icons is on by default, tell users how to disable it in the error messages.

Fixes https://github.com/flutter/flutter/issues/63248#issuecomment-671074906
