### PR TITLE
Change typo profileDemos to restDemos

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -212,7 +212,7 @@ void main([List<String> args = const <String>[]]) {
 
       // Execute the remaining tests.
       if (hybrid) {
-        await driver.requestData('profileDemos');
+        await driver.requestData('restDemos');
       } else {
         final Set<String> unprofiledDemos = Set<String>.from(_allDemos)..removeAll(kProfiledDemos);
         await runDemos(unprofiledDemos.toList(), driver);


### PR DESCRIPTION
The typo made profileDemos run twice without triggering restDemos.  It
didn't affect our test results because only profileDemos are reporting
performance metrics.
