### PR TITLE
[flutter_tools] null assertions off by default for web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -866,7 +866,8 @@ Future<void> _runWebDebugTest(String target, {
         ...<String>[
           '--enable-experiment',
           'non-nullable',
-          '--no-sound-null-safety'
+          '--no-sound-null-safety',
+          '--null-assertions',
         ],
       '-d',
       'chrome',

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -636,6 +636,7 @@ class WebDevFS implements DevFS {
     @required this.entrypoint,
     @required this.expressionCompiler,
     @required this.chromiumLauncher,
+    @required this.nullAssertions,
     this.testMode = false,
   });
 
@@ -651,6 +652,7 @@ class WebDevFS implements DevFS {
   final bool testMode;
   final ExpressionCompiler expressionCompiler;
   final ChromiumLauncher chromiumLauncher;
+  final bool nullAssertions;
 
   WebAssetServer webAssetServer;
 
@@ -791,8 +793,7 @@ class WebDevFS implements DevFS {
         'main_module.bootstrap.js',
         generateMainModule(
           entrypoint: entrypoint,
-          nullSafety: buildInfo.extraFrontEndOptions
-            ?.contains('--enable-experiment=non-nullable') ?? false,
+          nullAssertions: nullAssertions,
         ),
       );
       // TODO(jonahwilliams): refactor the asset code in this and the regular devfs to

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -469,6 +469,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           entrypoint: globals.fs.file(target).uri,
           expressionCompiler: expressionCompiler,
           chromiumLauncher: _chromiumLauncher,
+          nullAssertions: debuggingOptions.nullAssertions,
         );
         final Uri url = await device.devFS.create();
         if (debuggingOptions.buildInfo.isDebug) {

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -50,14 +50,14 @@ document.head.appendChild(requireEl);
 /// this object is the module.
 String generateMainModule({
   @required String entrypoint,
-  @required bool nullSafety,
+  @required bool nullAssertions,
 }) {
   return '''/* ENTRYPOINT_EXTENTION_MARKER */
 // Create the main module loaded below.
 define("main_module.bootstrap", ["$entrypoint", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
   dart_sdk._debugger.registerDevtoolsFormatter();
-  if ($nullSafety) {
+  if ($nullAssertions) {
     dart_sdk.dart.nonNullAsserts(true);
   }
 

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -23,7 +23,7 @@ void main() {
   test('generateMainModule embeds urls correctly', () {
     final String result = generateMainModule(
       entrypoint: 'foo/bar/main.js',
-      nullSafety: false,
+      nullAssertions: false,
     );
     // bootstrap main module has correct defined module.
     expect(result, contains('define("main_module.bootstrap", ["foo/bar/main.js", "dart_sdk"], '
@@ -33,7 +33,7 @@ void main() {
   test('generateMainModule includes null safety switches', () {
     final String result = generateMainModule(
       entrypoint: 'foo/bar/main.js',
-      nullSafety: true,
+      nullAssertions: true,
     );
 
     expect(result, contains(

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -462,6 +462,7 @@ void main() {
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
+      nullAssertions: true,
       buildInfo: const BuildInfo(
         BuildMode.debug,
         '',
@@ -574,6 +575,7 @@ void main() {
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
+      nullAssertions: true,
       buildInfo: const BuildInfo(
         BuildMode.debug,
         '',
@@ -689,6 +691,7 @@ void main() {
       testMode: true,
       expressionCompiler: null,
       chromiumLauncher: null,
+      nullAssertions: true,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -725,6 +728,7 @@ void main() {
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
+      nullAssertions: true,
       buildInfo: const BuildInfo(
         BuildMode.debug,
         '',


### PR DESCRIPTION
## Description

Like Android/iOS, only enable --null-assertions if asked. Previously this was enabled by default for web, but in general this has proved to be too breaking to enable by default.

https://github.com/flutter/flutter/issues/61042