### PR TITLE
Make deprecation notice link to website downloads

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -795,7 +795,8 @@ abstract class FlutterCommand extends Command<void> {
   void _printDeprecationWarning() {
     if (deprecated) {
       globals.printStatus('$warningMark The "$name" command is deprecated and '
-          'will be removed in a future version of Flutter.');
+          'will be removed in a future version of Flutter. '
+          'Refer to https://flutter.dev/docs/development/tools/sdk/releases');
       globals.printStatus('');
     }
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -797,7 +797,7 @@ abstract class FlutterCommand extends Command<void> {
       globals.printStatus('$warningMark The "$name" command is deprecated and '
           'will be removed in a future version of Flutter. '
           'See https://flutter.dev/docs/development/tools/sdk/releases '
-          'for previous releases of flutter.');
+          'for previous releases of Flutter.');
       globals.printStatus('');
     }
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -796,7 +796,8 @@ abstract class FlutterCommand extends Command<void> {
     if (deprecated) {
       globals.printStatus('$warningMark The "$name" command is deprecated and '
           'will be removed in a future version of Flutter. '
-          'Refer to https://flutter.dev/docs/development/tools/sdk/releases');
+          'See https://flutter.dev/docs/development/tools/sdk/releases '
+          'for previous releases of flutter.');
       globals.printStatus('');
     }
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -43,7 +43,7 @@ void main() {
         '--no-pub',
       ]);
       expect(testLogger.statusText, equals(
-        '[!] The "version" command is deprecated and will be removed in a future version of Flutter.\n\n'
+        '[!] The "version" command is deprecated and will be removed in a future version of Flutter. Refer to https://flutter.dev/docs/development/tools/sdk/releases\n\n'
         'v10.0.0\r\nv20.0.0\r\n30.0.0-dev.0.0\r\n31.0.0-0.0.pre\n'
       ));
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -46,7 +46,7 @@ void main() {
         '[!] The "version" command is deprecated '
             'and will be removed in a future version of Flutter. '
             'See https://flutter.dev/docs/development/tools/sdk/releases '
-            'for previous releases of flutter.\n\n'
+            'for previous releases of Flutter.\n\n'
         'v10.0.0\r\nv20.0.0\r\n30.0.0-dev.0.0\r\n31.0.0-0.0.pre\n'
       ));
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -43,7 +43,10 @@ void main() {
         '--no-pub',
       ]);
       expect(testLogger.statusText, equals(
-        '[!] The "version" command is deprecated and will be removed in a future version of Flutter. Refer to https://flutter.dev/docs/development/tools/sdk/releases\n\n'
+        '[!] The "version" command is deprecated '
+            'and will be removed in a future version of Flutter. '
+            'See https://flutter.dev/docs/development/tools/sdk/releases '
+            'for previous releases of flutter.\n\n'
         'v10.0.0\r\nv20.0.0\r\n30.0.0-dev.0.0\r\n31.0.0-0.0.pre\n'
       ));
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

*This PR updates the ```_printDeprecationWarning()``` method in the ```FlutterCommand``` class to make the deprecation notice output in the terminal by the command ```flutter version``` contain a reference to the https://flutter.dev/docs/development/tools/sdk/releases page where Flutter releases can be downloaded as pre-built archives.*

*The output before the change was:*
```zsh
[!] The "version" command is deprecated and will be removed in a future version of Flutter.

1.20.2
1.21.0-9.0.pre
1.20.1
...
0.0.6
v0.0.6
v0.0.20-alpha
```

*The output after the change will be:*
```zsh
[!] The "version" command is deprecated and will be removed in a future version of Flutter. Refer to https://flutter.dev/docs/development/tools/sdk/releases

1.20.2
1.21.0-9.0.pre
1.20.1
...
0.0.6
v0.0.6
v0.0.20-alpha
```

## Related Issues

Fixes #63787 

## Tests

I added the following tests:

* Updated the ```version ls``` test to check if the output links to the website downloads.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
