### PR TITLE
(insert|move|remove)ChildRenderObject Deprecation: Step 2

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -779,8 +779,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     if (slot is _CupertinoTextSelectionToolbarItemsSlot) {
       assert(child is RenderBox);
       _updateRenderObject(child as RenderBox, slot);
-      assert(renderObject.childToSlot.containsKey(child));
-      assert(renderObject.slotToChild.containsKey(slot));
+      assert(renderObject.slottedChildren.containsKey(slot));
       return;
     }
     if (slot is IndexedSlot) {
@@ -807,11 +806,9 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     // Check if the child is in a slot.
     if (slot is _CupertinoTextSelectionToolbarItemsSlot) {
       assert(child is RenderBox);
-      assert(renderObject.slotToChild.containsKey(slot));
-      assert(renderObject.childToSlot.containsKey(child));
+      assert(renderObject.slottedChildren.containsKey(slot));
       _updateRenderObject(null, slot);
-      assert(!renderObject.childToSlot.containsKey(child));
-      assert(!renderObject.slotToChild.containsKey(slot));
+      assert(!renderObject.slottedChildren.containsKey(slot));
       return;
     }
 
@@ -919,21 +916,22 @@ class _CupertinoTextSelectionToolbarItemsRenderBox extends RenderBox with Contai
        _page = page,
        super();
 
-  final Map<_CupertinoTextSelectionToolbarItemsSlot, RenderBox> slotToChild = <_CupertinoTextSelectionToolbarItemsSlot, RenderBox>{};
-  final Map<RenderBox, _CupertinoTextSelectionToolbarItemsSlot> childToSlot = <RenderBox, _CupertinoTextSelectionToolbarItemsSlot>{};
+  final Map<_CupertinoTextSelectionToolbarItemsSlot, RenderBox> slottedChildren = <_CupertinoTextSelectionToolbarItemsSlot, RenderBox>{};
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _CupertinoTextSelectionToolbarItemsSlot slot) {
     if (oldChild != null) {
       dropChild(oldChild);
-      childToSlot.remove(oldChild);
-      slotToChild.remove(slot);
+      slottedChildren.remove(slot);
     }
     if (newChild != null) {
-      childToSlot[newChild] = slot;
-      slotToChild[slot] = newChild;
+      slottedChildren[slot] = newChild;
       adoptChild(newChild);
     }
     return newChild;
+  }
+
+  bool _isSlottedChild(RenderBox child) {
+    return child == _backButton || child == _nextButton || child == _nextButtonDisabled;
   }
 
   int _page;
@@ -1001,7 +999,7 @@ class _CupertinoTextSelectionToolbarItemsRenderBox extends RenderBox with Contai
       childParentData.shouldPaint = false;
 
       // Skip slotted children and children on pages after the visible page.
-      if (childToSlot.containsKey(child) || currentPage > _page) {
+      if (_isSlottedChild(child) || currentPage > _page) {
         return;
       }
 
@@ -1165,9 +1163,9 @@ class _CupertinoTextSelectionToolbarItemsRenderBox extends RenderBox with Contai
     super.attach(owner);
 
     // Attach slot children.
-    childToSlot.forEach((RenderBox child, _) {
+    for (final RenderBox child in slottedChildren.values) {
       child.attach(owner);
-    });
+    }
   }
 
   @override
@@ -1176,9 +1174,9 @@ class _CupertinoTextSelectionToolbarItemsRenderBox extends RenderBox with Contai
     super.detach();
 
     // Detach slot children.
-    childToSlot.forEach((RenderBox child, _) {
+    for (final RenderBox child in slottedChildren.values) {
       child.detach();
-    });
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -2151,18 +2151,15 @@ class _RenderChipElement extends RenderObjectElement {
   void insertRenderObjectChild(RenderObject child, _ChipSlot slot) {
     assert(child is RenderBox);
     _updateRenderObject(child, slot);
-    assert(renderObject.childToSlot.keys.contains(child));
-    assert(renderObject.slotToChild.keys.contains(slot));
+    assert(renderObject.children.keys.contains(slot));
   }
 
   @override
   void removeRenderObjectChild(RenderObject child, _ChipSlot slot) {
     assert(child is RenderBox);
-    assert(renderObject.childToSlot[child] == slot);
-    assert(renderObject.slotToChild[slot] == child);
+    assert(renderObject.children[slot] == child);
     _updateRenderObject(null, slot);
-    assert(!renderObject.childToSlot.keys.contains(child));
-    assert(!renderObject.slotToChild.keys.contains(slot));
+    assert(!renderObject.children.keys.contains(slot));
   }
 
   @override
@@ -2258,8 +2255,7 @@ class _RenderChip extends RenderBox {
     enableAnimation.addListener(markNeedsPaint);
   }
 
-  final Map<_ChipSlot, RenderBox> slotToChild = <_ChipSlot, RenderBox>{};
-  final Map<RenderBox, _ChipSlot> childToSlot = <RenderBox, _ChipSlot>{};
+  final Map<_ChipSlot, RenderBox> children = <_ChipSlot, RenderBox>{};
 
   bool value;
   bool isEnabled;
@@ -2274,12 +2270,10 @@ class _RenderChip extends RenderBox {
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _ChipSlot slot) {
     if (oldChild != null) {
       dropChild(oldChild);
-      childToSlot.remove(oldChild);
-      slotToChild.remove(slot);
+      children.remove(slot);
     }
     if (newChild != null) {
-      childToSlot[newChild] = slot;
-      slotToChild[slot] = newChild;
+      children[slot] = newChild;
       adoptChild(newChild);
     }
     return newChild;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -645,18 +645,15 @@ class _RenderDecoration extends RenderBox {
        _expands = expands;
 
   static const double subtextGap = 8.0;
-  final Map<_DecorationSlot, RenderBox> slotToChild = <_DecorationSlot, RenderBox>{};
-  final Map<RenderBox, _DecorationSlot> childToSlot = <RenderBox, _DecorationSlot>{};
+  final Map<_DecorationSlot, RenderBox> children = <_DecorationSlot, RenderBox>{};
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _DecorationSlot slot) {
     if (oldChild != null) {
       dropChild(oldChild);
-      childToSlot.remove(oldChild);
-      slotToChild.remove(slot);
+      children.remove(slot);
     }
     if (newChild != null) {
-      childToSlot[newChild] = slot;
-      slotToChild[slot] = newChild;
+      children[slot] = newChild;
       adoptChild(newChild);
     }
     return newChild;
@@ -1657,18 +1654,15 @@ class _RenderDecorationElement extends RenderObjectElement {
   void insertRenderObjectChild(RenderObject child, _DecorationSlot slot) {
     assert(child is RenderBox);
     _updateRenderObject(child as RenderBox, slot);
-    assert(renderObject.childToSlot.keys.contains(child));
-    assert(renderObject.slotToChild.keys.contains(slot));
+    assert(renderObject.children.keys.contains(slot));
   }
 
   @override
   void removeRenderObjectChild(RenderObject child, _DecorationSlot slot) {
     assert(child is RenderBox);
-    assert(renderObject.childToSlot[child] == slot);
-    assert(renderObject.slotToChild[slot] == child);
+    assert(renderObject.children[slot] == child);
     _updateRenderObject(null, slot);
-    assert(!renderObject.childToSlot.keys.contains(child));
-    assert(!renderObject.slotToChild.keys.contains(slot));
+    assert(!renderObject.children.keys.contains(slot));
   }
 
   @override

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1253,18 +1253,15 @@ class _ListTileElement extends RenderObjectElement {
   void insertRenderObjectChild(RenderObject child, _ListTileSlot slot) {
     assert(child is RenderBox);
     _updateRenderObject(child as RenderBox, slot);
-    assert(renderObject.childToSlot.keys.contains(child));
-    assert(renderObject.slotToChild.keys.contains(slot));
+    assert(renderObject.children.keys.contains(slot));
   }
 
   @override
   void removeRenderObjectChild(RenderObject child, _ListTileSlot slot) {
     assert(child is RenderBox);
-    assert(renderObject.childToSlot[child] == slot);
-    assert(renderObject.slotToChild[slot] == child);
+    assert(renderObject.children[slot] == child);
     _updateRenderObject(null, slot);
-    assert(!renderObject.childToSlot.keys.contains(child));
-    assert(!renderObject.slotToChild.keys.contains(slot));
+    assert(!renderObject.children.keys.contains(slot));
   }
 
   @override
@@ -1299,18 +1296,15 @@ class _RenderListTile extends RenderBox {
   // The minimum padding on the top and bottom of the title and subtitle widgets.
   static const double _minVerticalPadding = 4.0;
 
-  final Map<_ListTileSlot, RenderBox> slotToChild = <_ListTileSlot, RenderBox>{};
-  final Map<RenderBox, _ListTileSlot> childToSlot = <RenderBox, _ListTileSlot>{};
+  final Map<_ListTileSlot, RenderBox> children = <_ListTileSlot, RenderBox>{};
 
   RenderBox _updateChild(RenderBox oldChild, RenderBox newChild, _ListTileSlot slot) {
     if (oldChild != null) {
       dropChild(oldChild);
-      childToSlot.remove(oldChild);
-      slotToChild.remove(slot);
+      children.remove(slot);
     }
     if (newChild != null) {
-      childToSlot[newChild] = slot;
-      slotToChild[slot] = newChild;
+      children[slot] = newChild;
       adoptChild(newChild);
     }
     return newChild;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6079,6 +6079,7 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
   @override
   void removeRenderObjectChild(RenderObject child, dynamic slot) {
     final RenderObjectWithChildMixin<RenderObject> renderObject = this.renderObject as RenderObjectWithChildMixin<RenderObject>;
+    assert(slot == null);
     assert(renderObject.child == child);
     renderObject.child = null;
     assert(renderObject == this.renderObject);


### PR DESCRIPTION
## Description

This follows 21cfed3 by removing the `childToSlot` pattern usages
where possible - namely, `RenderObject` subclasses.  There are still
usages of the pattern in `RenderObjectElement` subclasses, where they
use the pattern to efficiently forget a child in `forgetChild()`.

## Related Issues

#63269

## Tests

Test exemption: this just removes code.  The existing tests passing validates the change.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
