### PR TITLE
migrate flutter_gallery_sksl_warmup__transition_perf to e2e

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createFlutterGalleryTransitionsPerfSkSLWarmupE2ETest());
+}

--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e_ios32.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e_ios32.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createFlutterGalleryTransitionsPerfSkSLWarmupE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -109,6 +109,14 @@ TaskFunction createFlutterGalleryTransitionsPerfSkSLWarmupTest() {
   ).run;
 }
 
+TaskFunction createFlutterGalleryTransitionsPerfSkSLWarmupE2ETest() {
+  return E2EPerfTestWithSkSL(
+    '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',
+    'test_driver/transitions_perf_e2e.dart',
+    testDriver: 'test_driver/transitions_perf_e2e_test.dart',
+  ).run;
+}
+
 TaskFunction createBackdropFilterPerfTest({bool measureCpuGpu = false}) {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
@@ -504,13 +512,44 @@ class E2EPerfTest extends PerfTest {
     String testDirectory,
     String testTarget, {
     String summaryFilename,
+    String testDriver,
     List<String> benchmarkScoreKeys,
     }
   ) : super(
     testDirectory,
     testTarget,
     summaryFilename,
-    testDriver: 'test_driver/e2e_test.dart',
+    testDriver: testDriver?? 'test_driver/e2e_test.dart',
+    needsFullTimeline: false,
+    benchmarkScoreKeys: benchmarkScoreKeys ?? const <String>[
+      'average_frame_build_time_millis',
+      'worst_frame_build_time_millis',
+      '90th_percentile_frame_build_time_millis',
+      '99th_percentile_frame_build_time_millis',
+      'average_frame_rasterizer_time_millis',
+      'worst_frame_rasterizer_time_millis',
+      '90th_percentile_frame_rasterizer_time_millis',
+      '99th_percentile_frame_rasterizer_time_millis',
+      ],
+  );
+
+  @override
+  String get resultFilename => timelineFileName ?? 'e2e_perf_summary';
+}
+
+class E2EPerfTestWithSkSL extends PerfTestWithSkSL {
+  E2EPerfTestWithSkSL(
+    String testDirectory,
+    String testTarget, {
+    String summaryFilename,
+    String testDriver,
+    List<String> benchmarkScoreKeys,
+    }
+  ) : super(
+    testDirectory,
+    testTarget,
+    summaryFilename,
+    testDriver: testDriver?? 'test_driver/e2e_test.dart',
     needsFullTimeline: false,
     benchmarkScoreKeys: benchmarkScoreKeys ?? const <String>[
       'average_frame_build_time_millis',
@@ -535,12 +574,16 @@ class PerfTestWithSkSL extends PerfTest {
     String timelineFileName, {
     bool measureCpuGpu = false,
     String testDriver,
+    bool needsFullTimeline = true,
+    List<String> benchmarkScoreKeys,
   }) : super(
     testDirectory,
     testTarget,
     timelineFileName,
     measureCpuGpu: measureCpuGpu,
     testDriver: testDriver,
+    needsFullTimeline: needsFullTimeline,
+    benchmarkScoreKeys: benchmarkScoreKeys,
   );
 
   @override

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -77,7 +77,7 @@ TaskFunction createCullOpacityPerfTest() {
 }
 
 TaskFunction createCullOpacityPerfE2ETest() {
-  return E2EPerfTest(
+  return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test/cull_opacity_perf_e2e.dart',
   ).run;
@@ -110,7 +110,7 @@ TaskFunction createFlutterGalleryTransitionsPerfSkSLWarmupTest() {
 }
 
 TaskFunction createFlutterGalleryTransitionsPerfSkSLWarmupE2ETest() {
-  return E2EPerfTestWithSkSL(
+  return PerfTestWithSkSL.e2e(
     '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',
     'test_driver/transitions_perf_e2e.dart',
     testDriver: 'test_driver/transitions_perf_e2e_test.dart',
@@ -170,7 +170,7 @@ TaskFunction createPictureCachePerfTest() {
 }
 
 TaskFunction createPictureCachePerfE2ETest() {
-  return E2EPerfTest(
+  return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test/picture_cache_perf_e2e.dart',
   ).run;
@@ -292,7 +292,7 @@ TaskFunction createsMultiWidgetConstructPerfTest() {
 }
 
 TaskFunction createsMultiWidgetConstructPerfE2ETest() {
-  return E2EPerfTest(
+  return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test/multi_widget_construction_perf_e2e.dart',
   ).run;
@@ -388,7 +388,19 @@ class PerfTest {
     this.needsFullTimeline = true,
     this.benchmarkScoreKeys,
     this.dartDefine = '',
-  });
+    String resultFilename,
+  }): _resultFilename = resultFilename;
+
+  const PerfTest.e2e(
+    this.testDirectory,
+    this.testTarget, {
+    this.measureCpuGpu = false,
+    this.testDriver =  'test_driver/e2e_test.dart',
+    this.needsFullTimeline = false,
+    this.benchmarkScoreKeys = _ke2eDefaultScoreKeys,
+    this.dartDefine = '',
+    String resultFilename = 'e2e_perf_summary',
+  }) : saveTraceFile = false, timelineFileName = null, _resultFilename = resultFilename;
 
   /// The directory where the app under test is defined.
   final String testDirectory;
@@ -396,8 +408,9 @@ class PerfTest {
   final String testTarget;
   // The prefix name of the filename such as `<timelineFileName>.timeline_summary.json`.
   final String timelineFileName;
-  String get resultFilename => '$timelineFileName.timeline_summary';
   String get traceFilename => '$timelineFileName.timeline';
+  String get resultFilename => _resultFilename ?? '$timelineFileName.timeline_summary';
+  final String _resultFilename;
   /// The test file to run on the host.
   final String testDriver;
   /// Whether to collect CPU and GPU metrics.
@@ -488,14 +501,7 @@ class PerfTest {
         data,
         detailFiles: detailFiles.isNotEmpty ? detailFiles : null,
         benchmarkScoreKeys: benchmarkScoreKeys ?? <String>[
-          'average_frame_build_time_millis',
-          'worst_frame_build_time_millis',
-          '90th_percentile_frame_build_time_millis',
-          '99th_percentile_frame_build_time_millis',
-          'average_frame_rasterizer_time_millis',
-          'worst_frame_rasterizer_time_millis',
-          '90th_percentile_frame_rasterizer_time_millis',
-          '99th_percentile_frame_rasterizer_time_millis',
+          ..._ke2eDefaultScoreKeys,
           'average_vsync_transitions_missed',
           '90th_percentile_vsync_transitions_missed',
           '99th_percentile_vsync_transitions_missed',
@@ -507,65 +513,16 @@ class PerfTest {
   }
 }
 
-class E2EPerfTest extends PerfTest {
-  const E2EPerfTest(
-    String testDirectory,
-    String testTarget, {
-    String summaryFilename,
-    String testDriver,
-    List<String> benchmarkScoreKeys,
-    }
-  ) : super(
-    testDirectory,
-    testTarget,
-    summaryFilename,
-    testDriver: testDriver?? 'test_driver/e2e_test.dart',
-    needsFullTimeline: false,
-    benchmarkScoreKeys: benchmarkScoreKeys ?? const <String>[
-      'average_frame_build_time_millis',
-      'worst_frame_build_time_millis',
-      '90th_percentile_frame_build_time_millis',
-      '99th_percentile_frame_build_time_millis',
-      'average_frame_rasterizer_time_millis',
-      'worst_frame_rasterizer_time_millis',
-      '90th_percentile_frame_rasterizer_time_millis',
-      '99th_percentile_frame_rasterizer_time_millis',
-      ],
-  );
-
-  @override
-  String get resultFilename => timelineFileName ?? 'e2e_perf_summary';
-}
-
-class E2EPerfTestWithSkSL extends PerfTestWithSkSL {
-  E2EPerfTestWithSkSL(
-    String testDirectory,
-    String testTarget, {
-    String summaryFilename,
-    String testDriver,
-    List<String> benchmarkScoreKeys,
-    }
-  ) : super(
-    testDirectory,
-    testTarget,
-    summaryFilename,
-    testDriver: testDriver?? 'test_driver/e2e_test.dart',
-    needsFullTimeline: false,
-    benchmarkScoreKeys: benchmarkScoreKeys ?? const <String>[
-      'average_frame_build_time_millis',
-      'worst_frame_build_time_millis',
-      '90th_percentile_frame_build_time_millis',
-      '99th_percentile_frame_build_time_millis',
-      'average_frame_rasterizer_time_millis',
-      'worst_frame_rasterizer_time_millis',
-      '90th_percentile_frame_rasterizer_time_millis',
-      '99th_percentile_frame_rasterizer_time_millis',
-      ],
-  );
-
-  @override
-  String get resultFilename => timelineFileName ?? 'e2e_perf_summary';
-}
+const List<String> _ke2eDefaultScoreKeys = <String>[
+  'average_frame_build_time_millis',
+  'worst_frame_build_time_millis',
+  '90th_percentile_frame_build_time_millis',
+  '99th_percentile_frame_build_time_millis',
+  'average_frame_rasterizer_time_millis',
+  'worst_frame_rasterizer_time_millis',
+  '90th_percentile_frame_rasterizer_time_millis',
+  '99th_percentile_frame_rasterizer_time_millis',
+];
 
 class PerfTestWithSkSL extends PerfTest {
   PerfTestWithSkSL(
@@ -584,6 +541,20 @@ class PerfTestWithSkSL extends PerfTest {
     testDriver: testDriver,
     needsFullTimeline: needsFullTimeline,
     benchmarkScoreKeys: benchmarkScoreKeys,
+  );
+
+
+  PerfTestWithSkSL.e2e(
+    String testDirectory,
+    String testTarget, {
+    String testDriver =  'test_driver/e2e_test.dart',
+    String resultFilename = 'e2e_perf_summary',
+  }) : super.e2e(
+    testDirectory,
+    testTarget,
+    testDriver: testDriver,
+    needsFullTimeline: false,
+    resultFilename: resultFilename,
   );
 
   @override

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -397,7 +397,7 @@ class PerfTest {
     this.measureCpuGpu = false,
     this.testDriver =  'test_driver/e2e_test.dart',
     this.needsFullTimeline = false,
-    this.benchmarkScoreKeys = _ke2eDefaultScoreKeys,
+    this.benchmarkScoreKeys = _kCommonScoreKeys,
     this.dartDefine = '',
     String resultFilename = 'e2e_perf_summary',
   }) : saveTraceFile = false, timelineFileName = null, _resultFilename = resultFilename;
@@ -501,7 +501,7 @@ class PerfTest {
         data,
         detailFiles: detailFiles.isNotEmpty ? detailFiles : null,
         benchmarkScoreKeys: benchmarkScoreKeys ?? <String>[
-          ..._ke2eDefaultScoreKeys,
+          ..._kCommonScoreKeys,
           'average_vsync_transitions_missed',
           '90th_percentile_vsync_transitions_missed',
           '99th_percentile_vsync_transitions_missed',
@@ -513,7 +513,7 @@ class PerfTest {
   }
 }
 
-const List<String> _ke2eDefaultScoreKeys = <String>[
+const List<String> _kCommonScoreKeys = <String>[
   'average_frame_build_time_millis',
   'worst_frame_build_time_millis',
   '90th_percentile_frame_build_time_millis',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -216,6 +216,14 @@ tasks:
     required_agent_capabilities: ["mac/ios32"]
     flaky: true
 
+  flutter_gallery_sksl_warmup__transition_perf_e2e_ios32:
+    description: >
+      Measures the runtime performance of Flutter gallery transitions on iPhone4s
+      with SkSL shader warm-up with e2e.
+    stage: devicelab_ios
+    required_agent_capabilities: ["mac/ios32"]
+    flaky: true
+
   backdrop_filter_perf__timeline_summary:
     description: >
       Measures the runtime performance of backdrop filter blurs on Android.
@@ -795,6 +803,14 @@ tasks:
       with SkSL shader warm-up.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+
+  flutter_gallery_sksl_warmup__transition_perf_e2e:
+    description: >
+      Measures the runtime performance of Flutter gallery transitions on Android
+      with SkSL shader warm-up with e2e.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery__transition_perf_with_semantics:
     description: >

--- a/dev/integration_tests/flutter_gallery/.gitignore
+++ b/dev/integration_tests/flutter_gallery/.gitignore
@@ -1,1 +1,3 @@
 lib/generated_plugin_registrant.dart
+vmservice.out
+*.sksl.json


### PR DESCRIPTION
## Description

Migrate `flutter_gallery_sksl_warmup__transition_perf` to the host-independent solution to reduce flakiness

## Related Issues

#60559

## Tests

The PR is adding tests

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
