### PR TITLE
Increase simple animation delay and duration

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/simple_animation_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/simple_animation_perf_test.dart
@@ -10,5 +10,7 @@ void main() {
   macroPerfTest(
     'simple_animation_perf',
     kSimpleAnimationRouteName,
+    pageDelay: const Duration(seconds: 10),
+    duration: const Duration(seconds: 10),
   );
 }


### PR DESCRIPTION
Previously, the CPU/GPU measurement using gauge happened after the
driver test is done. Now, the measurement happens within the driver
test. So we need to properly increase the delay and duration to get a
comparable reading as the old gauge measurements.
