### PR TITLE
migrate cubic_bezier_perf to e2e

### DIFF
--- a/dev/benchmarks/macrobenchmarks/.gitignore
+++ b/dev/benchmarks/macrobenchmarks/.gitignore
@@ -1,2 +1,4 @@
 lib/generated_plugin_registrant.dart
 devtools_memory.json
+*.sksl.json
+vmservice.out

--- a/dev/benchmarks/macrobenchmarks/test/cubic_bezier_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/cubic_bezier_perf_e2e.dart
@@ -1,0 +1,11 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E('cubic_bezier_perf', kCubicBezierRouteName);
+}

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+// TODO(CareF): add sksl warmup version
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createCubicBezierPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
@@ -10,5 +10,5 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(createCubicBezierPerfE2ETest());
+  await task(createCubicBezierPerfSkSlWarmupE2ETest());
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -99,6 +99,13 @@ TaskFunction createCubicBezierPerfE2ETest() {
   ).run;
 }
 
+TaskFunction createCubicBezierPerfSkSlWarmupE2ETest() {
+  return PerfTestWithSkSL.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/cubic_bezier_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createCubicBezierPerfSkSLWarmupTest() {
   return PerfTestWithSkSL(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -92,6 +92,13 @@ TaskFunction createCubicBezierPerfTest() {
   ).run;
 }
 
+TaskFunction createCubicBezierPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/cubic_bezier_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createCubicBezierPerfSkSLWarmupTest() {
   return PerfTestWithSkSL(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -201,6 +201,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  cubic_bezier_perf__e2e_summary:
+    description: >
+      Measures the runtime performance of cubic bezier animations on Android.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
   cubic_bezier_perf_sksl_warmup__timeline_summary:
     description: >
       Measures the runtime performance of cubic bezier animations on Android

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -203,7 +203,8 @@ tasks:
 
   cubic_bezier_perf__e2e_summary:
     description: >
-      Measures the runtime performance of cubic bezier animations on Android.
+      Measures the runtime performance of cubic bezier animations on Android
+      using e2e.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
     flaky: true
@@ -214,6 +215,14 @@ tasks:
       with SkSL shader warm-up.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
+
+  cubic_bezier_perf_sksl_warmup__e2e_summary:
+    description: >
+      Measures the runtime performance of cubic bezier animations on Android
+      with SkSL shader warm-up using e2e.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery_sksl_warmup_ios32__transition_perf:
     description: >


### PR DESCRIPTION
## Description

This is break down of #62171, and should be merged when devicelab is of low load.

Additionally this also add the sksl warmup version on e2e. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
