### PR TITLE
Added_examples_for_Offstage

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2669,7 +2669,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// Difference in painting can be easily compared by the following sections of with Offstage where we don't bring
 /// the widget on screen and without Offstage where we bring the widget on screen.
 ///
-/// ### Without Offstage
+/// Without Offstage:
 ///
 /// ```dart
 /// import 'package:flutter/material.dart';
@@ -2695,7 +2695,11 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// }
 /// ```
 ///
-/// ### With Offstage
+/// {@end-tool}
+///
+/// {@tool dartpad --template=stateless_widget_material}
+///
+/// With Offstage:
 ///
 /// ```dart
 /// import 'package:flutter/material.dart';

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2653,7 +2653,21 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// painting anything, without making the child available for hit testing, and
 /// without taking any room in the parent.
 ///
-/// Difference in painting can be easily compared by the following sections of with and without Offstage.
+/// Offstage children are still active: they can receive focus and have keyboard
+/// input directed to them, you can also find them in the widget tree.
+///
+/// Animations continue to run in offstage children, and therefore use battery
+/// and CPU time, regardless of whether the animations end up being visible.
+///
+/// [Offstage] can be used to measure the dimensions of a widget without
+/// bringing it on screen (yet). To hide a widget from view while it is not
+/// needed, prefer removing the widget from the tree entirely rather than
+/// keeping it alive in an [Offstage] subtree.
+///
+/// {@tool snippet}
+///
+/// Difference in painting can be easily compared by the following sections of with Offstage where we don't bring 
+/// the widget on screen and without Offstage where we bring the widget on screen.
 ///
 /// ### Without Offstage
 ///
@@ -2709,16 +2723,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// }
 /// ```
 ///
-/// Offstage children are still active: they can receive focus and have keyboard
-/// input directed to them, you can also find them in the widget tree.
-///
-/// Animations continue to run in offstage children, and therefore use battery
-/// and CPU time, regardless of whether the animations end up being visible.
-///
-/// [Offstage] can be used to measure the dimensions of a widget without
-/// bringing it on screen (yet). To hide a widget from view while it is not
-/// needed, prefer removing the widget from the tree entirely rather than
-/// keeping it alive in an [Offstage] subtree.
+/// {@end-tool}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2653,8 +2653,64 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// painting anything, without making the child available for hit testing, and
 /// without taking any room in the parent.
 ///
+/// Difference in painting can be easily compared by the following sections of with and without Offstage.
+///
+/// ### Without Offstage
+///
+/// ```dart
+/// import 'package:flutter/material.dart';
+///
+/// void main() {
+///   runApp(MyApp());
+/// }
+///
+/// class MyApp extends StatelessWidget {
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return MaterialApp(
+///       home: Scaffold(
+///         body: Container(
+///           color: Colors.red,
+///           height: 120.0,
+///           width: 120.0,
+///         ),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ### With Offstage
+///
+/// ```dart
+/// import 'package:flutter/material.dart';
+///
+/// void main() {
+///   runApp(MyApp());
+/// }
+///
+/// class MyApp extends StatelessWidget {
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return MaterialApp(
+///       home: Scaffold(
+///         body: Offstage(
+///           child: Container(
+///             color: Colors.red,
+///             height: 120.0,
+///             width: 120.0,
+///           ),
+///         ),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+///
 /// Offstage children are still active: they can receive focus and have keyboard
-/// input directed to them.
+/// input directed to them, you can also find them in the widget tree.
 ///
 /// Animations continue to run in offstage children, and therefore use battery
 /// and CPU time, regardless of whether the animations end up being visible.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2664,7 +2664,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// needed, prefer removing the widget from the tree entirely rather than
 /// keeping it alive in an [Offstage] subtree.
 ///
-/// {@tool snippet}
+/// {@tool dartpad --template=stateless_widget_material}
 ///
 /// Difference in painting can be easily compared by the following sections of with Offstage where we don't bring
 /// the widget on screen and without Offstage where we bring the widget on screen.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2666,7 +2666,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///
 /// {@tool snippet}
 ///
-/// Difference in painting can be easily compared by the following sections of with Offstage where we don't bring 
+/// Difference in painting can be easily compared by the following sections of with Offstage where we don't bring
 /// the widget on screen and without Offstage where we bring the widget on screen.
 ///
 /// ### Without Offstage

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2684,7 +2684,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///       ),
 ///     );
 ///   }
-/// }
+///
 /// ```
 ///
 /// {@end-tool}
@@ -2708,7 +2708,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///       ),
 ///     );
 ///   }
-/// }
+///
 /// ```
 ///
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2672,15 +2672,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// Without Offstage:
 ///
 /// ```dart
-/// import 'package:flutter/material.dart';
 ///
-/// void main() {
-///   runApp(MyApp());
-/// }
-///
-/// class MyApp extends StatelessWidget {
-///
-///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
 ///       home: Scaffold(
@@ -2702,15 +2694,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// With Offstage:
 ///
 /// ```dart
-/// import 'package:flutter/material.dart';
 ///
-/// void main() {
-///   runApp(MyApp());
-/// }
-///
-/// class MyApp extends StatelessWidget {
-///
-///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
 ///       home: Scaffold(


### PR DESCRIPTION
## Description

Added sample code snippets for explaining the usage of Offstage in api docs with simple examples to help the user understand the usage of Offstage.

## Related Issues

Fixes #62737

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
