### PR TITLE
[null-safety] enable null assertions for framework tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -538,7 +538,7 @@ Future<void> _runAddToAppLifeCycleTests() async {
 
 Future<void> _runFrameworkTests() async {
   final bq.BigqueryApi bigqueryApi = await _getBigqueryApi();
-  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable'];
+  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable', '--null-assertions'];
   final List<String> trackWidgetCreationAlternatives = <String>['--track-widget-creation', '--no-track-widget-creation'];
 
   Future<void> runWidgets() async {

--- a/packages/flutter/lib/src/services/raw_keyboard_web.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_web.dart
@@ -36,7 +36,7 @@ class RawKeyEventDataWeb extends RawKeyEventData {
   ///
   /// See <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key>
   /// for more information.
-  final String key;
+  final String? key;
 
   /// The modifiers that were present when the key event occurred.
   ///
@@ -56,7 +56,7 @@ class RawKeyEventDataWeb extends RawKeyEventData {
   final int metaState;
 
   @override
-  String get keyLabel => key;
+  String? get keyLabel => key;
 
   @override
   PhysicalKeyboardKey get physicalKey {

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -149,7 +149,7 @@ void main() {
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
-    expect(() { painter.paint(null, Offset.zero); }, throwsFlutterError);
+    expect(() { painter.paint(null, Offset.zero); }, anyOf(throwsFlutterError, throwsAssertionError));
   });
 
   test('TextPainter requires textDirection', () {

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -6,8 +6,7 @@
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
-
-import '../flutter_test_alternative.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('TextSpan equals', () {
@@ -44,7 +43,6 @@ void main() {
             TextSpan(),
           ],
         ),
-        null,
         TextSpan(
           text: 'c',
         ),
@@ -59,7 +57,6 @@ void main() {
       '    "b"\n'
       '    TextSpan:\n'
       '      (empty)\n'
-      '  <null child>\n'
       '  TextSpan:\n'
       '    "c"\n'
     ));
@@ -245,21 +242,7 @@ void main() {
         null,
       ],
     );
-    FlutterError error;
-    try {
-      text.computeToPlainText(StringBuffer());
-    } on FlutterError catch (e) {
-      error = e;
-    }
-    expect(error, isNotNull);
-    expect(error.toStringDeep(),
-      'FlutterError\n'
-      '   TextSpan contains a null child.\n'
-      '   A TextSpan object with a non-null child list should not have any\n'
-      '   nulls in its child list.\n'
-      '   The full text in question was:\n'
-      '     TextSpan("foo bar")\n'
-    );
+    expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
   });
 
 }


### PR DESCRIPTION
## Description

Run framework tests with --null-assertions enabled.  https://github.com/flutter/flutter/issues/61042