### PR TITLE
[flutter_tools] handle OsError thrown during azure detector

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -119,6 +119,9 @@ class AzureDetector {
       // The HttpClient connected to a host, but it did not respond in a timely
       // fashion. Assume we are not on a bot.
       return _isRunningOnAzure = false;
+    } on OSError {
+      // The HttpClient might be running in a WSL1 environment.
+      return _isRunningOnAzure = false;
     }
     // We got a response. We're running on Azure.
     return _isRunningOnAzure = true;

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -148,6 +148,14 @@ void main() {
       });
     });
 
+    testWithoutContext('isRunningOnAzure returns false when OsError is thrown', () async {
+      when(mockHttpClient.getUrl(any)).thenAnswer((_) {
+        throw const OSError('Connection Refused', 111);
+      });
+
+      expect(await azureDetector.isRunningOnAzure, isFalse);
+    });
+
     testWithoutContext('isRunningOnAzure returns true when azure metadata is reachable', () async {
       when(mockHttpClient.getUrl(any)).thenAnswer((_) {
         return Future<HttpClientRequest>.value(mockHttpClientRequest);


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/64673

HttpClient may thrown an OSError on connection refused when running under WSL1