### PR TITLE
Provide the argument for a required parameter 'data'.

### DIFF
--- a/packages/flutter_test/lib/src/restoration.dart
+++ b/packages/flutter_test/lib/src/restoration.dart
@@ -60,7 +60,7 @@ class TestRestorationManager extends RestorationManager {
   /// To turn restoration back on call [restoreFrom].
   void disableRestoration() {
     _restorationData = null;
-    handleRestorationUpdateFromEngine(enabled: false);
+    handleRestorationUpdateFromEngine(enabled: false, data: null);
   }
 
   @override


### PR DESCRIPTION
The analyzer started reporing a new hint for `required` parameters in null safety, when referenced from a legacy library.
https://dart-review.googlesource.com/c/sdk/+/158343
As requested in https://github.com/dart-lang/sdk/issues/43026

Here we fix one violation of this hint.

It seems a bit non-standard to use `required` in combination with a nullable type, but might be OK if we look at this as a replacement of `@required` - sometimes to force the user to think about what value to provide, even it is `null`.