### PR TITLE
Reland: Increase threshold for usage of compute for utf8 decoding on large strings to 50 KB

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,6 +71,8 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
+    // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
+    // on a Pixel 4.
     if (data.lengthInBytes < 50 * 1024) {
       return utf8.decode(data.buffer.asUint8List());
     }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,8 +71,6 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
-    // 10KB takes about 3ms to parse on a Pixel 2 XL.
-    // See: https://github.com/dart-lang/sdk/issues/31954
     return utf8.decode(data.buffer.asUint8List());
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,15 +71,8 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
-    if (data.lengthInBytes < 10 * 1024) {
-      // 10KB takes about 3ms to parse on a Pixel 2 XL.
-      // See: https://github.com/dart-lang/sdk/issues/31954
-      return utf8.decode(data.buffer.asUint8List());
-    }
-    return compute(_utf8decode, data, debugLabel: 'UTF8 decode for "$key"');
-  }
-
-  static String _utf8decode(ByteData data) {
+    // 10KB takes about 3ms to parse on a Pixel 2 XL.
+    // See: https://github.com/dart-lang/sdk/issues/31954
     return utf8.decode(data.buffer.asUint8List());
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -185,7 +185,6 @@ abstract class CachingAssetBundle extends AssetBundle {
       return _structuredDataCache[key] as Future<T>;
     Completer<T>? completer;
     Future<T>? result;
-    var sw = Stopwatch()..start();
     loadString(key, cache: false).then<T>(parser).then<void>((T value) {
       result = SynchronousFuture<T>(value);
       _structuredDataCache[key] = result!;
@@ -205,9 +204,6 @@ abstract class CachingAssetBundle extends AssetBundle {
     // completer for it to use when it does run.
     completer = Completer<T>();
     _structuredDataCache[key] = completer.future;
-    completer.future.whenComplete(() {
-      print('LoadStructuredDataTook: ${sw.elapsedMilliseconds}');
-    });
     return completer.future;
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -564,7 +564,7 @@ class HotRunner extends ResidentRunner {
         }
         isolateNotifications.add(
           device.vmService.onIsolateEvent.firstWhere((vm_service.Event event) {
-            return event.kind == vm_service.EventKind.kIsolateRunnable;
+            return event.kind == vm_service.EventKind.kServiceExtensionAdded;
           }),
         );
       }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -562,6 +562,8 @@ class HotRunner extends ResidentRunner {
         } on vm_service.RPCError {
           // Do nothing, we're already subcribed.
         }
+        // Ideally this would wait for kIsolateRunnable, but either this subscription occurs too
+        // late to receive the event, or it is not forwarded for hot restarted isolates.
         isolateNotifications.add(
           device.vmService.onIsolateEvent.firstWhere((vm_service.Event event) {
             return event.kind == vm_service.EventKind.kServiceExtensionAdded;


### PR DESCRIPTION
## Description

Reland of https://github.com/flutter/flutter/pull/64350 with fixes to flutter_tools benchmark mode. Previously we were inadvertently using the isolate ready event from the compute isolate

#36552

On a local benchmark, removing compute is faster than compute in both debug and release mode on a Pixel 4. Looking for more confirmation on other older phone types.

Debug:
314 ms load/parse asset manifest with compute
91 ms load/parse without compute

Release:
14 ms load/parse with compute
2 ms load/parse without compute