### PR TITLE
Return host and port from devtools launcher

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -259,8 +259,8 @@ The returned `params` will contain:
 The `serve()` command starts a DevTools server if one isn't already running. The return value will contain:
 
 - `success` - whether the server started.
-- `host` - the address host of the server successfully started.
-- `port` - the port of the server successfully started.
+- `host` - the address host if the server successfully started.
+- `port` - the port if the server successfully started.
 
 ## 'flutter run --machine' and 'flutter attach --machine'
 

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -256,7 +256,11 @@ The returned `params` will contain:
 
 #### devtools.serve
 
-The `serve()` command starts a DevTools server if one isn't already running and returns the host and port of the server.
+The `serve()` command starts a DevTools server if one isn't already running. The return value will contain:
+
+- `success` - whether the server started.
+- `host` - the address host of the server successfully started.  
+- `port` - the port of the server successfully started.  
 
 ## 'flutter run --machine' and 'flutter attach --machine'
 

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -259,8 +259,8 @@ The returned `params` will contain:
 The `serve()` command starts a DevTools server if one isn't already running. The return value will contain:
 
 - `success` - whether the server started.
-- `host` - the address host of the server successfully started.  
-- `port` - the port of the server successfully started.  
+- `host` - the address host of the server successfully started.
+- `port` - the port of the server successfully started.
 
 ## 'flutter run --machine' and 'flutter attach --machine'
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -897,12 +897,19 @@ class DevToolsDomain extends Domain {
 
   Future<Map<String, dynamic>> serve([ Map<String, dynamic> args ]) async {
     _devtoolsLauncher ??= DevtoolsLauncher.instance;
-    final HttpServer server = await _devtoolsLauncher.serve();
+    final DevToolsServerAddress server = await _devtoolsLauncher.serve();
 
-    return<String, dynamic>{
-      'host': server.address.host,
-      'port': server.port,
-    };
+    if (server != null) {
+      return<String, dynamic>{
+        'host': server.host,
+        'port': server.port,
+        'success': server.success,
+      };
+    } else {
+      return<String, dynamic>{
+        'success': false,
+      };
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -899,17 +899,10 @@ class DevToolsDomain extends Domain {
     _devtoolsLauncher ??= DevtoolsLauncher.instance;
     final DevToolsServerAddress server = await _devtoolsLauncher.serve();
 
-    if (server != null) {
-      return<String, dynamic>{
-        'host': server.host,
-        'port': server.port,
-        'success': server.success,
-      };
-    } else {
-      return<String, dynamic>{
-        'success': false,
-      };
-    }
+    return<String, dynamic>{
+      'host': server?.host,
+      'port': server?.port,
+    };
   }
 
   @override

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1728,10 +1728,10 @@ class DevtoolsLauncher {
       _devtoolsServer ??= await devtools_server.serveDevTools(
         enableStdinCommands: false,
       );
-      return DevToolsServerAddress.succeeded(_devtoolsServer.address.host, _devtoolsServer.port);
+      return DevToolsServerAddress(_devtoolsServer.address.host, _devtoolsServer.port);
     } on Exception catch (e, st) {
       globals.printTrace('Failed to serve DevTools: $e\n$st');
-      return DevToolsServerAddress.failed();
+      return null;
     }
   }
 
@@ -1744,11 +1744,8 @@ class DevtoolsLauncher {
 }
 
 class DevToolsServerAddress {
-  DevToolsServerAddress._(this.host, this.port, this.success);
-  DevToolsServerAddress.succeeded(String host, int port): this._(host, port, true);
-  DevToolsServerAddress.failed(): this._(null, null, false);
+  DevToolsServerAddress(this.host, this.port);
 
   final String host;
   final int port;
-  final bool success;
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1723,15 +1723,16 @@ class DevtoolsLauncher {
     }
   }
 
-  Future<io.HttpServer> serve() async {
+  Future<DevToolsServerAddress> serve() async {
     try {
       _devtoolsServer ??= await devtools_server.serveDevTools(
         enableStdinCommands: false,
       );
+      return DevToolsServerAddress.succeeded(_devtoolsServer.address.host, _devtoolsServer.port);
     } on Exception catch (e, st) {
       globals.printTrace('Failed to serve DevTools: $e\n$st');
+      return DevToolsServerAddress.failed();
     }
-    return _devtoolsServer;
   }
 
   Future<void> close() async {
@@ -1740,4 +1741,14 @@ class DevtoolsLauncher {
   }
 
   static DevtoolsLauncher get instance => context.get<DevtoolsLauncher>() ?? DevtoolsLauncher();
+}
+
+class DevToolsServerAddress {
+  DevToolsServerAddress._(this.host, this.port, this.success);
+  DevToolsServerAddress.succeeded(String host, int port): this._(host, port, true);
+  DevToolsServerAddress.failed(): this._(null, null, false);
+
+  final String host;
+  final int port;
+  final bool success;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/common.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -311,43 +311,20 @@ void main() {
         responses.add,
         notifyingLogger: notifyingLogger,
       );
-      when(mockDevToolsLauncher.serve()).thenAnswer((_) async => DevToolsServerAddress.succeeded('127.0.0.1', 1234));
+      when(mockDevToolsLauncher.serve()).thenAnswer((_) async => DevToolsServerAddress('127.0.0.1', 1234));
 
       commands.add(<String, dynamic>{'id': 0, 'method': 'devtools.serve'});
       final Map<String, dynamic> response = await responses.stream.firstWhere((Map<String, dynamic> response) => response['id'] == 0);
       expect(response['result'], isNotEmpty);
-      expect(response['result']['host'], equals('127.0.0.1'));
-      expect(response['result']['port'], equals(1234));
-      expect(response['result']['success'], equals(true));
+      expect(response['result']['host'], '127.0.0.1');
+      expect(response['result']['port'], 1234);
       await responses.close();
       await commands.close();
     }, overrides: <Type, Generator>{
       DevtoolsLauncher: () => mockDevToolsLauncher,
     });
 
-    testUsingContext('devtools.serve command should return false for success on failure', () async {
-      final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
-      final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
-      daemon = Daemon(
-        commands.stream,
-        responses.add,
-        notifyingLogger: notifyingLogger,
-      );
-      when(mockDevToolsLauncher.serve()).thenAnswer((_) async => DevToolsServerAddress.failed());
-
-      commands.add(<String, dynamic>{'id': 0, 'method': 'devtools.serve'});
-      final Map<String, dynamic> response = await responses.stream.firstWhere((Map<String, dynamic> response) => response['id'] == 0);
-      expect(response['result'], isNotEmpty);
-      expect(response['result']['host'], equals(null));
-      expect(response['result']['port'], equals(null));
-      expect(response['result']['success'], equals(false));
-      await responses.close();
-      await commands.close();
-    }, overrides: <Type, Generator>{
-      DevtoolsLauncher: () => mockDevToolsLauncher,
-    });
-
-    testUsingContext('devtools.serve command should return false for success if null returned', () async {
+    testUsingContext('devtools.serve command should return null fields if null returned', () async {
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
@@ -360,9 +337,8 @@ void main() {
       commands.add(<String, dynamic>{'id': 0, 'method': 'devtools.serve'});
       final Map<String, dynamic> response = await responses.stream.firstWhere((Map<String, dynamic> response) => response['id'] == 0);
       expect(response['result'], isNotEmpty);
-      expect(response['result']['host'], equals(null));
-      expect(response['result']['port'], equals(null));
-      expect(response['result']['success'], equals(false));
+      expect(response['result']['host'], null);
+      expect(response['result']['port'], null);
       await responses.close();
       await commands.close();
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

This is a follow-up change to https://github.com/flutter/flutter/pull/62702. Initially we thought we would continue using the external `DevtoolsLauncher::serve` function to start an devtools from pre-built code for both external and internal situations, but we actually want to use an internal `serve` function instead. This change makes it possible to return the same information from flutter tools for both internal and external `serve` results, since we can't easily return an `HttpServer` from the internal function.

## Related Issues

See [previous PR](https://github.com/flutter/flutter/pull/62702)

## Tests
I modified the test of a successful serve of devtools to account for its changed return value.

I added the following tests:
- Failed devtools serve
- Devtools serve returning null (current internal return)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [X] Yes, this is a breaking change.
   - I added this function for use by the IntelliJ plugin only; the change there hasn't been made yet.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
