### PR TITLE
Fix SafeArea and SliverSafeArea debug flag properties

### DIFF
--- a/packages/flutter/lib/src/widgets/safe_area.dart
+++ b/packages/flutter/lib/src/widgets/safe_area.dart
@@ -125,9 +125,9 @@ class SafeArea extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(FlagProperty('left', value: left, ifTrue: 'avoid left padding'));
-    properties.add(FlagProperty('top', value: left, ifTrue: 'avoid top padding'));
-    properties.add(FlagProperty('right', value: left, ifTrue: 'avoid right padding'));
-    properties.add(FlagProperty('bottom', value: left, ifTrue: 'avoid bottom padding'));
+    properties.add(FlagProperty('top', value: top, ifTrue: 'avoid top padding'));
+    properties.add(FlagProperty('right', value: right, ifTrue: 'avoid right padding'));
+    properties.add(FlagProperty('bottom', value: bottom, ifTrue: 'avoid bottom padding'));
   }
 }
 
@@ -219,8 +219,8 @@ class SliverSafeArea extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(FlagProperty('left', value: left, ifTrue: 'avoid left padding'));
-    properties.add(FlagProperty('top', value: left, ifTrue: 'avoid top padding'));
-    properties.add(FlagProperty('right', value: left, ifTrue: 'avoid right padding'));
-    properties.add(FlagProperty('bottom', value: left, ifTrue: 'avoid bottom padding'));
+    properties.add(FlagProperty('top', value: top, ifTrue: 'avoid top padding'));
+    properties.add(FlagProperty('right', value: right, ifTrue: 'avoid right padding'));
+    properties.add(FlagProperty('bottom', value: bottom, ifTrue: 'avoid bottom padding'));
   }
 }

--- a/packages/flutter/test/widgets/safe_area_test.dart
+++ b/packages/flutter/test/widgets/safe_area_test.dart
@@ -316,17 +316,17 @@ void main() {
   });
 
   testWidgets('SliverSafeArea - properties', (WidgetTester tester) async {
-      const SliverSafeArea child = SliverSafeArea(
-        left: true,
-        right: false,
-        bottom: false,
-        sliver: SliverToBoxAdapter(child: SizedBox(width: 800.0, height: 100.0, child: Text('padded'))),
-      );
-      final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();
-      child.debugFillProperties(properties);
+    const SliverSafeArea child = SliverSafeArea(
+      left: true,
+      right: false,
+      bottom: false,
+      sliver: SliverToBoxAdapter(child: SizedBox(width: 800.0, height: 100.0, child: Text('padded'))),
+    );
+    final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();
+    child.debugFillProperties(properties);
 
-      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
-      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
-      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
-    });
+    expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
+    expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
+    expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
+  });
 }

--- a/packages/flutter/test/widgets/safe_area_test.dart
+++ b/packages/flutter/test/widgets/safe_area_test.dart
@@ -100,6 +100,7 @@ void main() {
       child.debugFillProperties(properties);
 
       expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid right padding'), false);
       expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
       expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
     });
@@ -327,6 +328,7 @@ void main() {
     child.debugFillProperties(properties);
 
     expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
+    expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid right padding'), false);
     expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
     expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
   });

--- a/packages/flutter/test/widgets/safe_area_test.dart
+++ b/packages/flutter/test/widgets/safe_area_test.dart
@@ -89,6 +89,20 @@ void main() {
       expect(tester.getBottomRight(find.byType(Placeholder)), const Offset(800.0, 600.0));
     });
 
+    testWidgets('SafeArea - properties', (WidgetTester tester) async {
+      const SafeArea child = SafeArea(
+        left: true,
+        right: false,
+        bottom: false,
+      );
+      final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();
+      child.debugFillProperties(properties);
+
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
+    });
+
     group('SafeArea maintains bottom viewPadding when specified for consumed bottom padding', () {
       Widget boilerplate(Widget child) {
         return Localizations(

--- a/packages/flutter/test/widgets/safe_area_test.dart
+++ b/packages/flutter/test/widgets/safe_area_test.dart
@@ -90,10 +90,11 @@ void main() {
     });
 
     testWidgets('SafeArea - properties', (WidgetTester tester) async {
-      const SafeArea child = SafeArea(
+      final SafeArea child = SafeArea(
         left: true,
         right: false,
         bottom: false,
+        child: Container()
       );
       final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();
       child.debugFillProperties(properties);

--- a/packages/flutter/test/widgets/safe_area_test.dart
+++ b/packages/flutter/test/widgets/safe_area_test.dart
@@ -314,4 +314,19 @@ void main() {
       ]);
     });
   });
+
+  testWidgets('SliverSafeArea - properties', (WidgetTester tester) async {
+      const SliverSafeArea child = SliverSafeArea(
+        left: true,
+        right: false,
+        bottom: false,
+        sliver: SliverToBoxAdapter(child: SizedBox(width: 800.0, height: 100.0, child: Text('padded'))),
+      );
+      final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();
+      child.debugFillProperties(properties);
+
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid left padding'), true);
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid top padding'), true);
+      expect(properties.properties.any((DiagnosticsNode n) => n is FlagProperty && n.toString() == 'avoid bottom padding'), false);
+    });
 }


### PR DESCRIPTION
## Description

Modifies the SafeArea and SliverSafeArea widgets to correct the debug flag properties that report what padding the widget is avoiding. Noticed when I was debugging my app layout.

## Related Issues

Fix is trivial. No issue has been created.

## Tests

No tests added as no new features added

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*