### PR TITLE
Tab bar improvements

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -396,6 +396,12 @@ class _IndicatorPainter extends CustomPainter {
     final EdgeInsets insets = indicatorPadding.resolve(_currentTextDirection);
     final Rect rect = Rect.fromLTWH(tabLeft, 0.0, tabRight - tabLeft, tabBarSize.height);
 
+    if (!(rect.size >= insets.collapsedSize)) {
+      throw FlutterError(
+          'indicatorPadding insets should be less than Tab Size\n'
+          'Rect Size : ${rect.size}, Insets: ${insets.toString()}'
+      );
+    }
     return insets.deflateRect(rect);
   }
 
@@ -819,7 +825,6 @@ class _TabBarState extends State<TabBar> {
       color = Colors.white;
 
     return UnderlineTabIndicator(
-//      insets: widget.indicatorPadding,
       borderSide: BorderSide(
         width: widget.indicatorWeight,
         color: color,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -320,6 +320,7 @@ class _IndicatorPainter extends CustomPainter {
     required this.indicatorSize,
     required this.tabKeys,
     required _IndicatorPainter? old,
+    required this.indicatorPadding,
   }) : assert(controller != null),
        assert(indicator != null),
        super(repaint: controller.animation) {
@@ -330,6 +331,7 @@ class _IndicatorPainter extends CustomPainter {
   final TabController controller;
   final Decoration indicator;
   final TabBarIndicatorSize? indicatorSize;
+  final EdgeInsetsGeometry indicatorPadding;
   final List<GlobalKey> tabKeys;
 
   // _currentTabOffsets and _currentTextDirection are set each time TabBar
@@ -391,7 +393,11 @@ class _IndicatorPainter extends CustomPainter {
       tabRight -= delta;
     }
 
-    return Rect.fromLTWH(tabLeft, 0.0, tabRight - tabLeft, tabBarSize.height);
+    //Applying indicatorPadding
+    final EdgeInsets insets = indicatorPadding.resolve(_currentTextDirection);
+    final Rect rect = Rect.fromLTWH(tabLeft, 0.0, tabRight - tabLeft, tabBarSize.height);
+
+    return insets.deflateRect(rect);
   }
 
   @override
@@ -654,26 +660,22 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// this property is ignored.
   final double indicatorWeight;
 
-  /// The horizontal padding for the line that appears below the selected tab.
+
+  /// Padding for indicator.
+  /// This property will now no longer be ignored even if indicator is declared
+  /// or provided by [TabBarTheme]
   ///
   /// For [isScrollable] tab bars, specifying [kTabLabelPadding] will align
   /// the indicator with the tab's text for [Tab] widgets and all but the
   /// shortest [Tab.text] values.
   ///
-  /// The [EdgeInsets.top] and [EdgeInsets.bottom] values of the
-  /// [indicatorPadding] are ignored.
-  ///
   /// The default value of [indicatorPadding] is [EdgeInsets.zero].
-  ///
-  /// If [indicator] is specified or provided from [TabBarTheme],
-  /// this property is ignored.
   final EdgeInsetsGeometry indicatorPadding;
 
   /// Defines the appearance of the selected tab indicator.
   ///
   /// If [indicator] is specified or provided from [TabBarTheme],
-  /// the [indicatorColor], [indicatorWeight], and [indicatorPadding]
-  /// properties are ignored.
+  /// the [indicatorColor], and [indicatorWeight] properties are ignored.
   ///
   /// The default, underline-style, selected tab indicator can be defined with
   /// [UnderlineTabIndicator].
@@ -818,7 +820,11 @@ class _TabBarState extends State<TabBar> {
       color = Colors.white;
 
     return UnderlineTabIndicator(
-      insets: widget.indicatorPadding,
+      // Bad: Commenting the line below. Since we already provided
+      //      indicatorPadding to the _indicatorPainter, we should not provide
+      //      insets to this widget.
+
+//      insets: widget.indicatorPadding,
       borderSide: BorderSide(
         width: widget.indicatorWeight,
         color: color,
@@ -866,6 +872,7 @@ class _TabBarState extends State<TabBar> {
       controller: _controller!,
       indicator: _indicator,
       indicatorSize: widget.indicatorSize ?? TabBarTheme.of(context).indicatorSize,
+      indicatorPadding: widget.indicatorPadding,
       tabKeys: _tabKeys,
       old: _indicatorPainter,
     );

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -393,7 +393,6 @@ class _IndicatorPainter extends CustomPainter {
       tabRight -= delta;
     }
 
-    //Applying indicatorPadding
     final EdgeInsets insets = indicatorPadding.resolve(_currentTextDirection);
     final Rect rect = Rect.fromLTWH(tabLeft, 0.0, tabRight - tabLeft, tabBarSize.height);
 
@@ -820,10 +819,6 @@ class _TabBarState extends State<TabBar> {
       color = Colors.white;
 
     return UnderlineTabIndicator(
-      // Bad: Commenting the line below. Since we already provided
-      //      indicatorPadding to the _indicatorPainter, we should not provide
-      //      insets to this widget.
-
 //      insets: widget.indicatorPadding,
       borderSide: BorderSide(
         width: widget.indicatorWeight,

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1536,7 +1536,7 @@ void main() {
     ));
   });
 
-  testWidgets('TabBar indicatorPadding(LTR) with LTRB padding', (WidgetTester tester) async {
+  testWidgets('TabBar with custom indicator and indicatorPadding(LTR)', (WidgetTester tester) async {
     const Color indicatorColor = Color(0xFF00FF00);
     const double padTop = 10.0;
     const double padBottom = 12.0;
@@ -1606,7 +1606,7 @@ void main() {
     ));
   });
 
-  testWidgets('TabBar indicatorPadding (RTL) with LTRB padding', (WidgetTester tester) async {
+  testWidgets('TabBar with custom indicator and indicatorPadding (RTL)', (WidgetTester tester) async {
     const Color indicatorColor = Color(0xFF00FF00);
     const double padTop = 10.0;
     const double padBottom = 12.0;
@@ -1676,7 +1676,7 @@ void main() {
     ));
   });
 
-  testWidgets('TabBar - directional indicatorPadding (LTR) with STEB padding', (WidgetTester tester) async {
+  testWidgets('TabBar with custom indicator - directional indicatorPadding (LTR)', (WidgetTester tester) async {
     final List<Widget > tabs = <Widget>[
       SizedBox(key: UniqueKey(), width: 130.0, height: 30.0),
       SizedBox(key: UniqueKey(), width: 140.0, height: 40.0),
@@ -1755,7 +1755,7 @@ void main() {
     ));
   });
 
-  testWidgets('TabBar - directional indicatorPadding (RTL) with STEB padding', (WidgetTester tester) async {
+  testWidgets('TabBar with custom indicator - directional indicatorPadding (RTL)', (WidgetTester tester) async {
     final List<Widget> tabs = <Widget>[
       SizedBox(key: UniqueKey(), width: 130.0, height: 30.0),
       SizedBox(key: UniqueKey(), width: 140.0, height: 40.0),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1536,6 +1536,307 @@ void main() {
     ));
   });
 
+  testWidgets('TabBar indicatorPadding(LTR) with LTRB padding', (WidgetTester tester) async {
+    const Color indicatorColor = Color(0xFF00FF00);
+    const double padTop = 10.0;
+    const double padBottom = 12.0;
+    const double padLeft = 8.0;
+    const double padRight = 4.0;
+    const Decoration indicator = BoxDecoration(color: indicatorColor);
+
+    final List<Widget> tabs = List<Widget>.generate(4, (int index) {
+      return Tab(text: 'Tab $index');
+    });
+
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: TabBar(
+            indicator: indicator,
+            indicatorPadding:
+            const EdgeInsets.fromLTRB(padLeft, padTop, padRight, padBottom),
+            controller: controller,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox tabBarBox =
+    tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 48.0);
+    // 48 = _kTabHeight(46) + indicatorWeight(2.0) ~default
+
+    const double indicatorBottom = 48.0 - padBottom;
+    const double indicatorTop = padTop;
+    double indicatorLeft = padLeft;
+    double indicatorRight = 200.0 - padRight;
+
+    expect(tabBarBox, paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+
+    // Select tab 3
+    controller.index = 3;
+    await tester.pumpAndSettle();
+
+    indicatorLeft = 600.0 + padLeft;
+    indicatorRight = 800.0 - padRight;
+
+    expect(tabBarBox, paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+  });
+
+  testWidgets('TabBar indicatorPadding (RTL) with LTRB padding', (WidgetTester tester) async {
+    const Color indicatorColor = Color(0xFF00FF00);
+    const double padTop = 10.0;
+    const double padBottom = 12.0;
+    const double padLeft = 8.0;
+    const double padRight = 4.0;
+    const Decoration indicator = BoxDecoration(color: indicatorColor);
+
+    final List<Widget> tabs = List<Widget>.generate(4, (int index) {
+      return Tab(text: 'Tab $index');
+    });
+
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        textDirection: TextDirection.rtl,
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: TabBar(
+          indicator: indicator,
+          indicatorPadding: const EdgeInsets.fromLTRB(padLeft, padTop, padRight, padBottom),
+          controller: controller,
+          tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox tabBarBox =
+    tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 48.0);
+    // 48 = _kTabHeight(46) + indicatorWeight(2.0) ~default
+    expect(tabBarBox.size.width, 800.0);
+    const double indicatorBottom = 48.0 - padBottom;
+    const double indicatorTop = padTop;
+    double indicatorLeft = 600.0 + padLeft;
+    double indicatorRight = 800.0 - padRight;
+
+    expect(tabBarBox, paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+
+    // Select tab 3
+    controller.index = 3;
+    await tester.pumpAndSettle();
+
+    indicatorLeft = padLeft;
+    indicatorRight = 200.0 - padRight;
+
+    expect(tabBarBox,paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+  });
+
+  testWidgets('TabBar - directional indicatorPadding (LTR) with STEB padding', (WidgetTester tester) async {
+    final List<Widget> tabs = <Widget>[
+      SizedBox(key: UniqueKey(), width: 130.0, height: 30.0),
+      SizedBox(key: UniqueKey(), width: 140.0, height: 40.0),
+      SizedBox(key: UniqueKey(), width: 150.0, height: 50.0),
+    ];
+    const Color indicatorColor = Color(0xFF00FF00);
+    const double padTop = 10.0;
+    const double padBottom = 12.0;
+    const double padStart = 8.0;
+    const double padEnd = 4.0;
+    const Decoration indicator = BoxDecoration(color: indicatorColor);
+    const double indicatorWeight = 2.0; // the default
+
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: TabBar(
+            indicator: indicator,
+            indicatorPadding: const EdgeInsetsDirectional.fromSTEB(
+              padStart, padTop, padEnd, padBottom),
+            isScrollable: true,
+            controller: controller,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    const double tabBarHeight = 50.0 + indicatorWeight; // 50 = max tab height
+    expect(tabBarBox.size.height, tabBarHeight);
+
+    // Tab0 width = 130, height = 30
+    double tabLeft = kTabLabelPadding.left;
+    double tabRight = tabLeft + 130.0;
+    double tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
+    double tabBottom = tabTop + 30.0;
+    Rect tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+
+    // Tab1 width = 140, height = 40
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 140.0;
+    tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
+    tabBottom = tabTop + 40.0;
+    tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+
+    // Tab2 width = 150, height = 50
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 150.0;
+    tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
+    tabBottom = tabTop + 50.0;
+    tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
+
+    // Tab 0 selected, indicator padding resolves to left: 8.0, right: 4.0
+    const double indicatorLeft = padStart;
+    final double indicatorRight = 130.0 + kTabLabelPadding.horizontal - padEnd;
+    const double indicatorTop = padTop;
+    const double indicatorBottom = tabBarHeight - padBottom;
+    expect(tabBarBox, paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+  });
+
+  testWidgets('TabBar - directional indicatorPadding (RTL) with STEB padding', (WidgetTester tester) async {
+    final List<Widget> tabs = <Widget>[
+      SizedBox(key: UniqueKey(), width: 130.0, height: 30.0),
+      SizedBox(key: UniqueKey(), width: 140.0, height: 40.0),
+      SizedBox(key: UniqueKey(), width: 150.0, height: 50.0),
+    ];
+    const Color indicatorColor = Color(0xFF00FF00);
+    const double padTop = 10.0;
+    const double padBottom = 12.0;
+    const double padStart = 8.0;
+    const double padEnd = 4.0;
+    const Decoration indicator = BoxDecoration(color: indicatorColor);
+    const double indicatorWeight = 2.0; // the default
+
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        textDirection: TextDirection.rtl,
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: TabBar(
+            indicator: indicator,
+            indicatorPadding: const EdgeInsetsDirectional.fromSTEB(
+              padStart, padTop, padEnd, padBottom),
+            isScrollable: true,
+            controller: controller,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox tabBarBox =
+    tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    const double tabBarHeight = 50.0 + indicatorWeight; // 50 = max tab height
+    expect(tabBarBox.size.height, tabBarHeight);
+
+    // Tab2 width = 150, height = 50
+    double tabLeft = kTabLabelPadding.left;
+    double tabRight = tabLeft + 150.0;
+    double tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
+    double tabBottom = tabTop + 50.0;
+    Rect tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
+
+    // Tab1 width = 140, height = 40
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 140.0;
+    tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
+    tabBottom = tabTop + 40.0;
+    tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+
+    // Tab0 width = 130, height = 30
+    tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
+    tabRight = tabLeft + 130.0;
+    tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
+    tabBottom = tabTop + 30.0;
+    tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
+    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+
+    // Tab 0 selected, indicator padding resolves to left: 4.0, right: 8.0
+    final double indicatorLeft = tabLeft - kTabLabelPadding.left + padEnd;
+    final double indicatorRight = tabRight + kTabLabelPadding.left - padStart;
+    const double indicatorTop = padTop;
+    const double indicatorBottom = tabBarHeight - padBottom;
+
+    expect(tabBarBox, paints..rect(
+      rect: Rect.fromLTRB(
+        indicatorLeft,
+        indicatorTop,
+        indicatorRight,
+        indicatorBottom,
+      ),
+      color: indicatorColor,
+    ));
+  });
+
   testWidgets('TabBar with labelPadding', (WidgetTester tester) async {
     const double indicatorWeight = 2.0; // default indicator weight
     const EdgeInsets labelPadding = EdgeInsets.only(left: 3.0, right: 7.0);

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1677,7 +1677,7 @@ void main() {
   });
 
   testWidgets('TabBar - directional indicatorPadding (LTR) with STEB padding', (WidgetTester tester) async {
-    final List<Widget> tabs = <Widget>[
+    final List<Widget > tabs = <Widget>[
       SizedBox(key: UniqueKey(), width: 130.0, height: 30.0),
       SizedBox(key: UniqueKey(), width: 140.0, height: 40.0),
       SizedBox(key: UniqueKey(), width: 150.0, height: 50.0),
@@ -1721,7 +1721,7 @@ void main() {
     double tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
     double tabBottom = tabTop + 30.0;
     Rect tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[0].key!)), tabRect);
 
     // Tab1 width = 140, height = 40
     tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
@@ -1729,7 +1729,7 @@ void main() {
     tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
     tabBottom = tabTop + 40.0;
     tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[1].key!)), tabRect);
 
     // Tab2 width = 150, height = 50
     tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
@@ -1737,7 +1737,7 @@ void main() {
     tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
     tabBottom = tabTop + 50.0;
     tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[2].key!)), tabRect);
 
     // Tab 0 selected, indicator padding resolves to left: 8.0, right: 4.0
     const double indicatorLeft = padStart;
@@ -1802,7 +1802,7 @@ void main() {
     double tabTop = (tabBarHeight - indicatorWeight - 50.0) / 2.0;
     double tabBottom = tabTop + 50.0;
     Rect tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[2].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[2].key!)), tabRect);
 
     // Tab1 width = 140, height = 40
     tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
@@ -1810,7 +1810,7 @@ void main() {
     tabTop = (tabBarHeight - indicatorWeight - 40.0) / 2.0;
     tabBottom = tabTop + 40.0;
     tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[1].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[1].key!)), tabRect);
 
     // Tab0 width = 130, height = 30
     tabLeft = tabRight + kTabLabelPadding.right + kTabLabelPadding.left;
@@ -1818,7 +1818,7 @@ void main() {
     tabTop = (tabBarHeight - indicatorWeight - 30.0) / 2.0;
     tabBottom = tabTop + 30.0;
     tabRect = Rect.fromLTRB(tabLeft, tabTop, tabRight, tabBottom);
-    expect(tester.getRect(find.byKey(tabs[0].key)), tabRect);
+    expect(tester.getRect(find.byKey(tabs[0].key!)), tabRect);
 
     // Tab 0 selected, indicator padding resolves to left: 4.0, right: 8.0
     final double indicatorLeft = tabLeft - kTabLabelPadding.left + padEnd;


### PR DESCRIPTION
## Description

This PR adds the ability to add padding to user defined indicators in TabBar. Earlier, the TabBar used to ignore indicatorPadding for user-defined indicators. 

To be specific, what I have done is, take this indicatorPadding property and pass it down to the _IndicatorPainter, this way, I apply the padding to the Rect inside which the CustomPainter is going to paint the indicator.

Also, UnderlineTabIndicator, takes in a `insets` parameter, which is set to `indicatorPadding`, and this is really where the indicatorPadding was originally being used. This parameter used to ignore `EdgeInsets.top` and `EdgeInsets.bottom` from the indicatorPadding. *Since I added indicatorPadding to the _IndicatorPainter class, it basically meant that the padding would be applied twice if it is still passed to UnderlineTabIndicator. Therefore, for the time-being, I have commented the line that passes the parameter, while creating the widget(Line-830)(If this feels like a good solution, we can just remove the line). I would really like a maintainers outlook on whether or not I should do this*, and figuring out what else we could do if not this.


## Related Issues

* #59728 

## Tests

Added tests for indicatorPadding being checked for both LTR and RTL text directions. Also added both the test using directional padding, ie, using STEB instead of LTRB.

In these tests, I give the indicator property of TabBar, which takes a Decoration object, a box decoration with a color, as this would cover the entire space available for the indicator. I set some values for the indicatorPadding and then expected to find a a rect being painted with the given padding applied.

## Screenshot
[<img src="https://user-images.githubusercontent.com/47733983/90167029-c5c58a80-ddb8-11ea-9bb2-4310c93ba5fa.jpeg" width=250>](https://user-images.githubusercontent.com/47733983/90167029-c5c58a80-ddb8-11ea-9bb2-4310c93ba5fa.jpeg)
To reproduce the behaviour, copy the contents of [this gist](https://gist.github.com/emem365/9697eecf5c17d9cdadf203178107c026) inside main.dart of a new flutter project.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
   
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
