### PR TITLE
Ignore unnecessary casts that can go away soon.

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -397,7 +397,7 @@ class AnimationController extends Animation<double>
   }
 
   void _internalSetValue(double newValue) {
-    _value = newValue.clamp(lowerBound, upperBound) as double;
+    _value = newValue.clamp(lowerBound, upperBound) as double; // ignore: unnecessary_cast
     if (_value == lowerBound) {
       _status = AnimationStatus.dismissed;
     } else if (_value == upperBound) {
@@ -581,7 +581,7 @@ class AnimationController extends Animation<double>
     stop();
     if (simulationDuration == Duration.zero) {
       if (value != target) {
-        _value = target.clamp(lowerBound, upperBound) as double;
+        _value = target.clamp(lowerBound, upperBound) as double; // ignore: unnecessary_cast
         notifyListeners();
       }
       _status = (_direction == _AnimationDirection.forward) ?
@@ -710,7 +710,7 @@ class AnimationController extends Animation<double>
     assert(!isAnimating);
     _simulation = simulation;
     _lastElapsedDuration = Duration.zero;
-    _value = simulation.x(0.0).clamp(lowerBound, upperBound) as double;
+    _value = simulation.x(0.0).clamp(lowerBound, upperBound) as double; // ignore: unnecessary_cast
     final TickerFuture result = _ticker!.start();
     _status = (_direction == _AnimationDirection.forward) ?
       AnimationStatus.forward :
@@ -787,7 +787,7 @@ class AnimationController extends Animation<double>
     _lastElapsedDuration = elapsed;
     final double elapsedInSeconds = elapsed.inMicroseconds.toDouble() / Duration.microsecondsPerSecond;
     assert(elapsedInSeconds >= 0.0);
-    _value = _simulation!.x(elapsedInSeconds).clamp(lowerBound, upperBound) as double;
+    _value = _simulation!.x(elapsedInSeconds).clamp(lowerBound, upperBound) as double; // ignore: unnecessary_cast
     if (_simulation!.isDone(elapsedInSeconds)) {
       _status = (_direction == _AnimationDirection.forward) ?
         AnimationStatus.completed :
@@ -822,7 +822,7 @@ class _InterpolationSimulation extends Simulation {
 
   @override
   double x(double timeInSeconds) {
-    final double t = (timeInSeconds / _durationInSeconds).clamp(0.0, 1.0) as double;
+    final double t = (timeInSeconds / _durationInSeconds).clamp(0.0, 1.0) as double; // ignore: unnecessary_cast
     if (t == 0.0)
       return _begin;
     else if (t == 1.0)

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -182,7 +182,7 @@ class Interval extends Curve {
     assert(end >= 0.0);
     assert(end <= 1.0);
     assert(end >= begin);
-    t = ((t - begin) / (end - begin)).clamp(0.0, 1.0) as double;
+    t = ((t - begin) / (end - begin)).clamp(0.0, 1.0) as double; // ignore: unnecessary_cast
     if (t == 0.0 || t == 1.0)
       return t;
     return curve.transform(t);
@@ -1189,7 +1189,7 @@ class ElasticInCurve extends Curve {
   double transformInternal(double t) {
     final double s = period / 4.0;
     t = t - 1.0;
-    return -math.pow(2.0, 10.0 * t) * math.sin((t - s) * (math.pi * 2.0) / period) as double;
+    return -math.pow(2.0, 10.0 * t) * math.sin((t - s) * (math.pi * 2.0) / period) as double; // ignore: unnecessary_cast
   }
 
   @override
@@ -1216,7 +1216,7 @@ class ElasticOutCurve extends Curve {
   @override
   double transformInternal(double t) {
     final double s = period / 4.0;
-    return math.pow(2.0, -10 * t) * math.sin((t - s) * (math.pi * 2.0) / period) + 1.0 as double;
+    return math.pow(2.0, -10 * t) * math.sin((t - s) * (math.pi * 2.0) / period) + 1.0 as double; // ignore: unnecessary_cast
   }
 
   @override
@@ -1248,7 +1248,7 @@ class ElasticInOutCurve extends Curve {
     if (t < 0.0)
       return -0.5 * math.pow(2.0, 10.0 * t) * math.sin((t - s) * (math.pi * 2.0) / period);
     else
-      return math.pow(2.0, -10.0 * t) * math.sin((t - s) * (math.pi * 2.0) / period) * 0.5 + 1.0 as double;
+      return math.pow(2.0, -10.0 * t) * math.sin((t - s) * (math.pi * 2.0) / period) * 0.5 + 1.0 as double; // ignore: unnecessary_cast
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -341,7 +341,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     // If the device incorrectly reports a pressure outside of pressureMin
     // and pressureMax, we still want this recognizer to respond normally.
     if (!value.isNaN)
-      value = value.clamp(0.0, 1.0) as double;
+      value = value.clamp(0.0, 1.0) as double; // ignore: unnecessary_cast
     return value;
   }
 

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -207,10 +207,10 @@ class HSVColor {
     if (b == null)
       return a._scaleAlpha(1.0 - t);
     return HSVColor.fromAHSV(
-      lerpDouble(a.alpha, b.alpha, t)!.clamp(0.0, 1.0) as double,
+      lerpDouble(a.alpha, b.alpha, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
       lerpDouble(a.hue, b.hue, t)! % 360.0,
-      lerpDouble(a.saturation, b.saturation, t)!.clamp(0.0, 1.0) as double,
-      lerpDouble(a.value, b.value, t)!.clamp(0.0, 1.0) as double,
+      lerpDouble(a.saturation, b.saturation, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
+      lerpDouble(a.value, b.value, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
     );
   }
 
@@ -291,7 +291,7 @@ class HSLColor {
     // Saturation can exceed 1.0 with rounding errors, so clamp it.
     final double saturation = lightness == 1.0
       ? 0.0
-      : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0) as double);
+      : ((delta / (1.0 - (2.0 * lightness - 1.0).abs())).clamp(0.0, 1.0) as double); // ignore: unnecessary_cast
     return HSLColor.fromAHSL(alpha, hue, saturation, lightness);
   }
 
@@ -391,10 +391,10 @@ class HSLColor {
     if (b == null)
       return a._scaleAlpha(1.0 - t);
     return HSLColor.fromAHSL(
-      lerpDouble(a.alpha, b.alpha, t)!.clamp(0.0, 1.0) as double,
+      lerpDouble(a.alpha, b.alpha, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
       lerpDouble(a.hue, b.hue, t)! % 360.0,
-      lerpDouble(a.saturation, b.saturation, t)!.clamp(0.0, 1.0) as double,
-      lerpDouble(a.lightness, b.lightness, t)!.clamp(0.0, 1.0) as double,
+      lerpDouble(a.saturation, b.saturation, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
+      lerpDouble(a.lightness, b.lightness, t)!.clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
     );
   }
 

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -162,12 +162,12 @@ abstract class EdgeInsetsGeometry {
   /// or equal to `min`, and less than or equal to `max`.
   EdgeInsetsGeometry clamp(EdgeInsetsGeometry min, EdgeInsetsGeometry max) {
     return _MixedEdgeInsets.fromLRSETB(
-      _left.clamp(min._left, max._left) as double,
-      _right.clamp(min._right, max._right) as double,
-      _start.clamp(min._start, max._start) as double,
-      _end.clamp(min._end, max._end) as double,
-      _top.clamp(min._top, max._top) as double,
-      _bottom.clamp(min._bottom, max._bottom) as double,
+      _left.clamp(min._left, max._left) as double, // ignore: unnecessary_cast
+      _right.clamp(min._right, max._right) as double, // ignore: unnecessary_cast
+      _start.clamp(min._start, max._start) as double, // ignore: unnecessary_cast
+      _end.clamp(min._end, max._end) as double, // ignore: unnecessary_cast
+      _top.clamp(min._top, max._top) as double, // ignore: unnecessary_cast
+      _bottom.clamp(min._bottom, max._bottom) as double, // ignore: unnecessary_cast
     );
   }
 
@@ -506,10 +506,10 @@ class EdgeInsets extends EdgeInsetsGeometry {
   @override
   EdgeInsetsGeometry clamp(EdgeInsetsGeometry min, EdgeInsetsGeometry max) {
     return EdgeInsets.fromLTRB(
-      _left.clamp(min._left, max._left) as double,
-      _top.clamp(min._top, max._top) as double,
-      _right.clamp(min._right, max._right) as double,
-      _bottom.clamp(min._bottom, max._bottom) as double,
+      _left.clamp(min._left, max._left) as double, // ignore: unnecessary_cast
+      _top.clamp(min._top, max._top) as double, // ignore: unnecessary_cast
+      _right.clamp(min._right, max._right) as double, // ignore: unnecessary_cast
+      _bottom.clamp(min._bottom, max._bottom) as double, // ignore: unnecessary_cast
     );
   }
 

--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -139,7 +139,7 @@ class FlutterLogoDecoration extends Decoration {
       t < 0.5 ? a.style : b.style,
       EdgeInsets.lerp(a.margin, b.margin, t)!,
       a._position + (b._position - a._position) * t,
-      (a._opacity + (b._opacity - a._opacity) * t).clamp(0.0, 1.0) as double,
+      (a._opacity + (b._opacity - a._opacity) * t).clamp(0.0, 1.0) as double, // ignore: unnecessary_cast
     );
   }
 

--- a/packages/flutter/lib/src/painting/geometry.dart
+++ b/packages/flutter/lib/src/painting/geometry.dart
@@ -65,7 +65,7 @@ Offset positionDependentBox({
   if (size.width - margin * 2.0 < childSize.width) {
     x = (size.width - childSize.width) / 2.0;
   } else {
-    final double normalizedTargetX = target.dx.clamp(margin, size.width - margin) as double;
+    final double normalizedTargetX = target.dx.clamp(margin, size.width - margin) as double; // ignore: unnecessary_cast
     final double edge = margin + childSize.width / 2.0;
     if (normalizedTargetX < edge) {
       x = margin;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -580,7 +580,7 @@ class TextPainter {
           newWidth = maxIntrinsicWidth;
           break;
       }
-      newWidth = newWidth.clamp(minWidth, maxWidth) as double;
+      newWidth = newWidth.clamp(minWidth, maxWidth) as double; // ignore: unnecessary_cast
       if (newWidth != _applyFloatingPointHack(_paragraph!.width)) {
         _paragraph!.layout(ui.ParagraphConstraints(width: newWidth));
       }

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -839,7 +839,7 @@ class TextStyle with Diagnosticable {
       fontFamily: fontFamily ?? this.fontFamily,
       fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       fontSize: fontSize == null ? null : fontSize! * fontSizeFactor + fontSizeDelta,
-      fontWeight: fontWeight == null ? null : FontWeight.values[(fontWeight!.index + fontWeightDelta).clamp(0, FontWeight.values.length - 1) as int],
+      fontWeight: fontWeight == null ? null : FontWeight.values[(fontWeight!.index + fontWeightDelta).clamp(0, FontWeight.values.length - 1) as int], // ignore: unnecessary_cast
       fontStyle: fontStyle ?? this.fontStyle,
       letterSpacing: letterSpacing == null ? null : letterSpacing! * letterSpacingFactor + letterSpacingDelta,
       wordSpacing: wordSpacing == null ? null : wordSpacing! * wordSpacingFactor + wordSpacingDelta,

--- a/packages/flutter/lib/src/physics/clamped_simulation.dart
+++ b/packages/flutter/lib/src/physics/clamped_simulation.dart
@@ -48,10 +48,10 @@ class ClampedSimulation extends Simulation {
   final double dxMax;
 
   @override
-  double x(double time) => simulation.x(time).clamp(xMin, xMax) as double;
+  double x(double time) => simulation.x(time).clamp(xMin, xMax) as double; // ignore: unnecessary_cast
 
   @override
-  double dx(double time) => simulation.dx(time).clamp(dxMin, dxMax) as double;
+  double dx(double time) => simulation.dx(time).clamp(dxMin, dxMax) as double; // ignore: unnecessary_cast
 
   @override
   bool isDone(double time) => simulation.isDone(time);

--- a/packages/flutter/lib/src/physics/friction_simulation.dart
+++ b/packages/flutter/lib/src/physics/friction_simulation.dart
@@ -116,7 +116,7 @@ class BoundedFrictionSimulation extends FrictionSimulation {
 
   @override
   double x(double time) {
-    return super.x(time).clamp(_minX, _maxX) as double;
+    return super.x(time).clamp(_minX, _maxX) as double; // ignore: unnecessary_cast
   }
 
   @override


### PR DESCRIPTION
## Description

The number promotion rules in null safety mode have been changed to
allow certain obvious operations to produce correct types
(e.g. `double + double` now produces `double`; previously it produced
`num`, so it required a cast to convert it to `double`).  Flutter
contains some casts to work around the drawbacks of the old rules;
once the new rules are implemented in the analyzer, those casts will
become unnecessary.  To cover the transition period, ignore the
unnecessary_cast hints now.  After the new rules have landed, we will
be able to remove the casts (and the "ignore" comments) completely.

## Related Issues

https://github.com/dart-lang/sdk/issues/42629 (this PR must be landed before the issue can be fixed).

## Tests

I added the following tests:

No tests.  These changes will be tested when the fix for https://github.com/dart-lang/sdk/issues/42629 rolls into Flutter.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
