### PR TITLE
Make SelectableText work better on web

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -447,6 +447,7 @@ class TextInputConfiguration {
   /// [actionLabel] may be null.
   const TextInputConfiguration({
     this.inputType = TextInputType.text,
+    this.readOnly = false,
     this.obscureText = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
@@ -469,6 +470,11 @@ class TextInputConfiguration {
 
   /// The type of information for which to optimize the text input control.
   final TextInputType inputType;
+
+  /// Whether the text field can be edited or not.
+  ///
+  /// Defaults to false.
+  final bool readOnly;
 
   /// Whether to hide the text being edited (e.g., for passwords).
   ///
@@ -580,6 +586,7 @@ class TextInputConfiguration {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'inputType': inputType.toJson(),
+      'readOnly': readOnly,
       'obscureText': obscureText,
       'autocorrect': autocorrect,
       'smartDashesType': smartDashesType.index.toString(),

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -73,6 +73,7 @@ void main() {
     test('sets expected defaults', () {
       const TextInputConfiguration configuration = TextInputConfiguration();
       expect(configuration.inputType, TextInputType.text);
+      expect(configuration.readOnly, false);
       expect(configuration.obscureText, false);
       expect(configuration.autocorrect, true);
       expect(configuration.actionLabel, null);
@@ -83,6 +84,7 @@ void main() {
     test('text serializes to JSON', () async {
       const TextInputConfiguration configuration = TextInputConfiguration(
         inputType: TextInputType.text,
+        readOnly: true,
         obscureText: true,
         autocorrect: false,
         actionLabel: 'xyzzy',
@@ -93,6 +95,7 @@ void main() {
         'signed': null,
         'decimal': null,
       });
+      expect(json['readOnly'], true);
       expect(json['obscureText'], true);
       expect(json['autocorrect'], false);
       expect(json['actionLabel'], 'xyzzy');
@@ -111,6 +114,7 @@ void main() {
         'signed': false,
         'decimal': true,
       });
+      expect(json['readOnly'], false);
       expect(json['obscureText'], true);
       expect(json['autocorrect'], false);
       expect(json['actionLabel'], 'xyzzy');


### PR DESCRIPTION
## Description

`SelectableText` works partially on the web. It lets the user select text with text, but the following things are missing:

- Ability to copy the selected text.
- Ability to change the selection via a physical keyboard.

That's because the browser has no idea about the state of text selection.

`SelectableText` uses a read-only text field under the hood. In order to make it fully work on the web, we need to let the read-only text field establish a connection to the engine.

Depends on engine PR: https://github.com/flutter/engine/pull/20520

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47234

## Tests

I added the following tests:

- `test/services/text_input_test.dart`
- `test/widgets/editable_text_test.dart`

I'm also planning to add an integration test once this is landed.