### PR TITLE
Increase threshold for usage of compute for utf8 decoding on large strings to 50 KB

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,6 +71,8 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
+    // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
+    // on a Pixel 4.
     if (data.lengthInBytes < 50 * 1024) {
       return utf8.decode(data.buffer.asUint8List());
     }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,8 +71,6 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
-    // 10KB takes about 3ms to parse on a Pixel 2 XL.
-    // See: https://github.com/dart-lang/sdk/issues/31954
     return utf8.decode(data.buffer.asUint8List());
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,15 +71,8 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
-    if (data.lengthInBytes < 10 * 1024) {
-      // 10KB takes about 3ms to parse on a Pixel 2 XL.
-      // See: https://github.com/dart-lang/sdk/issues/31954
-      return utf8.decode(data.buffer.asUint8List());
-    }
-    return compute(_utf8decode, data, debugLabel: 'UTF8 decode for "$key"');
-  }
-
-  static String _utf8decode(ByteData data) {
+    // 10KB takes about 3ms to parse on a Pixel 2 XL.
+    // See: https://github.com/dart-lang/sdk/issues/31954
     return utf8.decode(data.buffer.asUint8List());
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -185,7 +185,6 @@ abstract class CachingAssetBundle extends AssetBundle {
       return _structuredDataCache[key] as Future<T>;
     Completer<T>? completer;
     Future<T>? result;
-    var sw = Stopwatch()..start();
     loadString(key, cache: false).then<T>(parser).then<void>((T value) {
       result = SynchronousFuture<T>(value);
       _structuredDataCache[key] = result!;
@@ -205,9 +204,6 @@ abstract class CachingAssetBundle extends AssetBundle {
     // completer for it to use when it does run.
     completer = Completer<T>();
     _structuredDataCache[key] = completer.future;
-    completer.future.whenComplete(() {
-      print('LoadStructuredDataTook: ${sw.elapsedMilliseconds}');
-    });
     return completer.future;
   }
 


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/issues/36552

On a local benchmark, removing compute is faster than compute in both debug and release mode on a Pixel 4. Looking for more confirmation on other older phone types.


Debug:
314 ms load/parse asset manifest with compute
91 ms load/parse without compute

Release:
14 ms load/parse with compute
2 ms load/parse without compute

I measured perf by inserting a stopwatch/print:

```
diff --git a/packages/flutter/lib/src/services/asset_bundle.dart b/packages/flutter/lib/src/services/asset_bundle.dart
index 0e8bb02874..f0028a0103 100644
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -178,6 +178,7 @@ abstract class CachingAssetBundle extends AssetBundle {
       return _structuredDataCache[key] as Future<T>;
     Completer<T>? completer;
     Future<T>? result;
+    var sw = Stopwatch()..start();
     loadString(key, cache: false).then<T>(parser).then<void>((T value) {
       result = SynchronousFuture<T>(value);
       _structuredDataCache[key] = result!;
@@ -197,6 +198,9 @@ abstract class CachingAssetBundle extends AssetBundle {
     // completer for it to use when it does run.
     completer = Completer<T>();
     _structuredDataCache[key] = completer.future;
+    completer.future.whenComplete(() {
+      print('LoadStructuredDataTook: ${sw.elapsedMilliseconds}');
+    });
     return completer.future;
   }
```