### PR TITLE
Typo fix in finders.dart documentation (bySemanticsLabel)

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -298,7 +298,7 @@ class CommonFinders {
   /// ## Sample code
   ///
   /// ```dart
-  /// expect(find.BySemanticsLabel('Back'), findsOneWidget);
+  /// expect(find.bySemanticsLabel('Back'), findsOneWidget);
   /// ```
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips


### PR DESCRIPTION
The code in the documentation of `bySemanticsLabel` is not correct: `expect(find.BySemanticsLabel('Back'), findsOneWidget);`. The method is called `bySemanticsLabel` and not `BySemanticsLabel`.