### PR TITLE
Add FrameTiming delay to watchPerformance

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
@@ -35,14 +35,12 @@ Future<void> watchPerformance(
   final Future<void> delayForFrameTimings =
       Future<void>.delayed(const Duration(seconds: 2));
 
-  await delayForFrameTimings;
+  await delayForFrameTimings; // flush old FrameTimings
   final List<FrameTiming> frameTimings = <FrameTiming>[];
   final TimingsCallback watcher = frameTimings.addAll;
   binding.addTimingsCallback(watcher);
   await action();
-  await delayForFrameTimings;
-  await Future<void>.delayed(const Duration(seconds: 2));
-
+  await delayForFrameTimings; // make sure all FrameTimings are reported
   binding.removeTimingsCallback(watcher);
   final FrameTimingSummarizer frameTimes = FrameTimingSummarizer(frameTimings);
   binding.reportData = <String, dynamic>{reportKey: frameTimes.summary};

--- a/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
@@ -32,15 +32,15 @@ Future<void> watchPerformance(
   // The engine could batch FrameTimings and send them only once per second.
   // Delay for a sufficient time so either old FrameTimings are flushed and not
   // interfering our measurements here, or new FrameTimings are all reported.
-  final Future<void> delayForFrameTimings =
+  Future<void> delayForFrameTimings() =>
       Future<void>.delayed(const Duration(seconds: 2));
 
-  await delayForFrameTimings; // flush old FrameTimings
+  await delayForFrameTimings(); // flush old FrameTimings
   final List<FrameTiming> frameTimings = <FrameTiming>[];
   final TimingsCallback watcher = frameTimings.addAll;
   binding.addTimingsCallback(watcher);
   await action();
-  await delayForFrameTimings; // make sure all FrameTimings are reported
+  await delayForFrameTimings(); // make sure all FrameTimings are reported
   binding.removeTimingsCallback(watcher);
   final FrameTimingSummarizer frameTimes = FrameTimingSummarizer(frameTimings);
   binding.reportData = <String, dynamic>{reportKey: frameTimes.summary};

--- a/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/e2e_utils.dart
@@ -28,10 +28,21 @@ Future<void> watchPerformance(
     }
     return true;
   }());
+
+  // The engine could batch FrameTimings and send them only once per second.
+  // Delay for a sufficient time so either old FrameTimings are flushed and not
+  // interfering our measurements here, or new FrameTimings are all reported.
+  final Future<void> delayForFrameTimings =
+      Future<void>.delayed(const Duration(seconds: 2));
+
+  await delayForFrameTimings;
   final List<FrameTiming> frameTimings = <FrameTiming>[];
   final TimingsCallback watcher = frameTimings.addAll;
   binding.addTimingsCallback(watcher);
   await action();
+  await delayForFrameTimings;
+  await Future<void>.delayed(const Duration(seconds: 2));
+
   binding.removeTimingsCallback(watcher);
   final FrameTimingSummarizer frameTimes = FrameTimingSummarizer(frameTimings);
   binding.reportData = <String, dynamic>{reportKey: frameTimes.summary};


### PR DESCRIPTION
It allows (1) old FrameTimings to be flushed and not interfering our
measurements here, and (2) new FrameTimings to be all reported.

Fixes https://github.com/flutter/flutter/issues/64778
