### PR TITLE
[flutter_tools] handle invalid yaml in plugin dependency

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -311,7 +311,13 @@ Plugin _pluginFromPackage(String name, Uri packageRoot) {
   if (!globals.fs.isFileSync(pubspecPath)) {
     return null;
   }
-  final dynamic pubspec = loadYaml(globals.fs.file(pubspecPath).readAsStringSync());
+  dynamic pubspec;
+
+  try {
+    pubspec = loadYaml(globals.fs.file(pubspecPath).readAsStringSync());
+  } on YamlException {
+    // Do nothing, potentially not a plugin.
+  }
   if (pubspec == null) {
     return null;
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -315,7 +315,8 @@ Plugin _pluginFromPackage(String name, Uri packageRoot) {
 
   try {
     pubspec = loadYaml(globals.fs.file(pubspecPath).readAsStringSync());
-  } on YamlException {
+  } on YamlException catch (err) {
+    globals.printTrace('Failed to parse plugin manifest for $name: $err');
     // Do nothing, potentially not a plugin.
   }
   if (pubspec == null) {


### PR DESCRIPTION
## Description

Do not crash if a dependency has an invalid plugin specification. It was hard to find invalid yaml, so I used: https://stackoverflow.com/questions/40872314/invalid-yaml-file