### PR TITLE
Textfield tests corrected

### DIFF
--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1965,7 +1965,7 @@ void main() {
 
   testWidgets('long press drag can edge scroll', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+      text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges' * 60,
     );
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6737,7 +6737,7 @@ void main() {
 
   testWidgets('long press drag can edge scroll', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+      text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges' * 60,
     );
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -2876,7 +2876,7 @@ void main() {
         home: Material(
           child: Center(
             child: SelectableText(
-              'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed pretium nisl. Proin tristique facilisis eros, vitae laoreet leo. Morbi venenatis sapien sem, in venenatis erat pretium sit amet. Integer varius urna eget orci faucibus volutpat. Nulla tempor at nibh eget condimentum. Duis porta in augue at fermentum. Proin volutpat tellus sem, vel posuere enim tincidunt a. Nam ullamcorper est eu orci suscipit, quis consectetur nulla vulputate. Nunc at odio in massa lobortis finibus sit amet ac libero. Aenean massa eros, lobortis quis egestas ac, ultricies id augue. Nunc laoreet magna eu ex aliquet cursus.',
               maxLines: 1,
             ),
           ),


### PR DESCRIPTION
## Description
The `long press drag can edge scroll` tests for `TextField`s and `SelectableText`s do not guarantee that the text is large enough to be needed to scroll. I've used the `*` operator for `TextFields` to multiply the original text by some arbitrary number to ensure the text will need to scroll. While I've simply added a larger text for the `SelectableText` test.

## Related Issues

#64059

## Checklist


- [ x I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

