### PR TITLE
Add separators builder for AnimatedList

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -303,14 +303,18 @@ class AnimatedList extends StatefulWidget {
         assert(separatorBuilder != null),
         assert(initialItemCount != null && initialItemCount >= 0),
         itemBuilder =
-        ((BuildContext context, int index, Animation<double> animation) =>
-            Flex(
-              direction: scrollDirection,
-              children: <Widget>[
-                itemBuilder(context, index, animation),
-                separatorBuilder(context, index, animation),
-              ],
-            )),
+        ((BuildContext context, int index, Animation<double> animation) {
+          if (index == 0) {
+            return itemBuilder(context, index, animation);
+          }
+          return  Flex(
+            direction: scrollDirection,
+            children: <Widget>[
+              separatorBuilder(context, index, animation),
+              itemBuilder(context, index, animation),
+            ],
+          );
+        }),
         super(key: key);
 
   /// Called, as needed, to build list item widgets.

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -285,6 +285,34 @@ class AnimatedList extends StatefulWidget {
        assert(initialItemCount != null && initialItemCount >= 0),
        super(key: key);
 
+  /// Creates a scrolling container with separators that animates items and
+  /// separators when they are inserted or removed.
+  AnimatedList.separated({
+    Key key,
+    @required AnimatedListItemBuilder itemBuilder,
+    @required AnimatedListItemBuilder separatorBuilder,
+    this.initialItemCount = 0,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.controller,
+    this.primary,
+    this.physics,
+    this.shrinkWrap = false,
+    this.padding,
+  })  : assert(itemBuilder != null),
+        assert(separatorBuilder != null),
+        assert(initialItemCount != null && initialItemCount >= 0),
+        itemBuilder =
+        ((BuildContext context, int index, Animation<double> animation) =>
+            Flex(
+              direction: scrollDirection,
+              children: <Widget>[
+                itemBuilder(context, index, animation),
+                separatorBuilder(context, index, animation),
+              ],
+            )),
+        super(key: key);
+
   /// Called, as needed, to build list item widgets.
   ///
   /// List items are only built when they're scrolled into view.


### PR DESCRIPTION
## Description

Introduced an additional constructor for `AnimatedList` to build an animated list with separators. Same as `ListView.separated()`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48226

## Tests

I added the following tests:

A widget test for `AnimatedList.separated()` in `packages/flutter/test/widgets/animated_list_test.dart`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
