### PR TITLE
Add an infra issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,0 +1,22 @@
+---
+name: I want to file a bug or feature request to the infrastructure
+about: As a Flutter contributor, you have run into problems with the build/test/release
+  infrastructure, including the build and performance dashboards, devicelab, LUCI etc. Or you have
+  new ideas around those systems.
+title: ''
+labels: 'team: infra'
+assignees: ''
+
+---
+
+<!--  Thank you for contributing to Flutter!
+
+      If you are filing a bug, please add the steps to reproduce, expected and actual results.
+
+      If you are filing a feature request, please describe the use case and a proposal.
+
+      If you are requesting a small infra task with P0 or P1 priority, please add it to the
+      "Infra Ticket Queue" project with "New" column, explain why the task is needed and what
+      actions need to perform (if you happen to know). No need to set an assignee; the infra oncall
+      will triage and process the infra ticket queue.
+-->

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,8 +1,9 @@
 ---
-name: I want to file a bug or feature request to the infrastructure
+name: I want to file a bug or feature request about Flutter's CI infrastructure
 about: As a Flutter contributor, you have run into problems with the build/test/release
-  infrastructure, including the build and performance dashboards, devicelab, LUCI etc. Or you have
-  new ideas around those systems.
+  infrastructure, including the build and performance dashboards
+  (http://flutter-dashboard.appspot.com), devicelab, LUCI (https://ci.chromium.org/p/flutter) etc.
+  Or you have new ideas around those systems.
 title: ''
 labels: 'team: infra'
 assignees: ''


### PR DESCRIPTION
## Description

We need a template for people to file infra issues, especially for issues in the infra ticket queue. 

## Related Issues

Bug: https://github.com/flutter/flutter/issues/63105

