### PR TITLE
bug fix for flutter_gallery__transition_perf(_with_semantics)

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
@@ -13,6 +13,18 @@ Future<void> main() async {
   await task(() async {
     final TaskResult withoutSemantics = await createGalleryTransitionTest()();
     final TaskResult withSemantics = await createGalleryTransitionTest(semanticsEnabled: true)();
+    if (withSemantics.benchmarkScoreKeys.isEmpty || withoutSemantics.benchmarkScoreKeys.isEmpty) {
+      String message = 'Lack of data';
+      if (withSemantics.benchmarkScoreKeys.isEmpty) {
+        message += ' for test with semantics';
+        if (withoutSemantics.benchmarkScoreKeys.isEmpty) {
+          message += ' and without semantics';
+        }
+      } else {
+        message += 'for test without semantics';
+      }
+      return TaskResult.failure(message);
+    }
 
     final List<String> benchmarkScoreKeys = <String>[];
     final Map<String, dynamic> data = <String, dynamic>{};

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -64,8 +64,8 @@ class GalleryTransitionTest {
       await flutter('packages', options: <String>['get']);
 
       final String testDriver = driverFile ?? (semanticsEnabled
-          ? '${testFile}_test'
-          : '${testFile}_with_semantics_test');
+          ? '${testFile}_with_semantics_test'
+          : '${testFile}_test');
 
       await flutter('drive', options: <String>[
         '--profile',


### PR DESCRIPTION
## Description

This is a bug fix for a wrong use of semantics flag for a device lab test. This should close #63793 and fix the fake regression. 

I also added a failure report to `dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart`