### PR TITLE
Fix bug with missing App.framework

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -96,7 +96,7 @@ end
 #                                          Optional, defaults to two levels up from the directory of this script.
 #                                          MyApp/my_flutter/.ios/Flutter/../..
 def install_flutter_application_pod(flutter_application_path)
-  app_framework_dir = File.expand_path('App.framework', File.join('..', __FILE__))
+  app_framework_dir = File.expand_path(File.expand_path('..', __FILE__), 'App.framework')
   app_framework_dylib = File.join(app_framework_dir, 'App')
   if !File.exist?(app_framework_dylib)
     # Fake an App.framework to have something to link against if the xcode backend script has not run yet.


### PR DESCRIPTION
Two weeks ago, for some reason `__dir__` was replaced with this File.join thing which is doesn't really work, as it would create something like this:

/Users/work/Documents/Playground/AddToAppBug/my_flutter/.ios/Flutter/Users/work/Documents/Playground/AddToAppBug/my_flutter/.ios/Flutter/App.framework

when we wanted this

/Users/work/Documents/Playground/AddToAppBug/my_flutter/.ios/Flutter/App.framework

So if you are compiling app from fresh state, it would not create App.framework where it should, "pod install" would not include App.framework in the copy frameworks script, and the finished build would have no App.framework inside.

Typically this will occur in builds from CI, but not locally, as people don't clean that often.

@jmagman FYI