### PR TITLE
Add arguments for required parameters.

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
@@ -226,6 +226,7 @@ class _GestureTransformableState extends State<GestureTransformable> with Ticker
       },
       onTapUp: widget.onTapUp == null ? null : (TapUpDetails details) {
         widget.onTapUp(TapUpDetails(
+          kind: details.kind,
           globalPosition: fromViewport(details.globalPosition - getOffset(context), _transform),
         ));
       },

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -34,6 +34,7 @@ void main() {
         config = AutofillConfiguration(
           uniqueIdentifier: null,
           autofillHints: const <String>['test'],
+          currentEditingValue: const TextEditingValue(),
         );
       } catch (e) {
         expect(e.toString(), contains('uniqueIdentifier != null'));
@@ -45,6 +46,7 @@ void main() {
         config = AutofillConfiguration(
           uniqueIdentifier: 'id',
           autofillHints: null,
+          currentEditingValue: const TextEditingValue(),
         );
       } catch (e) {
         expect(e.toString(), contains('autofillHints != null'));
@@ -59,6 +61,7 @@ void main() {
         const AutofillConfiguration config = AutofillConfiguration(
           uniqueIdentifier: 'id',
           autofillHints: <String>[],
+          currentEditingValue: TextEditingValue(),
         );
 
         json = config.toJson();


### PR DESCRIPTION
With https://dart-review.googlesource.com/c/sdk/+/158343 that fixes https://github.com/dart-lang/sdk/issues/43026 the analyzer will start reporting hints when a `required` (in null safety) parameter does not have the argument in a legacy library. This PR fixes the existing violations in Flutter.