### PR TITLE
Use real flutter root for finding pub in command integration test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:mockito/mockito.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -17,13 +18,16 @@ import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/dart/analysis.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
+  setUpAll(() {
+    Cache.flutterRoot = getFlutterRoot();
+  });
+
   AnalysisServer server;
   Directory tempDir;
   FileSystem fileSystem;
@@ -33,13 +37,11 @@ void main() {
   Logger logger;
 
   setUp(() {
-    platform = const LocalPlatform();
     fileSystem = LocalFileSystem.instance;
     platform = const LocalPlatform();
     processManager = const LocalProcessManager();
     terminal = AnsiTerminal(platform: platform, stdio: Stdio());
     logger = BufferLogger(outputPreferences: OutputPreferences.test(), terminal: terminal);
-    FlutterCommandRunner.initFlutterRoot();
     tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_analysis_test.');
   });
 


### PR DESCRIPTION
## Description


This "hermetic" test uses real pub.

`FlutterCommandRunner.initFlutterRoot();` was setting the cache root to `../..`.  
`analyze_continuously_test` runs `pub get` relative to the temp directory, and `../../bin/cache/dart-sdk/bin/pub` doesn't exist there.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64008

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*