### PR TITLE
run the test longer time for multi_widget_construction_perf

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
@@ -11,7 +11,7 @@ void main() {
     'multi_widget_construction_perf',
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
-    duration: const Duration(seconds: 10),
-    timeout: const Duration(seconds: 45),
+    duration: const Duration(seconds: 20),
+    timeout: const Duration(seconds: 60),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
@@ -11,7 +11,7 @@ void main() {
     'multi_widget_construction_perf',
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
-    duration: const Duration(seconds: 10),
-    timeout: const Duration(seconds: 45),
+    duration: const Duration(seconds: 20),
+    timeout: const Duration(seconds: 60),
   );
 }

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -170,6 +170,7 @@ tasks:
       Measures the runtime performance of constructing and destructing widgets on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   multi_widget_construction_perf__e2e_summary:
     description: >


### PR DESCRIPTION
## Description

**This may seem to result in a regression but it's intended!**

The current version, especially the e2e version, have the 90th percentile frame build time number jumping to 20% larger in some test runs. We believe the reason is the 90th percentile lies accidentally at a transition place: 
![figure_2](https://user-images.githubusercontent.com/11715538/90686660-ae175780-e239-11ea-9f26-da517b645da5.png)
(the plot is the sorted frame build time in microsecond, and the vertical line is 90-th percentile). 

Change the test sample duration to a larger number may reduce this issue. We mark the driver version flaky here because this change requires larger memory and may #59263. #59263 typically is more often seen on my local test device than on device lab, so I'm not sure if it's as a severe problem on device lab. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
