### PR TITLE
Hide benchmark a/b results from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /dev/benchmarks/mega_gallery/
 /dev/bots/.recipe_deps
 /dev/bots/android_tools/
+/dev/devicelab/ABresults*.json
 /dev/docs/doc/
 /dev/docs/flutter.docs.zip
 /dev/docs/lib/


### PR DESCRIPTION
## Description

Running benchmarks in a/b test mode generates files like `dev/devicelab/ABresults1.json`,  `dev/devicelab/ABresults2.json`, etc. They always show up in `git status` which is annoying. This PR makes them invisible to git.