### PR TITLE
Fixes router to not report route information when it is already up to…

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -395,7 +395,6 @@ class _RouterState<T> extends State<Router<T>> {
     if (widget.routeInformationProvider != null) {
       _processInitialRoute();
     }
-    _lastSeenLocation = widget.routeInformationProvider?.value?.location;
   }
 
   bool _routeInformationReportingTaskScheduled = false;
@@ -552,6 +551,7 @@ class _RouterState<T> extends State<Router<T>> {
   void _processInitialRoute() {
     _currentRouteInformationParserTransaction = Object();
     _currentRouterDelegateTransaction = Object();
+    _lastSeenLocation = widget.routeInformationProvider.value.location;
     widget.routeInformationParser
       .parseRouteInformation(widget.routeInformationProvider.value)
       .then<T>(_verifyRouteInformationParserStillCurrent(_currentRouteInformationParserTransaction, widget))
@@ -563,6 +563,7 @@ class _RouterState<T> extends State<Router<T>> {
   void _handleRouteInformationProviderNotification() {
     _currentRouteInformationParserTransaction = Object();
     _currentRouterDelegateTransaction = Object();
+    _lastSeenLocation = widget.routeInformationProvider.value.location;
     widget.routeInformationParser
       .parseRouteInformation(widget.routeInformationProvider.value)
       .then<T>(_verifyRouteInformationParserStillCurrent(_currentRouteInformationParserTransaction, widget))

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -434,6 +434,47 @@ void main() {
     expect(reportedRouteInformation.location, 'update');
   });
 
+  testWidgets('router does not report when route information is up to date with route information provider', (WidgetTester tester) async {
+    RouteInformation reportedRouteInformation;
+    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
+      onRouterReport: (RouteInformation information) {
+        // Makes sure we only report once after manually cleaning up.
+        expect(reportedRouteInformation, isNull);
+        reportedRouteInformation = information;
+      }
+    );
+    provider.value = const RouteInformation(
+      location: 'initial',
+    );
+    final SimpleRouterDelegate delegate = SimpleRouterDelegate(reportConfiguration: true);
+    delegate.builder = (BuildContext context, RouteInformation routeInformation) {
+      return Text(routeInformation.location);
+    };
+
+    await tester.pumpWidget(buildBoilerPlate(
+      Router<RouteInformation>(
+        routeInformationProvider: provider,
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: delegate,
+      )
+    ));
+    expect(find.text('initial'), findsOneWidget);
+    expect(reportedRouteInformation, isNull);
+
+    provider.value = const RouteInformation(
+      location: 'update',
+    );
+    // This notify listener will schedule route reporting.
+    delegate.notifyListeners();
+    await tester.pump();
+
+    expect(find.text('initial'), findsNothing);
+    expect(find.text('update'), findsOneWidget);
+    // The router should not report because the route name because it is already
+    // up to date.
+    expect(reportedRouteInformation, isNull);
+  });
+
   testWidgets('PlatformRouteInformationProvider works', (WidgetTester tester) async {
     final RouteInformationProvider provider = PlatformRouteInformationProvider(
       initialRouteInformation: const RouteInformation(

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -438,8 +438,6 @@ void main() {
     RouteInformation reportedRouteInformation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
       onRouterReport: (RouteInformation information) {
-        // Makes sure we only report once after manually cleaning up.
-        expect(reportedRouteInformation, isNull);
         reportedRouteInformation = information;
       }
     );
@@ -460,18 +458,18 @@ void main() {
     ));
     expect(find.text('initial'), findsOneWidget);
     expect(reportedRouteInformation, isNull);
-
+    // This will cause the router to rebuild.
     provider.value = const RouteInformation(
       location: 'update',
     );
-    // This notify listener will schedule route reporting.
+    // This will schedule the route reporting.
     delegate.notifyListeners();
     await tester.pump();
 
     expect(find.text('initial'), findsNothing);
     expect(find.text('update'), findsOneWidget);
-    // The router should not report because the route name because it is already
-    // up to date.
+    // The router should not report because the route name is already up to
+    // date.
     expect(reportedRouteInformation, isNull);
   });
 


### PR DESCRIPTION
… date

## Description

I ran into this situation when I was implementing the engine side work. When the web engine sends didPushRouteInformation the router rebuild correctly, but it also report the route information change back to engine again which causes the web engine to create a duplicate browser history entry.

This pr fixes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64589

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
