### PR TITLE
Surface Windows build errors in non-verbose mode

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -257,6 +257,9 @@ abstract class ProcessUtils {
   /// If [filter] is non-null, all lines that do not match it are removed. If
   /// [mapFunction] is present, all lines that match [filter] are also forwarded
   /// to [mapFunction] for further processing.
+  ///
+  /// If [stdoutErrorMatcher] is non-null, matching lines from stdout will be
+  /// treated as errors, just as if they had been logged to stderr instead.
   Future<int> stream(
     List<String> cmd, {
     String workingDirectory,
@@ -264,6 +267,7 @@ abstract class ProcessUtils {
     String prefix = '',
     bool trace = false,
     RegExp filter,
+    RegExp stdoutErrorMatcher,
     StringConverter mapFunction,
     Map<String, String> environment,
   });
@@ -485,6 +489,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     String prefix = '',
     bool trace = false,
     RegExp filter,
+    RegExp stdoutErrorMatcher,
     StringConverter mapFunction,
     Map<String, String> environment,
   }) async {
@@ -504,7 +509,9 @@ class _DefaultProcessUtils implements ProcessUtils {
         }
         if (line != null) {
           final String message = '$prefix$line';
-          if (trace) {
+          if (stdoutErrorMatcher?.hasMatch(line) == true) {
+            _logger.printError(message, wrap: false);
+          } else if (trace) {
             _logger.printTrace(message);
           } else {
             _logger.printStatus(message, wrap: false);

--- a/packages/flutter_tools/templates/app/windows.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app/windows.tmpl/flutter/CMakeLists.txt
@@ -80,11 +80,13 @@ add_dependencies(flutter_wrapper_app flutter_assemble)
 # _phony_ is a non-existent file to force this command to run every time,
 # since currently there's no way to get a full input/output list from the
 # flutter tool.
+set(PHONY_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/_phony_")
+set_source_files_properties("${PHONY_OUTPUT}" PROPERTIES SYMBOLIC TRUE)
 add_custom_command(
   OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
     ${CPP_WRAPPER_SOURCES_CORE} ${CPP_WRAPPER_SOURCES_PLUGIN}
     ${CPP_WRAPPER_SOURCES_APP}
-    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+    ${PHONY_OUTPUT}
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"


### PR DESCRIPTION
## Description

Makes Windows builds extract things that look like warnings and errors from stdout, where MSBuild sends all output, and reports them as errors to the logger (essentially making them behave as if they had gone to stderr). This means that native build failures will no longer be completely invisible in non-verbose mode.

Also fixes an existing warning so that it won't show up in every build: The custom step in the Windows template CMake to do the re-entrant Flutter step includes a dummy output file to force the step to run every time. This causes a warning from VS. Marking it SYMBOLIC to indicate that it's not a real output file causes CMake to generate that VS step with the output validation step disabled so that it won't warn.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/33583

## Tests

I added the following tests: Tests the regex extraction against sample normal and error lines, and ensures that it properly finds only the latter.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
