### PR TITLE
Revert "Ensure time picker input mode lays out correctly in RTL"

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1414,68 +1414,58 @@ class _TimePickerInputState extends State<_TimePickerInput> {
                 ),
                 const SizedBox(width: 12.0),
               ],
-              Expanded(
-                child: Row(
-                  // Hour/minutes should not change positions in RTL locales.
-                  textDirection: TextDirection.ltr,
-                  children: <Widget>[
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          const SizedBox(height: 8.0),
-                          _HourTextField(
-                            selectedTime: _selectedTime,
-                            style: hourMinuteStyle,
-                            validator: _validateHour,
-                            onSavedSubmitted: _handleHourSavedSubmitted,
-                            onChanged: _handleHourChanged,
-                          ),
-                          const SizedBox(height: 8.0),
-                          if (!hourHasError && !minuteHasError)
-                            ExcludeSemantics(
-                              child: Text(
-                                MaterialLocalizations.of(context).timePickerHourLabel,
-                                style: theme.textTheme.caption,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                        ],
+              Expanded(child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const SizedBox(height: 8.0),
+                  _HourMinuteTextField(
+                    selectedTime: _selectedTime,
+                    isHour: true,
+                    style: hourMinuteStyle,
+                    validator: _validateHour,
+                    onSavedSubmitted: _handleHourSavedSubmitted,
+                    onChanged: _handleHourChanged,
+                  ),
+                  const SizedBox(height: 8.0),
+                  if (!hourHasError && !minuteHasError)
+                    ExcludeSemantics(
+                      child: Text(
+                        MaterialLocalizations.of(context).timePickerHourLabel,
+                        style: theme.textTheme.caption,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 8.0),
-                      height: _kTimePickerHeaderControlHeight,
-                      child: _StringFragment(timeOfDayFormat: timeOfDayFormat),
-                    ),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          const SizedBox(height: 8.0),
-                          _MinuteTextField(
-                            selectedTime: _selectedTime,
-                            style: hourMinuteStyle,
-                            validator: _validateMinute,
-                            onSavedSubmitted: _handleMinuteSavedSubmitted,
-                          ),
-                          const SizedBox(height: 8.0),
-                          if (!hourHasError && !minuteHasError)
-                            ExcludeSemantics(
-                              child: Text(
-                                MaterialLocalizations.of(context).timePickerMinuteLabel,
-                                style: theme.textTheme.caption,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
+                ],
+              )),
+              Container(
+                margin: const EdgeInsets.only(top: 8.0),
+                height: _kTimePickerHeaderControlHeight,
+                child: _StringFragment(timeOfDayFormat: timeOfDayFormat),
               ),
+              Expanded(child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const SizedBox(height: 8.0),
+                  _HourMinuteTextField(
+                    selectedTime: _selectedTime,
+                    isHour: false,
+                    style: hourMinuteStyle,
+                    validator: _validateMinute,
+                    onSavedSubmitted: _handleMinuteSavedSubmitted,
+                  ),
+                  const SizedBox(height: 8.0),
+                  if (!hourHasError && !minuteHasError)
+                    ExcludeSemantics(
+                      child: Text(
+                        MaterialLocalizations.of(context).timePickerMinuteLabel,
+                        style: theme.textTheme.caption,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                ],
+              )),
               if (!use24HourDials && timeOfDayFormat != TimeOfDayFormat.a_space_h_colon_mm) ...<Widget>[
                 const SizedBox(width: 12.0),
                 _DayPeriodControl(
@@ -1495,61 +1485,6 @@ class _TimePickerInputState extends State<_TimePickerInput> {
             const SizedBox(height: 2.0),
         ],
       ),
-    );
-  }
-}
-
-class _HourTextField extends StatelessWidget {
-  const _HourTextField({
-    Key key,
-    @required this.selectedTime,
-    @required this.style,
-    @required this.validator,
-    @required this.onSavedSubmitted,
-    @required this.onChanged,
-  }) : super(key: key);
-
-  final TimeOfDay selectedTime;
-  final TextStyle style;
-  final FormFieldValidator<String> validator;
-  final ValueChanged<String> onSavedSubmitted;
-  final ValueChanged<String> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return _HourMinuteTextField(
-      selectedTime: selectedTime,
-      isHour: true,
-      style: style,
-      validator: validator,
-      onSavedSubmitted: onSavedSubmitted,
-      onChanged: onChanged,
-    );
-  }
-}
-
-class _MinuteTextField extends StatelessWidget {
-  const _MinuteTextField({
-    Key key,
-    @required this.selectedTime,
-    @required this.style,
-    @required this.validator,
-    @required this.onSavedSubmitted,
-  }) : super(key: key);
-
-  final TimeOfDay selectedTime;
-  final TextStyle style;
-  final FormFieldValidator<String> validator;
-  final ValueChanged<String> onSavedSubmitted;
-
-  @override
-  Widget build(BuildContext context) {
-    return _HourMinuteTextField(
-      selectedTime: selectedTime,
-      isHour: false,
-      style: style,
-      validator: validator,
-      onSavedSubmitted: onSavedSubmitted,
     );
   }
 }

--- a/packages/flutter_localizations/test/material/time_picker_test.dart
+++ b/packages/flutter_localizations/test/material/time_picker_test.dart
@@ -8,16 +8,10 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _TimePickerLauncher extends StatelessWidget {
-  const _TimePickerLauncher({
-    Key key,
-    this.onChanged,
-    this.locale,
-    this.entryMode = TimePickerEntryMode.dial,
-  }) : super(key: key);
+  const _TimePickerLauncher({ Key key, this.onChanged, this.locale }) : super(key: key);
 
   final ValueChanged<TimeOfDay> onChanged;
   final Locale locale;
-  final TimePickerEntryMode entryMode;
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +28,6 @@ class _TimePickerLauncher extends StatelessWidget {
                 onPressed: () async {
                   onChanged(await showTimePicker(
                     context: context,
-                    initialEntryMode: entryMode,
                     initialTime: const TimeOfDay(hour: 7, minute: 0),
                   ));
                 },
@@ -212,73 +205,6 @@ void main() {
 
     tester.binding.window.physicalSizeTestValue = null;
     tester.binding.window.devicePixelRatioTestValue = null;
-  });
-
-  testWidgets('can localize input mode in all known formats', (WidgetTester tester) async {
-    final Finder stringFragmentTextFinder = find.descendant(
-      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_StringFragment'),
-      matching: find.byType(Text),
-    ).first;
-    final Finder hourControlFinder = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_HourTextField');
-    final Finder minuteControlFinder = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_MinuteTextField');
-    final Finder dayPeriodControlFinder = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodControl');
-
-    // TODO(yjbanov): also test `HH.mm` (in_ID), `a h:mm` (ko_KR) and `HH:mm น.` (th_TH) when we have .arb files for them
-    final List<Locale> locales = <Locale>[
-      const Locale('en', 'US'), //'h:mm a'
-      const Locale('en', 'GB'), //'HH:mm'
-      const Locale('es', 'ES'), //'H:mm'
-      const Locale('fr', 'CA'), //'HH \'h\' mm'
-      const Locale('zh', 'ZH'), //'ah:mm'
-      const Locale('fa', 'IR'), //'H:mm' but RTL
-    ];
-
-    for (final Locale locale in locales) {
-      await tester.pumpWidget(_TimePickerLauncher(onChanged: (TimeOfDay time) { }, locale: locale, entryMode: TimePickerEntryMode.input));
-      await tester.tap(find.text('X'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-
-      final Text stringFragmentText = tester.widget(stringFragmentTextFinder);
-      final double hourLeftOffset = tester.getTopLeft(hourControlFinder).dx;
-      final double minuteLeftOffset = tester.getTopLeft(minuteControlFinder).dx;
-      final double stringFragmentLeftOffset = tester.getTopLeft(stringFragmentTextFinder).dx;
-
-      if (locale == const Locale('en', 'US')) {
-        final double dayPeriodLeftOffset = tester.getTopLeft(dayPeriodControlFinder).dx;
-        expect(stringFragmentText.data, ':');
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-        expect(minuteLeftOffset, lessThan(dayPeriodLeftOffset));
-      } else if (locale == const Locale('en', 'GB')) {
-        expect(stringFragmentText.data, ':');
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-        expect(dayPeriodControlFinder, findsNothing);
-      } else if (locale == const Locale('es', 'ES')) {
-        expect(stringFragmentText.data, ':');
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-        expect(dayPeriodControlFinder, findsNothing);
-      } else if (locale == const Locale('fr', 'CA')) {
-        expect(stringFragmentText.data, 'h');
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-        expect(dayPeriodControlFinder, findsNothing);
-      } else if (locale == const Locale('zh', 'ZH')) {
-        final double dayPeriodLeftOffset = tester.getTopLeft(dayPeriodControlFinder).dx;
-        expect(stringFragmentText.data, ':');
-        expect(dayPeriodLeftOffset, lessThan(hourLeftOffset));
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-      } else if (locale == const Locale('fa', 'IR')) {
-        // Even though this is an RTL locale, the hours and minutes positions should remain the same.
-        expect(stringFragmentText.data, ':');
-        expect(hourLeftOffset, lessThan(stringFragmentLeftOffset));
-        expect(stringFragmentLeftOffset, lessThan(minuteLeftOffset));
-        expect(dayPeriodControlFinder, findsNothing);
-      }
-      await finishPicker(tester);
-    }
   });
 
   testWidgets('uses single-ring 24-hour dial for all formats', (WidgetTester tester) async {


### PR DESCRIPTION
Reverts flutter/flutter#63599

This was reverted because flutter/flutter#63599, the ":" separator became vertically offset from the hours and minutes because of the addition of a nested Row widget that didn't specify the crossAxisAlignment appropriately. This ended up being caught by internal screenshot tests and so was reverted.