### PR TITLE
Revert "run the test longer time for multi_widget_construction_perf"

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
@@ -11,7 +11,7 @@ void main() {
     'multi_widget_construction_perf',
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
-    duration: const Duration(seconds: 20),
-    timeout: const Duration(seconds: 60),
+    duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
@@ -11,7 +11,7 @@ void main() {
     'multi_widget_construction_perf',
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
-    duration: const Duration(seconds: 20),
-    timeout: const Duration(seconds: 60),
+    duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -170,7 +170,6 @@ tasks:
       Measures the runtime performance of constructing and destructing widgets on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   multi_widget_construction_perf__e2e_summary:
     description: >


### PR DESCRIPTION
Reverts flutter/flutter#64185 
The increase of time is indeed causing the original test to fail, due to memory limitation. 