### PR TITLE
Corrected the required fields in the constructors.

### DIFF
--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -146,7 +146,7 @@ abstract class Gradient {
   /// no other rotation or perspective transformations have been applied to the
   /// [Canvas]. If null, no transformation is applied.
   const Gradient({
-    required this.colors,
+    @required this.colors,
     this.stops,
     this.transform,
   }) : assert(colors != null);
@@ -366,7 +366,7 @@ class LinearGradient extends Gradient {
   const LinearGradient({
     this.begin = Alignment.centerLeft,
     this.end = Alignment.centerRight,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     GradientTransform? transform,
@@ -596,7 +596,7 @@ class RadialGradient extends Gradient {
   const RadialGradient({
     this.center = Alignment.center,
     this.radius = 0.5,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     this.focal,
@@ -872,7 +872,7 @@ class SweepGradient extends Gradient {
     this.center = Alignment.center,
     this.startAngle = 0.0,
     this.endAngle = math.pi * 2,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     GradientTransform? transform,


### PR DESCRIPTION
Errors were showing in VS Code because the constructor argument for the list of colors was marked with 'required' instead of '@required'

### Description
Simply changed 'required' to '@required' in the constructors.

### Related Issues
Issue #63908