### PR TITLE
Print dex when analyzing the APK

### DIFF
--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -160,7 +160,6 @@ class ApkExtractor {
         'packages',
         apkFile.path,
       ],
-      printStdout: false,
     );
     _classes = Set<String>.from(
       packages


### PR DESCRIPTION
This would help debug how the test is running on different environments.  I disabled stdout because it was quite verbose and didn't see value at the time. 