### PR TITLE
Make large jumpTo recommend deferred loading

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -145,8 +145,22 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   double get maxScrollExtent => _maxScrollExtent;
   double _maxScrollExtent;
 
-  /// The implied amount of velocity when pixels are forced without respect to
-  /// scroll physics, such as when [forcePixels] or [jumpTo] is used.
+  /// The additional velocity added for a [forcePixels] change in a single
+  /// frame.
+  ///
+  /// This value is used by [recommendDeferredLoading] in addition to the
+  /// [activity]'s [ScrollActivity.velocity] to ask the [physics] whether or
+  /// not to defer loading. It accounts for the fact that a [forcePixels] call
+  /// may involve a [ScrollActivity] with 0 velocity, but the scrollable is
+  /// still instantaneously moving from its current position to a potentially
+  /// very far position, and which is of interest to callers of
+  /// [recommendDeferredLoading].
+  ///
+  /// For example, if a scrollable is currently at 5000 pixels, and we [jumpTo]
+  /// 0 to get back to the top of the list, we would have an implied velocity of
+  /// -5000 and an `activity.velocity` of 0. The jump may be going past a
+  /// number of resource intensive widgets which should avoid doing work if the
+  /// position jumps past them.
   double _impliedVelocity = 0;
 
   @override
@@ -347,6 +361,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   @protected
   void forcePixels(double value) {
     assert(pixels != null);
+    assert(value != null);
     _impliedVelocity = value - _pixels;
     _pixels = value;
     notifyListeners();

--- a/packages/flutter/test/widgets/scroll_position_test.dart
+++ b/packages/flutter/test/widgets/scroll_position_test.dart
@@ -229,4 +229,41 @@ void main() {
     );
     expect(controller.position.pixels, equals(0.0));
   });
+
+  testWidgets('jumpTo recomends deferred loading', (WidgetTester tester) async {
+    int loadedWithDeferral = 0;
+    int buildCount = 0;
+    const double height = 500;
+    await tester.pumpWidget(MaterialApp(
+      home: ListView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          buildCount += 1;
+          if (Scrollable.recommendDeferredLoadingForContext(context)) {
+            loadedWithDeferral += 1;
+          }
+          return const SizedBox(height: height);
+        },
+      ),
+    ));
+
+    // The two visible on screen should have loaded without deferral.
+    expect(buildCount, 2);
+    expect(loadedWithDeferral, 0);
+
+    final ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+    position.jumpTo(height * 100);
+    await tester.pump();
+
+    // All but the first two that were loaded normally should have gotten a
+    // recommendation to defer.
+    expect(buildCount, 102);
+    expect(loadedWithDeferral, 100);
+
+    position.jumpTo(height * 102);
+    await tester.pump();
+
+    // The smaller jump should not have recommended deferral.
+    expect(buildCount, 104);
+    expect(loadedWithDeferral, 100);
+  });
 }


### PR DESCRIPTION
## Description

Before this patch, a fling of a scrollable will end up recommending deferred loading, but not a similarly large (or larger) `jumpTo`.

This adds an `_impliedVelocity` field to `ScrollPosition` that tracks how many pixels were forced in a single frame, and adds that to the activity's velocity when asking the `ScrollPhysics` whether we should defer.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64124

## Tests

I added the following tests:

Test that this works as expected when using jumpTo with large values.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
