### PR TITLE
[null-safety] remove sound-null-safety by default, remove experiment flag

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -537,7 +537,7 @@ Future<void> _runAddToAppLifeCycleTests() async {
 
 Future<void> _runFrameworkTests() async {
   final bq.BigqueryApi bigqueryApi = await _getBigqueryApi();
-  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable', '--null-assertions'];
+  final List<String> nullSafetyOptions = <String>['--null-assertions', '--no-sound-null-safety'];
   final List<String> trackWidgetCreationAlternatives = <String>['--track-widget-creation', '--no-track-widget-creation'];
 
   Future<void> runWidgets() async {


### PR DESCRIPTION
## Description

To allow tests to begin migrating to null safety, sound null safety needs to be disabled. Also removes the experiment flag that is unnecessary since the framework is on the SDK allowlist.
