### PR TITLE
Add GestureDetector.onDoubleTapDown()

### DIFF
--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -229,7 +229,9 @@ class GestureDetector extends StatelessWidget {
     this.onTertiaryTapDown,
     this.onTertiaryTapUp,
     this.onTertiaryTapCancel,
+    this.onDoubleTapDown,
     this.onDoubleTap,
+    this.onDoubleTapCancel,
     this.onLongPress,
     this.onLongPressStart,
     this.onLongPressMoveUpdate,
@@ -428,6 +430,14 @@ class GestureDetector extends StatelessWidget {
   ///  * [kTertiaryButton], the button this callback responds to.
   final GestureTapCancelCallback onTertiaryTapCancel;
 
+  /// A pointer that might cause a double tap has contacted the screen at a
+  /// particular location.
+  ///
+  /// See also:
+  ///
+  ///  * [kTertiaryButton], the button this callback responds to.
+  final GestureTapDownCallback onDoubleTapDown;
+
   /// The user has tapped the screen with a primary button at the same location
   /// twice in quick succession.
   ///
@@ -435,6 +445,14 @@ class GestureDetector extends StatelessWidget {
   ///
   ///  * [kPrimaryButton], the button this callback responds to.
   final GestureTapCallback onDoubleTap;
+
+  /// The pointer that previously triggered [onDoubleTapDown] will not end up
+  /// causing a double tap.
+  ///
+  /// See also:
+  ///
+  ///  * [kPrimaryButton], the button this callback responds to.
+  final GestureTapCancelCallback onDoubleTapCancel;
 
   /// Called when a long press gesture with a primary button has been recognized.
   ///
@@ -774,7 +792,10 @@ class GestureDetector extends StatelessWidget {
       gestures[DoubleTapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
         () => DoubleTapGestureRecognizer(debugOwner: this),
         (DoubleTapGestureRecognizer instance) {
-          instance.onDoubleTap = onDoubleTap;
+          instance
+            ..onDoubleTapDown = onDoubleTapDown
+            ..onDoubleTap = onDoubleTap
+            ..onDoubleTapCancel = onDoubleTapCancel;
         },
       );
     }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -433,9 +433,15 @@ class GestureDetector extends StatelessWidget {
   /// A pointer that might cause a double tap has contacted the screen at a
   /// particular location.
   ///
+  /// Triggered immediately after the down event of the second tap.
+  ///
+  /// If the user completes the double tap and the gesture wins, [onDoubleTap]
+  /// will be called after this callback. Otherwise, [onDoubleTapCancel] will
+  /// be called after this callback.
+  ///
   /// See also:
   ///
-  ///  * [kTertiaryButton], the button this callback responds to.
+  ///  * [kPrimaryButton], the button this callback responds to.
   final GestureTapDownCallback onDoubleTapDown;
 
   /// The user has tapped the screen with a primary button at the same location


### PR DESCRIPTION
## Description

This change adds `GestureDetector.onDoubleTapDown` and `GestureDetector.onDoubleTapCancel`
callbacks (and corresponding callbacks to the double tap gesture recognizer as well).

The `onDoubleTapDown` callback will pass tap down details so that callers can capture the details
for when the `onDoubleTap` callback fires.

The `onDoubleTapCancel` callback will fire after `onDoubleTapDown` if the gesture loses the arena.

## Related Issues

https://github.com/flutter/flutter/issues/20000

## Tests

`double_tap_test.dart` already contained test cases for various interesting scenarios, so rather
than writing _new_ tests, this change updates all existing tests to add extra expectations around
whether and when the new callbacks fire in the test cases.

Note that I did restructure the tests in that file to use `setUp()` and `tearDown()`.  I did so for
the following reasons:

1. It saves a significant amount of boilerplate in the test file
1. Previously, an exception in one test would cause _other_ tests to fail, because it would cause the gesture recognizer to fail to get properly disposed of

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
