### PR TITLE
Clamp TabController animation value when calc _DragAnimation.value

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -500,7 +500,9 @@ class _DragAnimation extends Animation<double> with AnimationWithParentMixin<dou
   @override
   double get value {
     assert(!controller.indexIsChanging);
-    return (controller.animation.value - index.toDouble()).abs().clamp(0.0, 1.0) as double;
+    final double controllerMaxValue = (controller.length - 1).toDouble();
+    final double controllerValue = controller.animation.value.clamp(0.0, controllerMaxValue) as double;
+    return (controllerValue - index.toDouble()).abs().clamp(0.0, 1.0) as double;
   }
 }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2671,6 +2671,57 @@ void main() {
     expect(pageView.physics.toString().contains('ClampingScrollPhysics'), isFalse);
   });
 
+  testWidgets('TabController changes offset attribute', (WidgetTester tester) async {
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: 2,
+    );
+
+    Color firstColor;
+    Color secondColor;
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(
+          controller: controller,
+          labelColor: Colors.white,
+          unselectedLabelColor: Colors.black,
+          tabs: <Widget>[
+            Builder(builder: (BuildContext context) {
+              firstColor = DefaultTextStyle.of(context).style.color;
+              return const Text('First');
+            }),
+            Builder(builder: (BuildContext context) {
+              secondColor = DefaultTextStyle.of(context).style.color;
+              return const Text('Second');
+            }),
+          ],
+        ),
+      ),
+    );
+
+    expect(firstColor, equals(Colors.white));
+    expect(secondColor, equals(Colors.black));
+
+    controller.offset = 0.6;
+    await tester.pump();
+
+    expect(firstColor, equals(Color.lerp(Colors.white, Colors.black, 0.6)));
+    expect(secondColor, equals(Color.lerp(Colors.black, Colors.white, 0.6)));
+
+    controller.index = 1;
+    await tester.pump();
+
+    expect(firstColor, equals(Colors.black));
+    expect(secondColor, equals(Colors.white));
+
+    controller.offset = 0.6;
+    await tester.pump();
+
+    expect(firstColor, equals(Colors.black));
+    expect(secondColor, equals(Colors.white));
+  });
+
   testWidgets('Crash on dispose', (WidgetTester tester) async {
     await tester.pumpWidget(Padding(padding: const EdgeInsets.only(right: 200.0), child: TabBarDemo()));
     await tester.tap(find.byIcon(Icons.directions_bike));


### PR DESCRIPTION
## Description

see [demo](https://dartpad.dev/cf3e344cfdb5aa08a17c0d36aeaa0681)

## Tests

I added the following tests:

*TabController changes offset attribute*

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

No
