### PR TITLE
Temporarily disable the mac/android test on LUCI

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -259,7 +259,6 @@ tasks:
       Checks that flavored builds work on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-    on_luci: true
 
   channels_integration_test:
     description: >


### PR DESCRIPTION
Because the test bed's CPU is too hot.

Bug: https://github.com/flutter/flutter/issues/64723
