### PR TITLE
Ignore/fix dead_code checks for weak-only null checks.

### DIFF
--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -366,7 +366,10 @@ class TextSpan extends InlineSpan {
     assert(() {
       if (children != null) {
         for (final InlineSpan child in children!) {
-          if (child == null) {
+          // `child` has a non-nullable return type, but might be null when
+          // running with weak checking, so we need to null check it anyway (and
+          // ignore the warning that the null-handling logic is dead code).
+          if (child == null) { // ignore: dead_code
             throw FlutterError.fromParts(<DiagnosticsNode>[
               ErrorSummary('TextSpan contains a null child.'),
               ErrorDescription(
@@ -474,9 +477,12 @@ class TextSpan extends InlineSpan {
     if (children == null)
       return const <DiagnosticsNode>[];
     return children!.map<DiagnosticsNode>((InlineSpan child) {
+      // `child` has a non-nullable return type, but might be null when running
+      // with weak checking, so we need to null check it anyway (and ignore the
+      // warning that the null-handling logic is dead code).
       if (child != null) {
         return child.toDiagnosticsNode();
-      } else {
+      } else { // ignore: dead_code
         return DiagnosticsNode.message('<null child>');
       }
     }).toList();

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -821,7 +821,6 @@ class TextStyle with Diagnosticable {
     assert(wordSpacing != null || (wordSpacingFactor == 1.0 && wordSpacingDelta == 0.0));
     assert(heightFactor != null);
     assert(heightDelta != null);
-    assert(heightFactor != null || (heightFactor == 1.0 && heightDelta == 0.0));
     assert(decorationThicknessFactor != null);
     assert(decorationThicknessDelta != null);
     assert(decorationThickness != null || (decorationThicknessFactor == 1.0 && decorationThicknessDelta == 0.0));


### PR DESCRIPTION
## Description

Now that https://github.com/dart-lang/sdk/issues/41985 is fixed, the
analyzer detects dead code due to "unnecessary" null checks.  Since we
want to retain null checks in Flutter even when they appear
unnecessary (in order to preserve runtime behavior in weak mode), we
need to suppress these dead code hints.

Note that one assertion is removed by this PR (`heightFactor != null
|| (heightFactor == 1.0 && heightDelta == 0.0)`).  This is because
`heightFactor == 1.0 && heightDelta == 0.0` can only be true if
`heightFactor != null`, so this assertion is equivalent to simply
asserting that `heightFactor != null`, which is already asserted two
lines above.

## Related Issues

https://github.com/dart-lang/sdk/issues/41985 (this was fixed in the Dart SDK but the fix has not yet rolled into Flutter; this PR must be landed before the Dart SDK can roll into Flutter).

## Tests

N/A since this change does not affect behavior, it merely avoids dead code hints and removes a redundant assertion.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
