### PR TITLE
[devicelab] Enable a LUCI try builder.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -98,7 +98,6 @@ tasks:
       Gallery for iOS from Mac.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    on_luci: true
 
   flutter_gallery_win__compile:
     description: >
@@ -467,6 +466,7 @@ tasks:
       Builds an obfuscated app and verifies contents and structure
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
+    on_luci: true
 
   tiles_scroll_perf_ios__timeline_summary:
     description: >

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -79,10 +79,16 @@
          "enabled":true
       },
       {
-         "name": "Windows tool_tests",
-         "repo": "flutter",
-         "task_name": "win_tool_tests",
-         "enabled":true
+        "name": "Windows tool_tests",
+        "repo": "flutter",
+        "task_name": "win_tool_tests",
+        "enabled":true
+      },
+      {
+        "name": "testonly_devicelab_tests",
+        "repo": "flutter",
+        "taskName": "testonly_devicelab_tests",
+        "enabled": true
       }
    ]
 }


### PR DESCRIPTION
This will allow us to run devicelab tests on LUCI in presubmit, which provides a better log viewer.

As the capacity is limited, we will only add a small amount of tests in the beginning. The selected tests are fast and stable, and they cover different configurations:
- android_defines_test: linux/android
- flavors_test: mac/android
- ios_content_validation_test: mac/ios

Example build: https://chromium-swarm.appspot.com/task?id=4e1771414675dc10, which takes about 7 minutes.

Bug: https://github.com/flutter/flutter/issues/64003

