### PR TITLE
Incorrect path.join usage might be causing Windows test failures

### DIFF
--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -254,7 +254,7 @@ Future<void> main() async {
 
       section('Check file access modes for read-only asset from Flutter module');
 
-      final String readonlyDebugAssetFilePath = path.join(
+      final String readonlyDebugAssetFilePath = path.joinAll(<String>[
         hostApp.path,
         'SampleApp',
         'build',
@@ -262,10 +262,10 @@ Future<void> main() async {
         'merged_assets',
         'debug',
         'out',
-        'flutter_assets'
-        'assets'
+        'flutter_assets',
+        'assets',
         'read-only.txt',
-      );
+      ]);
       final File readonlyDebugAssetFile = File(readonlyDebugAssetFilePath);
       if (!exists(readonlyDebugAssetFile)) {
         return TaskResult.failure('Failed to copy read-only asset file');
@@ -326,7 +326,7 @@ Future<void> main() async {
 
       section('Check file access modes for read-only asset from Flutter module');
 
-      final String readonlyReleaseAssetFilePath = path.join(
+      final String readonlyReleaseAssetFilePath = path.joinAll(<String>[
         hostApp.path,
         'SampleApp',
         'build',
@@ -337,7 +337,7 @@ Future<void> main() async {
         'flutter_assets',
         'assets',
         'read-only.txt',
-      );
+      ]);
       final File readonlyReleaseAssetFile = File(readonlyReleaseAssetFilePath);
       if (!exists(readonlyReleaseAssetFile)) {
         return TaskResult.failure('Failed to copy read-only asset file');

--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -42,7 +42,8 @@ Future<void> main() async {
 
       final File readonlyTxtAssetFile = await File(path.join(
         projectDir.path,
-        'assets/read-only.txt'
+        'assets',
+        'read-only.txt'
       ))
       .create(recursive: true);
 
@@ -261,7 +262,9 @@ Future<void> main() async {
         'merged_assets',
         'debug',
         'out',
-        'flutter_assets/assets/read-only.txt',
+        'flutter_assets'
+        'assets'
+        'read-only.txt',
       );
       final File readonlyDebugAssetFile = File(readonlyDebugAssetFilePath);
       if (!exists(readonlyDebugAssetFile)) {
@@ -331,7 +334,9 @@ Future<void> main() async {
         'merged_assets',
         'release',
         'out',
-        'flutter_assets/assets/read-only.txt',
+        'flutter_assets',
+        'assets',
+        'read-only.txt',
       );
       final File readonlyReleaseAssetFile = File(readonlyReleaseAssetFilePath);
       if (!exists(readonlyReleaseAssetFile)) {

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -254,7 +254,7 @@ Future<void> main() async {
 
       section('Check file access modes for read-only asset from Flutter module');
 
-      final String readonlyDebugAssetFilePath = path.join(
+      final String readonlyDebugAssetFilePath = path.joinAll(<String>[
         hostApp.path,
         'app',
         'build',
@@ -265,7 +265,7 @@ Future<void> main() async {
         'flutter_assets',
         'assets',
         'read-only.txt',
-      );
+      ]);
       final File readonlyDebugAssetFile = File(readonlyDebugAssetFilePath);
       if (!exists(readonlyDebugAssetFile)) {
         return TaskResult.failure('Failed to copy read-only asset file');
@@ -326,7 +326,7 @@ Future<void> main() async {
 
       section('Check file access modes for read-only asset from Flutter module');
 
-      final String readonlyReleaseAssetFilePath = path.join(
+      final String readonlyReleaseAssetFilePath = path.joinAll(<String>[
         hostApp.path,
         'app',
         'build',
@@ -337,7 +337,7 @@ Future<void> main() async {
         'flutter_assets',
         'assets',
         'read-only.txt',
-      );
+      ]);
       final File readonlyReleaseAssetFile = File(readonlyReleaseAssetFilePath);
       if (!exists(readonlyReleaseAssetFile)) {
         return TaskResult.failure('Failed to copy read-only asset file');

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -42,7 +42,8 @@ Future<void> main() async {
 
       final File readonlyTxtAssetFile = await File(path.join(
         projectDir.path,
-        'assets/read-only.txt'
+        'assets',
+        'read-only.txt'
       ))
       .create(recursive: true);
 
@@ -261,7 +262,9 @@ Future<void> main() async {
         'merged_assets',
         'debug',
         'out',
-        'flutter_assets/assets/read-only.txt',
+        'flutter_assets',
+        'assets',
+        'read-only.txt',
       );
       final File readonlyDebugAssetFile = File(readonlyDebugAssetFilePath);
       if (!exists(readonlyDebugAssetFile)) {
@@ -331,7 +334,9 @@ Future<void> main() async {
         'merged_assets',
         'release',
         'out',
-        'flutter_assets/assets/read-only.txt',
+        'flutter_assets',
+        'assets',
+        'read-only.txt',
       );
       final File readonlyReleaseAssetFile = File(readonlyReleaseAssetFilePath);
       if (!exists(readonlyReleaseAssetFile)) {


### PR DESCRIPTION
I'm guessing this incorrect path.join usage is causing LUCI failures on windows like https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8871652713241732960/+/steps/run_test.dart_for_hostonly_devicelab_tests_shard_and_subshard_3_last/0/stdout