### PR TITLE
[devicelab] disable image list duration tests

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -441,12 +441,14 @@ tasks:
       Measures image loading performance on release (aot) build.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   image_list_jit_reported_duration:
     description: >
       Measures image loading performance on debug (jit) build.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   build_benchmark:
     description: >


### PR DESCRIPTION
## Description

These tests have a specified certificate which has expired. They should be rewritten differently to not require renewing this cert, perhaps by using an HttpClient override to simulate network loading?


https://github.com/flutter/flutter/blob/master/examples/image_list/lib/main.dart#L19