### PR TITLE
[flutter_tools] correctly forward error only stdout in non-verbose modes

### DIFF
--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh";
+			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
 		36C290D58D35783923B6B124 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh\ntouch Flutter/ephemeral/tripwire\n";
+			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh";
 		};
 		36C290D58D35783923B6B124 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -93,12 +93,3 @@ RunCommand "${FLUTTER_ROOT}/bin/flutter"                                    \
     --build-outputs="${build_outputs_path}"                                 \
     --output="${ephemeral_dir}"                                             \
    "${build_mode}_macos_bundle_flutter_assets"
-
-if [[ $? -ne 0 ]]; then
-  EchoError "Failed to build ${project_path}."
-  exit -1
-fi
-
-# Ensure that Xcode dependency analysis does not incorrectly skip the flutter step if
-# its configuration (build mode, defines) changes without an input file changing.
-touch macos/Flutter/ephemeral/tripwire

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -93,3 +93,12 @@ RunCommand "${FLUTTER_ROOT}/bin/flutter"                                    \
     --build-outputs="${build_outputs_path}"                                 \
     --output="${ephemeral_dir}"                                             \
    "${build_mode}_macos_bundle_flutter_assets"
+
+if [[ $? -ne 0 ]]; then
+  EchoError "Failed to build ${project_path}."
+  exit -1
+fi
+
+# Ensure that Xcode dependency analysis does not incorrectly skip the flutter step if
+# its configuration (build mode, defines) changes without an input file changing.
+touch macos/Flutter/ephemeral/tripwire

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -87,10 +87,12 @@ Future<void> buildMacOS({
       'OBJROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
       'SYMROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
       if (verboseLogging)
-        'VERBOSE_SCRIPT_LOGGING=YES',
+        'VERBOSE_SCRIPT_LOGGING=YES'
+      else
+        '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
-    ], trace: true);
+    ], trace: false);
   } finally {
     status.cancel();
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -14,6 +14,8 @@ import '../ios/xcodeproj.dart';
 import '../project.dart';
 import 'cocoapod_utils.dart';
 
+final RegExp _anyOutput = RegExp('.*');
+
 /// Builds the macOS project through xcodebuild.
 // TODO(jonahwilliams): refactor to share code with the existing iOS code.
 Future<void> buildMacOS({
@@ -92,7 +94,10 @@ Future<void> buildMacOS({
         '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
-    ], trace: false);
+    ],
+    trace: true,
+    stdoutErrorMatcher: _anyOutput,
+  );
   } finally {
     status.cancel();
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -14,6 +14,8 @@ import '../ios/xcodeproj.dart';
 import '../project.dart';
 import 'cocoapod_utils.dart';
 
+/// When run in -quiet mode, Xcode only prints from the underlying tasks to stdout.
+/// Passing this regexp to trace moves the stdout output to stderr.
 final RegExp _anyOutput = RegExp('.*');
 
 /// Builds the macOS project through xcodebuild.
@@ -96,7 +98,7 @@ Future<void> buildMacOS({
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ],
     trace: true,
-    stdoutErrorMatcher: _anyOutput,
+    stdoutErrorMatcher: verboseLogging ? null : _anyOutput,
   );
   } finally {
     status.cancel();

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -280,7 +280,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh";
+			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -280,7 +280,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh\ntouch Flutter/ephemeral/tripwire\n";
+			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -86,7 +86,9 @@ void main() {
         'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
         'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
         if (verbose)
-          'VERBOSE_SCRIPT_LOGGING=YES',
+          'VERBOSE_SCRIPT_LOGGING=YES'
+        else
+          '-quiet',
         'COMPILER_INDEX_STORE_ENABLE=NO',
       ],
       stdout: 'STDOUT STUFF',
@@ -129,15 +131,15 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
-  testUsingContext('macOS build does not spew stdout to status logger', () async {
+  testUsingContext('macOS build forwards Stdout to status logger', () async {
     final BuildCommand command = BuildCommand();
     createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--debug']
     );
-    expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
-    expect(testLogger.traceText, contains('STDOUT STUFF'));
+    expect(testLogger.statusText, contains('STDOUT STUFF'));
+    expect(testLogger.traceText, isNot(contains('STDOUT STUFF')));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -131,15 +131,16 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
-  testUsingContext('macOS build forwards Stdout to status logger', () async {
+  testUsingContext('macOS build forwards error stdout to status logger error', () async {
     final BuildCommand command = BuildCommand();
     createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--debug']
     );
-    expect(testLogger.statusText, contains('STDOUT STUFF'));
+    expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
     expect(testLogger.traceText, isNot(contains('STDOUT STUFF')));
+    expect(testLogger.errorText, contains('STDOUT STUFF'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
## Description

Xcode is internally aware of the distinction between stderr and stdout, but will forward everything to stdout by default. Providing the `-quiet` flag will cause it to only surface what it considers an "error" as part of stdout.

Additionally, the inclusion of the "touch" after the assemble script meant that in the event assemble failed, the overall status code would still be 0.

Fixes https://github.com/flutter/flutter/issues/63748