### PR TITLE
Fix tests that use bogus objects, update TestImageInfo interface

### DIFF
--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -4,11 +4,13 @@
 
 // @dart = 2.8
 
+import 'dart:typed_data';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../painting/mocks_for_image_cache.dart';
+import '../painting/image_data.dart';
 import '../widgets/semantics_tester.dart';
 
 Future<void> pumpWidgetWithBoilerplate(WidgetTester tester, Widget widget) async {
@@ -27,14 +29,15 @@ Future<void> pumpWidgetWithBoilerplate(WidgetTester tester, Widget widget) async
   );
 }
 
-void main() {
+Future<void> main() async {
+
   testWidgets('Need at least 2 tabs', (WidgetTester tester) async {
     try {
       await pumpWidgetWithBoilerplate(tester, CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
         ],
       ));
@@ -49,14 +52,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
         currentIndex: 1,
@@ -83,13 +86,13 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
             label: 'Tab 1',
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
             label: 'Tab 2',
           ),
         ],
@@ -115,14 +118,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
         currentIndex: 1,
@@ -156,14 +159,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
         data: const MediaQueryData(platformBrightness: Brightness.dark),
         child: CupertinoTabBar(
-          items: const <BottomNavigationBarItem>[
+          items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 1'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 1'),
             ),
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 2'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 2'),
             ),
           ],
           currentIndex: 1,
@@ -193,14 +196,14 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabBar(
-          items: const <BottomNavigationBarItem>[
+          items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 1'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 1'),
             ),
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 2'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 2'),
             ),
           ],
           currentIndex: 1,
@@ -224,14 +227,14 @@ void main() {
       CupertinoApp(
         theme: const CupertinoThemeData(brightness: Brightness.dark),
         home: CupertinoTabBar(
-          items: const <BottomNavigationBarItem>[
+          items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 1'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 1'),
             ),
             BottomNavigationBarItem(
-              icon: ImageIcon(TestImageProvider(24, 24)),
-              title: Text('Tab 2'),
+              icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+              title: const Text('Tab 2'),
             ),
           ],
           currentIndex: 1,
@@ -254,21 +257,21 @@ void main() {
   });
 
   testWidgets('Use active icon', (WidgetTester tester) async {
-    const TestImageProvider activeIcon = TestImageProvider(16, 16);
-    const TestImageProvider inactiveIcon = TestImageProvider(24, 24);
+    final MemoryImage activeIcon = MemoryImage(Uint8List.fromList(kBlueSquare));
+    final MemoryImage inactiveIcon = MemoryImage(Uint8List.fromList(kTransparentImage));
 
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
             icon: ImageIcon(inactiveIcon),
             activeIcon: ImageIcon(activeIcon),
-            title: Text('Tab 2'),
+            title: const Text('Tab 2'),
           ),
         ],
         currentIndex: 1,
@@ -288,14 +291,14 @@ void main() {
 
   testWidgets('Adjusts height to account for bottom padding', (WidgetTester tester) async {
     final CupertinoTabBar tabBar = CupertinoTabBar(
-      items: const <BottomNavigationBarItem>[
+      items: <BottomNavigationBarItem>[
         BottomNavigationBarItem(
-          icon: ImageIcon(TestImageProvider(24, 24)),
-          title: Text('Aka'),
+          icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+          title: const Text('Aka'),
         ),
         BottomNavigationBarItem(
-          icon: ImageIcon(TestImageProvider(24, 24)),
-          title: Text('Shiro'),
+          icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+          title: const Text('Shiro'),
         ),
       ],
     );
@@ -329,14 +332,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
       ),
@@ -347,14 +350,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
         backgroundColor: const Color(0xFFFFFFFF), // Opaque white.
@@ -370,14 +373,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
         currentIndex: 1,
@@ -395,14 +398,14 @@ void main() {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 1'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 1'),
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(TestImageProvider(24, 24)),
-            title: Text('Tab 2'),
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            title: const Text('Tab 2'),
           ),
         ],
       ),
@@ -425,7 +428,7 @@ void main() {
   });
 
   testWidgets('Title of items should be nullable', (WidgetTester tester) async {
-    const TestImageProvider iconProvider = TestImageProvider(16, 16);
+    final MemoryImage iconProvider = MemoryImage(Uint8List.fromList(kTransparentImage));
     final List<int> itemsTapped = <int>[];
 
     await pumpWidgetWithBoilerplate(
@@ -433,12 +436,12 @@ void main() {
         MediaQuery(
           data: const MediaQueryData(),
           child: CupertinoTabBar(
-            items: const <BottomNavigationBarItem>[
+            items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
                 icon: ImageIcon(
-                  TestImageProvider(24, 24),
+                  MemoryImage(Uint8List.fromList(kTransparentImage)),
                 ),
-                title: Text('Tab 1'),
+                title: const Text('Tab 1'),
               ),
               BottomNavigationBarItem(
                 icon: ImageIcon(
@@ -465,18 +468,18 @@ void main() {
         MediaQuery(
           data: const MediaQueryData(),
           child: CupertinoTabBar(
-            items: const <BottomNavigationBarItem>[
+            items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
                 icon: ImageIcon(
-                  TestImageProvider(24, 24),
+                  MemoryImage(Uint8List.fromList(kTransparentImage)),
                 ),
-                title: Text('Tab 1'),
+                title: const Text('Tab 1'),
               ),
               BottomNavigationBarItem(
                 icon: ImageIcon(
-                  TestImageProvider(24, 24),
+                  MemoryImage(Uint8List.fromList(kTransparentImage)),
                 ),
-                title: Text('Tab 2'),
+                title: const Text('Tab 2'),
               ),
             ],
           ),
@@ -491,18 +494,18 @@ void main() {
         MediaQuery(
           data: const MediaQueryData(),
           child: CupertinoTabBar(
-            items: const <BottomNavigationBarItem>[
+            items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
                 icon: ImageIcon(
-                  TestImageProvider(24, 24),
+                  MemoryImage(Uint8List.fromList(kTransparentImage)),
                 ),
-                title: Text('Tab 1'),
+                title: const Text('Tab 1'),
               ),
               BottomNavigationBarItem(
                 icon: ImageIcon(
-                  TestImageProvider(24, 24),
+                  MemoryImage(Uint8List.fromList(kTransparentImage)),
                 ),
-                title: Text('Tab 2'),
+                title: const Text('Tab 2'),
               ),
             ],
             backgroundColor: const Color(0xFFFFFFFF), // Opaque white.

--- a/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
@@ -4,11 +4,13 @@
 
 // @dart = 2.8
 
+import 'dart:typed_data';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../../painting/mocks_for_image_cache.dart';
+import '../../painting/image_data.dart';
 
 List<int> selectedTabs;
 
@@ -287,7 +289,7 @@ void main() {
               tabBar: CupertinoTabBar(
                 items: List<BottomNavigationBarItem>.generate(
                   10,
-                  (int i) => BottomNavigationBarItem(icon: const ImageIcon(TestImageProvider(24, 23)), title: Text('$i')),
+                  (int i) => BottomNavigationBarItem(icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))), title: Text('$i')),
                 ),
               ),
               tabBuilder: (BuildContext context, int index) => const Text('content'),
@@ -322,14 +324,14 @@ void main() {
 
 CupertinoTabBar _buildTabBar({ int selectedTab = 0 }) {
   return CupertinoTabBar(
-    items: const <BottomNavigationBarItem>[
+    items: <BottomNavigationBarItem>[
       BottomNavigationBarItem(
-        icon: ImageIcon(TestImageProvider(24, 24)),
-        title: Text('Tab 1'),
+        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        title: const Text('Tab 1'),
       ),
       BottomNavigationBarItem(
-        icon: ImageIcon(TestImageProvider(24, 24)),
-        title: Text('Tab 2'),
+        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        title: const Text('Tab 2'),
       ),
     ],
     currentIndex: selectedTab,

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -4,10 +4,12 @@
 
 // @dart = 2.8
 
+import 'dart:typed_data';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../painting/mocks_for_image_cache.dart';
+import '../painting/image_data.dart';
 import '../rendering/mock_canvas.dart';
 
 /// Integration tests testing both [CupertinoPageScaffold] and [CupertinoTabScaffold].
@@ -208,14 +210,14 @@ void main() {
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
             backgroundColor: CupertinoColors.white,
-            items: const <BottomNavigationBarItem>[
+            items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
-                icon: ImageIcon(TestImageProvider(24, 24)),
-                title: Text('Tab 1'),
+                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                title: const Text('Tab 1'),
               ),
               BottomNavigationBarItem(
-                icon: ImageIcon(TestImageProvider(24, 24)),
-                title: Text('Tab 2'),
+                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                title: const Text('Tab 2'),
               ),
             ],
           ),
@@ -248,14 +250,14 @@ void main() {
           ),
           child: CupertinoTabScaffold(
             tabBar: CupertinoTabBar(
-              items: const <BottomNavigationBarItem>[
+              items: <BottomNavigationBarItem>[
                 BottomNavigationBarItem(
-                  icon: ImageIcon(TestImageProvider(24, 24)),
-                  title: Text('Tab 1'),
+                  icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                  title: const Text('Tab 1'),
                 ),
                 BottomNavigationBarItem(
-                  icon: ImageIcon(TestImageProvider(24, 24)),
-                  title: Text('Tab 2'),
+                  icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                  title: const Text('Tab 2'),
                 ),
               ],
             ),
@@ -298,14 +300,14 @@ void main() {
       CupertinoApp(
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
-            items: const <BottomNavigationBarItem>[
+            items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
-                icon: ImageIcon(TestImageProvider(24, 24)),
-                title: Text('Tab 1'),
+                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                title: const Text('Tab 1'),
               ),
               BottomNavigationBarItem(
-                icon: ImageIcon(TestImageProvider(24, 24)),
-                title: Text('Tab 2'),
+                icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+                title: const Text('Tab 2'),
               ),
             ],
           ),

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -4,10 +4,12 @@
 
 // @dart = 2.8
 
+import 'dart:typed_data';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../painting/mocks_for_image_cache.dart';
+import '../painting/image_data.dart';
 import '../rendering/rendering_tester.dart';
 
 List<int> selectedTabs;
@@ -44,7 +46,7 @@ void main() {
 
   BottomNavigationBarItem tabGenerator(int index) {
     return BottomNavigationBarItem(
-      icon: const ImageIcon(TestImageProvider(24, 24)),
+      icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
       title: Text('Tab ${index + 1}'),
     );
   }
@@ -1081,7 +1083,7 @@ void main() {
               tabBar: CupertinoTabBar(
                 items: List<BottomNavigationBarItem>.generate(
                   10,
-                  (int i) => BottomNavigationBarItem(icon: const ImageIcon(TestImageProvider(24, 23)), title: Text('$i')),
+                  (int i) => BottomNavigationBarItem(icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))), title: Text('$i')),
                 ),
               ),
               tabBuilder: (BuildContext context, int index) => const Text('content'),
@@ -1116,14 +1118,14 @@ void main() {
 
 CupertinoTabBar _buildTabBar({ int selectedTab = 0 }) {
   return CupertinoTabBar(
-    items: const <BottomNavigationBarItem>[
+    items: <BottomNavigationBarItem>[
       BottomNavigationBarItem(
-        icon: ImageIcon(TestImageProvider(24, 24)),
-        title: Text('Tab 1'),
+        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        title: const Text('Tab 1'),
       ),
       BottomNavigationBarItem(
-        icon: ImageIcon(TestImageProvider(24, 24)),
-        title: Text('Tab 2'),
+        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        title: const Text('Tab 2'),
       ),
     ],
     currentIndex: selectedTab,

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -31,7 +31,9 @@ class TestImageInfo implements ImageInfo {
 }
 
 class TestImageProvider extends ImageProvider<int> {
-  const TestImageProvider(this.key, this.imageValue, { this.image });
+  const TestImageProvider(this.key, this.imageValue, { this.image = const TestImage() })
+      : assert(image != null);
+
   final int key;
   final int imageValue;
   final ui.Image image;


### PR DESCRIPTION
The `ImageInfo` class says that the `image` field is non-nullable. In trying to update the test interface to match for https://github.com/flutter/flutter/pull/64582, I found the tester segfaulted because the cupertino tests I'm fixing here now pass in a bogus dart:ui Image implementation, which results in https://github.com/flutter/flutter/issues/64598