### PR TITLE
Restore docs linux post submit cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -192,7 +192,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: docs-linux # linux-only
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'bin/**') && $CIRRUS_PR != ''"
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'bin/**') || $CIRRUS_PR == ''"
       environment:
         # TODO(tvolkert): optimize CPU and MEMORY settings once #60646 is resolved.
         CPU: 4

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -192,6 +192,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: docs-linux # linux-only
+      # TODO(fujino): Make this pre-submit only once #64212 is fixed
       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'bin/**') || $CIRRUS_PR == ''"
       environment:
         # TODO(tvolkert): optimize CPU and MEMORY settings once #60646 is resolved.


### PR DESCRIPTION
## Description

Restore `docs-linux` on cirrus post-submit, as LUCI does not support uploading yet. This reverts the `docs-linux` change from https://github.com/flutter/flutter/pull/63995.

## Related Issues

Related to https://github.com/flutter/flutter/issues/64212 (but does not fix)