### PR TITLE
InteractiveViewer scale interpretation improvement

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -684,6 +684,22 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     }
   }
 
+  // Decide which type of gesture this is by comparing the amount of scale
+  // and rotation in the gesture, if any. Scale starts at 1 and rotation
+  // starts at 0. Pan will have no scale and no rotation because it uses only one
+  // finger.
+  _GestureType _getGestureType(ScaleUpdateDetails details) {
+    final double scale = !widget.scaleEnabled ? 1.0 : details.scale;
+    final double rotation = !_rotateEnabled ? 0.0 : details.rotation;
+    if ((scale - 1).abs() > rotation.abs()) {
+      return _GestureType.scale;
+    } else if (rotation != 0.0) {
+      return _GestureType.rotate;
+    } else {
+      return _GestureType.pan;
+    }
+  }
+
   // Handle the start of a gesture. All of pan, scale, and rotate are handled
   // with GestureDetector's scale gesture.
   void _onScaleStart(ScaleStartDetails details) {
@@ -723,23 +739,30 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     final Offset focalPointScene = _transformationController.toScene(
       details.localFocalPoint,
     );
-    _gestureType ??= _getGestureType(
-      !widget.scaleEnabled ? 1.0 : details.scale,
-      !_rotateEnabled ? 0.0 : details.rotation,
-    );
-    if (_gestureType == _GestureType.pan) {
-      _panAxis ??= _getPanAxis(_referenceFocalPoint, focalPointScene);
-    }
 
+    if (_gestureType == _GestureType.pan) {
+      // When a gesture first starts, it sometimes has zero scale and rotation
+      // despite being a two-finger gesture. Here the gesture is allowed to be
+      // reinterpreted as its correct type after originally being marked as a
+      // pan.
+      final _GestureType currentGestureType = _getGestureType(details);
+      if (currentGestureType != _GestureType.pan) {
+        _gestureType = currentGestureType;
+      }
+    } else {
+      _gestureType ??= _getGestureType(details);
+    }
     if (!_gestureIsSupported(_gestureType)) {
       return;
     }
 
+    if (_gestureType == _GestureType.pan) {
+      _panAxis ??= _getPanAxis(_referenceFocalPoint, focalPointScene);
+    }
+
     switch (_gestureType) {
       case _GestureType.scale:
-        if (_scaleStart == null) {
-          return;
-        }
+        assert(_scaleStart != null);
         // details.scale gives us the amount to change the scale as of the
         // start of this gesture, so calculate the amount to scale as of the
         // previous call to _onScaleUpdate.
@@ -789,7 +812,8 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         return;
 
       case _GestureType.pan:
-        if (_referenceFocalPoint == null || details.scale != 1.0) {
+        assert(_referenceFocalPoint != null);
+        if (details.scale != 1.0) {
           return;
         }
         // Translate so that the same point in the scene is underneath the
@@ -1080,20 +1104,6 @@ enum _GestureType {
 double _getFinalTime(double velocity, double drag) {
   const double effectivelyMotionless = 10.0;
   return math.log(effectivelyMotionless / velocity) / math.log(drag / 100);
-}
-
-// Decide which type of gesture this is by comparing the amount of scale
-// and rotation in the gesture, if any. Scale starts at 1 and rotation
-// starts at 0. Pan will have 0 scale and 0 rotation because it uses only one
-// finger.
-_GestureType _getGestureType(double scale, double rotation) {
-  if ((scale - 1).abs() > rotation.abs()) {
-    return _GestureType.scale;
-  } else if (rotation != 0) {
-    return _GestureType.rotate;
-  } else {
-    return _GestureType.pan;
-  }
 }
 
 // Return the translation from the given Matrix4 as an Offset.

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -745,19 +745,12 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       // rotation despite being a two-finger gesture. Here the gesture is
       // allowed to be reinterpreted as its correct type after originally
       // being marked as a pan.
-      final _GestureType currentGestureType = _getGestureType(details);
-      if (currentGestureType != _GestureType.pan) {
-        _gestureType = currentGestureType;
-      }
+      _gestureType = _getGestureType(details);
     } else {
       _gestureType ??= _getGestureType(details);
     }
     if (!_gestureIsSupported(_gestureType)) {
       return;
-    }
-
-    if (_gestureType == _GestureType.pan) {
-      _panAxis ??= _getPanAxis(_referenceFocalPoint, focalPointScene);
     }
 
     switch (_gestureType) {
@@ -813,9 +806,13 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
       case _GestureType.pan:
         assert(_referenceFocalPoint != null);
+        // details may have a change in scale here when scaleEnabled is false.
+        // In an effort to keep the behavior similar whether or not scaleEnabled
+        // is true, these gestures are thrown away.
         if (details.scale != 1.0) {
           return;
         }
+        _panAxis ??= _getPanAxis(_referenceFocalPoint, focalPointScene);
         // Translate so that the same point in the scene is underneath the
         // focal point before and after the movement.
         final Offset translationChange = focalPointScene - _referenceFocalPoint;

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -741,10 +741,10 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     );
 
     if (_gestureType == _GestureType.pan) {
-      // When a gesture first starts, it sometimes has zero scale and rotation
-      // despite being a two-finger gesture. Here the gesture is allowed to be
-      // reinterpreted as its correct type after originally being marked as a
-      // pan.
+      // When a gesture first starts, it sometimes has no change in scale and
+      // rotation despite being a two-finger gesture. Here the gesture is
+      // allowed to be reinterpreted as its correct type after originally
+      // being marked as a pan.
       final _GestureType currentGestureType = _getGestureType(details);
       if (currentGestureType != _GestureType.pan) {
         _gestureType = currentGestureType;


### PR DESCRIPTION
## Description

Users [reported](https://github.com/flutter/flutter/issues/63006) difficulty in activating a scale gesture. This seemed to be due to some scale gestures beginning with a scale of 1.0, which were interpreted as pan gestures.  This PR allows pan gesture to become scale gestures if they later have a change in scale, which makes the experience much more smooth.

## Related Issues

Closes https://github.com/flutter/flutter/issues/63281
Closes https://github.com/flutter/flutter/issues/63006

## Tests

I added the following tests:

  * Test that a pan gesture that later has scale is allowed to scale the scene.