### PR TITLE
Add NavigatorState.(add|remove)Observer

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2764,8 +2764,19 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// Observers added via this method are distinct from the immutable
   /// [Navigator.observers] list that is specified when the navigator is
   /// constructed.
+  ///
+  /// This may only be called when this state is [mounted]. The
+  /// [NavigatorObserver.navigator] field of the observer will be set to this
+  /// state. When this state is disposed, if the observer is still registered,
+  /// the [NavigatorObserver.navigator] field of the observer will be set to
+  /// null. Generally, widgets will manage their observer lifecycle in a [State]
+  /// object and handle such changes in their [State.didChangeDependencies]
+  /// method.
+  ///
+  /// An observer may only be associated with one navigator at a time.
   void addObserver(NavigatorObserver observer) {
     assert(observer.navigator == null);
+    assert(mounted);
     _addedObservers.add(observer);
     observer._navigator = this;
     _updateEffectiveObservers();

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2771,7 +2771,41 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// the [NavigatorObserver.navigator] field of the observer will be set to
   /// null. Generally, widgets will manage their observer lifecycle in a [State]
   /// object and handle such changes in their [State.didChangeDependencies]
-  /// method.
+  /// method, like so:
+  ///
+  /// ```dart
+  /// class MyWidgetState extends State<MyWidget> {
+  ///   final MyObserver observer = MyObserver();
+  ///
+  ///   void _addObserver() {
+  ///     Navigator.of(context).addObserver(observer);
+  ///   }
+  ///
+  ///   void _removeObserver() {
+  ///     if (observer.navigator != null) {
+  ///       observer.navigator.removeObserver(observer);
+  ///     }
+  ///   }
+  ///
+  ///   @override
+  ///   void didChangeDependencies() {
+  ///     super.didChangeDependencies();
+  ///     _removeObserver();
+  ///     _addObserver();
+  ///   }
+  ///
+  ///   @override
+  ///   void dispose() {
+  ///     _removeObserver();
+  ///     super.dispose();
+  ///   }
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     ...
+  ///   }
+  /// }
+  /// ```
   ///
   /// An observer may only be associated with one navigator at a time.
   void addObserver(NavigatorObserver observer) {


### PR DESCRIPTION
## Description

This adds `NavigatorState.addObserver` and `NavigatorState.removeObserver`, to allow
callers to dynamically add and remove observers to the navigator.  This should prove useful
to stateful widgets deeper in the app's widget hierarchy that want a hook into the navigator's
observers list.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64442

## Tests

I added the following tests:

* A test of adding an observer from a descendant widget (and the observer getting properly notified)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
