### PR TITLE
add different workload & add -products * to vswhere calls to check both Visual Studio IDE and standalone Build Tools.

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -351,8 +351,8 @@ class VisualStudio {
     ];
     Map<String, dynamic> visualStudioDetails;
     // Check in the order of stable VS, stable BT, pre-release VS, pre-release BT
-    for(final bool checkForPrerelease in <bool>[false, true]){
-      for(final String requiredWorkload in _requiredWorkloads){
+    for (final bool checkForPrerelease in <bool>[false, true]) {
+      for (final String requiredWorkload in _requiredWorkloads) {
         visualStudioDetails ??= _visualStudioDetails(
           validateRequirements: true,
           additionalArguments: checkForPrerelease

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -183,11 +183,6 @@ class VisualStudio {
     'vswhere.exe',
   );
 
-  /// Workload ID for use with vswhere requirements.
-  ///
-  /// See https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids
-  static const String _requiredWorkload = 'Microsoft.VisualStudio.Workload.NativeDesktop';
-
   /// Components for use with vswhere requirements.
   ///
   /// Maps from component IDs to description in the installer UI.
@@ -274,13 +269,13 @@ class VisualStudio {
     final List<String> requirementArguments = validateRequirements
         ? <String>[
             '-requires',
-            _requiredWorkload,
             ..._requiredComponents(_minimumSupportedVersion).keys
           ]
         : <String>[];
     try {
       final List<String> defaultArguments = <String>[
         '-format', 'json',
+        '-products', '*',
         '-utf8',
         '-latest',
       ];

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -183,6 +183,17 @@ class VisualStudio {
     'vswhere.exe',
   );
 
+  /// Workload ID for use with vswhere requirements.
+  ///
+  /// See https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids
+  static const String _requiredWorkload = 'Microsoft.VisualStudio.Workload.NativeDesktop';
+
+  /// Workload ID for use with vswhere requirements for Build Tools.
+  ///
+  /// Workload ID is different between Visual Studio IDE and Build Tools.
+  /// See https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools
+  static const String _requiredBuildToolsWorkload = 'Microsoft.VisualStudio.Workload.VCTools';
+
   /// Components for use with vswhere requirements.
   ///
   /// Maps from component IDs to description in the installer UI.
@@ -262,13 +273,17 @@ class VisualStudio {
   /// Returns the details dictionary for the newest version of Visual Studio.
   /// If [validateRequirements] is set, the search will be limited to versions
   /// that have all of the required workloads and components.
+  /// [requiredWorkload] should be set to [_requiredBuildToolsWorkload] when
+  /// checking the Build Tools.
   Map<String, dynamic> _visualStudioDetails({
       bool validateRequirements = false,
       List<String> additionalArguments,
+      String requiredWorkload = _requiredWorkload
     }) {
     final List<String> requirementArguments = validateRequirements
         ? <String>[
             '-requires',
+            requiredWorkload,
             ..._requiredComponents(_minimumSupportedVersion).keys
           ]
         : <String>[];
@@ -345,6 +360,19 @@ class VisualStudio {
     visualStudioDetails ??= _visualStudioDetails(
         validateRequirements: true,
         additionalArguments: <String>[...minimumVersionArguments, _vswherePrereleaseArgument]);
+    // If Visual Studio IDE is not found, try searching for Build Tools.
+    visualStudioDetails ??= _visualStudioDetails(
+        validateRequirements: true,
+        additionalArguments: minimumVersionArguments,
+        requiredWorkload: _requiredBuildToolsWorkload
+        );
+    // If Visual Studio IDE and a stable version Build Tools are not found,
+    // try searching for a pre-release version Build Tools.
+    visualStudioDetails ??= _visualStudioDetails(
+        validateRequirements: true,
+        additionalArguments: <String>[...minimumVersionArguments, _vswherePrereleaseArgument],
+        requiredWorkload: _requiredBuildToolsWorkload
+        );
 
     if (visualStudioDetails != null) {
       if (installationHasIssues(visualStudioDetails)) {

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -69,7 +69,6 @@ const Map<String, dynamic> _missingStatusResponse = <String, dynamic>{
 // Arguments for a vswhere query to search for an installation with the
 // requirements.
 const List<String> _requirements = <String>[
-  'Microsoft.VisualStudio.Workload.NativeDesktop',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
   'Microsoft.VisualStudio.Component.VC.CMake.Project',
 ];
@@ -98,6 +97,8 @@ void setMockVswhereResponse(
       vswherePath,
       '-format',
       'json',
+      '-products',
+      '*',
       '-utf8',
       '-latest',
       ...?additionalArguments,

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -41,6 +41,20 @@ const Map<String, dynamic> _defaultResponse = <String, dynamic>{
   },
 };
 
+// A minimum version of a response where a Build Tools installation was found.
+const Map<String, dynamic> _defaultBuildToolsResponse = <String, dynamic>{
+  'installationPath': visualStudioPath,
+  'displayName': 'Visual Studio Build Tools 2019',
+  'installationVersion': '16.7.30413.136',
+  'isRebootRequired': false,
+  'isComplete': true,
+  'isLaunchable': true,
+  'isPrerelease': false,
+  'catalog': <String, dynamic>{
+    'productDisplayVersion': '16.7.2',
+  },
+};
+
 // A response for a VS installation that's too old.
 const Map<String, dynamic> _tooOldResponse = <String, dynamic>{
   'installationPath': visualStudioPath,
@@ -69,6 +83,15 @@ const Map<String, dynamic> _missingStatusResponse = <String, dynamic>{
 // Arguments for a vswhere query to search for an installation with the
 // requirements.
 const List<String> _requirements = <String>[
+  'Microsoft.VisualStudio.Workload.NativeDesktop',
+  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+  'Microsoft.VisualStudio.Component.VC.CMake.Project',
+];
+
+// Arguments for a vswhere query to search for a Build Tools installation with the
+// requirements.
+const List<String> _requirementsBuildTools = <String>[
+  'Microsoft.VisualStudio.Workload.VCTools',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
   'Microsoft.VisualStudio.Component.VC.CMake.Project',
 ];
@@ -135,6 +158,38 @@ void setMockPrereleaseVisualStudioInstallation(
     fileSystem,
     processManager,
     _requirements,
+    <String>['-version', '16', '-prerelease'],
+    response,
+  );
+}
+
+// Sets whether or not a vswhere query with the required components will
+// return an Build Tools installation.
+void setMockCompatibleVisualStudioBuildToolsInstallation(
+  Map<String, dynamic> response,
+  FileSystem fileSystem,
+  FakeProcessManager processManager,
+) {
+  setMockVswhereResponse(
+    fileSystem,
+    processManager,
+    _requirementsBuildTools,
+    <String>['-version', '16'],
+    response,
+  );
+}
+
+// Sets whether or not a vswhere query with the required components will
+// return a pre-release Build Tools installation.
+void setMockPrereleaseVisualStudioBuildToolsInstallation(
+  Map<String, dynamic> response,
+  FileSystem fileSystem,
+  FakeProcessManager processManager,
+) {
+  setMockVswhereResponse(
+    fileSystem,
+    processManager,
+    _requirementsBuildTools,
     <String>['-version', '16', '-prerelease'],
     response,
   );
@@ -307,6 +362,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         null,
         fixture.fileSystem,
@@ -354,6 +419,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         _tooOldResponse,
         fixture.fileSystem,
@@ -375,6 +450,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -402,6 +487,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -421,6 +516,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -450,6 +555,52 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockAnyVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isPrerelease, true);
+    });
+
+    testWithoutContext('isInstalled returns true when a prerelease version of Build Tools is present', () {
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultBuildToolsResponse)
+        ..['isPrerelease'] = true;
+      setMockCompatibleVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        response,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         null,
         fixture.fileSystem,
@@ -474,6 +625,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         _tooOldResponse,
         fixture.fileSystem,
@@ -494,6 +655,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -526,6 +697,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
 
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isLaunchable'] = false;
@@ -549,6 +730,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -580,6 +771,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -599,6 +800,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -628,6 +839,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
 
       expect(visualStudio.cmakePath, isNull);
     });
@@ -648,6 +869,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
 
       expect(visualStudio.hasNecessaryComponents, false);
     });
@@ -662,6 +893,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -692,6 +933,16 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
       setMockEncodedAnyVisualStudioInstallation(
         '{',
         fixture.fileSystem,
@@ -711,6 +962,52 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockAnyVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
+      expect(visualStudio.hasNecessaryComponents, true);
+      expect(visualStudio.cmakePath, equals(cmakePath));
+    });
+
+    testWithoutContext('Everything returns good values when Build Tools is present with all components', () {
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        _defaultBuildToolsResponse,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
@@ -747,6 +1044,16 @@ void main() {
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockCompatibleVisualStudioBuildToolsInstallation(
+        null,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+      setMockPrereleaseVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -285,6 +285,32 @@ VisualStudioFixture setUpVisualStudio() {
   return VisualStudioFixture(visualStudio, fileSystem, processManager);
 }
 
+// Set all vswhere query with the required components return null.
+void setNoViableToolchainInstallation(
+  VisualStudioFixture fixture,
+) {
+  setMockCompatibleVisualStudioInstallation(
+    null,
+    fixture.fileSystem,
+    fixture.processManager,
+  );
+  setMockCompatibleVisualStudioBuildToolsInstallation(
+    null,
+    fixture.fileSystem,
+    fixture.processManager,
+  );
+  setMockPrereleaseVisualStudioInstallation(
+    null,
+    fixture.fileSystem,
+    fixture.processManager,
+  );
+  setMockPrereleaseVisualStudioBuildToolsInstallation(
+    null,
+    fixture.fileSystem,
+    fixture.processManager,
+  );
+}
+
 void main() {
   group('Visual Studio', () {
     testWithoutContext('isInstalled returns false when vswhere is missing', () {
@@ -352,26 +378,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         null,
         fixture.fileSystem,
@@ -409,26 +417,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _tooOldResponse,
         fixture.fileSystem,
@@ -444,26 +434,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _missingStatusResponse,
         fixture.fileSystem,
@@ -477,26 +449,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -510,26 +464,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _tooOldResponse,
         fixture.fileSystem,
@@ -550,23 +486,13 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioInstallation(
-        response,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
       setMockCompatibleVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockAnyVisualStudioInstallation(
-        null,
+      setMockPrereleaseVisualStudioInstallation(
+        response,
         fixture.fileSystem,
         fixture.processManager,
       );
@@ -586,23 +512,18 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioInstallation(
+      setMockCompatibleVisualStudioBuildToolsInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
+      setMockPrereleaseVisualStudioInstallation(
         null,
         fixture.fileSystem,
         fixture.processManager,
       );
       setMockPrereleaseVisualStudioBuildToolsInstallation(
         response,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockAnyVisualStudioInstallation(
-        null,
         fixture.fileSystem,
         fixture.processManager,
       );
@@ -615,26 +536,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _tooOldResponse,
         fixture.fileSystem,
@@ -649,26 +552,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
 
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isComplete'] = false;
@@ -687,26 +571,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
 
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isLaunchable'] = false;
@@ -724,26 +589,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
 
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isRebootRequired'] = true;
@@ -761,26 +607,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -794,26 +622,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -834,21 +644,6 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
 
       expect(visualStudio.cmakePath, isNull);
     });
@@ -864,21 +659,6 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
 
       expect(visualStudio.hasNecessaryComponents, false);
     });
@@ -887,26 +667,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockAnyVisualStudioInstallation(
         _defaultResponse,
         fixture.fileSystem,
@@ -923,26 +685,8 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      setMockCompatibleVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
+      setNoViableToolchainInstallation(fixture);
+
       setMockEncodedAnyVisualStudioInstallation(
         '{',
         fixture.fileSystem,
@@ -958,26 +702,6 @@ void main() {
 
       setMockCompatibleVisualStudioInstallation(
         _defaultResponse,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockAnyVisualStudioInstallation(
-        null,
         fixture.fileSystem,
         fixture.processManager,
       );
@@ -997,23 +721,8 @@ void main() {
         fixture.fileSystem,
         fixture.processManager,
       );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
       setMockCompatibleVisualStudioBuildToolsInstallation(
         _defaultBuildToolsResponse,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockAnyVisualStudioInstallation(
-        null,
         fixture.fileSystem,
         fixture.processManager,
       );
@@ -1040,21 +749,6 @@ void main() {
 
       setMockCompatibleVisualStudioInstallation(
         olderButCompleteVersionResponse,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockCompatibleVisualStudioBuildToolsInstallation(
-        null,
-        fixture.fileSystem,
-        fixture.processManager,
-      );
-      setMockPrereleaseVisualStudioBuildToolsInstallation(
-        null,
         fixture.fileSystem,
         fixture.processManager,
       );


### PR DESCRIPTION
## Description

The default `products` parameter of  `vswhere` [dose not contains standalone Build Tools product](https://github.com/microsoft/vswhere/issues/22#issuecomment-283813710), which makes Build Tools cannot be found.

Meanwhile, it is components rather than workload to be the requirement, and [the workload id is different in Visual Studio Build Tools](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools) with same component ids.

~~This PR hence adds `products *` and removes workload id in `requires` list to make standalone Build Tools findable.~~
This PR hence adds `products *` and add different workload ids to check both Visual Studio IDE and standalone Build Tools.

## Related Issues

https://github.com/flutter/flutter/issues/39067

## Tests

I added the following tests:

- Visual Studio isInstalled returns true when a prerelease version of Build Tools is present

- Visual Studio Everything returns good values when Build Tools is present with all components

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
