### PR TITLE
[flutter_tools] Rename channel with appropriate word

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -82,8 +82,7 @@ class FlutterVersion {
 
   /// Whether we are currently on the master branch.
   bool get isMaster {
-    final String branchName = getBranchName();
-    return !<String>['dev', 'beta', 'stable'].contains(branchName);
+    return getBranchName() == 'master';
   }
 
   // Beware: Keep order in accordance with stability
@@ -125,7 +124,7 @@ class FlutterVersion {
         );
         _channel = channel.substring(slash + 1);
       } else if (channel.isEmpty) {
-        _channel = 'unknown';
+        _channel = 'local';
       } else {
         _channel = channel;
       }
@@ -752,9 +751,9 @@ class GitTagVersion {
 
   static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false}) {
     if (fetchTags) {
-      final String channel = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
-      if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
-        globals.printTrace('Skipping request to fetchTags - on well known channel $channel.');
+      final String branch = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
+      if (branch == 'dev' || branch == 'beta' || branch == 'stable') {
+        globals.printTrace('Skipping request to fetchTags - on well known channel $branch.');
       } else {
         _runGit('git fetch $_flutterGit --tags -f', processUtils, workingDirectory);
       }


### PR DESCRIPTION
## Description

* class `FlutterVersion` `bool get isMaster` method more accurate. @jonahwilliams help confirm thanks!

In flutter channel most refer to upstream branch in https://github.com/flutter/flutter.git.
* class `GitTagVersion` `static GitTagVersion determine` similar to class `FlutterVersion` `String getBranchName`, the git command: `git rev-parse --abbrev-ref HEAD` wants to get current checked out branch. so `branch` is a better name than `channel`.

Another suggestion is channel default name now is 'unknown', but I think 'local' maybe more suitable.
* Current situation: `flutter doctor` displayed upstream channel(branch), but when user checkout local branch the result is 'unknown'.The 'unknown' scene can be explained that it is a local scene.

## Related Issues

I encountered some developer who were surprised by the results of `flutter doctor` unknown, this looks like an anomaly.

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
