### PR TITLE
Change iOS plugin simulator archs from allow list to deny list

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -45,6 +45,7 @@ Future<void> main() async {
             'lint',
             objcPodspecPath,
             '--allow-warnings',
+            '--verbose',
           ],
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
@@ -63,6 +64,7 @@ Future<void> main() async {
             objcPodspecPath,
             '--allow-warnings',
             '--use-libraries',
+            '--verbose',
           ],
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',

--- a/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
 
-  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 end

--- a/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
 
-  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
## Description

The intention of adding `VALID_ARCHS` allow list was to exclude `i386` simulators.  However, at some point Flutter will need to run on [the new ARM simulators](https://github.com/flutter/flutter/issues/64502).  Change the allow list to a deny list and just exclude `i386`.

## Related Issues
`VALID_ARCHS` added in https://github.com/flutter/flutter/pull/41828
Discovered with https://github.com/flutter/flutter/pull/63252.

## Tests

This is already tested in [plugin_lint_mac](https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/plugin_lint_mac.dart).

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*