### PR TITLE
InteractiveViewer child positioning docs

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -19,7 +19,22 @@ import 'ticker_provider.dart';
 ///
 /// The user can transform the child by dragging to pan or pinching to zoom.
 ///
+/// By default, InteractiveViewer may draw outside of its original area of the
+/// screen, such as when a child is zoomed in and increases in size. However, it
+/// will not receive gestures outside of its original area. To prevent
+/// InteractiveViewer from drawing outside of its original size, wrap it in a
+/// [ClipRect]. Or, to prevent dead areas where InteractiveViewer does not
+/// receive gestures, be sure that the InteractiveViewer widget is the size of
+/// the area that should be interactive. See
+/// [flutter-go](https://github.com/justinmc/flutter-go) for an example of
+/// robust positioning of an InteractiveViewer child that works for all screen
+/// sizes and child sizes.
+///
 /// The [child] must not be null.
+///
+/// See also:
+///   * The [Flutter Gallery's transformations demo](https://github.com/flutter/gallery/blob/master/lib/demos/reference/transformations_demo.dart),
+///     which includes the use of InteractiveViewer.
 ///
 /// {@tool dartpad --template=stateless_widget_scaffold}
 /// This example shows a simple Container that can be panned and zoomed.


### PR DESCRIPTION
## Description

It came up in an [issue](https://github.com/flutter/flutter/issues/63999#issuecomment-675645420) that it's very easy to create "dead zones" where InteractiveViewer is not interactive.  This PR adds some information in the docs about this to help users out, along with links to examples.

## Related Issues

https://github.com/flutter/flutter/issues/63999

## Tests

None, docs change.