### PR TITLE
Hook up soft keyboard "next" and "previous" buttons so that they move the focus by default

### DIFF
--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1336,18 +1336,27 @@ void main() {
     expect(changedValue, clipboardContent);
   });
 
-  testWidgets('Does not lose focus by default when "next" action is pressed', (WidgetTester tester) async {
+  testWidgets('Moves focus to the next field by default when "next" action is pressed', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
+    final GlobalKey previousKey = GlobalKey();
+    final GlobalKey nextKey = GlobalKey();
 
     final Widget widget = MaterialApp(
-      home: EditableText(
-        backgroundCursorColor: Colors.grey,
-        controller: TextEditingController(),
-        focusNode: focusNode,
-        style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
-        cursorColor: Colors.blue,
-        selectionControls: materialTextSelectionControls,
-        keyboardType: TextInputType.text,
+      home: Column(
+        children: <Widget>[
+          TextButton(child: Text('Previous Widget', key: previousKey), onPressed: (){}),
+          EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: TextEditingController(),
+            focusNode: focusNode,
+            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
+            cursorColor: Colors.blue,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+            autofocus: true,
+          ),
+          TextButton(child: Text('Next Widget', key: nextKey), onPressed: (){}),
+        ],
       ),
     );
     await tester.pumpWidget(widget);
@@ -1362,8 +1371,51 @@ void main() {
     await tester.testTextInput.receiveAction(TextInputAction.next);
     await tester.pump();
 
-    // Still has focus after pressing "next".
-    expect(focusNode.hasFocus, true);
+    // Next node has focus after pressing 'next' button.
+    expect(focusNode.hasFocus, isFalse);
+    expect(Focus.of(previousKey.currentContext).hasFocus, isFalse);
+    expect(Focus.of(nextKey.currentContext).hasFocus, isTrue);
+  });
+
+  testWidgets('Moves focus to the previous field by default when "previous" action is pressed', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    final GlobalKey previousKey = GlobalKey();
+    final GlobalKey nextKey = GlobalKey();
+
+    final Widget widget = MaterialApp(
+      home: Column(
+        children: <Widget>[
+          TextButton(child: Text('Previous Widget', key: previousKey), onPressed: (){}),
+          EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: TextEditingController(),
+            focusNode: focusNode,
+            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
+            cursorColor: Colors.blue,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+            autofocus: true,
+          ),
+          TextButton(child: Text('Next Widget', key: nextKey), onPressed: (){}),
+        ],
+      ),
+    );
+    await tester.pumpWidget(widget);
+
+    // Select EditableText to give it focus.
+    final Finder textFinder = find.byType(EditableText);
+    await tester.tap(textFinder);
+    await tester.pump();
+
+    assert(focusNode.hasFocus);
+
+    await tester.testTextInput.receiveAction(TextInputAction.previous);
+    await tester.pump();
+
+    // Next node has focus after pressing 'previous' button.
+    expect(focusNode.hasFocus, isFalse);
+    expect(Focus.of(nextKey.currentContext).hasFocus, isFalse);
+    expect(Focus.of(previousKey.currentContext).hasFocus, isTrue);
   });
 
   testWidgets('Does not lose focus by default when "done" action is pressed and onEditingComplete is provided', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1336,87 +1336,91 @@ void main() {
     expect(changedValue, clipboardContent);
   });
 
-  testWidgets('Moves focus to the next field by default when "next" action is pressed', (WidgetTester tester) async {
-    final FocusNode focusNode = FocusNode();
-    final GlobalKey previousKey = GlobalKey();
-    final GlobalKey nextKey = GlobalKey();
+  // The variants to test in the next test.
+  final ValueVariant<TextInputAction> focusVariants = ValueVariant<TextInputAction>(
+    TextInputAction.values.toSet(),
+  );
 
-    final Widget widget = MaterialApp(
-      home: Column(
-        children: <Widget>[
-          TextButton(child: Text('Previous Widget', key: previousKey), onPressed: (){}),
-          EditableText(
-            backgroundCursorColor: Colors.grey,
-            controller: TextEditingController(),
-            focusNode: focusNode,
-            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
-            cursorColor: Colors.blue,
-            selectionControls: materialTextSelectionControls,
-            keyboardType: TextInputType.text,
-            autofocus: true,
-          ),
-          TextButton(child: Text('Next Widget', key: nextKey), onPressed: (){}),
-        ],
-      ),
-    );
-    await tester.pumpWidget(widget);
+  testWidgets('Handles focus correctly when action is invoked',
+      (WidgetTester tester) async {
+    // The expectations for each of the types of TextInputAction.
+    const Map<TextInputAction, bool> actionShouldLoseFocus =
+    <TextInputAction, bool>{
+      TextInputAction.none: false,
+      TextInputAction.unspecified: false,
+      TextInputAction.done: true,
+      TextInputAction.go: true,
+      TextInputAction.search: true,
+      TextInputAction.send: true,
+      TextInputAction.continueAction: false,
+      TextInputAction.join: false,
+      TextInputAction.route: false,
+      TextInputAction.emergencyCall: false,
+      TextInputAction.newline: true,
+      TextInputAction.next: true,
+      TextInputAction.previous: true,
+    };
 
-    // Select EditableText to give it focus.
-    final Finder textFinder = find.byType(EditableText);
-    await tester.tap(textFinder);
-    await tester.pump();
+    final TextInputAction action = focusVariants.currentValue;
+    expect(actionShouldLoseFocus.containsKey(action), isTrue);
 
-    assert(focusNode.hasFocus);
+    Future<void> _ensureCorrectFocusHandlingForAction(
+        TextInputAction action, {
+          @required bool shouldLoseFocus,
+          bool shouldFocusNext = false,
+          bool shouldFocusPrevious = false,
+        }) async {
+      final FocusNode focusNode = FocusNode();
+      final GlobalKey previousKey = GlobalKey();
+      final GlobalKey nextKey = GlobalKey();
 
-    await tester.testTextInput.receiveAction(TextInputAction.next);
-    await tester.pump();
+      final Widget widget = MaterialApp(
+        home: Column(
+          children: <Widget>[
+            TextButton(
+                child: Text('Previous Widget', key: previousKey),
+                onPressed: () {}),
+            EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: TextEditingController(),
+              focusNode: focusNode,
+              style: Typography.material2018(platform: TargetPlatform.android)
+                  .black
+                  .subtitle1,
+              cursorColor: Colors.blue,
+              selectionControls: materialTextSelectionControls,
+              keyboardType: TextInputType.text,
+              autofocus: true,
+            ),
+            TextButton(
+                child: Text('Next Widget', key: nextKey), onPressed: () {}),
+          ],
+        ),
+      );
+      await tester.pumpWidget(widget);
 
-    // Next node has focus after pressing 'next' button.
-    expect(focusNode.hasFocus, isFalse);
-    expect(Focus.of(previousKey.currentContext).hasFocus, isFalse);
-    expect(Focus.of(nextKey.currentContext).hasFocus, isTrue);
-  });
+      assert(focusNode.hasFocus);
 
-  testWidgets('Moves focus to the previous field by default when "previous" action is pressed', (WidgetTester tester) async {
-    final FocusNode focusNode = FocusNode();
-    final GlobalKey previousKey = GlobalKey();
-    final GlobalKey nextKey = GlobalKey();
+      await tester.testTextInput.receiveAction(action);
+      await tester.pump();
 
-    final Widget widget = MaterialApp(
-      home: Column(
-        children: <Widget>[
-          TextButton(child: Text('Previous Widget', key: previousKey), onPressed: (){}),
-          EditableText(
-            backgroundCursorColor: Colors.grey,
-            controller: TextEditingController(),
-            focusNode: focusNode,
-            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
-            cursorColor: Colors.blue,
-            selectionControls: materialTextSelectionControls,
-            keyboardType: TextInputType.text,
-            autofocus: true,
-          ),
-          TextButton(child: Text('Next Widget', key: nextKey), onPressed: (){}),
-        ],
-      ),
-    );
-    await tester.pumpWidget(widget);
+      expect(Focus.of(nextKey.currentContext).hasFocus, equals(shouldFocusNext));
+      expect(Focus.of(previousKey.currentContext).hasFocus, equals(shouldFocusPrevious));
+      expect(focusNode.hasFocus, equals(!shouldLoseFocus));
+    }
 
-    // Select EditableText to give it focus.
-    final Finder textFinder = find.byType(EditableText);
-    await tester.tap(textFinder);
-    await tester.pump();
-
-    assert(focusNode.hasFocus);
-
-    await tester.testTextInput.receiveAction(TextInputAction.previous);
-    await tester.pump();
-
-    // Next node has focus after pressing 'previous' button.
-    expect(focusNode.hasFocus, isFalse);
-    expect(Focus.of(nextKey.currentContext).hasFocus, isFalse);
-    expect(Focus.of(previousKey.currentContext).hasFocus, isTrue);
-  });
+    try {
+      await _ensureCorrectFocusHandlingForAction(
+        action,
+        shouldLoseFocus: actionShouldLoseFocus[action],
+        shouldFocusNext: action == TextInputAction.next,
+        shouldFocusPrevious: action == TextInputAction.previous,
+      );
+    } on PlatformException {
+      // on Android, continueAction isn't supported.
+      expect(action, equals(TextInputAction.continueAction));
+    }
+  }, variant: focusVariants);
 
   testWidgets('Does not lose focus by default when "done" action is pressed and onEditingComplete is provided', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1336,16 +1336,15 @@ void main() {
     expect(changedValue, clipboardContent);
   });
 
-  // The variants to test in the next test.
-  final ValueVariant<TextInputAction> focusVariants = ValueVariant<TextInputAction>(
+  // The variants to test in the focus handling test.
+  final ValueVariant<TextInputAction> focusVariants = ValueVariant<
+      TextInputAction>(
     TextInputAction.values.toSet(),
   );
 
-  testWidgets('Handles focus correctly when action is invoked',
-      (WidgetTester tester) async {
+  testWidgets('Handles focus correctly when action is invoked', (WidgetTester tester) async {
     // The expectations for each of the types of TextInputAction.
-    const Map<TextInputAction, bool> actionShouldLoseFocus =
-    <TextInputAction, bool>{
+    const Map<TextInputAction, bool> actionShouldLoseFocus = <TextInputAction, bool>{
       TextInputAction.none: false,
       TextInputAction.unspecified: false,
       TextInputAction.done: true,
@@ -1384,9 +1383,7 @@ void main() {
               backgroundCursorColor: Colors.grey,
               controller: TextEditingController(),
               focusNode: focusNode,
-              style: Typography.material2018(platform: TargetPlatform.android)
-                  .black
-                  .subtitle1,
+              style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1,
               cursorColor: Colors.blue,
               selectionControls: materialTextSelectionControls,
               keyboardType: TextInputType.text,

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -296,13 +296,13 @@ class TargetPlatformVariant extends TestVariant<TargetPlatform> {
 ///   value3,
 /// }
 ///
-/// final ValueVariant<TestScenario> testVariants = ValueVariant<TestScenario>(
+/// final ValueVariant<TestScenario> variants = ValueVariant<TestScenario>(
 ///   <TestScenario>{value1, value2},
 /// );
 ///
 /// testWidgets('Test handling of TestScenario', (WidgetTester tester) {
-///   expect(testVariants.currentValue, equals(value1));
-/// });
+///   expect(variants.currentValue, equals(value1));
+/// }, variant: variants);
 /// ```
 /// {@end-tool}
 class ValueVariant<T> extends TestVariant<T> {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -271,6 +271,61 @@ class TargetPlatformVariant extends TestVariant<TargetPlatform> {
   }
 }
 
+/// A [TestVariant] that runs separate tests with each of the given values.
+///
+/// To use this variant, define it before the test, and then access
+/// [currentValue] inside the test.
+///
+/// The values are typically enums, but they don't have to be. The `toString`
+/// for the given value will be used to describe the variant. Values will have
+/// their type name stripped from their `toString` output, so that enum values
+/// will only print the value, not the type.
+///
+/// {@tool snippet}
+/// This example shows how to set up the test to access the [currentValue]. In
+/// this example, two tests will be run, one with `value1`, and one with
+/// `value2`. The test with `value2` will fail. The names of the tests will be:
+///
+///   - `Test handling of TestScenario (value1)`
+///   - `Test handling of TestScenario (value2)`
+///
+/// ```dart
+/// enum TestScenario {
+///   value1,
+///   value2,
+///   value3,
+/// }
+///
+/// final ValueVariant<TestScenario> testVariants = ValueVariant<TestScenario>(
+///   <TestScenario>{value1, value2},
+/// );
+///
+/// testWidgets('Test handling of TestScenario', (WidgetTester tester) {
+///   expect(testVariants.currentValue, equals(value1));
+/// });
+/// ```
+/// {@end-tool}
+class ValueVariant<T> extends TestVariant<T> {
+  /// Creates a [ValueVariant] that tests the given [values].
+  ValueVariant(this.values);
+
+  /// Returns the value currently under test.
+  T get currentValue => _currentValue;
+  T _currentValue;
+
+  @override
+  final Set<T> values;
+
+  @override
+  String describeValue(T value) => value.toString().replaceFirst('$T.', '');
+
+  @override
+  Future<T> setUp(T value) async => _currentValue = value;
+
+  @override
+  Future<void> tearDown(T value, T memento) async {}
+}
+
 /// The warning message to show when a benchmark is performed with assert on.
 const String kDebugWarning = '''
 ┏╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍┓


### PR DESCRIPTION
## Description

Focus will be moved automatically if `onEditingComplete` is not specified, but must
by moved manually if `onEditingComplete` is specified.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/63575

## Tests

- Added tests to make sure that the focus moves, and removed a test that verified that the focus was not lost.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.