### PR TITLE
Removed the inputFormatters from the text input fields used by the Date Pickers

### DIFF
--- a/packages/flutter/lib/src/material/pickers/input_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_picker.dart
@@ -16,12 +16,12 @@ import '../theme.dart';
 import 'date_picker_common.dart';
 import 'date_utils.dart' as utils;
 
-/// A [TextFormField] configured to accept and validate a date entered by the user.
+/// A [TextFormField] configured to accept and validate a date entered by a user.
 ///
-/// The text entered into this field will be constrained to only allow digits
-/// and separators. When saved or submitted, the text will be parsed into a
-/// [DateTime] according to the ambient locale. If the input text doesn't parse
-/// into a date, the [errorFormatText] message will be displayed under the field.
+/// When the field is saved or submitted, the text will be parsed into a
+/// [DateTime] according to the ambient locale's compact date format. If the
+/// input text doesn't parse into a date, the [errorFormatText] message will
+/// be displayed under the field.
 ///
 /// [firstDate], [lastDate], and [selectableDayPredicate] provide constraints on
 /// what days are valid. If the input date isn't in the date range or doesn't pass
@@ -231,50 +231,11 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
       ),
       validator: _validateDate,
-      inputFormatters: <TextInputFormatter>[
-        DateTextInputFormatter(localizations.dateSeparator),
-      ],
       keyboardType: TextInputType.datetime,
       onSaved: _handleSaved,
       onFieldSubmitted: _handleSubmitted,
       autofocus: widget.autofocus,
       controller: _controller,
-    );
-  }
-}
-
-/// A `TextInputFormatter` set up to format dates.
-//
-// This is not publicly exported (see pickers.dart), as it is
-// just meant for internal use by `InputDatePickerFormField` and
-// `InputDateRangePicker`.
-class DateTextInputFormatter extends TextInputFormatter {
-
-  /// Creates a date formatter with the given separator.
-  DateTextInputFormatter(
-    this.separator
-  ) : _filterFormatter = FilteringTextInputFormatter.allow(RegExp('[\\d$_commonSeparators\\$separator]+'));
-
-  /// List of common separators that are used in dates. This is used to make
-  /// sure that if given platform's [TextInputType.datetime] keyboard doesn't
-  /// provide the given locale's separator character, they can still enter the
-  /// separator using one of these characters (slash, period, comma, dash, or
-  /// space).
-  static const String _commonSeparators = r'\/\.,-\s';
-
-  /// The date separator for the current locale.
-  final String separator;
-
-  // Formatter that will filter out all characters except digits and date
-  // separators.
-  final TextInputFormatter _filterFormatter;
-
-  @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    final TextEditingValue filteredValue = _filterFormatter.formatEditUpdate(oldValue, newValue);
-    return filteredValue.copyWith(
-      // Replace any non-digits with the given separator
-      text: filteredValue.text.replaceAll(RegExp(r'[\D]'), separator),
     );
   }
 }

--- a/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
@@ -14,7 +14,6 @@ import '../text_field.dart';
 import '../theme.dart';
 
 import 'date_utils.dart' as utils;
-import 'input_date_picker.dart' show DateTextInputFormatter;
 
 /// Provides a pair of text fields that allow the user to enter the start and
 /// end dates that represent a range of dates.
@@ -124,7 +123,6 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
   String _startErrorText;
   String _endErrorText;
   bool _autoSelected = false;
-  List<TextInputFormatter> _inputFormatters;
 
   @override
   void initState() {
@@ -146,9 +144,6 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    _inputFormatters = <TextInputFormatter>[
-      DateTextInputFormatter(localizations.dateSeparator),
-    ];
     if (_startDate != null) {
       _startInputText = localizations.formatCompactDate(_startDate);
       final bool selectText = widget.autofocus && !_autoSelected;
@@ -247,7 +242,6 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
               labelText: widget.fieldStartLabelText ?? localizations.dateRangeStartLabel,
               errorText: _startErrorText,
             ),
-            inputFormatters: _inputFormatters,
             keyboardType: TextInputType.datetime,
             onChanged: _handleStartChanged,
             autofocus: widget.autofocus,
@@ -264,7 +258,6 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
               labelText: widget.fieldEndLabelText ?? localizations.dateRangeEndLabel,
               errorText: _endErrorText,
             ),
-            inputFormatters: _inputFormatters,
             keyboardType: TextInputType.datetime,
             onChanged: _handleEndChanged,
           ),

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -741,7 +741,8 @@ void main() {
         field.controller.clear();
 
         await tester.pumpAndSettle();
-        await tester.enterText(find.byType(TextField), '20202014');
+        await tester.enterText(find.byType(TextField), '20 days, 3 months, 2003');
+        expect(find.text('20 days, 3 months, 2003'), findsOneWidget);
         expect(find.text(errorFormatText), findsNothing);
 
         await tester.tap(find.text('OK'));


### PR DESCRIPTION
## Description

The current Date Picker implementation uses `inputFormatters` on the text input fields to restrict the input text to only digits and a date separator. However, there are some locales that don't have a single character separator, so this restriction is causing more problems than it is helping (see #63373). This PR removes the inputFormatters and just lets the user enter what ever characters they want and lets the validation take care of the error.

## Related Issues

Fixes: #63373

## Tests

Updated the invalid format text test to check that non-digit characters are allowed, but will generate an error if submitted.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
