### PR TITLE
Fix version parsing

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -759,18 +759,22 @@ class GitTagVersion {
         _runGit('git fetch $_flutterGit --tags -f', processUtils, workingDirectory);
       }
     }
-    final String tag = _runGit(
-      'git tag --points-at HEAD', processUtils, workingDirectory).trim();
+    final List<String> tags = _runGit(
+      'git tag --points-at HEAD', processUtils, workingDirectory).trim().split('\n');
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');
-    if (stableTagPattern.hasMatch(tag)) {
-      return parse(tag);
+    for (final String tag in tags) {
+      if (stableTagPattern.hasMatch(tag.trim())) {
+        return parse(tag);
+      }
     }
     // Next check for a dev tag
     final RegExp devTagPattern = RegExp(r'^\d+\.\d+\.\d+-\d+\.\d+\.pre$');
-    if (devTagPattern.hasMatch(tag)) {
-      return parse(tag);
+    for (final String tag in tags) {
+      if (devTagPattern.hasMatch(tag.trim())) {
+        return parse(tag);
+      }
     }
 
     // If we're not currently on a tag, use git describe to find the most

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -759,8 +759,6 @@ class GitTagVersion {
         _runGit('git fetch $_flutterGit --tags -f', processUtils, workingDirectory);
       }
     }
-    //final List<String> tags = _runGit(
-    //  'git tag --contains HEAD', processUtils, workingDirectory).split('\n');
     final String tag = _runGit(
       'git tag --points-at HEAD', processUtils, workingDirectory).trim();
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -759,24 +759,20 @@ class GitTagVersion {
         _runGit('git fetch $_flutterGit --tags -f', processUtils, workingDirectory);
       }
     }
-    final List<String> tags = _runGit(
-      'git tag --contains HEAD', processUtils, workingDirectory).split('\n');
+    //final List<String> tags = _runGit(
+    //  'git tag --contains HEAD', processUtils, workingDirectory).split('\n');
+    final String tag = _runGit(
+      'git tag --points-at HEAD', processUtils, workingDirectory).trim();
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');
-    for (final String tag in tags) {
-      final String trimmedTag = tag.trim();
-      if (stableTagPattern.hasMatch(trimmedTag)) {
-        return parse(trimmedTag);
-      }
+    if (stableTagPattern.hasMatch(tag)) {
+      return parse(tag);
     }
     // Next check for a dev tag
     final RegExp devTagPattern = RegExp(r'^\d+\.\d+\.\d+-\d+\.\d+\.pre$');
-    for (final String tag in tags) {
-      final String trimmedTag = tag.trim();
-      if (devTagPattern.hasMatch(trimmedTag)) {
-        return parse(trimmedTag);
-      }
+    if (devTagPattern.hasMatch(tag)) {
+      return parse(tag);
     }
 
     // If we're not currently on a tag, use git describe to find the most

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -323,7 +323,7 @@ void main() {
         fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>[
-              'git', 'tag', '--contains', 'HEAD',
+              'git', 'tag', '--points-at', 'HEAD',
             ],
             stdout: '',
           ),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -185,7 +185,7 @@ void main() {
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync('git fetch https://github.com/flutter/flutter.git --tags'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
-        when(processManager.runSync('git tag --contains HEAD'.split(' '),
+        when(processManager.runSync('git tag --points-at HEAD'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync('git describe --match *.*.* --first-parent --long --tags'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -483,6 +483,7 @@ void main() {
       <FakeCommand>[
         const FakeCommand(
           command: <String>['git', 'tag', '--points-at', 'HEAD'],
+          // This tests the unlikely edge case where a dev release made it to stable without any cherry picks
           stdout: '1.2.3-6.0.pre\n$stableTag',
         ),
       ],

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -477,6 +477,24 @@ void main() {
     expect(gitTagVersion.frameworkVersionFor('abcd1234'), stableTag);
   });
 
+  testUsingContext('determine favors stable tag over dev tag if both idenitfy HEAD', () {
+    const String stableTag = '1.2.3';
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(
+      <FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'tag', '--points-at', 'HEAD'],
+          stdout: '1.2.3-6.0.pre\n$stableTag',
+        ),
+      ],
+    );
+    final ProcessUtils processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
+    final GitTagVersion gitTagVersion = GitTagVersion.determine(processUtils, workingDirectory: '.');
+    expect(gitTagVersion.frameworkVersionFor('abcd1234'), stableTag);
+  });
+
   testUsingContext('determine reports correct git describe version if HEAD is not at a tag', () {
     const String devTag = '1.2.3-2.0.pre';
     const String headRevision = 'abcd1234';

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -461,12 +461,12 @@ void main() {
   testUsingContext('determine favors stable tags over dev tags', () {
     final MockProcessUtils mockProcessUtils = MockProcessUtils();
     when(mockProcessUtils.runSync(
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(
       ProcessResult(1, 0, '1.2.3-0.0.pre\n1.2.3\n1.2.3-0.1.pre', ''),
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
     final GitTagVersion version = GitTagVersion.determine(mockProcessUtils, workingDirectory: '.');
     expect(version.gitTag, '1.2.3');
@@ -494,12 +494,12 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(106, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
     when(processUtils.runSync(
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(
       RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
 
     GitTagVersion.determine(processUtils, workingDirectory: '.');
@@ -539,12 +539,12 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
     when(processUtils.runSync(
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(
       RunResult(ProcessResult(108, 0, '', ''),
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
@@ -579,12 +579,12 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(109, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(
       RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
     when(processUtils.runSync(
       <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
@@ -624,12 +624,12 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(109, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(
       RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--contains', 'HEAD'],
+      <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
     when(processUtils.runSync(
       <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
@@ -765,7 +765,7 @@ void fakeData(
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(105, 0, '', ''));
   when(pm.runSync(
-    <String>['git', 'tag', '--contains', 'HEAD'],
+    <String>['git', 'tag', '--points-at', 'HEAD'],
     workingDirectory: anyNamed('workingDirectory'),
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(106, 0, '', ''));

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -458,29 +458,6 @@ void main() {
     );
   });
 
-  testUsingContext('determine favors stable tags over dev tags', () {
-    final MockProcessUtils mockProcessUtils = MockProcessUtils();
-    when(mockProcessUtils.runSync(
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(
-      ProcessResult(1, 0, '1.2.3-0.0.pre\n1.2.3\n1.2.3-0.1.pre', ''),
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-    ));
-    final GitTagVersion version = GitTagVersion.determine(mockProcessUtils, workingDirectory: '.');
-    expect(version.gitTag, '1.2.3');
-    expect(version.devPatch, null);
-    expect(version.devVersion, null);
-    // We shouldn't have to fallback to git describe, because we are exactly
-    // on a release tag.
-    verifyNever(mockProcessUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    ));
-  });
-
   testUsingContext('determine does not call fetch --tags', () {
     final MockProcessUtils processUtils = MockProcessUtils();
     when(processUtils.runSync(


### PR DESCRIPTION
## Description

When detecting if the current git HEAD is at a tag, `git tag --contains HEAD` was used, which returns a list of tags that are at HEAD or include HEAD as an ancestor. This was wrong, and lead to https://github.com/flutter/flutter/issues/63159. Instead, this PR uses `git tag --points-at HEAD`, which will only return tags that are exactly on HEAD.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/63159