### PR TITLE
Roll new gallery to help flaky Crane test

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
+const String galleryVersion = '9eb1ff89a0cd5fd4333215fc62d735becf74da4a';


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/64328

We'll remove the timeout from Crane test later and roll again. For now,
hopefully this would reduce the flaky rate and save some infra resources
before the timeout removal PR is ready.
