### PR TITLE
Update icon button splash radius to prevent overflow in appbar

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -141,11 +141,11 @@ class IconButton extends StatelessWidget {
   /// or an [ImageIcon].
   const IconButton({
     Key key,
-    this.iconSize = 20.0,
+    this.iconSize = 24.0,
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,
-    this.splashRadius,
+    this.splashRadius = 20.0,
     @required this.icon,
     this.color,
     this.focusColor,
@@ -170,13 +170,13 @@ class IconButton extends StatelessWidget {
 
   /// The size of the icon inside the button.
   ///
-  /// This property must not be null. It defaults to 20.0.
+  /// This property must not be null. It defaults to 24.0.
   ///
   /// The size given here is passed down to the widget in the [icon] property
   /// via an [IconTheme]. Setting the size here instead of in, for example, the
   /// [Icon.size] property allows the [IconButton] to size the splash area to
   /// fit the [Icon]. If you were to set the size of the [Icon] using
-  /// [Icon.size] instead, then the [IconButton] would default to 20.0 and then
+  /// [Icon.size] instead, then the [IconButton] would default to 24.0 and then
   /// the [Icon] itself would likely get clipped.
   final double iconSize;
 
@@ -210,7 +210,7 @@ class IconButton extends StatelessWidget {
 
   /// The splash radius.
   ///
-  /// If null, default splash radius of [Material.defaultSplashRadius] is used.
+  /// If null, it defaults to 20.0.
   final double splashRadius;
 
   /// The icon to display inside the button.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -141,7 +141,7 @@ class IconButton extends StatelessWidget {
   /// or an [ImageIcon].
   const IconButton({
     Key key,
-    this.iconSize = 24.0,
+    this.iconSize = 20.0,
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -170,13 +170,13 @@ class IconButton extends StatelessWidget {
 
   /// The size of the icon inside the button.
   ///
-  /// This property must not be null. It defaults to 24.0.
+  /// This property must not be null. It defaults to 20.0.
   ///
   /// The size given here is passed down to the widget in the [icon] property
   /// via an [IconTheme]. Setting the size here instead of in, for example, the
   /// [Icon.size] property allows the [IconButton] to size the splash area to
   /// fit the [Icon]. If you were to set the size of the [Icon] using
-  /// [Icon.size] instead, then the [IconButton] would default to 24.0 and then
+  /// [Icon.size] instead, then the [IconButton] would default to 20.0 and then
   /// the [Icon] itself would likely get clipped.
   final double iconSize;
 


### PR DESCRIPTION
Solves issue #64702

## Description

As mentioned in issue #64702 , the icon button splash (which is auto generated) always overflows. Hence by reducing the splash radius, the overflow is prevented. 

## Related Issues

Issue #64702 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.