### PR TITLE
[flutter_tool] Fix amberctl host address

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/amber_ctl.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/amber_ctl.dart
@@ -58,25 +58,30 @@ class FuchsiaAmberCtl {
   /// Teaches the amber instance running on [device] about the Fuchsia package
   /// server accessible via [configUrl].
   Future<bool> addSrc(FuchsiaDevice device, FuchsiaPackageServer server) async {
-    final String configUrl = '${server.interfaceStrippedUrl}/config.json';
-    final RunResult result =
-        await device.shell('amber_ctl add_src -x -f $configUrl');
+    final String localIp = await device.hostAddress;
+    final String configUrl = 'http://[$localIp]:${server.port}/config.json';
+    final RunResult result = await device.shell(
+      'amber_ctl add_src -x -f $configUrl',
+    );
     return result.exitCode == 0;
   }
 
   /// Instructs the amber instance running on [device] to forget about the
   /// Fuchsia package server that it was accessing via [serverUrl].
   Future<bool> rmSrc(FuchsiaDevice device, FuchsiaPackageServer server) async {
-    final RunResult result =
-        await device.shell('amber_ctl rm_src -n ${server.interfaceStrippedUrl}');
+    final String localIp = await device.hostAddress;
+    final RunResult result = await device.shell(
+      'amber_ctl rm_src -n http://[$localIp]:${server.port}/',
+    );
     return result.exitCode == 0;
   }
 
   /// Instructs the amber instance running on [device] to prefetch the package
   /// [packageName].
   Future<bool> getUp(FuchsiaDevice device, String packageName) async {
-    final RunResult result =
-        await device.shell('amber_ctl get_up -n $packageName');
+    final RunResult result = await device.shell(
+      'amber_ctl get_up -n $packageName',
+    );
     return result.exitCode == 0;
   }
 
@@ -84,15 +89,21 @@ class FuchsiaAmberCtl {
   /// pkg_resolver repo config, and teaches the pkg_resolver instance running
   /// on [device] about the [FuchsiaPackageServer].
   Future<bool> addRepoCfg(FuchsiaDevice device, FuchsiaPackageServer server) async {
-    final String configUrl = '${server.interfaceStrippedUrl}/config.json';
-    final RunResult result =
-        await device.shell('amber_ctl add_repo_cfg -n ${server.name} -f $configUrl');
+    final String localIp = await device.hostAddress;
+    final String configUrl = 'http://[$localIp]:${server.port}/config.json';
+    final RunResult result = await device.shell(
+      'amber_ctl add_repo_cfg -n ${server.name} -f $configUrl',
+    );
     return result.exitCode == 0;
   }
 
   /// Instructs the pkg_resolver instance running on [device] to prefetch the
   /// package [packageName].
-  Future<bool> pkgCtlResolve(FuchsiaDevice device, FuchsiaPackageServer server, String packageName) async {
+  Future<bool> pkgCtlResolve(
+    FuchsiaDevice device,
+    FuchsiaPackageServer server,
+    String packageName,
+  ) async {
     final String packageUrl = 'fuchsia-pkg://${server.name}/$packageName';
     final RunResult result = await device.shell('pkgctl resolve $packageUrl');
     return result.exitCode == 0;
@@ -100,7 +111,10 @@ class FuchsiaAmberCtl {
 
   /// Instructs the pkg_resolver instance running on [device] to forget about
   /// the Fuchsia package server that it was accessing via [serverUrl].
-  Future<bool> pkgCtlRepoRemove(FuchsiaDevice device, FuchsiaPackageServer server) async {
+  Future<bool> pkgCtlRepoRemove(
+    FuchsiaDevice device,
+    FuchsiaPackageServer server,
+  ) async {
     final String repoUrl = 'fuchsia-pkg://${server.name}';
     final RunResult result = await device.shell('pkgctl repo rm $repoUrl');
     return result.exitCode == 0;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -195,19 +195,10 @@ class FuchsiaPackageServer {
 
   Process _process;
 
-  /// The URL that can be used by the device to access this package server.
-  String get url => Uri(scheme: 'http', host: _host, port: _port).toString();
-
-  /// The URL that is stripped of interface name if it is an ipv6 address,
-  /// which should be supplied to amber_ctl to configure access to host.
-  String get interfaceStrippedUrl => Uri(
-    scheme: 'http',
-    host: (isIPv6Address(_host.split('%').first)) ? '[${_host.split('%').first}]' : _host,
-    port: _port,
-  ).toString();
-
   // The name used to reference the server by fuchsia-pkg:// urls.
   final String name;
+
+  int get port => _port;
 
   /// Uses [FuchiaPM.newrepo] and [FuchsiaPM.serve] to spin up a new Fuchsia
   /// package server.

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -246,6 +246,47 @@ void main() {
       FuchsiaSdk: () => MockFuchsiaSdk(),
       ProcessManager: () => MockProcessManager(),
     });
+
+    testUsingContext('hostAddress parsing works', () async {
+      when(globals.processManager.run(any)).thenAnswer((Invocation _) async {
+        return ProcessResult(
+          1,
+          0,
+          'fe80::8c6c:2fff:fe3d:c5e1%ethp0003 50666 fe80::5054:ff:fe63:5e7a%ethp0003 22',
+          '',
+        );
+      });
+      final FuchsiaDevice device = FuchsiaDevice('id');
+      expect(await device.hostAddress, 'fe80::8c6c:2fff:fe3d:c5e1%25ethp0003');
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      FuchsiaSdk: () => MockFuchsiaSdk(),
+      ProcessManager: () => MockProcessManager(),
+    });
+
+    testUsingContext('hostAddress parsing throws tool error on failure', () async {
+      when(globals.processManager.run(any)).thenAnswer((Invocation _) async {
+        return ProcessResult(1, 1, '', '');
+      });
+      final FuchsiaDevice device = FuchsiaDevice('id');
+      expect(() async => await device.hostAddress, throwsToolExit());
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      FuchsiaSdk: () => MockFuchsiaSdk(),
+      ProcessManager: () => MockProcessManager(),
+    });
+
+    testUsingContext('hostAddress parsing throws tool error on empty response', () async {
+      when(globals.processManager.run(any)).thenAnswer((Invocation _) async {
+        return ProcessResult(1, 0, '', '');
+      });
+      final FuchsiaDevice device = FuchsiaDevice('id');
+      expect(() async => await device.hostAddress, throwsToolExit());
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      FuchsiaSdk: () => MockFuchsiaSdk(),
+      ProcessManager: () => MockProcessManager(),
+    });
   });
 
   group('displays friendly error when', () {

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -71,21 +71,6 @@ void main() {
       FuchsiaArtifacts: () => mockFuchsiaArtifacts,
       ProcessManager: () => mockProcessManager,
     });
-
-    testWithoutContext('ipv6 formatting logic of FuchsiaPackageServer', () {
-      const String host = 'fe80::ec4:7aff:fecc:ea8f%eno2';
-      const int port = 23;
-
-      expect(
-        FuchsiaPackageServer('a', 'b', host, port).url,
-        'http://[fe80::ec4:7aff:fecc:ea8f%25eno2]:23',
-      );
-
-      expect(
-        FuchsiaPackageServer('a', 'b', host, port).interfaceStrippedUrl,
-        'http://[fe80::ec4:7aff:fecc:ea8f]:23',
-      );
-    });
   });
 }
 


### PR DESCRIPTION
This PR updates the way that the tool determines by which address a Fuchsia device should name the package server that the tool starts. In particular, it updates it to match what `fuchsia_ctl` does. I have tested manually with Fuchsia's `terminal` configuration running under FEMU.

Unit test in fuchsia_device_test.dart.