### PR TITLE
Revert "Add native stacktrace field for PlatformException"

### DIFF
--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -80,10 +80,9 @@ abstract class MethodCodec {
 
   /// Encodes an error result into a binary envelope.
   ///
-  /// The specified error [code], human-readable error [message], error
-  /// [details] correspond to the fields of [PlatformException] and error
-  /// [stacktrace] correspond to stacktrace from native platforms.
-  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details, String? stacktrace});
+  /// The specified error [code], human-readable error [message], and error
+  /// [details] correspond to the fields of [PlatformException].
+  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details });
 }
 
 
@@ -108,7 +107,6 @@ class PlatformException implements Exception {
     required this.code,
     this.message,
     this.details,
-    this.stacktrace,
   }) : assert(code != null);
 
   /// An error code.
@@ -120,18 +118,8 @@ class PlatformException implements Exception {
   /// Error details, possibly null.
   final dynamic details;
 
-  /// Native stacktrace for the error, possibly null.
-  /// This is strictly for native platform stacktrace.
-  /// The stacktrace info on dart platform can be found within the try-catch block for example:
-  /// try {
-  ///   ...
-  /// } catch (e, stacktrace) {
-  ///   print(stacktrace);
-  /// }
-  final String? stacktrace;
-
   @override
-  String toString() => 'PlatformException($code, $message, $details, $stacktrace)';
+  String toString() => 'PlatformException($code, $message, $details)';
 }
 
 /// Thrown to indicate that a platform interaction failed to find a handling

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -152,16 +152,6 @@ class JSONMethodCodec implements MethodCodec {
         message: decoded[1] as String,
         details: decoded[2],
       );
-    if (decoded.length == 4
-        && decoded[0] is String
-        && (decoded[1] == null || decoded[1] is String)
-        && (decoded[3] == null || decoded[3] is String))
-      throw PlatformException(
-        code: decoded[0] as String,
-        message: decoded[1] as String,
-        details: decoded[2],
-        stacktrace: decoded[3] as String,
-      );
     throw FormatException('Invalid envelope: $decoded');
   }
 
@@ -171,9 +161,9 @@ class JSONMethodCodec implements MethodCodec {
   }
 
   @override
-  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details, String? stacktrace}) {
+  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details }) {
     assert(code != null);
-    return const JSONMessageCodec().encodeMessage(<dynamic>[code, message, details, stacktrace])!;
+    return const JSONMessageCodec().encodeMessage(<dynamic>[code, message, details])!;
   }
 }
 
@@ -557,13 +547,12 @@ class StandardMethodCodec implements MethodCodec {
   }
 
   @override
-  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details, String? stacktrace}) {
+  ByteData encodeErrorEnvelope({ required String code, String? message, dynamic details }) {
     final WriteBuffer buffer = WriteBuffer();
     buffer.putUint8(1);
     messageCodec.writeValue(buffer, code);
     messageCodec.writeValue(buffer, message);
     messageCodec.writeValue(buffer, details);
-    messageCodec.writeValue(buffer, stacktrace);
     return buffer.done();
   }
 
@@ -578,9 +567,8 @@ class StandardMethodCodec implements MethodCodec {
     final dynamic errorCode = messageCodec.readValue(buffer);
     final dynamic errorMessage = messageCodec.readValue(buffer);
     final dynamic errorDetails = messageCodec.readValue(buffer);
-    final String? errorStacktrace = (buffer.hasRemaining) ? messageCodec.readValue(buffer) as String : null;
     if (errorCode is String && (errorMessage == null || errorMessage is String) && !buffer.hasRemaining)
-      throw PlatformException(code: errorCode, message: errorMessage as String, details: errorDetails, stacktrace: errorStacktrace);
+      throw PlatformException(code: errorCode, message: errorMessage as String, details: errorDetails);
     else
       throw const FormatException('Invalid envelope');
   }

--- a/packages/flutter/test/services/message_codecs_test.dart
+++ b/packages/flutter/test/services/message_codecs_test.dart
@@ -10,7 +10,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
-import 'package:matcher/matcher.dart';
 import '../flutter_test_alternative.dart';
 import 'message_codecs_testing.dart';
 
@@ -37,70 +36,12 @@ void main() {
       final ByteData helloByteData = string.encodeMessage('hello');
 
       final ByteData offsetByteData = ByteData.view(
-        helloWorldByteData.buffer,
-        helloByteData.lengthInBytes,
-        helloWorldByteData.lengthInBytes - helloByteData.lengthInBytes,
+          helloWorldByteData.buffer,
+          helloByteData.lengthInBytes,
+          helloWorldByteData.lengthInBytes - helloByteData.lengthInBytes,
       );
 
       expect(string.decodeMessage(offsetByteData), ' world');
-    });
-  });
-  group('Standard method codec', () {
-    const MethodCodec method = StandardMethodCodec();
-    test('should decode error envelope without native stacktrace', () {
-      final ByteData errorData = method.encodeErrorEnvelope(
-        code: 'errorCode',
-        message: 'errorMessage',
-        details: 'errorDetails',
-      );
-      expect(
-          () => method.decodeEnvelope(errorData),
-          throwsA(predicate((PlatformException e) =>
-              e is PlatformException &&
-              e.code == 'errorCode' &&
-              e.message == 'errorMessage' &&
-              e.details == 'errorDetails')));
-    });
-    test('should decode error envelope with native stacktrace.', () {
-      final ByteData errorData = method.encodeErrorEnvelope(
-        code: 'errorCode',
-        message: 'errorMessage',
-        details: 'errorDetails',
-        stacktrace: 'errorStacktrace',
-      );
-      expect(
-          () => method.decodeEnvelope(errorData),
-          throwsA(predicate((PlatformException e) =>
-              e is PlatformException && e.stacktrace == 'errorStacktrace')));
-    });
-  });
-  group('Json method codec', () {
-    const JSONMethodCodec json = JSONMethodCodec();
-    test('should decode error envelope without native stacktrace', () {
-      final ByteData errorData = json.encodeErrorEnvelope(
-        code: 'errorCode',
-        message: 'errorMessage',
-        details: 'errorDetails',
-      );
-      expect(
-          () => json.decodeEnvelope(errorData),
-          throwsA(predicate((PlatformException e) =>
-              e is PlatformException &&
-              e.code == 'errorCode' &&
-              e.message == 'errorMessage' &&
-              e.details == 'errorDetails')));
-    });
-    test('should decode error envelope with native stacktrace.', () {
-      final ByteData errorData = json.encodeErrorEnvelope(
-        code: 'errorCode',
-        message: 'errorMessage',
-        details: 'errorDetails',
-        stacktrace: 'errorStacktrace',
-      );
-      expect(
-          () => json.decodeEnvelope(errorData),
-          throwsA(predicate((PlatformException e) =>
-              e is PlatformException && e.stacktrace == 'errorStacktrace')));
     });
   });
   group('JSON message codec', () {
@@ -210,22 +151,8 @@ void main() {
         standard,
         1.0,
         <int>[
-          6,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0xf0,
-          0x3f,
+          6, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0xf0, 0x3f,
         ],
       );
     });

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -131,7 +131,6 @@ void main() {
             'bad',
             'Something happened',
             <String, dynamic>{'a': 42, 'b': 3.14},
-            'errorStacktrace',
           ]);
         },
       );
@@ -142,7 +141,6 @@ void main() {
         expect(e.code, equals('bad'));
         expect(e.message, equals('Something happened'));
         expect(e.details, equals(<String, dynamic>{'a': 42, 'b': 3.14}));
-        expect(e.stacktrace, equals('errorStacktrace'));
       } catch (e) {
         fail('PlatformException expected');
       }


### PR DESCRIPTION
Reverts flutter/flutter#63502

This breaks the channel integration tests:

```
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: Failed to handle method call result
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: java.lang.IllegalArgumentException: Invalid envelope: ["error",null,null,null]
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at io.flutter.plugin.common.JSONMethodCodec.decodeEnvelope(JSONMethodCodec.java:91)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at io.flutter.plugin.common.MethodChannel$IncomingResultHandler.reply(MethodChannel.java:207)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at io.flutter.embedding.engine.dart.DartMessenger.handlePlatformMessageResponse(DartMessenger.java:103)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessageResponse(FlutterJNI.java:703)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at android.os.MessageQueue.nativePollOnce(Native Method)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at android.os.MessageQueue.next(MessageQueue.java:336)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at android.os.Looper.loop(Looper.java:174)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at android.app.ActivityThread.main(ActivityThread.java:7356)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at java.lang.reflect.Method.invoke(Native Method)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
08-13 14:02:25.172  2404  2404 E MethodChannel#json-method: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

@cyanglaz 