### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery ... full_screen_dialog_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -126,13 +126,13 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
             style: dialogTextStyle,
           ),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text('CANCEL'),
               onPressed: () {
                 Navigator.of(context).pop(false); // Pops the confirmation dialog but not the page.
               },
             ),
-            FlatButton(
+            TextButton(
               child: const Text('DISCARD'),
               onPressed: () {
                 Navigator.of(context).pop(true); // Returning true to _onWillPop will pop again.
@@ -152,7 +152,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
       appBar: AppBar(
         title: Text(_hasName ? _eventName : 'Event Name TBD'),
         actions: <Widget> [
-          FlatButton(
+          TextButton(
             child: Text('SAVE', style: theme.textTheme.bodyText2.copyWith(color: Colors.white)),
             onPressed: () {
               Navigator.pop(context, DismissDialogAction.save);


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, per #59702.