### PR TITLE
macrobenchmarks remove duplicate e2e driver

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
@@ -3,55 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
-import 'package:e2e/common.dart' as e2e;
-import 'package:flutter_driver/flutter_driver.dart';
+import 'package:e2e/e2e_driver.dart' as driver;
 
-import 'package:path/path.dart' as path;
-
-const JsonEncoder _prettyEncoder = JsonEncoder.withIndent('  ');
-
-/// Flutter Driver test output directory.
-///
-/// Tests should write any output files to this directory. Defaults to the path
-/// set in the FLUTTER_TEST_OUTPUTS_DIR environment variable, or `build` if
-/// unset.
-String testOutputsDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? 'build';
-
-String testOutputFilename = 'e2e_perf_summary';
-
-Future<void> main() async {
-  final FlutterDriver driver = await FlutterDriver.connect();
-  final String jsonResult =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
-  final e2e.Response response = e2e.Response.fromJson(jsonResult);
-  await driver.close();
-
-  if (response.allTestsPassed) {
-    print('All tests passed.');
-
-    await fs.directory(testOutputsDirectory).create(recursive: true);
-    final File file = fs.file(path.join(
-      testOutputsDirectory,
-      '$testOutputFilename.json'
-    ));
-    final String resultString = _encodeJson(
-      response.data['performance'] as Map<String, dynamic>,
-      true,
+Future<void> main() => driver.e2eDriver(
+  timeout: const Duration(minutes: 5),
+  responseDataCallback: (Map<String, dynamic> data) async {
+    await driver.writeResponseData(
+      data['performance'] as Map<String, dynamic>,
+      testOutputFilename: 'e2e_perf_summary',
     );
-    await file.writeAsString(resultString);
-
-    exit(0);
-  } else {
-    print('Failure Details:\n${response.formattedFailureDetails}');
-    exit(1);
   }
-}
-
-String _encodeJson(Map<String, dynamic> jsonObject, bool pretty) {
-  return pretty
-    ? _prettyEncoder.convert(jsonObject)
-    : json.encode(jsonObject);
-}
+);


### PR DESCRIPTION
## Description

The e2e driver part has been moved to e2e package. Remove the duplicate in macrobenchmarks. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
