### PR TITLE
remove flaky flag for flutter_gallery_sksl_warmup__transition_perf_e2e

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -809,7 +809,6 @@ tasks:
       with SkSL shader warm-up with e2e.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__transition_perf_with_semantics:
     description: >


### PR DESCRIPTION
Remove flaky flag as the android version is proven to be stable. 

Issue with `flutter_gallery_sksl_warmup__transition_perf_e2e_ios32` is tracked in #64771, similar to its driver version `flutter_gallery_sksl_warmup_ios32__transition_perf`, and should remain flagged. 