### PR TITLE
Use Pixel4 for better wait times

### DIFF
--- a/dev/bots/firebase_testlab.sh
+++ b/dev/bots/firebase_testlab.sh
@@ -18,7 +18,9 @@
 devices=(
   # Pixel 3
   "model=blueline,version=28"
-  "model=blueline,version=29"
+  
+  # Pixel 4
+  "model=flame,version=29"
 
   # Moto Z XT1650
   "model=griffin,version=24"

--- a/dev/bots/firebase_testlab.sh
+++ b/dev/bots/firebase_testlab.sh
@@ -18,7 +18,7 @@
 devices=(
   # Pixel 3
   "model=blueline,version=28"
-  
+
   # Pixel 4
   "model=flame,version=29"
 


### PR DESCRIPTION
According to the firebase team, these have lower wait times for tests.

@blasten 