### PR TITLE
Pass --verbose-logging to flutter_tester

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -800,6 +800,7 @@ class FlutterPlatform extends PlatformPlugin {
       '--skia-deterministic-rendering',
       '--enable-dart-profiling',
       '--non-interactive',
+      '--verbose-logging',
       '--use-test-fonts',
       '--packages=$packages',
       if (nullAssertions)

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -123,6 +123,49 @@ void main() {
       }, overrides: contextOverrides);
     });
 
+    group('The arguments that are passed to the test process', () {
+      MockPlatform mockPlatform;
+      MockProcessManager mockProcessManager;
+      FlutterPlatform flutterPlatform;
+      final Map<Type, Generator> contextOverrides = <Type, Generator>{
+        Platform: () => mockPlatform,
+        ProcessManager: () => mockProcessManager,
+        FileSystem: () => fileSystem,
+      };
+
+      setUp(() {
+        mockPlatform = MockPlatform();
+        when(mockPlatform.isWindows).thenReturn(false);
+        mockProcessManager = MockProcessManager();
+        flutterPlatform = TestFlutterPlatform();
+        when(mockPlatform.environment).thenReturn(<String, String>{});
+      });
+
+      Future<Set<String>> captureArguments() async {
+        flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
+        when(mockProcessManager.start(
+            any,
+            environment: anyNamed('environment')),
+        ).thenAnswer((_) {
+          return Future<Process>.value(MockProcess());
+        });
+        await untilCalled(mockProcessManager.start(any, environment: anyNamed('environment')));
+        final VerificationResult toVerify = verify(mockProcessManager.start(
+          captureAny,
+          environment: anyNamed('environment'),
+        ));
+        expect(toVerify.captured, hasLength(1));
+        expect(toVerify.captured.first, isA<List<String>>());
+        final List<String> command = toVerify.captured.first as List<String>;
+        return command.where((String element) => element.startsWith('-')).toSet();
+      }
+
+      testUsingContext('contain --verbose-logging', () async {
+        final Set<String> capturedArguments = await captureArguments();
+        expect(capturedArguments, contains('--verbose-logging'));
+      }, overrides: contextOverrides);
+    });
+
     testUsingContext('installHook creates a FlutterPlatform', () {
       expect(() => installHook(
         buildMode: BuildMode.debug,


### PR DESCRIPTION
## Description

This updates our test harness to pass `--verbose-logging` to the flutter_tester process when running tests. This may help surface root causes when tests fail due to crashing flutter_tester runs.

## Tests

I added the following tests:

* A test that verifies that we pass the `--verbose-logging` to the test process.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
