### PR TITLE
migrate textfield_perf to e2e

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
@@ -12,7 +12,10 @@ void main() {
   macroPerfTestE2E(
     'textfield_perf',
     kTextRouteName,
-    // The driver version doesn't have this delay.
+    // The driver version doesn't have this delay because the delay caused
+    // by the communication between the host and the test device is long enough
+    // for the driver test, but there isn't such delay in this host independent
+    // test.
     pageDelay: const Duration(milliseconds: 50),
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('basic-textfield'));

--- a/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'textfield_perf',
+    kTextRouteName,
+    // The driver version doesn't have this delay.
+    pageDelay: const Duration(milliseconds: 50),
+    body: (WidgetController controller) async {
+      final Finder textfield = find.byKey(const ValueKey<String>('basic-textfield'));
+      controller.tap(textfield);
+      // Caret should be cached, so repeated blinking should not require recompute.
+      await Future<void>.delayed(const Duration(milliseconds: 5000));
+    },
+  );
+}

--- a/dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createTextfieldPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -281,6 +281,13 @@ TaskFunction createTextfieldPerfTest() {
   ).run;
 }
 
+TaskFunction createTextfieldPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/textfield_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createColorFilterAndFadePerfTest() {
   return PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -263,6 +263,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  textfield_perf__e2e_summary:
+    description: >
+      Measures the runtime performance of textfield on Android.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+    flaky: true
+
   color_filter_and_fade_perf__timeline_summary:
     description: >
       Measures the runtime performance of color filter with fade on Android.


### PR DESCRIPTION
## Description

This is break down of #62171, and should be merged when devicelab is of low load.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
