### PR TITLE
fix: typo fixed from ENTER to SPACE

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -71,7 +71,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 ///
 /// {@tool dartpad --template=stateful_widget_material}
 /// This example shows how to move the focus to the next field when the user
-/// presses the ENTER key.
+/// presses the SPACE key.
 ///
 /// ```dart imports
 /// import 'package:flutter/services.dart';


### PR DESCRIPTION
## Description

*This fixes a Typo error in the form field example, by switching to using space instead of enter as the example for moving to the next field.*

## Related Issues

Fixes [*#63912*](https://github.com/flutter/flutter/issues/63912)

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[Example Code]: https://master-api.flutter.dev/flutter/material/TextFormField-class.html#material.TextFormField.2

