### PR TITLE
Updated old button references in dev/integration_tests/flutter_gallery ... snackbar_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -40,7 +40,7 @@ class _SnackBarDemoState extends State<SnackBarDemo> {
           const Text(_text1),
           const Text(_text2),
           Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               child: const Text('SHOW A SNACKBAR'),
               onPressed: () {
                 final int thisSnackBarIndex = _snackBarIndex++;


### PR DESCRIPTION
Replaced uses of RaisedButton with ElevatedButton per #59702.