### PR TITLE
[64522] Fix : renamed context in FlutterErrorDetails

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -393,7 +393,7 @@ class FlutterErrorDetails with Diagnosticable {
     this.exception,
     this.stack,
     this.library = 'Flutter framework',
-    this.context,
+    this.errorDiagnostics,
     this.stackFilter,
     this.informationCollector,
     this.silent = false,
@@ -402,7 +402,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// Creates a copy of the error details but with the given fields replaced
   /// with new values.
   FlutterErrorDetails copyWith({
-    DiagnosticsNode? context,
+    DiagnosticsNode? errorDiagnostics,
     dynamic exception,
     InformationCollector? informationCollector,
     String? library,
@@ -411,7 +411,7 @@ class FlutterErrorDetails with Diagnosticable {
     IterableFilter<String>? stackFilter,
   }) {
     return FlutterErrorDetails(
-      context: context ?? this.context,
+      errorDiagnostics: errorDiagnostics ?? this.errorDiagnostics,
       exception: exception ?? this.exception,
       informationCollector: informationCollector ?? this.informationCollector,
       library: library ?? this.library,
@@ -496,7 +496,7 @@ class FlutterErrorDetails with Diagnosticable {
   ///    applicable.
   ///  * [FlutterError], which is the most common place to use
   ///    [FlutterErrorDetails].
-  final DiagnosticsNode? context;
+  final DiagnosticsNode? errorDiagnostics;
 
   /// A callback which filters the [stack] trace. Receives an iterable of
   /// strings representing the frames encoded in the way that


### PR DESCRIPTION
## Description
It is an issue about the meaning of `context` name among parameters in `FlutterErrorDetails`.
Now PR has been modified to a name that has a different meaning.
## Related Issues
#64522 

## Tests
NONE

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.