### PR TITLE
drop xcpretty for tests

### DIFF
--- a/dev/ci/mac/Gemfile
+++ b/dev/ci/mac/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 # If fastlane fails with a wrong Google Cloud dependency, bump this version,
 # e.g. https://github.com/flutter/flutter/pull/43362
 gem 'fastlane', '2.134.0'
-gem 'xcpretty', '0.3.0'
 
 # Don't pin cocoapods so we can catch breakages from upstream changes, e.g.
 # https://github.com/flutter/flutter/issues/41144

--- a/dev/integration_tests/ios_add2app_life_cycle/build_and_test.sh
+++ b/dev/integration_tests/ios_add2app_life_cycle/build_and_test.sh
@@ -14,13 +14,9 @@ popd
 pod install
 os_version=$(xcrun --show-sdk-version --sdk iphonesimulator)
 
-PRETTY="cat"
-if which xcpretty; then
-  PRETTY="xcpretty"
-fi
 
-set -o pipefail && xcodebuild \
+xcodebuild \
   -workspace ios_add2app.xcworkspace \
   -scheme ios_add2app \
   -sdk "iphonesimulator$os_version" \
-  -destination "OS=$os_version,name=iPhone X" test | $PRETTY
+  -destination "OS=$os_version,name=iPhone X" test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/63781

xcpretty obfuscates important failure information.