### PR TITLE
Changes to initialDate for CalendarDatePicker should update the state.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -165,17 +165,13 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
   @override
   void initState() {
     super.initState();
-    _mode = widget.initialCalendarMode;
-    _currentDisplayedMonthDate = DateTime(widget.initialDate.year, widget.initialDate.month);
-    _selectedDate = widget.initialDate;
+    _initWidgetState();
   }
 
   @override
   void didUpdateWidget(CalendarDatePicker oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _mode = widget.initialCalendarMode;
-    _currentDisplayedMonthDate = DateTime(widget.initialDate.year, widget.initialDate.month);
-    _selectedDate = widget.initialDate;
+    _initWidgetState();
   }
 
   @override
@@ -183,6 +179,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
     super.didChangeDependencies();
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
+    assert(debugCheckHasDirectionality(context));
     _localizations = MaterialLocalizations.of(context);
     _textDirection = Directionality.of(context);
     if (!_announcedInitialDate) {
@@ -192,6 +189,12 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
         _textDirection,
       );
     }
+  }
+
+  void _initWidgetState() {
+    _mode = widget.initialCalendarMode;
+    _currentDisplayedMonthDate = DateTime(widget.initialDate.year, widget.initialDate.month);
+    _selectedDate = widget.initialDate;
   }
 
   void _vibrate() {
@@ -294,6 +297,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
+    assert(debugCheckHasDirectionality(context));
     return Stack(
       children: <Widget>[
         SizedBox(

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -12,6 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../color_scheme.dart';
+import '../debug.dart';
 import '../divider.dart';
 import '../icon_button.dart';
 import '../icons.dart';
@@ -170,8 +171,18 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
   }
 
   @override
+  void didUpdateWidget(CalendarDatePicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _mode = widget.initialCalendarMode;
+    _currentDisplayedMonthDate = DateTime(widget.initialDate.year, widget.initialDate.month);
+    _selectedDate = widget.initialDate;
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    assert(debugCheckHasMaterial(context));
+    assert(debugCheckHasMaterialLocalizations(context));
     _localizations = MaterialLocalizations.of(context);
     _textDirection = Directionality.of(context);
     if (!_announcedInitialDate) {
@@ -281,6 +292,8 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMaterial(context));
+    assert(debugCheckHasMaterialLocalizations(context));
     return Stack(
       children: <Widget>[
         SizedBox(
@@ -512,6 +525,14 @@ class _MonthPickerState extends State<_MonthPicker> {
     super.didChangeDependencies();
     _localizations = MaterialLocalizations.of(context);
     _textDirection = Directionality.of(context);
+  }
+
+  @override
+  void didUpdateWidget(_MonthPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialMonth != oldWidget.initialMonth) {
+      _showMonth(widget.initialMonth);
+    }
   }
 
   @override

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -825,6 +825,62 @@ void main() {
     });
   });
 
+  group('CalendarDatePicker', () {
+    // Tests for the standalone CalendarDatePicker class
+    testWidgets('Updates to initialDate parameter is reflected in the state', (WidgetTester tester) async {
+      final Key pickerKey = UniqueKey();
+      final DateTime initialDate = DateTime(2020, 1, 21);
+      final DateTime updatedDate = DateTime(1976, 2, 23);
+      const Color selectedColor = Color(0xff2196f3); // default primary color
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarDatePicker(
+            key: pickerKey,
+            initialDate: initialDate,
+            firstDate: DateTime(1970, 1, 1),
+            lastDate: DateTime(2099, 31, 12),
+            onDateChanged: (DateTime value) {},
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // Month should show as January 2020
+      expect(find.text('January 2020'), findsOneWidget);
+      // Selected date should be painted with a colored circle
+      expect(
+        Material.of(tester.element(find.text('21'))),
+        paints..circle(color: selectedColor, style: PaintingStyle.fill)
+      );
+
+      // Change to the updated initialDate
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarDatePicker(
+            key: pickerKey,
+            initialDate: updatedDate,
+            firstDate: DateTime(1970, 1, 1),
+            lastDate: DateTime(2099, 31, 12),
+            onDateChanged: (DateTime value) {},
+          ),
+        ),
+      ));
+      // Wait for the page scroll animation to finish
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // Month should show as February 1976
+      expect(find.text('January 2020'), findsNothing);
+      expect(find.text('February 1976'), findsOneWidget);
+      // Selected date should be painted with a colored circle
+      expect(
+          Material.of(tester.element(find.text('23'))),
+          paints..circle(color: selectedColor, style: PaintingStyle.fill)
+      );
+
+    });
+  });
+
   group('Haptic feedback', () {
     const Duration hapticFeedbackInterval = Duration(milliseconds: 10);
     FeedbackTester feedback;


### PR DESCRIPTION
## Description

If the `initialDate` parameter of `CalendarDatePicker()` changes as the results of actions outside the picker, the new selected date and displayed month won't be updated. This PR fixes that.

## Related Issues

Fixes: #64040

## Tests

I added a new test to check for this API specifically.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
