### PR TITLE
[windows] Propagate startup errors in template

### DIFF
--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
@@ -8,15 +8,22 @@ FlutterWindow::FlutterWindow(RunLoop* run_loop,
 
 FlutterWindow::~FlutterWindow() {}
 
-void FlutterWindow::OnCreate() {
-  Win32Window::OnCreate();
+bool FlutterWindow::OnCreate() {
+  if (!Win32Window::OnCreate()) {
+    return false;
+  }
 
   // The size here is arbitrary since SetChildContent will resize it.
   flutter_controller_ =
       std::make_unique<flutter::FlutterViewController>(100, 100, project_);
+  // Ensure that basic setup of the controller was successful.
+  if (!flutter_controller_->engine() || !flutter_controller_->view()) {
+    return false;
+  }
   RegisterPlugins(flutter_controller_.get());
   run_loop_->RegisterFlutterInstance(flutter_controller_.get());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
+  return true;
 }
 
 void FlutterWindow::OnDestroy() {

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.h
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.h
@@ -20,7 +20,7 @@ class FlutterWindow : public Win32Window {
 
  protected:
   // Win32Window:
-  void OnCreate() override;
+  bool OnCreate() override;
   void OnDestroy() override;
 
  private:

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
@@ -122,9 +122,11 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);
 
-  OnCreate();
+  if (!window) {
+    return false;
+  }
 
-  return window != nullptr;
+  return OnCreate();
 }
 
 // static
@@ -240,8 +242,9 @@ void Win32Window::SetQuitOnClose(bool quit_on_close) {
   quit_on_close_ = quit_on_close;
 }
 
-void Win32Window::OnCreate() {
+bool Win32Window::OnCreate() {
   // No-op; provided for subclasses.
+  return true;
 }
 
 void Win32Window::OnDestroy() {

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.h
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.h
@@ -62,8 +62,8 @@ class Win32Window {
                                  LPARAM const lparam) noexcept;
 
   // Called when CreateAndShow is called, allowing subclass window-related
-  // setup.
-  virtual void OnCreate();
+  // setup. Subclasses should return false if setup fails.
+  virtual bool OnCreate();
 
   // Called when Destroy is called.
   virtual void OnDestroy();


### PR DESCRIPTION
## Description

Adjusts the startup flow in the Windows app template slightly so that an
engine initialization failure will correctly cause
FlutterWindow::CreateAndShow to return false.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61968

## Tests

I added the following tests: None; would require special-purpose e2e testing of a failure case that only happens when using the build output incorrectly.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
