### PR TITLE
[Feature]More understandable message

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -91,7 +91,9 @@ void main() {
         fail('Expect exception');
       } on ToolExit catch (e) {
         expect(e.exitCode ?? 1, 1);
-        expect(e.message, contains('Test file not found: $testFile'));
+    expect(e.message, contains('Test file not found: $testFile. '
+        'You should make without _test.dart file and _test.dart file. '
+        'And you should set without _test.dart for --target option.'));
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,


### PR DESCRIPTION
## Description

The culture of writing test code doesn't take root by such as confusing error messages.
This is the root of all sorts of evils that give up writing test code and increase the number of software engineers who don't write test codes.
Let's make the error message easy to understand.

## Related Issues

https://github.com/flutter/flutter/issues/62626

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ x] No, no existing tests failed, so this is *not* a breaking change.
- [ x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [x ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [x ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
