### PR TITLE
Fix negative usableCrossAxisExtent in release mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,3 +64,4 @@ Brian Wang <xinlei966@gmail.com>
 CaiJingLong <cjl_spy@163.com>
 Alex Li <google@alexv525.com>
 Ram Navan <hiramprasad@gmail.com>
+meritozh <ah841814092@gmail.com>

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -328,7 +328,8 @@ class SliverGridDelegateWithFixedCrossAxisCount extends SliverGridDelegate {
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
     assert(_debugAssertIsValid());
-    final double usableCrossAxisExtent = constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1);
+    final double usableCrossAxisExtent = math.max(0.0,
+        constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1));
     final double childCrossAxisExtent = usableCrossAxisExtent / crossAxisCount;
     final double childMainAxisExtent = childCrossAxisExtent / childAspectRatio;
     return SliverGridRegularTileLayout(
@@ -427,7 +428,8 @@ class SliverGridDelegateWithMaxCrossAxisExtent extends SliverGridDelegate {
   SliverGridLayout getLayout(SliverConstraints constraints) {
     assert(_debugAssertIsValid(constraints.crossAxisExtent));
     final int crossAxisCount = (constraints.crossAxisExtent / (maxCrossAxisExtent + crossAxisSpacing)).ceil();
-    final double usableCrossAxisExtent = constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1);
+    final double usableCrossAxisExtent = math.max(0.0,
+        constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1));
     final double childCrossAxisExtent = usableCrossAxisExtent / crossAxisCount;
     final double childMainAxisExtent = childCrossAxisExtent / childAspectRatio;
     return SliverGridRegularTileLayout(

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -309,6 +309,44 @@ void main() {
   );
 
   testWidgets(
+    'SliverGrid negative usableCrossAxisExtent',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 4,
+              height: 4,
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  SliverGrid(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 8,
+                    ),
+                    delegate: SliverChildListDelegate(
+                      <Widget>[
+                        Container(child: const Center(child: Text('A'))),
+                        Container(child: const Center(child: Text('B'))),
+                        Container(child: const Center(child: Text('C'))),
+                        Container(child: const Center(child: Text('D'))),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
     'SliverList can handle inaccurate scroll offset due to changes in children list',
       (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/pull/59888.


### PR DESCRIPTION
## Description

In release mode, `constraints.crossAxisExtent` maybe zero, will cause `usableCrossAxisExtent` be negative, then throwing some incomprehensible rendering exception.

- v1.12.13, our application report

```
Invalid argument(s): 0.0
#0      _Double.clamp (dart:core-patch/double.dart:185)
#1      BoxConstraints.enforce (package:flutter/src/rendering/box.dart:213)
#2      RenderConstrainedBox.performLayout (package:flutter/src/rendering/proxy_box.dart:262)
#3      RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#4      RenderLimitedBox.performLayout (package:flutter/src/rendering/proxy_box.dart:349)
#5      RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#6      RenderStack.performLayout (package:flutter/src/rendering/stack.dart:557)
#7      RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#8      RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#9      RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#10     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#11     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#12     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#13     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#14     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#15     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#16     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#17     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#18     RenderSliverGrid.performLayout (package:flutter/src/rendering/sliver_grid.dart:571)
#19     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#20     RenderSliverEdgeInsetsPadding.performLayout (package:flutter/src/rendering/sliver_padding.dart:134)
#21     RenderSliverPadding.performLayout (package:flutter/src/rendering/sliver_padding.dart:373)
#22     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#23     RenderViewportBase.layoutChildSequence (package:flutter/src/rendering/viewport.dart:410)
#24     RenderViewport._attemptLayout (package:flutter/src/rendering/viewport.dart:1367)
#25     RenderViewport.performLayout (package:flutter/src/rendering/viewport.dart:1285)
#26     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#27     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#28     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#29     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#30     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#31     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#32     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#33     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#34     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#35     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#36     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#37     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#38     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#39     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#40     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#41     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#42     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#43     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#44     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#45     RenderPadding.performLayout (package:flutter/src/rendering/shifted_box.dart:206)
#46     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#47     RenderConstrainedBox.performLayout (package:flutter/src/rendering/proxy_box.dart:259)
#48     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#49     MultiChildLayoutDelegate.layoutChild (package:flutter/src/rendering/custom_layout.dart:163)
#50     _ScaffoldLayout.performLayout (package:flutter/src/material/scaffold.dart:477)
#51     MultiChildLayoutDelegate._callPerformLayout (package:flutter/src/rendering/custom_layout.dart:232)
#52     RenderCustomMultiChildLayoutBox.performLayout (package:flutter/src/rendering/custom_layout.dart:391)
#53     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#54     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#55     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#56     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105)
#57     _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1232)
#58     RenderObject.layout (package:flutter/src/rendering/object.dart:1748)
#59     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:557)
#60     RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:1594)
#61     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:847)
#62     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:350)
#63     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:778)
#64     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:287)
#65     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1109)
#66     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1048)
#67     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:964)
#68     _rootRun (dart:async/zone.dart:1126)
#69     _CustomZone.run (dart:async/zone.dart:1023)
#70     _CustomZone.runGuarded (dart:async/zone.dart:925)
#71     _invoke (dart:ui/hooks.dart:273)
#72     _drawFrame (dart:ui/hooks.dart:217)
```

- master, demo app report:

```
flutter:
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'
...
```

## Related Issues

#58216, #6537 

## Tests

add test `SliverGrid negative usableCrossAxisExtent`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
