### PR TITLE
Revert "[null-safety] enable null assertions for framework tests"

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -538,7 +538,7 @@ Future<void> _runAddToAppLifeCycleTests() async {
 
 Future<void> _runFrameworkTests() async {
   final bq.BigqueryApi bigqueryApi = await _getBigqueryApi();
-  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable', '--null-assertions'];
+  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable'];
   final List<String> trackWidgetCreationAlternatives = <String>['--track-widget-creation', '--no-track-widget-creation'];
 
   Future<void> runWidgets() async {

--- a/packages/flutter/lib/src/services/raw_keyboard_web.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_web.dart
@@ -36,7 +36,7 @@ class RawKeyEventDataWeb extends RawKeyEventData {
   ///
   /// See <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key>
   /// for more information.
-  final String? key;
+  final String key;
 
   /// The modifiers that were present when the key event occurred.
   ///
@@ -56,7 +56,7 @@ class RawKeyEventDataWeb extends RawKeyEventData {
   final int metaState;
 
   @override
-  String? get keyLabel => key;
+  String get keyLabel => key;
 
   @override
   PhysicalKeyboardKey get physicalKey {

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -149,7 +149,7 @@ void main() {
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
-    expect(() { painter.paint(null, Offset.zero); }, anyOf(throwsFlutterError, throwsAssertionError));
+    expect(() { painter.paint(null, Offset.zero); }, throwsFlutterError);
   });
 
   test('TextPainter requires textDirection', () {

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -6,7 +6,8 @@
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart';
+
+import '../flutter_test_alternative.dart';
 
 void main() {
   test('TextSpan equals', () {
@@ -43,6 +44,7 @@ void main() {
             TextSpan(),
           ],
         ),
+        null,
         TextSpan(
           text: 'c',
         ),
@@ -57,6 +59,7 @@ void main() {
       '    "b"\n'
       '    TextSpan:\n'
       '      (empty)\n'
+      '  <null child>\n'
       '  TextSpan:\n'
       '    "c"\n'
     ));
@@ -242,7 +245,21 @@ void main() {
         null,
       ],
     );
-    expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
+    FlutterError error;
+    try {
+      text.computeToPlainText(StringBuffer());
+    } on FlutterError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error.toStringDeep(),
+      'FlutterError\n'
+      '   TextSpan contains a null child.\n'
+      '   A TextSpan object with a non-null child list should not have any\n'
+      '   nulls in its child list.\n'
+      '   The full text in question was:\n'
+      '     TextSpan("foo bar")\n'
+    );
   });
 
 }


### PR DESCRIPTION
Reverts flutter/flutter#64071

New test failures:
```
1:53 +891 ~12 -1: /b/s/w/ir/k/flutter/packages/flutter/test/rendering/simple_semantics_test.dart: only send semantics update if semantics have changed [E]                                            
  'package:flutter/src/semantics/semantics.dart': Failed assertion: line 0: 'value != null': is not true.
  dart:core                                             _AssertionError._throwNewNullAssertion
  package:flutter/src/semantics/semantics.dart          SemanticsConfiguration.explicitChildNodes=
  package:flutter/src/rendering/proxy_box.dart 4527:12  RenderSemanticsAnnotations.describeSemanticsConfiguration
  test/rendering/simple_semantics_test.dart 69:11       TestRender.describeSemanticsConfiguration
  package:flutter/src/rendering/object.dart 2524:7      RenderObject._semanticsConfiguration
  package:flutter/src/rendering/object.dart 1429:34     RenderObject.attach
  package:flutter/src/rendering/object.dart 3021:11     RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14     RenderObjectWithChildMixin.attach
  package:flutter/src/foundation/node.dart 132:13       AbstractNode.adoptChild
  package:flutter/src/rendering/object.dart 1290:11     RenderObject.adoptChild
  package:flutter/src/rendering/object.dart 3016:7      RenderObjectWithChildMixin.child=
  test/rendering/rendering_tester.dart 170:23           layout
  test/rendering/simple_semantics_test.dart 31:5        main.<fn>
```
```
01:55 +897 ~12 -2: /b/s/w/ir/k/flutter/packages/flutter/test/rendering/reattach_test.dart: objects can be detached and re-attached: layout [E]                                                         
  'package:flutter/src/semantics/semantics.dart': Failed assertion: line 0: 'value != null': is not true.
  dart:core                                               _AssertionError._throwNewNullAssertion
  package:flutter/src/semantics/semantics.dart            SemanticsConfiguration.explicitChildNodes=
  package:flutter/src/rendering/proxy_box.dart 4527:12    RenderSemanticsAnnotations.describeSemanticsConfiguration
  package:flutter/src/rendering/object.dart 2524:7        RenderObject._semanticsConfiguration
  package:flutter/src/rendering/object.dart 1429:34       RenderObject.attach
  package:flutter/src/rendering/object.dart 3021:11       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/custom_paint.dart 494:11  RenderCustomPaint.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/rendering/object.dart 3023:14       RenderObjectWithChildMixin.attach
  package:flutter/src/foundation/node.dart 132:13         AbstractNode.adoptChild
  package:flutter/src/rendering/object.dart 1290:11       RenderObject.adoptChild
  package:flutter/src/rendering/object.dart 3016:7        RenderObjectWithChildMixin.child=
  test/rendering/rendering_tester.dart 170:23             layout
```
https://api.cirrus-ci.com/v1/task/6444243294093312/logs/main.log
Also seen on LUCI.