### PR TITLE
Ignore another dead_code hint for a weak-only null check.

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -672,7 +672,10 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       PaintingBinding.instance!.imageCache!.evict(key);
       rethrow;
     }
-    if (data == null) {
+    // Note: `key.bundle.load` has a non-nullable return type, but might be null
+    // when running with weak checking, so we need to null check it anyway (and
+    // ignore the warning that the null-handling logic is dead code).
+    if (data == null) { // ignore: dead_code
       PaintingBinding.instance!.imageCache!.evict(key);
       throw StateError('Unable to read data');
     }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -672,8 +672,8 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       PaintingBinding.instance!.imageCache!.evict(key);
       rethrow;
     }
-    // Note: `key.bundle.load` has a non-nullable return type, but might be null
-    // when running with weak checking, so we need to null check it anyway (and
+    // `key.bundle.load` has a non-nullable return type, but might be null when
+    // running with weak checking, so we need to null check it anyway (and
     // ignore the warning that the null-handling logic is dead code).
     if (data == null) { // ignore: dead_code
       PaintingBinding.instance!.imageCache!.evict(key);


### PR DESCRIPTION
## Description

When https://github.com/dart-lang/sdk/issues/41985 is fixed, the
analyzer will begin detecting dead code due to "unnecessary" null
checks.  Since we want to retain null checks in Flutter even when they
appear unnecessary (in order to preserve runtime behavior in weak
mode), we need to suppress these dead code hints.

(This is a follow-up to https://github.com/flutter/flutter/pull/63007; an additional case appeared before I had a chance to land the fix for https://github.com/dart-lang/sdk/issues/41985).

## Related Issues

https://github.com/dart-lang/sdk/issues/41985 (PR must land before this issue can be fixed)

## Tests

N/A since this change does not affect behavior, it merely avoids dead code hints.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
