### PR TITLE
migrate post_backdrop_filter_perf to e2e

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/post_backdrop_filter_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/post_backdrop_filter_perf_e2e.dart
@@ -1,0 +1,29 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'post_backdrop_filter_perf',
+    kPostBackdropFilterRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+    body: (WidgetController controller) async {
+      final Finder backdropFilterCheckbox = find.byKey(const ValueKey<String>('bdf-checkbox'));
+      await controller.tap(backdropFilterCheckbox);
+      await Future<void>.delayed(const Duration(milliseconds: 500)); // BackdropFilter on
+      await controller.tap(backdropFilterCheckbox);
+      await Future<void>.delayed(const Duration(milliseconds: 500)); // BackdropFilter off
+
+      final Finder animateButton = find.byKey(const ValueKey<String>('bdf-animate'));
+      await controller.tap(animateButton);
+      await Future<void>.delayed(const Duration(milliseconds: 1000)); // Now animate
+    },
+  );
+}

--- a/dev/devicelab/bin/tasks/post_backdrop_filter_perf_ios__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/post_backdrop_filter_perf_ios__e2e_summary.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+// TODO(CareF): add it to manifest.yaml
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createPostBackdropFilterPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -153,6 +153,13 @@ TaskFunction createPostBackdropFilterPerfTest({bool measureCpuGpu = false}) {
   ).run;
 }
 
+TaskFunction createPostBackdropFilterPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/post_backdrop_filter_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createSimpleAnimationPerfTest({bool measureCpuGpu = false}) {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -563,6 +563,13 @@ tasks:
     required_agent_capabilities: ["mac/ios"]
     flaky: true
 
+  # post_backdrop_filter_perf_ios__e2e_summary:
+  #   description: >
+  #     Measures the runtime performance of animations after a backdrop filter is removed on iOS.
+  #   stage: devicelab_ios
+  #   required_agent_capabilities: ["mac/iphonexs"]
+  #   flaky: true
+
   complex_layout_scroll_perf_ios__timeline_summary:
     description: >
       Measures the runtime performance of the Complex Layout sample app on


### PR DESCRIPTION
## Description

This is break down of #62171, and should be merged when devicelab is of low load.

**This one is special for CPU/GPU measurement, and need further modification** 
See #59238

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
