### PR TITLE
Revert "Reland: Increase threshold for usage of compute for utf8 decoding on large strings to 50 KB"

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -71,13 +71,11 @@ abstract class AssetBundle {
     // that the null-handling logic is dead code).
     if (data == null)
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
-    // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
-    // on a Pixel 4.
-    if (data.lengthInBytes < 50 * 1024) {
+    if (data.lengthInBytes < 10 * 1024) {
+      // 10KB takes about 3ms to parse on a Pixel 2 XL.
+      // See: https://github.com/dart-lang/sdk/issues/31954
       return utf8.decode(data.buffer.asUint8List());
     }
-    // For strings larger than 50 KB, run the computation in an isolate to
-    // avoid causing main thread jank.
     return compute(_utf8decode, data, debugLabel: 'UTF8 decode for "$key"');
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -562,11 +562,9 @@ class HotRunner extends ResidentRunner {
         } on vm_service.RPCError {
           // Do nothing, we're already subcribed.
         }
-        // Ideally this would wait for kIsolateRunnable, but either this subscription occurs too
-        // late to receive the event, or it is not forwarded for hot restarted isolates.
         isolateNotifications.add(
           device.vmService.onIsolateEvent.firstWhere((vm_service.Event event) {
-            return event.kind == vm_service.EventKind.kServiceExtensionAdded;
+            return event.kind == vm_service.EventKind.kIsolateRunnable;
           }),
         );
       }


### PR DESCRIPTION
Reverts flutter/flutter#64498

Caused a regression in hot reload time (https://github.com/flutter/flutter/issues/64649) on infra. Though this can't be repro'd locally, revert now to be safe and verify that the infra numbers improve