### PR TITLE
[fuchsia] Refactor fuchsia_ctl use to a function

### DIFF
--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -44,23 +44,23 @@ fi
 # Wrapper function to pass common args to fuchsia_ctl.
 fuchsia_ctl() {
   $script_dir/fuchsia_ctl -d $device_name \
-      --device-finder-path $script_dir/device-finder $@
+      --device-finder-path $script_dir/device-finder "$@"
 }
 
 reboot() {
   echo "$(date) START:DEVICE_LOGS ------------------------------------------"
   fuchsia_ctl ssh \
-      -c "log_listener --dump_logs yes --file /tmp/log.txt" \
       --timeout-seconds $ssh_timeout_seconds \
-      --identity-file $pkey
+      --identity-file $pkey \
+      -c "log_listener --dump_logs yes --file /tmp/log.txt"
   # As we are not using recipes we don't have a way to know the location
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
   fuchsia_ctl ssh \
-       -c "cat /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey
+       --identity-file $pkey \
+       -c "cat /tmp/log.txt"
   echo "$(date) END:DEVICE_LOGS ------------------------------------------"
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.

--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -41,8 +41,15 @@ else
   echo "Connecting to device $device_name"
 fi
 
+# Wrapper function to pass common args to fuchsia_ctl.
+fuchsia_ctl() {
+  $script_dir/fuchsia_ctl -d $device_name \
+      --device-finder-path $script_dir/device-finder $@
+}
+
 reboot() {
-  $script_dir/fuchsia_ctl -d $device_name ssh \
+  echo "$(date) START:DEVICE_LOGS ------------------------------------------"
+  fuchsia_ctl ssh \
       -c "log_listener --dump_logs yes --file /tmp/log.txt" \
       --timeout-seconds $ssh_timeout_seconds \
       --identity-file $pkey
@@ -50,17 +57,15 @@ reboot() {
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
-  $script_dir/fuchsia_ctl -d $device_name \
-       --device-finder-path $script_dir/device-finder \
-       ssh \
+  fuchsia_ctl ssh \
        -c "cat /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
        --identity-file $pkey
+  echo "$(date) END:DEVICE_LOGS ------------------------------------------"
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.
-  $script_dir/fuchsia_ctl -d $device_name \
-      --device-finder-path $script_dir/device-finder \
-      ssh --identity-file $pkey \
+  fuchsia_ctl ssh \
+      --identity-file $pkey \
       -c "dm reboot-recovery" || true
   echo "$(date) END:REBOOT --------------------------------------------"
 }
@@ -69,13 +74,12 @@ trap reboot EXIT
 
 echo "$(date) START:PAVING ------------------------------------------"
 ssh-keygen -y -f $pkey > key.pub
-$script_dir/fuchsia_ctl -d $device_name pave  -i $1 --public-key "key.pub"
+fuchsia_ctl pave -i $1 --public-key "key.pub"
 echo "$(date) END:PAVING --------------------------------------------"
 
 
 echo "$(date) START:PUSH_PACKAGES -------------------------------"
-$script_dir/fuchsia_ctl push-packages \
-    -d $device_name \
+fuchsia_ctl push-packages \
     --identity-file $pkey \
     --repoArchive generic-x64.tar.gz \
     -p tiles -p tiles_ctl

--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -50,7 +50,9 @@ reboot() {
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
-  $script_dir/fuchsia_ctl -d $device_name ssh \
+  $script_dir/fuchsia_ctl -d $device_name \
+       --device-finder-path $script_dir/device-finder \
+       ssh \
        -c "cat /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
        --identity-file $pkey


### PR DESCRIPTION
## Description

- Ensure always passing common variables (device name, dev finder)
  - Log listener commands forgot to pass this


## Related Issues

https://github.com/flutter/flutter/issues/57044

## Tests

Ran script locally to verify function didn't break the current process.

This is a bash script to run tests from the SDK against Fuchsia.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
