### PR TITLE
enable soft transition when adding switch control accessibility feature flag

### DIFF
--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1000,6 +1000,10 @@ class MockAccessibilityFeature implements AccessibilityFeatures {
 
   @override
   bool get reduceMotion => true;
+
+  @override
+  // ignore: override_on_non_overriding_member
+  bool get switchControl => true;
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1001,6 +1001,8 @@ class MockAccessibilityFeature implements AccessibilityFeatures {
   @override
   bool get reduceMotion => true;
 
+  // TODO(chunhtai): remove this ignore once engine side is merged,
+  // https://github.com/flutter/flutter/issues/37974.
   @override
   // ignore: override_on_non_overriding_member
   bool get switchControl => true;


### PR DESCRIPTION
## Description

The engine side changes https://github.com/flutter/engine/pull/20566 will fail a framework test, this pr enables the soft transition.

This workaround should be removed as part of https://github.com/flutter/flutter/pull/63986

## Related Issues

https://github.com/flutter/flutter/issues/37974

## Tests

I added the following tests:

Temporary work around that will be removed later, the test of adding a new accessibility feature will be in both engine and framework pr that are to be merged later.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
