### PR TITLE
Add rect logic to getOffsetToReveal when onlySlivers is true

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -718,7 +718,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     // `rect`'s coordinates to a scroll offset. It is going to be:
     //
     // - the `pivot` RenderBox if it exists.
-    // - otherwise the `target` RenderSliver.
+    // - the `target` RenderSliver otherwise .
     //
     // `leadingScrollOffset` is currently the scrollOffset within `child`, to
     // our new reference frame (`pivot` or `target`).
@@ -819,7 +819,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
         break;
       case GrowthDirection.reverse:
         // If child's growth direction is reverse, when viewport.offset is
-        // `leadingScrollOffset` it is just outside of the viewport.
+        // `leadingScrollOffset`, it is positioned just outside of the leading
+        // edge of the viewport.
         switch (axis) {
           case Axis.vertical:
             leadingScrollOffset -= targetRect.height;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -734,7 +734,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     // `rect` in the new intermediate coordinate system.
     Rect rectLocal;
     // Our new reference frame render object's main axis extent.
-    double localMaxExtent;
+    double pivotExtent;
     GrowthDirection growthDirection;
 
     // `leadingScrollOffset` is currently the scrollOffset of our new reference
@@ -748,10 +748,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       growthDirection = pivotParent.constraints.growthDirection;
       switch (axis) {
         case Axis.horizontal:
-          localMaxExtent = pivot.size.width;
+          pivotExtent = pivot.size.width;
           break;
         case Axis.vertical:
-          localMaxExtent = pivot.size.height;
+          pivotExtent = pivot.size.height;
           break;
       }
       rect ??= target.paintBounds;
@@ -763,7 +763,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       growthDirection = targetSliver.constraints.growthDirection;
       // TODO(LongCatIsLooong): make sure this works if `targetSliver` is a
       // persistent header, when #56413 relands.
-      localMaxExtent = targetSliver.geometry.scrollExtent;
+      pivotExtent = targetSliver.geometry.scrollExtent;
       if (rect == null) {
         switch (axis) {
           case Axis.horizontal:
@@ -787,7 +787,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       return RevealedOffset(offset: offset.pixels, rect: rect);
     }
 
-    assert(localMaxExtent != null);
+    assert(pivotExtent != null);
     assert(rect != null);
     assert(rectLocal != null);
     assert(growthDirection != null);
@@ -799,7 +799,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     // The scroll offset within `child` to `rect`.
     switch (applyGrowthDirectionToAxisDirection(axisDirection, growthDirection)) {
       case AxisDirection.up:
-        leadingScrollOffset += localMaxExtent - rectLocal.bottom;
+        leadingScrollOffset += pivotExtent - rectLocal.bottom;
         targetMainAxisExtent = rectLocal.height;
         break;
       case AxisDirection.right:
@@ -811,7 +811,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
         targetMainAxisExtent = rectLocal.height;
         break;
       case AxisDirection.left:
-        leadingScrollOffset += localMaxExtent - rectLocal.right;
+        leadingScrollOffset += pivotExtent - rectLocal.right;
         targetMainAxisExtent = rectLocal.width;
         break;
     }

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -220,7 +220,7 @@ void main() {
                 );
                 children.add(sliver);
                 return SliverPadding(
-                  padding: const EdgeInsets.all(22.0),
+                  padding: const EdgeInsets.only(top: 22.0, bottom: 23.0),
                   sliver: sliver,
                 );
               }),
@@ -234,10 +234,16 @@ void main() {
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22);
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22 - 100);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 - 100);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 + 2);
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 - (200 - 4));
   });
 
   testWidgets('Viewport getOffsetToReveal Sliver - right', (WidgetTester tester) async {
@@ -261,7 +267,7 @@ void main() {
                 );
                 children.add(sliver);
                 return SliverPadding(
-                  padding: const EdgeInsets.all(22.0),
+                  padding: const EdgeInsets.only(left: 22.0, right: 23.0),
                   sliver: sliver,
                 );
               }),
@@ -275,10 +281,16 @@ void main() {
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22);
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22 - 100);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 - 100);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 + 1);
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 22 - (200 - 3));
   });
 
   testWidgets('Viewport getOffsetToReveal Sliver - up', (WidgetTester tester) async {
@@ -302,7 +314,7 @@ void main() {
                 );
                 children.add(sliver);
                 return SliverPadding(
-                  padding: const EdgeInsets.all(22.0),
+                  padding: const EdgeInsets.only(top: 22.0, bottom: 23.0),
                   sliver: sliver,
                 );
               }),
@@ -316,17 +328,25 @@ void main() {
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22);
+    // Does not include the bottom padding of children[5] thus + 23 instead of + 22.
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 23);
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22 - 100);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 23 - 100);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 23 + (100 - 4));
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, - 200 + 6 * (100 + 22 + 23) - 22 - 2);
   });
 
   testWidgets('Viewport getOffsetToReveal Sliver - up - reverse growth', (WidgetTester tester) async {
     const Key centerKey = ValueKey<String>('center');
+    const EdgeInsets padding = EdgeInsets.only(top: 22.0, bottom: 23.0);
     final Widget centerSliver = SliverPadding(
       key: centerKey,
-      padding: const EdgeInsets.all(22.0),
+      padding: padding,
       sliver: SliverToBoxAdapter(
         child: Container(
           height: 100.0,
@@ -339,7 +359,7 @@ void main() {
       child: const Text('Tile lower'),
     );
     final Widget lowerSliver = SliverPadding(
-      padding: const EdgeInsets.all(22.0),
+      padding: padding,
       sliver: SliverToBoxAdapter(
         child: lowerItem,
       ),
@@ -370,13 +390,20 @@ void main() {
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
     expect(revealed.offset, - 100 - 22 - 100);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, - 22 - 4);
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, -200 - 22 - 2);
   });
 
   testWidgets('Viewport getOffsetToReveal Sliver - left - reverse growth', (WidgetTester tester) async {
     const Key centerKey = ValueKey<String>('center');
+    const EdgeInsets padding = EdgeInsets.only(left: 22.0, right: 23.0);
     final Widget centerSliver = SliverPadding(
       key: centerKey,
-      padding: const EdgeInsets.all(22.0),
+      padding: padding,
       sliver: SliverToBoxAdapter(
         child: Container(
           width: 100.0,
@@ -389,7 +416,7 @@ void main() {
       child: const Text('Tile lower'),
     );
     final Widget lowerSliver = SliverPadding(
-      padding: const EdgeInsets.all(22.0),
+      padding: padding,
       sliver: SliverToBoxAdapter(
         child: lowerItem,
       ),
@@ -421,6 +448,12 @@ void main() {
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
     expect(revealed.offset, - 100 - 22 - 200);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, - 22 - 3);
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, - 300 - 22 - 1);
   });
 
   testWidgets('Viewport getOffsetToReveal Sliver - left', (WidgetTester tester) async {
@@ -445,7 +478,7 @@ void main() {
                 );
                 children.add(sliver);
                 return SliverPadding(
-                  padding: const EdgeInsets.all(22.0),
+                  padding: const EdgeInsets.only(left: 22.0, right: 23.0),
                   sliver: sliver,
                 );
               }),
@@ -459,10 +492,16 @@ void main() {
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5], skipOffstage: false));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 23);
 
     revealed = viewport.getOffsetToReveal(target, 1.0);
-    expect(revealed.offset, 5 * (100 + 22 + 22) + 22 - 100);
+    expect(revealed.offset, 5 * (100 + 22 + 23) + 23 - 100);
+
+    // With rect specified.
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, 6 * (100 + 22 + 23) - 22 - 3);
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTRB(1, 2, 3, 4));
+    expect(revealed.offset, -200  + 6 * (100 + 22 + 23) - 22 - 1);
   });
 
   testWidgets('Nested Viewports showOnScreen', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Currently we disregard `rect` in `getOffsetToReveal`'s `leadingScrollOffset` calculation when `onlySlivers` is true. This PR adds the missing logic in that branch. This is needed to reland #56413, as persistent headers will have their own `showOnScreen` overrides once that PR relands.

Also moved some code from #56413 into this PR.

## Related Issues

#25507

## Tests

Improved existing tests.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
