### PR TITLE
Split AOT tooling

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -628,6 +628,14 @@ class FlutterPlugin implements Plugin<Project> {
         if (project.hasProperty('performance-measurement-file')) {
             performanceMeasurementFileValue = project.property('performance-measurement-file')
         }
+        Boolean splitAotValue = false
+        if (project.hasProperty('split-aot')) {
+            splitAotValue = project.property('split-aot').toBoolean()
+        }
+        Boolean setupSplitAotValue = false
+        if (project.hasProperty('setup-split-aot')) {
+            setupSplitAotValue = project.property('setup-split-aot').toBoolean()
+        }
         def targetPlatforms = getTargetPlatforms()
         def addFlutterDeps = { variant ->
             if (shouldSplitPerAbi()) {
@@ -644,6 +652,7 @@ class FlutterPlugin implements Plugin<Project> {
                 }
             }
             String variantBuildMode = buildModeFor(variant.buildType)
+            println "VAR BUILD MODE: ${variantBuildMode}"
             String taskName = toCammelCase(["compile", FLUTTER_BUILD_PREFIX, variant.name])
             FlutterTask compileTask = project.tasks.create(name: taskName, type: FlutterTask) {
                 flutterRoot this.flutterRoot
@@ -668,6 +677,8 @@ class FlutterPlugin implements Plugin<Project> {
                 dartDefines dartDefinesValue
                 bundleSkSLPath bundleSkSLPathValue
                 performanceMeasurementFile performanceMeasurementFileValue
+                splitAot splitAotValue
+                setupSplitAot setupSplitAotValue
                 doLast {
                     project.exec {
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -678,7 +689,9 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
+            
             File libJar = project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/libs.jar")
+            println libJar.path
             Task packFlutterAppAotTask = project.tasks.create(name: "packLibs${FLUTTER_BUILD_PREFIX}${variant.name.capitalize()}", type: Jar) {
                 destinationDir libJar.parentFile
                 archiveName libJar.name
@@ -686,7 +699,7 @@ class FlutterPlugin implements Plugin<Project> {
                 targetPlatforms.each { targetPlatform ->
                     String abi = PLATFORM_ARCH_MAP[targetPlatform]
                     from("${compileTask.intermediateDir}/${abi}") {
-                        include "*.so"
+                        include "app.so"
                         // Move `app.so` to `lib/<abi>/libapp.so`
                         rename { String filename ->
                             return "lib/${abi}/lib${filename}"
@@ -694,9 +707,33 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
+            // if (splitAotValue) {
+            //     File libJar2 = project.file("${project.buildDir}/../module/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/libs.jar")
+            //     println libJar2.path
+            //     Task nextTask = project.tasks.create(name: "packLibsModule${FLUTTER_BUILD_PREFIX}${variant.name.capitalize()}", type: Jar) {
+            //         destinationDir libJar2.parentFile
+            //         archiveName libJar2.name
+            //         dependsOn compileTask
+            //         targetPlatforms.each { targetPlatform ->
+            //             println "RUNNING CUSTOM COPY LIB JAR TSK ${variant}"
+            //             String abi = PLATFORM_ARCH_MAP[targetPlatform]
+            //             from("${compileTask.intermediateDir}/${abi}") {
+            //                 include "*part.so"
+            //                 // Move `app.so` to `lib/<abi>/libapp.so`
+            //                 rename { String filename ->
+            //                     return "lib/${abi}/lib${filename}"
+            //                 }
+            //             }
+            //         }
+            //     }
+            //     addApiDependencies(project, variant.name, project.files {
+            //         nextTask
+            //     })
+            // }
             addApiDependencies(project, variant.name, project.files {
                 packFlutterAppAotTask
             })
+
             // We build an AAR when this property is defined.
             boolean isBuildingAar = project.hasProperty('is-plugin')
             // In add to app scenarios, a Gradle project contains a `:flutter` and `:app` project.
@@ -768,7 +805,11 @@ class FlutterPlugin implements Plugin<Project> {
                 }
             }
         }
-        if (project.android.hasProperty("applicationVariants")) {
+        if (setupSplitAotValue) {
+            println "DOING SETUP STUFF"
+            addFlutterDeps(project.android.applicationVariants[1]);
+        } else if (project.android.hasProperty("applicationVariants")) {
+            println "DOING NORMAL STUFF"
             project.android.applicationVariants.all { variant ->
                 addFlutterDeps(variant)
                 // Copy the output APKs into a known location, so `flutter run` or `flutter build apk`
@@ -779,6 +820,7 @@ class FlutterPlugin implements Plugin<Project> {
                 //   * `abi` can be `armeabi-v7a|arm64-v8a|x86|x86_64` only if the flag `split-per-abi` is set.
                 //   * `flavor-name` is the flavor used to build the app in lower case if the assemble task is called.
                 //   * `build-mode` can be `release|debug|profile`.
+                println "VARIANT: ${variant.name}"
                 variant.outputs.all { output ->
                     // `assemble` became `assembleProvider` in AGP 3.3.0.
                     def assembleTask = variant.hasProperty("assembleProvider")
@@ -863,6 +905,10 @@ abstract class BaseFlutterTask extends DefaultTask {
     @Optional @Input
     String bundleSkSLPath
     String performanceMeasurementFile;
+    @Optional @Input
+    Boolean splitAot
+    @Optional @Input
+    Boolean setupSplitAot
 
     @OutputFiles
     FileCollection getDependenciesFiles() {
@@ -944,6 +990,12 @@ abstract class BaseFlutterTask extends DefaultTask {
             if (extraFrontEndOptions != null) {
                 args "--ExtraFrontEndOptions=${extraFrontEndOptions}"
             }
+            if (splitAot == true) {
+                args "--SplitAot=true"
+            }
+            if (setupSplitAot == true) {
+                args "--SetupSplitAot=true"
+            }
             args ruleNames
         }
     }
@@ -999,6 +1051,72 @@ class FlutterTask extends BaseFlutterTask {
           sources += readDependencies(depfile, true)
         }
         return sources + project.files('pubspec.yaml')
+    }
+
+    @OutputFiles
+    FileCollection getOutputFiles() {
+        FileCollection sources = project.files()
+        for (File depfile in getDependenciesFiles()) {
+          sources += readDependencies(depfile, false)
+        }
+        return sources
+    }
+
+    @TaskAction
+    void build() {
+        buildBundle()
+    }
+}
+
+class SplitAotTask extends DefaultTask {
+    File flutterRoot
+    // File flutterExecutable
+    // String buildMode
+    // @Optional @Input
+    // String localEngine
+    // @Optional @Input
+    // String localEngineSrcPath
+    // @Input
+    // Boolean fastStart
+    // @Input
+    // String targetPath
+    // @Optional
+    // Boolean verbose
+    // @Optional @Input
+    // String[] fileSystemRoots
+    // @Optional @Input
+    // String fileSystemScheme
+    // @Input
+    // Boolean trackWidgetCreation
+    // @Optional @Input
+    // List<String> targetPlatformValues
+    // File sourceDir
+    // File intermediateDir
+    // @Optional @Input
+    // String extraFrontEndOptions
+    // @Optional @Input
+    // String extraGenSnapshotOptions
+    // @Optional @Input
+    // String splitDebugInfo
+    // @Optional @Input
+    // Boolean treeShakeIcons
+    // @Optional @Input
+    // Boolean dartObfuscation
+    // @Optional @Input
+    // String dartDefines
+    // @Optional @Input
+    // String bundleSkSLPath
+    // String performanceMeasurementFile;
+    // @Optional @Input
+    // Boolean splitAot
+
+    @OutputFiles
+    FileCollection getDependenciesFiles() {
+        FileCollection depfiles = project.files()
+
+        // Includes all sources used in the flutter compilation.
+        depfiles += project.files("${intermediateDir}/flutter_build.d")
+        return depfiles
     }
 
     @OutputFiles

--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -45,6 +45,18 @@ abstract class AndroidBuilder {
     @required AndroidBuildInfo androidBuildInfo,
     @required String target,
   });
+
+  Future<void> buildSplitAab({
+    @required FlutterProject project,
+    @required AndroidBuildInfo androidBuildInfo,
+    @required String target,
+  });
+
+  Future<void> buildSplitSetup({
+    @required FlutterProject project,
+    @required AndroidBuildInfo androidBuildInfo,
+    @required String target,
+  });
 }
 
 /// Default implementation of [AarBuilder].
@@ -109,6 +121,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
       );
     } finally {
       globals.androidSdk?.reinitialize();
+
     }
   }
 
@@ -129,6 +142,48 @@ class _AndroidBuilderImpl extends AndroidBuilder {
       );
     } finally {
       globals.androidSdk?.reinitialize();
+    }
+  }
+
+  /// Builds the Split App Bundle.
+  @override
+  Future<void> buildSplitAab({
+    @required FlutterProject project,
+    @required AndroidBuildInfo androidBuildInfo,
+    @required String target,
+  }) async {
+    try {
+      await buildGradleApp(
+        project: project,
+        androidBuildInfo: androidBuildInfo,
+        target: target,
+        isBuildingBundle: true,
+        isSetup: false,
+        localGradleErrors: gradleErrors,
+      );
+    } finally {
+      globals.androidSdk?.reinitialize();
+    }
+  }
+
+    /// Builds the Split App Bundle.
+  @override
+  Future<void> buildSplitSetup({
+    @required FlutterProject project,
+    @required AndroidBuildInfo androidBuildInfo,
+    @required String target,
+  }) async {
+    try {
+      await buildGradleApp(
+        project: project,
+        androidBuildInfo: androidBuildInfo,
+        target: target,
+        isBuildingBundle: true,
+        isSetup: true,
+        localGradleErrors: gradleErrors,
+      );
+    } finally {
+      // globals.androidSdk?.reinitialize();d
     }
   }
 }

--- a/packages/flutter_tools/lib/src/android/setup_split_aot.dart
+++ b/packages/flutter_tools/lib/src/android/setup_split_aot.dart
@@ -1,0 +1,235 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+
+import '../base/common.dart';
+import '../base/file_system.dart';
+import '../build_info.dart';
+import '../build_system/build_system.dart';
+import '../build_system/depfile.dart';
+import '../build_system/targets/android.dart';
+import '../build_system/targets/assets.dart';
+import '../build_system/targets/common.dart';
+import '../build_system/targets/ios.dart';
+import '../build_system/targets/linux.dart';
+import '../build_system/targets/macos.dart';
+import '../build_system/targets/web.dart';
+import '../build_system/targets/windows.dart';
+import '../cache.dart';
+import '../convert.dart';
+import '../globals.dart' as globals;
+import '../project.dart';
+import '../reporting/reporting.dart';
+import '../runner/flutter_command.dart';
+
+void setupBundleGradle(Environment env, BuildResult result) {
+  print('setup Bundle Gradle');
+  
+  Directory androidDir = env.projectDir.childDirectory('android');
+
+	List<FileSystemEntity> files = env.outputDir.listSync(recursive: true);
+  while (files.length != 0) {
+    if (files.last is File) {
+    	File file = files.last;
+      String subPath = file.path;
+      if (!subPath.contains('manifest.json')) {
+        files.removeLast();
+        continue;
+      }
+      // Read gen_snapshot manifest
+			String fileString = file.readAsStringSync();
+			Map manifest = jsonDecode(fileString);
+
+			// Setup android source directory
+			print('FINDING MODULES ${file.path}');
+			for (Map loadingUnitMetadata in manifest['loadingUnits']) {
+				if (loadingUnitMetadata['id'] == 1) continue;
+				String moduleName = 'module${loadingUnitMetadata['id'].toString()}';
+				print('FOUND MODULE: $moduleName');
+  			Directory moduleDir = androidDir.childDirectory(moduleName);
+			  setupFiles(moduleDir, androidDir, moduleName, false, result, env);
+			}
+			break;
+    }
+    files.removeLast();
+  }
+
+}
+
+void setupFiles(Directory moduleDir, Directory androidDir, String moduleName, bool isBase, BuildResult result, Environment env) {
+  print('setupFiles');
+  // File(path.join(rootDir, moduleSoPath)).copySync(path.join(modulePath, 'lib', 'libflutter.so'));
+
+  File stringRes = androidDir.childDirectory('app').childDirectory('src').childDirectory('main').childDirectory('res').childDirectory('values').childFile('strings.xml');
+  stringRes.createSync(recursive: true);
+  stringRes.writeAsStringSync(
+'''
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="${moduleName}Name">$moduleName</string>
+</resources>
+
+''', flush: true);
+
+  File androidManifest = moduleDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
+  androidManifest.createSync(recursive: true);
+//   androidManifest.writeAsStringSync(
+// '''
+// <manifest xmlns:dist="http://schemas.android.com/apk/distribution"
+//     package="com.example.$moduleName"
+//     split="$moduleName"
+//     android:isFeatureSplit="${isBase ? false : true}">
+
+//     <dist:module dist:instant="false"
+//         dist:title="@string/$moduleName"
+//         <dist:fusing dist:include="true" />
+//     </dist:module>
+//     <dist:delivery>
+//         <dist:install-time>
+//             <dist:removable value="false" />
+//         </dist:install-time>
+//         <dist:on-demand/>
+//     </dist:delivery>
+//     <application android:hasCode="${isBase ? 'true' : 'false'}"${isBase ? ' tools:replace="android:hasCode"' : ''}>
+//     </application>
+// </manifest>
+// ''', flush: true);
+
+  androidManifest.writeAsStringSync(
+'''
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
+    package="com.example.$moduleName">
+
+    <dist:$moduleName
+        dist:instant="false"
+        dist:title="@string/${moduleName}Name">
+        <dist:delivery>
+            <dist:on-demand />
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:$moduleName>
+</manifest>
+''', flush: true);
+
+	// settings.gradle add ':module'
+  File settingsGradle = androidDir.childFile('settings.gradle');
+  File settingsGradleTemp = androidDir.childFile('settings.gradle.temp');
+  if (settingsGradleTemp.existsSync()) settingsGradleTemp.deleteSync();
+  List<String> lines = settingsGradle.readAsLinesSync();
+  for (String line in lines) {
+    if (line.length >= 7 && line.substring(0, 7) == 'include') {
+      List<String> elements = line.substring(7).split(', ');
+      bool moduleFound = false;
+      for (int i = 1; i < elements.length; i++) {
+        if (elements[i] == '\':$moduleName\'') {
+          moduleFound = true;
+          break;
+        }
+      }
+      if (!moduleFound) {
+        line += ', \':$moduleName\'';
+      }
+    }
+    settingsGradleTemp.writeAsStringSync('$line\n', mode: FileMode.append, flush: true);
+  }
+  settingsGradleTemp.copySync(settingsGradle.path);
+  settingsGradleTemp.deleteSync();
+
+
+  // app/build.gradle add dynamicFeatures = [':modules', ...]
+  File appBuildGradle = androidDir.childDirectory('app').childFile('build.gradle');
+  File appBuildGradleTemp = androidDir.childDirectory('app').childFile('build.gradle.temp');
+  if (appBuildGradleTemp.existsSync()) appBuildGradleTemp.deleteSync();
+  lines = appBuildGradle.readAsLinesSync();
+  bool inAndroidBlock = false;
+  int androidStartLineIndex = 0;
+  int androidEndLineIndex = 0;
+  for (int lineNum = 0; lineNum < lines.length; lineNum++) {
+  	String line = lines[lineNum];
+  	if (line.contains('android') && line.contains('{')) {
+  		inAndroidBlock = true;
+  		androidStartLineIndex = lineNum;
+  	} else if (inAndroidBlock && line.length > 0 && line.substring(0, 1) == '}') {
+  		inAndroidBlock = false;
+  		androidEndLineIndex = lineNum;
+  		appBuildGradleTemp.writeAsStringSync('    dynamicFeatures = [\':$moduleName\']\n', mode: FileMode.append, flush: true);
+  	}
+
+  	if (inAndroidBlock) {
+  		if (line.contains('dynamicFeatures = [')) {
+  			List<String> components = line.substring(line.lastIndexOf('dynamicFeatures = [\'') + 20, line.length - 2).split(', ');
+  			if (!components.contains(':$moduleName')) {
+  				components.add(':$moduleName');
+  			}
+  			line = '    dynamicFeatures = [\'${components.first}\'';
+  			components.removeAt(0);
+  			for (String component in components) {
+  				line += ', \'$component\'';
+  			}
+  			line += ']';
+  			inAndroidBlock = false;
+  		}
+  	}
+    appBuildGradleTemp.writeAsStringSync('$line\n', mode: FileMode.append, flush: true);
+  }
+  appBuildGradleTemp.copySync(appBuildGradle.path);
+  appBuildGradleTemp.deleteSync();
+
+  File moduleBuildGradle = moduleDir.childFile('build.gradle');
+  moduleBuildGradle.createSync(recursive: true);
+  moduleBuildGradle.writeAsStringSync(
+'''
+apply plugin: "com.android.dynamic-feature"
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 28
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation project(":app")
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
+}
+
+''', flush: true);
+
+  // MOVE TO ASSEMBLE/POSTBUILD
+  Directory jniLibsDir = moduleDir.childDirectory('src').childDirectory('main').childDirectory('jniLibs');
+  jniLibsDir.createSync(recursive: true);
+  List<FileSystemEntity> files = env.outputDir.listSync(recursive: true);
+  while (files.length != 0) {
+    FileSystemEntity file = files.last;
+    if (file is File) {
+      String subPath = file.path;
+      if (!subPath.contains('part.so')) {
+        files.removeLast();
+        continue;
+      }
+      subPath = subPath.substring(subPath.lastIndexOf('release/') + 8);
+      print(jniLibsDir.childFile(subPath).path);
+      jniLibsDir.childFile(subPath).createSync(recursive: true);
+      (file as File).copySync(jniLibsDir.childFile(subPath).path);
+    }
+    files.removeLast();
+  }
+}

--- a/packages/flutter_tools/lib/src/android/split_bundle.dart
+++ b/packages/flutter_tools/lib/src/android/split_bundle.dart
@@ -1,0 +1,258 @@
+
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:path/path.dart' as path;
+import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
+
+// The flutter build command and gen_snapshot should be run first to produce the expected files for this script.
+
+String rootDir = path.join('..', '..', '..');
+String splitDir = path.join('build', 'split');
+String resDir = path.join(rootDir, 'android', 'app', 'src', 'main', 'res');
+String androidManifestPath = path.join(rootDir, 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+String bundleToolFileName = 'bundletool-all-1.0.0.jar';
+String aapt2Path = path.join(rootDir, splitDir, 'tools', 'aapt2-4.2.0-alpha05-6645012-osx', 'aapt2');
+String aapt2CompiledResOutput = path.join(rootDir, splitDir, 'compiled_resources');
+
+String aapt2URL = 'https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/';
+String aapt2Version = '4.2.0-alpha06-6645012';
+String platform = 'osx';
+
+void main() async {
+	rootDir = Directory(rootDir).absolute.path;
+
+	// Download aapt2 tool
+	String aapt2JarPath = '$splitDir/aapt2.jar';
+	File aapt2Jar = File(aapt2JarPath);
+	HttpClient().getUrl(Uri.parse('$aapt2URL$aapt2Version/aapt2-$aapt2Version-$platform.jar'))
+    .then((HttpClientRequest request) => request.close())
+    .then((HttpClientResponse response) => 
+        response.pipe(aapt2Jar.openWrite()));
+
+  // Decode the Zip file
+  final archive = ZipDecoder().decodeBytes(aapt2Jar.readBytesSync());
+  // Extract the contents of the Zip archive to disk.
+  for (final file in archive) {
+    final filename = file.name;
+    if (file.isFile) {
+      final data = file.content as List<int>;
+      File('$splitDir/aapt2/' + filename)
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(data);
+    } else {
+      Directory('out/' + filename)
+        ..create(recursive: true);
+    }
+  }
+
+  // aapt2 compile
+	await Directory(aapt2CompiledResOutput).delete(recursive: true);
+	await Directory(aapt2CompiledResOutput).create(recursive: true);
+	Process.run(aapt2Path, [
+		'compile',
+		'--dir',
+		resDir,
+		'-o',
+		aapt2CompiledResOutput,
+	]).then((ProcessResult results) {
+	  print(results.stdout);
+	  print(results.stderr);
+	})
+	.catchError((e) {
+	  print(e);
+	});
+
+
+	// compiled_resources.txt by adding filenames of .flat files.
+	File flatFiles = new File(path.join(aapt2CompiledResOutput, 'compiled_resources.txt'));
+	await flatFiles.create(recursive: true);
+	IOSink sink = flatFiles.openWrite();
+	for (int i = 0; i < filesInDir.length; i++) {
+		FileSystemEntity entity = filesInDir[i];
+		if (entity is File) {
+			File file = entity;
+			if (file.path.substring(file.path.length - 5) == '.flat') {
+				sink.write('${file.path} ');
+			}
+		}
+	}
+	await sink.flush();
+	sink.close();
+
+
+	// aapt2 link --proto-format -o output.apk \
+	// -I android_sdk/platforms/android_version/android.jar \
+	// --manifest project_root/module_root/src/main/AndroidManifest.xml \
+	// -R compiled_resources/*.flat \
+	// --auto-add-overlay
+
+	// aapt2 link
+	await Directory(aapt2CompiledResOutput).create(recursive: true);
+	Process.run(aapt2Path, [
+		'link',
+		// '-h',
+		'--proto-format',
+		'-o',
+		path.join(aapt2CompiledResOutput, 'output.apk'),
+		'--manifest',
+		androidManifestPath,
+		'-R',
+		path.join(aapt2CompiledResOutput, 'compiled_resources.txt'),
+		// '--auto-add-overlay',
+		'-I',
+		'/Users/garyq/Library/Android/sdk/platforms/android-28/android.jar'
+	]).then((ProcessResult results) {
+	  print(results.stdout);
+	  print(results.stderr);
+	})
+	.catchError((e) {
+	  print(e);
+	});
+
+	// extract resources.pb
+
+	// gen_snapshot
+
+	// Read gen_snapshot manifest
+	File file = File(path.join('..', 'manifest.json'));
+	String fileString = await file.readAsString();
+	Map manifest = jsonDecode(fileString);
+	ZipFileEncoder encoder = ZipFileEncoder();
+
+	// Create bundletool zips
+	List<Module> modules = List<Module>();
+	for (Map loadingUnitMetadata in manifest['loadingUnits']) {
+		Module module = Module(loadingUnitMetadata);
+
+		await module.createDir();
+
+		await module.setupFiles();
+
+		await module.zip(encoder);
+
+		modules.add(module);
+	}
+
+	// call bundle_tool to build aab
+	String modulesArg = '--modules=';
+	for (Module module in modules) {
+		if (!module.isBase) {
+			modulesArg += ',';
+		}
+		modulesArg += module.zipPath;
+	}
+	List<String> bundletoolArgs = [
+		'-Xms300m', // Set minimum and maximum heap size to the same value
+  	'-Xmx300m', // Set minimum and maximum heap size to the same value
+  	'-jar',
+  	path.join(rootDir, splitDir, 'tools', bundleToolFileName),
+  	'build-bundle',
+  	'--output',
+  	path.join(rootDir, splitDir, 'appbundle.aab'),
+  	modulesArg,
+	];
+
+	// Process.run('java', bundletoolArgs).then((ProcessResult results) {
+	//   print(results.stdout);
+	//   print(results.stderr);
+	// })
+	// .catchError((e) {
+	//   print(e);
+	// });
+}
+
+class Module {
+	Module(Map metadata) {
+		id = metadata['id'];
+		isBase = id == 1;
+		moduleName = isBase ? 'base' : id.toString();
+		moduleSoPath = metadata['path'];
+		modulePath = path.join(rootDir, splitDir, 'modules', moduleName);
+		zipPath = path.join(rootDir, splitDir, 'modules', '$moduleName.zip');
+	}
+
+	int id;
+	bool isBase;
+	String moduleName;
+	String moduleSoPath;
+	String modulePath;
+	String zipPath;
+
+	void createDir() async {
+		Directory moduleDir = Directory(path.join(modulePath));
+		if (moduleDir.existsSync()) {
+			await moduleDir.delete(recursive: true);
+		}
+
+		await Directory(path.join(modulePath, 'manifest')).create(recursive: true);
+	  await Directory(path.join(modulePath, 'dex')).create(recursive: true);
+	  await Directory(path.join(modulePath, 'res')).create(recursive: true);
+		await Directory(path.join(modulePath, 'assets')).create(recursive: true);
+	  await Directory(path.join(modulePath, 'root')).create(recursive: true);
+	  await Directory(path.join(modulePath, 'lib')).create(recursive: true);
+	}
+
+	void setupFiles() async {
+		await File(path.join(rootDir, moduleSoPath)).copy(path.join(modulePath, 'lib', 'libflutter.so'));
+
+	  File androidManifest = new File(path.join(modulePath, 'manifest', 'AndroidManifest.xml'));
+	  await androidManifest.create(recursive: true);
+	  IOSink sink = androidManifest.openWrite();
+// 	  sink.write(
+// '''
+// <manifest xmlns:dist="http://schemas.android.com/apk/distribution"
+//     split="$moduleName"
+//     android:isFeatureSplit="${isBase ? false : true}">
+
+//     <dist:module dist:instant="false"
+//     		dist:title="@string/module$id"
+//     		<dist:fusing dist:include="true" />
+// 		</dist:module>
+// 		<dist:delivery>
+// 				<dist:install-time>
+// 						<dist:removable value="false" />
+// 				</dist:install-time>
+// 				<dist:on-demand/>
+// 		</dist:delivery>
+// 		<application android:hasCode="${isBase ? 'true' : 'false'}"${isBase ? ' tools:replace="android:hasCode"' : ''}>
+// 		</application>
+// </manifest>
+// ''');
+
+	  sink.write(
+'''
+<manifest xmlns:dist="http://schemas.android.com/apk/distribution"
+    split="$moduleName"
+    android:isFeatureSplit="${isBase ? false : true}">
+
+    <dist:module dist:instant="false"
+    		dist:title="@string/module$id"
+    		<dist:fusing dist:include="true" />
+		</dist:module>
+		<dist:delivery>
+				<dist:install-time>
+						<dist:removable value="false" />
+				</dist:install-time>
+				<dist:on-demand/>
+		</dist:delivery>
+		<application android:hasCode="${isBase ? 'true' : 'false'}"${isBase ? ' tools:replace="android:hasCode"' : ''}>
+		</application>
+</manifest>
+''');
+	  sink.close();
+
+	  File resources = new File(path.join(modulePath, 'resources.pb'));
+	  await resources.create(recursive: true);
+	  sink = resources.openWrite();
+	  sink.write(
+'''
+''');
+	  sink.close();
+	}
+
+	void zip(ZipFileEncoder encoder) async {
+	  encoder.zipDirectory(Directory(modulePath), filename: zipPath);
+	}
+}

--- a/packages/flutter_tools/lib/src/base/error_handling_file_system.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_file_system.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io' as io show Directory, File, Link;
+import 'dart:io' as io show Directory, File, Link, FileSystemEntity;
 
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -194,6 +194,7 @@ class AndroidBuildInfo {
     this.splitPerAbi = false,
     this.shrink = false,
     this.fastStart = false,
+    this.splitAot = false,
   });
 
   // The build info containing the mode and flavor.
@@ -214,6 +215,8 @@ class AndroidBuildInfo {
 
   /// Whether to bootstrap an empty application.
   final bool fastStart;
+
+  final bool splitAot;
 }
 
 /// A summary of the compilation strategy used for Dart.

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -43,6 +43,10 @@ const String kExtraFrontEndOptions = 'ExtraFrontEndOptions';
 /// This is expected to be a comma separated list of strings.
 const String kExtraGenSnapshotOptions = 'ExtraGenSnapshotOptions';
 
+const String kSplitAot = 'SplitAot';
+
+const String kSetupSplitAot = 'SetupSplitAot';
+
 /// Whether to strip source code information out of release builds and where to save it.
 const String kSplitDebugInfo = 'SplitDebugInfo';
 

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -17,6 +17,8 @@ import 'build_bundle.dart';
 import 'build_fuchsia.dart';
 import 'build_ios.dart';
 import 'build_ios_framework.dart';
+import 'build_split_aot.dart';
+import 'build_setup_split_aot.dart';
 import 'build_web.dart';
 
 class BuildCommand extends FlutterCommand {
@@ -24,6 +26,8 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildAarCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
+    addSubcommand(BuildSetupSplitAotCommand(verboseHelp: verboseHelp));
+    addSubcommand(BuildSplitAotCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAotCommand());
     addSubcommand(BuildIOSCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildIOSFrameworkCommand(

--- a/packages/flutter_tools/lib/src/commands/build_setup_split_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_setup_split_aot.dart
@@ -1,0 +1,109 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../android/android_builder.dart';
+import '../android/build_validation.dart';
+import '../android/gradle_utils.dart';
+import '../base/terminal.dart';
+import '../build_info.dart';
+import '../cache.dart';
+import '../globals.dart' as globals;
+import '../project.dart';
+import '../reporting/reporting.dart';
+import '../runner/flutter_command.dart' show FlutterCommandResult;
+import 'build.dart';
+
+class BuildSetupSplitAotCommand extends BuildSubCommand {
+  BuildSetupSplitAotCommand({bool verboseHelp = false}) {
+    addTreeShakeIconsFlag();
+    usesTargetOption();
+    addBuildModeFlags(verboseHelp: verboseHelp);
+    usesFlavorOption();
+    usesPubOption();
+    usesBuildNumberOption();
+    usesBuildNameOption();
+    addSplitDebugInfoOption();
+    addDartObfuscationOption();
+    usesDartDefineOption();
+    usesExtraFrontendOptions();
+    addBundleSkSLPathOption(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
+    addBuildPerformanceFile(hide: !verboseHelp);
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    argParser
+      ..addFlag('split-per-abi',
+        negatable: false,
+        help: 'Whether to split the APKs per ABIs. '
+              'To learn more, see: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split',
+      )
+      ..addMultiOption('target-platform',
+        splitCommas: true,
+        defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
+        allowed: <String>['android-arm', 'android-arm64', 'android-x86', 'android-x64'],
+        help: 'The target platform for which the app is compiled.',
+      );
+    usesTrackWidgetCreation(verboseHelp: verboseHelp);
+  }
+
+  @override
+  final String name = 'setupsplitaot';
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
+    DevelopmentArtifact.androidGenSnapshot,
+  };
+
+  @override
+  final String description = 'Build an Android split AAB file from your app.\n\n'
+    "This command can build debug and release versions of your application. 'debug' builds support "
+    "debugging and a quick development cycle. 'release' builds don't support debugging and are "
+    'suitable for deploying to app stores.';
+
+  @override
+  Future<Map<CustomDimensions, String>> get usageValues async {
+    final Map<CustomDimensions, String> usage = <CustomDimensions, String>{};
+
+    usage[CustomDimensions.commandBuildApkTargetPlatform] =
+        stringsArg('target-platform').join(',');
+    usage[CustomDimensions.commandBuildApkSplitPerAbi] =
+        boolArg('split-per-abi').toString();
+
+    if (boolArg('release')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'release';
+    } else if (boolArg('debug')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'debug';
+    } else if (boolArg('profile')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'profile';
+    } else {
+      // The build defaults to release.
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'release';
+    }
+    return usage;
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    if (globals.androidSdk == null) {
+      exitWithNoSdkMessage();
+    }
+    final BuildInfo buildInfo = getBuildInfo();
+    final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(
+      buildInfo,
+      splitPerAbi: boolArg('split-per-abi'),
+      targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
+      shrink: false,
+      splitAot: true,
+    );
+    validateBuild(androidBuildInfo);
+
+    await androidBuilder.buildSplitSetup(
+      project: FlutterProject.current(),
+      target: targetFile,
+      androidBuildInfo: androidBuildInfo,
+    );
+    return FlutterCommandResult.success();
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/build_split_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_split_aot.dart
@@ -1,0 +1,109 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../android/android_builder.dart';
+import '../android/build_validation.dart';
+import '../android/gradle_utils.dart';
+import '../base/terminal.dart';
+import '../build_info.dart';
+import '../cache.dart';
+import '../globals.dart' as globals;
+import '../project.dart';
+import '../reporting/reporting.dart';
+import '../runner/flutter_command.dart' show FlutterCommandResult;
+import 'build.dart';
+
+class BuildSplitAotCommand extends BuildSubCommand {
+  BuildSplitAotCommand({bool verboseHelp = false}) {
+    addTreeShakeIconsFlag();
+    usesTargetOption();
+    addBuildModeFlags(verboseHelp: verboseHelp);
+    usesFlavorOption();
+    usesPubOption();
+    usesBuildNumberOption();
+    usesBuildNameOption();
+    addSplitDebugInfoOption();
+    addDartObfuscationOption();
+    usesDartDefineOption();
+    usesExtraFrontendOptions();
+    addBundleSkSLPathOption(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
+    addBuildPerformanceFile(hide: !verboseHelp);
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    argParser
+      ..addFlag('split-per-abi',
+        negatable: false,
+        help: 'Whether to split the APKs per ABIs. '
+              'To learn more, see: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split',
+      )
+      ..addMultiOption('target-platform',
+        splitCommas: true,
+        defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
+        allowed: <String>['android-arm', 'android-arm64', 'android-x86', 'android-x64'],
+        help: 'The target platform for which the app is compiled.',
+      );
+    usesTrackWidgetCreation(verboseHelp: verboseHelp);
+  }
+
+  @override
+  final String name = 'splitaot';
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
+    DevelopmentArtifact.androidGenSnapshot,
+  };
+
+  @override
+  final String description = 'Build an Android split AAB file from your app.\n\n'
+    "This command can build debug and release versions of your application. 'debug' builds support "
+    "debugging and a quick development cycle. 'release' builds don't support debugging and are "
+    'suitable for deploying to app stores.';
+
+  @override
+  Future<Map<CustomDimensions, String>> get usageValues async {
+    final Map<CustomDimensions, String> usage = <CustomDimensions, String>{};
+
+    usage[CustomDimensions.commandBuildApkTargetPlatform] =
+        stringsArg('target-platform').join(',');
+    usage[CustomDimensions.commandBuildApkSplitPerAbi] =
+        boolArg('split-per-abi').toString();
+
+    if (boolArg('release')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'release';
+    } else if (boolArg('debug')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'debug';
+    } else if (boolArg('profile')) {
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'profile';
+    } else {
+      // The build defaults to release.
+      usage[CustomDimensions.commandBuildApkBuildMode] = 'release';
+    }
+    return usage;
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    if (globals.androidSdk == null) {
+      exitWithNoSdkMessage();
+    }
+    final BuildInfo buildInfo = getBuildInfo();
+    final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(
+      buildInfo,
+      splitPerAbi: boolArg('split-per-abi'),
+      targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
+      shrink: false,
+      splitAot: true,
+    );
+    validateBuild(androidBuildInfo);
+
+    await androidBuilder.buildSplitAab(
+      project: FlutterProject.current(),
+      target: targetFile,
+      androidBuildInfo: androidBuildInfo,
+    );
+    return FlutterCommandResult.success();
+  }
+}


### PR DESCRIPTION
This is a WIP draft of tooling for building Split AOT Android App Bundles

go/flutter-aot-split

Structure:

The build process is split into two steps

- Prebuild/Setup: Runs gen_snapshot to generate the loading unit manifest, which is used to generate the necessary directory structure in the `android` folder for each module. The changes and loading units generated are displayed for verification by developer.
- Build: Uses gradle bundle<variant> task to run gen_snapshot, place the .so files in the correct places, and build an AAB. Before building, we will verify the loading units match the results of the last successful prebuild/setup process. If not, we ask to re-run the setup to ensure.


