### PR TITLE
migrate simple_animation_perf to e2e

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/simple_animation_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/simple_animation_perf_e2e.dart
@@ -10,5 +10,6 @@ void main() {
   macroPerfTestE2E(
     'simple_animation_perf',
     kSimpleAnimationRouteName,
+    measureCpuGpu: true,
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/simple_animation_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/simple_animation_perf_e2e.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'simple_animation_perf',
+    kSimpleAnimationRouteName,
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 import 'package:macrobenchmarks/common.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:macrobenchmarks/main.dart' as app;
+import 'package:vm_service/vm_service.dart' as vm;
 
 typedef ControlCallback = Future<void> Function(WidgetController controller);
 
@@ -19,6 +20,7 @@ void macroPerfTestE2E(
   Duration timeout = const Duration(seconds: 30),
   ControlCallback body,
   ControlCallback setup,
+  bool measureCpuGpu = false,
 }) {
   final WidgetsBinding _binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   assert(_binding is IntegrationTestWidgetsFlutterBinding);
@@ -57,12 +59,42 @@ void macroPerfTestE2E(
       await setup(tester);
     }
 
-    await binding.watchPerformance(() async {
+    Future<void> testBody() async {
       final Future<void> durationFuture = tester.binding.delayed(duration);
       if (body != null) {
         await body(tester);
       }
       await durationFuture;
+    }
+
+    vm.Timeline timeline;
+    await binding.watchPerformance(() async {
+      if (measureCpuGpu) {
+        timeline = await binding.traceTimeline(testBody, streams: <String>['Embedder']);
+      } else {
+        await testBody();
+      }
     });
+
+    if (measureCpuGpu) {
+      final List<double> cpuUsage = timeline.traceEvents.where(
+        (vm.TimelineEvent event) => event.json['name'] == 'CpuUsage').map<double>(
+        (vm.TimelineEvent event) => double.parse(event.json['args']['total_cpu_usage'] as String)
+      ).toList();
+      if (cpuUsage.isNotEmpty) {
+        binding.reportData['average_cpu_usage'] = cpuUsage.reduce(
+          (double a, double b) => a + b,
+        ) / cpuUsage.length;
+      }
+      final List<double> gpuUsage = timeline.traceEvents.where(
+        (vm.TimelineEvent event) => event.json['name'] == 'GpuUsage').map<double>(
+        (vm.TimelineEvent event) => double.parse(event.json['args']['gpu_usage'] as String)
+      ).toList();
+      if (gpuUsage.isNotEmpty) {
+        binding.reportData['average_gpu_usage'] = gpuUsage.reduce(
+          (double a, double b) => a + b,
+        ) / gpuUsage.length;
+      }
+    }
   }, semanticsEnabled: false, timeout: Timeout(timeout));
 }

--- a/dev/devicelab/bin/tasks/simple_animation_perf_ios__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/simple_animation_perf_ios__e2e_summary.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+// TODO(CareF): add it to manifest.yaml
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createSimpleAnimationPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/simple_animation_perf_ios__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/simple_animation_perf_ios__e2e_summary.dart
@@ -11,5 +11,5 @@ import 'package:flutter_devicelab/framework/framework.dart';
 // TODO(CareF): add it to manifest.yaml
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  await task(createSimpleAnimationPerfE2ETest());
+  await task(createSimpleAnimationPerfE2ETest(measureCpuGpu: true));
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -172,7 +172,14 @@ TaskFunction createSimpleAnimationPerfTest({bool measureCpuGpu = true}) {
   ).run;
 }
 
-TaskFunction createAnimatedPlaceholderPerfTest({bool measureCpuGpu = true}) {
+TaskFunction createSimpleAnimationPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/simple_animation_perf_e2e.dart',
+  ).run;
+}
+
+TaskFunction createAnimatedPlaceholderPerfTest({bool measureCpuGpu = false}) {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test_driver/run_app.dart',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -172,10 +172,18 @@ TaskFunction createSimpleAnimationPerfTest({bool measureCpuGpu = true}) {
   ).run;
 }
 
-TaskFunction createSimpleAnimationPerfE2ETest() {
+TaskFunction createSimpleAnimationPerfE2ETest({bool measureCpuGpu = true}) {
   return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test/simple_animation_perf_e2e.dart',
+    measureCpuGpu: measureCpuGpu,
+    benchmarkScoreKeys: <String>[
+      ..._kCommonScoreKeys,
+    if (measureCpuGpu) ...<String>[
+      'average_cpu_usage',
+      'average_gpu_usage',
+    ],
+    ]
   ).run;
 }
 
@@ -555,8 +563,8 @@ class PerfTest {
   const PerfTest.e2e(
     this.testDirectory,
     this.testTarget, {
-    this.measureCpuGpu = true,
-    this.measureMemory = true,
+    this.measureCpuGpu = false,
+    this.measureMemory = false,
     this.testDriver =  'test_driver/e2e_test.dart',
     this.needsFullTimeline = false,
     this.benchmarkScoreKeys = _kCommonScoreKeys,


### PR DESCRIPTION
## Description

This is break down of #62171, and should be merged when devicelab is of low load.

**This one is special for CPU/GPU measurement, and need further modification** 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
