### PR TITLE
Move away from deprecated NoSuchMethodError to NoSuchMethodError.withInvocation

### DIFF
--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -178,7 +178,8 @@ Future<void> main() async {
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
       exception: exception,
     ));
-    expect(console.join('\n'), 'Another exception was thrown: NoSuchMethodError: int has no foo method accepting arguments (_, _)');
+    expect(console.join('\n'),
+      'Another exception was thrown: NoSuchMethodError: int has no foo method accepting arguments (_, _)');
     console.clear();
     FlutterError.resetErrorCount();
   });

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -162,22 +162,23 @@ Future<void> main() async {
 
   test('Error reporting - NoSuchMethodError', () async {
     expect(console, isEmpty);
-    final dynamic exception = NoSuchMethodError(5, #foo, <dynamic>[2, 4], null); // ignore: deprecated_member_use
+    final dynamic exception = new NoSuchMethodError.withInvocation(5,
+        new Invocation.method(#foo, <dynamic>[2, 4]));
+
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
       exception: exception,
     ));
     expect(console.join('\n'), matches(
       r'^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
       r'The following NoSuchMethodError was thrown:\n'
-      r'Receiver: 5\n'
-      r'Tried calling: foo = 2, 4\n'
+      r'int has no foo method accepting arguments \(_, _\)\n'
       r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
       exception: exception,
     ));
-    expect(console.join('\n'), 'Another exception was thrown: NoSuchMethodError: Receiver: 5');
+    expect(console.join('\n'), 'Another exception was thrown: NoSuchMethodError: int has no foo method accepting arguments (_, _)');
     console.clear();
     FlutterError.resetErrorCount();
   });

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -162,8 +162,8 @@ Future<void> main() async {
 
   test('Error reporting - NoSuchMethodError', () async {
     expect(console, isEmpty);
-    final dynamic exception = new NoSuchMethodError.withInvocation(5,
-        new Invocation.method(#foo, <dynamic>[2, 4]));
+    final dynamic exception = NoSuchMethodError.withInvocation(5,
+        Invocation.method(#foo, <dynamic>[2, 4]));
 
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
       exception: exception,


### PR DESCRIPTION
## Description

`NoSuchMethodError` constructor was deprecated, migrate flutter test to `NoSuchMethodError.withInvocation`.

Fixes https://github.com/dart-lang/sdk/issues/33144

Underlying issue https://github.com/dart-lang/sdk/issues/33124 was fixed in May, 2020, but use of deprecated method in flutter remained. This PR moves flutter away from deprecated method.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
