### PR TITLE
Fix FittedBox BoxFit.scaleDown sizing

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2353,7 +2353,7 @@ class RenderFittedBox extends RenderProxyBox {
   }
 
   bool _fitAffectsLayout(BoxFit fit) {
-    switch(fit) {
+    switch (fit) {
       case BoxFit.scaleDown:
         return true;
       default:
@@ -2364,13 +2364,13 @@ class RenderFittedBox extends RenderProxyBox {
   /// How to inscribe the child into the space allocated during layout.
   BoxFit get fit => _fit;
   BoxFit _fit;
-  set fit(BoxFit newFit) {
-    assert(newFit != null);
-    final BoxFit lastFit = _fit;
-    if (lastFit == newFit)
+  set fit(BoxFit value) {
+    assert(value != null);
+    if (_fit == value)
       return;
-    _fit = newFit;
-    if (_fitAffectsLayout(lastFit) || _fitAffectsLayout(newFit)) {
+    final BoxFit lastFit = _fit;
+    _fit = value;
+    if (_fitAffectsLayout(lastFit) || _fitAffectsLayout(value)) {
       markNeedsLayout();
     } else {
       _clearPaintData();
@@ -2417,7 +2417,6 @@ class RenderFittedBox extends RenderProxyBox {
   void performLayout() {
     if (child != null) {
       child.layout(const BoxConstraints(), parentUsesSize: true);
-
       switch (fit) {
         case BoxFit.scaleDown:
           final BoxConstraints sizeConstraints = constraints.loosen();
@@ -2428,7 +2427,6 @@ class RenderFittedBox extends RenderProxyBox {
           size = constraints.constrainSizeAndAttemptToPreserveAspectRatio(child.size);
           break;
       }
-
       _clearPaintData();
     } else {
       size = constraints.smallest;

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -550,7 +550,6 @@ void main() {
 
   testWidgets('Switching to and from BoxFit.scaleDown causes relayout', (WidgetTester tester) async {
     final Key outside = UniqueKey();
-    final Key inside = UniqueKey();
 
     final Widget scaleDownWidget = Center(
       child: Container(
@@ -559,7 +558,6 @@ void main() {
           key: outside,
           fit: BoxFit.scaleDown,
           child: Container(
-            key: inside,
             width: 100.0,
             height: 50.0,
           ),
@@ -573,7 +571,6 @@ void main() {
         child: FittedBox(
           key: outside,
           child: Container(
-            key: inside,
             width: 100.0,
             height: 50.0,
           ),

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -486,6 +486,114 @@ void main() {
     await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container(), clipBehavior: Clip.antiAlias));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
+
+  testWidgets('BoxFit.scaleDown matches size of child', (WidgetTester tester) async {
+    final Key outside = UniqueKey();
+    final Key inside = UniqueKey();
+
+    // Does not scale up when child is smaller than constraints
+
+    await tester.pumpWidget(
+      Center(
+        child: Container(
+          width: 200.0,
+          child: FittedBox(
+            key: outside,
+            fit: BoxFit.scaleDown,
+            child: Container(
+              key: inside,
+              width: 100.0,
+              height: 50.0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox outsideBox = tester.firstRenderObject(find.byKey(outside));
+    final RenderBox insideBox = tester.firstRenderObject(find.byKey(inside));
+
+    expect(outsideBox.size.width, 200.0);
+    expect(outsideBox.size.height, 50.0);
+
+    Offset outsidePoint = outsideBox.localToGlobal(Offset.zero);
+    Offset insidePoint = insideBox.localToGlobal(Offset.zero);
+    expect(insidePoint - outsidePoint, equals(const Offset(50.0, 0.0)));
+
+    // Scales down when child is bigger than constraints
+
+    await tester.pumpWidget(
+      Center(
+        child: Container(
+          width: 200.0,
+          child: FittedBox(
+            key: outside,
+            fit: BoxFit.scaleDown,
+            child: Container(
+              key: inside,
+              width: 400.0,
+              height: 200.0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(outsideBox.size.width, 200.0);
+    expect(outsideBox.size.height, 100.0);
+
+    outsidePoint = outsideBox.localToGlobal(Offset.zero);
+    insidePoint = insideBox.localToGlobal(Offset.zero);
+
+    expect(insidePoint - outsidePoint, equals(Offset.zero));
+  });
+
+  testWidgets('Switching to and from BoxFit.scaleDown causes relayout', (WidgetTester tester) async {
+    final Key outside = UniqueKey();
+    final Key inside = UniqueKey();
+
+    final Widget scaleDownWidget = Center(
+      child: Container(
+        width: 200.0,
+        child: FittedBox(
+          key: outside,
+          fit: BoxFit.scaleDown,
+          child: Container(
+            key: inside,
+            width: 100.0,
+            height: 50.0,
+          ),
+        ),
+      ),
+    );
+
+    final Widget coverWidget = Center(
+      child: Container(
+        width: 200.0,
+        child: FittedBox(
+          key: outside,
+          child: Container(
+            key: inside,
+            width: 100.0,
+            height: 50.0,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(scaleDownWidget);
+
+    final RenderBox outsideBox = tester.firstRenderObject(find.byKey(outside));
+    expect(outsideBox.size.height, 50.0);
+
+    await tester.pumpWidget(coverWidget);
+
+    expect(outsideBox.size.height, 100.0);
+
+    await tester.pumpWidget(scaleDownWidget);
+
+    expect(outsideBox.size.height, 50.0);
+  });
 }
 
 List<Type> getLayers() {


### PR DESCRIPTION
## Description

Currently FittedBox can be much bigger than the child when using BoxFit.scaleDown because it always attempts to preserve the child's aspect ratio (see attached issue for what that looks like).

This PR fixes that by adding a special case for BoxFit.scaleDown during layout, which will loosen the constrains passed to `constrainSizeAndAttemptToPreserveAspectRatio`, allowing FittedBox to match the size of its child better.

Because the current behavior of this corner case is awkward and not covered under existing tests, I don't think the change will likely affect customers.

## Related Issues

Fixes #42776

## Tests

I added the following tests:

1. BoxFit.scaleDown matches size of child
2. Switching to and from BoxFit.scaleDown causes relayout

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*