### PR TITLE
ClipboardStatusNotifier should handle errors in Clipboard.getData

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1512,7 +1512,7 @@ class ClipboardStatusNotifier extends ValueNotifier<ClipboardStatus> with Widget
   bool get disposed => _disposed;
 
   /// Check the [Clipboard] and update [value] if needed.
-  void update() {
+  void update() async {
     // iOS 14 added a notification that appears when an app accesses the
     // clipboard. To avoid the notification, don't access the clipboard on iOS,
     // and instead always shown the paste button, even when the clipboard is
@@ -1532,15 +1532,26 @@ class ClipboardStatusNotifier extends ValueNotifier<ClipboardStatus> with Widget
         break;
     }
 
-    Clipboard.getData(Clipboard.kTextPlain).then((ClipboardData data) {
-      final ClipboardStatus clipboardStatus = data != null && data.text != null && data.text.isNotEmpty
-          ? ClipboardStatus.pasteable
-          : ClipboardStatus.notPasteable;
-      if (_disposed || clipboardStatus == value) {
+    ClipboardData data;
+    try {
+      data = await Clipboard.getData(Clipboard.kTextPlain);
+    } catch (stacktrace) {
+      // In the case of an error from the Clipboard API, set the value to
+      // unknown so that it will try to update again later.
+      if (_disposed || value == ClipboardStatus.unknown) {
         return;
       }
-      value = clipboardStatus;
-    });
+      value = ClipboardStatus.unknown;
+      return;
+    }
+
+    final ClipboardStatus clipboardStatus = data != null && data.text != null && data.text.isNotEmpty
+        ? ClipboardStatus.pasteable
+        : ClipboardStatus.notPasteable;
+    if (_disposed || clipboardStatus == value) {
+      return;
+    }
+    value = clipboardStatus;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1512,7 +1512,7 @@ class ClipboardStatusNotifier extends ValueNotifier<ClipboardStatus> with Widget
   bool get disposed => _disposed;
 
   /// Check the [Clipboard] and update [value] if needed.
-  void update() async {
+  Future<void> update() async {
     // iOS 14 added a notification that appears when an app accesses the
     // clipboard. To avoid the notification, don't access the clipboard on iOS,
     // and instead always shown the paste button, even when the clipboard is


### PR DESCRIPTION
## Description

Some very rare errors were reported in ClipboardStatusNotifier.  This PR attempts to avoid them by handling errors that come from Clipboard.getData.

I'm not sure what could cause Clipboard.getData to throw an error, but we should handle that case anyway.

## Related Issues

Somewhat related to https://github.com/flutter/flutter/issues/60145
Problem originally brought up in chat.

## Tests

I added the following tests:

  * Test that a mocked Clipboard that throws an error doesn't cause ClipboardStatusNotifier to throw an error.
  * Test the success case as well.

## Breaking Change

Not a breaking change, but the return type of ClipboardStatusNotifier.update() was changed from void to a Future, as it should be for an async operation.