### PR TITLE
Use idevicedebug instead of ios-deploy for iOS app launch

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -56,6 +56,7 @@ enum Artifact {
   webPrecompiledCanvaskitSoundSdkSourcemaps,
 
   iosDeploy,
+  idevicedebug,
   idevicesyslog,
   idevicescreenshot,
   iproxy,
@@ -122,6 +123,8 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'kernel_worker.dart.snapshot';
     case Artifact.iosDeploy:
       return 'ios-deploy';
+    case Artifact.idevicedebug:
+      return 'idevicedebug';
     case Artifact.idevicesyslog:
       return 'idevicesyslog';
     case Artifact.idevicescreenshot:
@@ -288,6 +291,7 @@ class CachedArtifacts implements Artifacts {
         final String artifactFileName = _artifactToFileName(artifact);
         final String engineDir = _getEngineArtifactsPath(platform, mode);
         return _fileSystem.path.join(engineDir, artifactFileName);
+      case Artifact.idevicedebug:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         final String artifactFileName = _artifactToFileName(artifact);
@@ -565,6 +569,7 @@ class LocalEngineArtifacts implements Artifacts {
         return _fileSystem.path.join(_dartSdkPath(_fileSystem), 'bin', 'snapshots', artifactFileName);
       case Artifact.kernelWorkerSnapshot:
         return _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', artifactFileName);
+      case Artifact.idevicedebug:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName).path;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1254,6 +1254,7 @@ class IosUsbArtifacts extends CachedArtifact {
     'libimobiledevice': <String>[
       'idevicescreenshot',
       'idevicesyslog',
+      'idevicedebug',
     ],
     'usbmuxd': <String>[
       'iproxy',

--- a/packages/flutter_tools/lib/src/ios/idevicedebug.dart
+++ b/packages/flutter_tools/lib/src/ios/idevicedebug.dart
@@ -1,0 +1,142 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+import '../base/common.dart';
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../convert.dart';
+import 'devices.dart';
+
+/// Wraps idevicedebug command line tool to interact with the device's debug server.
+///
+/// See https://github.com/libimobiledevice/libimobiledevice.
+class IDeviceDebug {
+  IDeviceDebug({
+    @required String iDeviceDebugPath,
+    @required Logger logger,
+    @required ProcessManager processManager,
+    @required MapEntry<String, String> dyLdLibEntry,
+  }) : _dyLdLibEntry = dyLdLibEntry,
+        _logger = logger,
+        _processUtils = ProcessUtils(processManager: processManager, logger: logger),
+        _iDeviceDebugPath = iDeviceDebugPath;
+
+  /// Create a [IDeviceDebug] for testing.
+  ///
+  /// This specifies the path to idevicedebug as 'idevicedebug` and the dyLdLibEntry as
+  /// 'DYLD_LIBRARY_PATH: /path/to/libs'.
+  factory IDeviceDebug.test({
+    @required Logger logger,
+    @required ProcessManager processManager,
+  }) {
+    return IDeviceDebug(
+      iDeviceDebugPath: 'idevicedebug',
+      logger: logger,
+      processManager: processManager,
+      dyLdLibEntry: const MapEntry<String, String>(
+        'DYLD_LIBRARY_PATH', '/path/to/libs',
+      ),
+    );
+  }
+
+  final String _iDeviceDebugPath;
+  final ProcessUtils _processUtils;
+  final Logger _logger;
+  final MapEntry<String, String> _dyLdLibEntry;
+
+  Future<IDeviceDebugRun> runApp({
+    @required String deviceId,
+    @required String bundleIdentifier,
+    @required List<String> launchArguments,
+    @required IOSDeviceInterface interfaceType,
+  }) async {
+    // Run in interactive mode (via script) to convince
+    // idevicedebug it has a terminal attached to redirect stdout.
+    final List<String> launchCommand = <String>[
+      'script',
+      '-t',
+      '0',
+      '/dev/null',
+      _iDeviceDebugPath,
+      '--udid',
+      deviceId,
+      '--debug',
+      if (interfaceType == IOSDeviceInterface.network)
+        '--network',
+      'run',
+      bundleIdentifier,
+      // Arguments after "run bundle-id" are launch arguments.
+      if (launchArguments.isNotEmpty)
+        ...launchArguments,
+    ];
+
+    final Process iDeviceDebugProcess = await _processUtils.start(
+      launchCommand,
+      environment: Map<String, String>.fromEntries(
+        <MapEntry<String, String>>[_dyLdLibEntry],
+      ),
+    );
+
+    final Completer<int> debuggerCompleter = Completer<int>();
+
+    final StreamSubscription<String> stdoutSubscription = iDeviceDebugProcess.stdout
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+      _logger.printTrace('idevicedebug: $line');
+      if (line.contains('Entering run loop')) {
+        // The app successfully launched.
+        debuggerCompleter.complete(0);
+      }
+    });
+    final StreamSubscription<String> stderrSubscription = iDeviceDebugProcess.stderr
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+      _logger.printTrace('idevicedebug error: $line');
+    });
+    unawaited(iDeviceDebugProcess.exitCode.then((int exitCode) {
+      _logger.printTrace('idevicedebug exited with code $exitCode');
+      unawaited(stdoutSubscription.cancel());
+      unawaited(stderrSubscription.cancel());
+    }).whenComplete(() async {
+      // May have already completed on a timeout.
+      if (!debuggerCompleter.isCompleted) {
+        debuggerCompleter.complete(await iDeviceDebugProcess.exitCode);
+      }
+    }));
+
+    return IDeviceDebugRun(
+      iDeviceDebugProcess: iDeviceDebugProcess,
+      status: debuggerCompleter.future.timeout(const Duration(seconds: 10), onTimeout: () {
+        _logger.printTrace('idevicedebug timed out in 10 seconds, exiting.');
+        iDeviceDebugProcess?.kill();
+        return 15; // SIGTERM
+      }));
+  }
+}
+
+/// Wrapper around a idevicedebug process and the results of the run.
+///
+/// The idevicedebug needs to stay alive to keep the app running.
+/// Check [status] to see if the app successfully launched, since the process
+/// will not have exited.
+class IDeviceDebugRun {
+  IDeviceDebugRun({
+    this.iDeviceDebugProcess,
+    this.status,
+  });
+
+  Process iDeviceDebugProcess;
+
+  /// Future completes when the app has successfully launched,
+  /// or with the process exit code if the process errored or timed out.
+  final Future<int> status;
+}

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -109,9 +109,12 @@ class IOSDeploy {
     );
   }
 
-  /// Installs and then runs the specified app bundle.
+  /// Installs, mounts developer disk image, then runs the specified app bundle.
   ///
   /// Uses ios-deploy and returns the exit code.
+  /// Launching the app with the debugger no longer works in iOS 14 due
+  /// to the debugger lockdown service being renamed, and the process always fails.
+  /// See https://github.com/ios-control/ios-deploy/issues/469
   Future<int> runApp({
     @required String deviceId,
     @required String bundlePath,
@@ -185,14 +188,9 @@ Your device is locked. Unlock your device first before running.
 ═══════════════════════════════════════════════════════════════════════════════════''',
       emphasis: true);
     } else if (stdout.contains(unknownAppLaunchError)) {
-      _logger.printError('''
-═══════════════════════════════════════════════════════════════════════════════════
-Error launching app. Try launching from within Xcode via:
-    open ios/Runner.xcworkspace
-
-Your Xcode version may be too old for your iOS version.
-═══════════════════════════════════════════════════════════════════════════════════''',
-      emphasis: true);
+      // ios-deploy no longer works in iOS 14 due to the debugger lockdown service
+      // being renamed, and this error will always happen.
+      // https://github.com/ios-control/ios-deploy/issues/469
     }
 
     return stdout;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -20,6 +20,7 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../ios/devices.dart';
+import '../ios/idevicedebug.dart';
 import '../ios/ios_deploy.dart';
 import '../ios/iproxy.dart';
 import '../ios/mac.dart';
@@ -230,6 +231,15 @@ class XCDevice {
         platform: platform,
         processManager: processManager,
       ),
+      _iDeviceDebug = IDeviceDebug(
+        iDeviceDebugPath: artifacts.getArtifactPath(
+          Artifact.idevicedebug,
+          platform: TargetPlatform.ios,
+        ),
+        logger: logger,
+        processManager: processManager,
+        dyLdLibEntry: cache.dyLdLibEntry,
+      ),
       _iProxy = iproxy,
       _xcode = xcode {
 
@@ -244,6 +254,7 @@ class XCDevice {
   final Logger _logger;
   final IMobileDevice _iMobileDevice;
   final IOSDeploy _iosDeploy;
+  final IDeviceDebug _iDeviceDebug;
   final Xcode _xcode;
   final IProxy _iProxy;
 
@@ -392,7 +403,7 @@ class XCDevice {
         .listen((String line) {
         _logger.printTrace('xcdevice observe error: $line');
       });
-      unawaited(_deviceObservationProcess.exitCode.then((int status) {
+      unawaited(_deviceObservationProcess.exitCode.then((int exitCode) {
         _logger.printTrace('xcdevice exited with code $exitCode');
         unawaited(stdoutSubscription.cancel());
         unawaited(stderrSubscription.cancel());
@@ -510,6 +521,7 @@ class XCDevice {
         fileSystem: globals.fs,
         logger: _logger,
         iosDeploy: _iosDeploy,
+        iDeviceDebug: _iDeviceDebug,
         iMobileDevice: _iMobileDevice,
         platform: globals.platform,
         vmServiceConnectUri: vm_service_io.vmServiceConnectUri,

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -363,6 +363,8 @@ void main() {
         ..createSync();
       iosUsbArtifacts.location.childFile('idevicesyslog')
         .createSync();
+      iosUsbArtifacts.location.childFile('idevicedebug')
+        .createSync();
 
       expect(iosUsbArtifacts.isUpToDateInner(), true);
 

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/idevicedebug.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
@@ -33,6 +34,11 @@ void main() {
   final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
   final FakePlatform linuxPlatform = FakePlatform(operatingSystem: 'linux');
   final FakePlatform windowsPlatform = FakePlatform(operatingSystem: 'windows');
+  IDeviceDebug iDeviceDebug;
+  setUp(() {
+    iDeviceDebug = IDeviceDebug.test(logger: BufferLogger.test(), processManager: FakeProcessManager.any());
+  });
+
 
   group('IOSDevice', () {
     final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
@@ -74,6 +80,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         sdkVersion: '13.3',
@@ -91,6 +98,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
@@ -105,6 +113,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
@@ -119,6 +128,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
@@ -133,6 +143,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
@@ -147,6 +158,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
@@ -164,6 +176,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         sdkVersion: '13.3',
@@ -189,6 +202,7 @@ void main() {
               logger: logger,
               platform: platform,
               iosDeploy: iosDeploy,
+              iDeviceDebug: iDeviceDebug,
               iMobileDevice: iMobileDevice,
               name: 'iPhone 1',
               sdkVersion: '13.3',
@@ -280,6 +294,7 @@ void main() {
           logger: logger,
           platform: macPlatform,
           iosDeploy: iosDeploy,
+          iDeviceDebug: iDeviceDebug,
           iMobileDevice: iMobileDevice,
           name: 'iPhone 1',
           sdkVersion: '13.3',
@@ -347,6 +362,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         logger: logger,
         platform: macPlatform,
@@ -362,6 +378,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        iDeviceDebug: iDeviceDebug,
         iMobileDevice: iMobileDevice,
         logger: logger,
         platform: macPlatform,

--- a/packages/flutter_tools/test/general.shard/ios/idevicedebug_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/idevicedebug_test.dart
@@ -1,0 +1,129 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/idevicedebug.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main () {
+  BufferLogger logger;
+
+  // This setup is required to inject the context.
+  setUp(() {
+    logger = BufferLogger.test();
+  });
+
+  testWithoutContext('IDeviceDebug.runApp calls idevicedebug with correct arguments and returns 0 on success', () async {
+    const String deviceId = '123';
+    const String bundleId = 'com.example.app';
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'script',
+          '-t',
+          '0',
+          '/dev/null',
+          'idevicedebug',
+          '--udid',
+          deviceId,
+          '--debug',
+          '--network',
+          'run',
+          bundleId,
+          '--enable-dart-profiling',
+          '--enable-service-port-fallback',
+        ], environment: <String, String>{'DYLD_LIBRARY_PATH': '/path/to/libs'},
+      )
+    ]);
+    final IDeviceDebug iDeviceDebug = IDeviceDebug.test(logger: logger, processManager: processManager);
+    final IDeviceDebugRun run = await iDeviceDebug.runApp(
+      deviceId: deviceId,
+      bundleIdentifier: bundleId,
+        launchArguments: <String>['--enable-dart-profiling', '--enable-service-port-fallback'],
+        interfaceType: IOSDeviceInterface.network,
+    );
+
+    expect(await run.status, 0);
+    expect(processManager.hasRemainingExpectations, false);
+    expect(logger.traceText, contains('idevicedebug exited with code 0'));
+  });
+
+  testWithoutContext('IDeviceDebug.runApp returns non-zero exit code when idevicedebug does the same', () async {
+    const String deviceId = '123';
+    const String bundleId = 'com.example.app';
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'script',
+          '-t',
+          '0',
+          '/dev/null',
+          'idevicedebug',
+          '--udid',
+          deviceId,
+          '--debug',
+          'run',
+          bundleId,
+          '--enable-dart-profiling',
+          '--enable-service-port-fallback',
+        ], environment: <String, String>{'DYLD_LIBRARY_PATH': '/path/to/libs'},
+        exitCode: 1
+      )
+    ]);
+    final IDeviceDebug iDeviceDebug = IDeviceDebug.test(logger: logger, processManager: processManager);
+    final IDeviceDebugRun run = await iDeviceDebug.runApp(
+      deviceId: deviceId,
+      bundleIdentifier: bundleId,
+      launchArguments: <String>['--enable-dart-profiling', '--enable-service-port-fallback'],
+      interfaceType: IOSDeviceInterface.usb,
+    );
+
+    expect(await run.status, 1);
+    expect(processManager.hasRemainingExpectations, false);
+    expect(logger.traceText, contains('idevicedebug exited with code 1'));
+  });
+
+  testWithoutContext('IDeviceDebug.runApp reports when the process has launched, before the process exits', () async {
+    const String deviceId = '123';
+    const String bundleId = 'com.example.app';
+
+    // Don't let the process complete until after the app has "launched".
+    final Completer<void> completer = Completer<void>();
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: const <String>[
+          'script',
+          '-t',
+          '0',
+          '/dev/null',
+          'idevicedebug',
+          '--udid',
+          deviceId,
+          '--debug',
+          'run',
+          bundleId,
+        ],
+        stdout: 'Entering run loop',
+        completer: completer,
+      )
+    ]);
+    final IDeviceDebug iDeviceDebug = IDeviceDebug.test(logger: logger, processManager: processManager);
+    final IDeviceDebugRun run = await iDeviceDebug.runApp(
+      deviceId: deviceId,
+      bundleIdentifier: bundleId,
+      launchArguments: <String>[],
+      interfaceType: IOSDeviceInterface.usb,
+    );
+
+    expect(await run.status, 0);
+    expect(logger.traceText, isNot(contains('idevicedebug exited')));
+    expect(processManager.hasRemainingExpectations, false);
+    completer.complete();
+  });
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/idevicedebug.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -239,6 +240,7 @@ void main() {
     final bool wasAppInstalled = await device.installApp(iosApp);
 
     expect(wasAppInstalled, false);
+    expect(processManager.hasRemainingExpectations, isFalse);
   });
 
   testWithoutContext('IOSDevice.uninstallApp catches ProcessException from ios-deploy', () async {
@@ -262,6 +264,7 @@ void main() {
     final bool wasAppUninstalled = await device.uninstallApp(iosApp);
 
     expect(wasAppUninstalled, false);
+    expect(processManager.hasRemainingExpectations, isFalse);
   });
 }
 
@@ -302,6 +305,7 @@ IOSDevice setUpIOSDevice({
       artifacts: artifacts,
       cache: cache,
     ),
+    iDeviceDebug: IDeviceDebug.test(logger: logger, processManager: processManager),
     iProxy: IProxy.test(logger: logger, processManager: processManager),
     interfaceType: interfaceType,
     vmServiceConnectUri: (String string, {Log log}) async => MockVmService(),

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -85,6 +85,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     fileSystem: fileSystem,
     logger: BufferLogger.test(),
     iosDeploy: null, // not used in this test
+    iDeviceDebug: null,
     iMobileDevice: null, // not used in this test
     platform: FakePlatform(operatingSystem: 'macos'),
     name: 'iPhone 1',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/idevicedebug.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -331,6 +332,7 @@ IOSDevice setUpIOSDevice({
       artifacts: artifacts,
       cache: cache,
     ),
+    iDeviceDebug: IDeviceDebug.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     iMobileDevice: IMobileDevice(
       logger: logger,
       processManager: processManager ?? FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/fallback_discovery.dart';
+import 'package:flutter_tools/src/ios/idevicedebug.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
@@ -440,6 +441,10 @@ IOSDevice setUpIOSDevice({
       processManager: processManager ?? FakeProcessManager.any(),
       artifacts: artifacts,
       cache: cache,
+    ),
+    iDeviceDebug: IDeviceDebug.test(
+      logger: logger ?? BufferLogger.test(),
+      processManager: processManager ?? FakeProcessManager.any()
     ),
     cpuArchitecture: DarwinArch.arm64,
     interfaceType: IOSDeviceInterface.usb,


### PR DESCRIPTION
## Description

Use libimobiledevice `idevicedebug` instead of `ios-deploy` to launch iOS apps.  Keep using `ios-deploy` to install and load the developer disk image.

This PR is dependent on adding a `idevicedebug` artifact.

Note to future version of myself: built libimobiledevice with this `PKG_CONFIG_PATH` (with `libusbmuxd` checked out in a sibling directory):
```
export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:../libusbmuxd/src/:/usr/local/opt/openssl/lib/pkgconfig && ./autogen.sh
```

## Related Issues

https://github.com/flutter/flutter/issues/64045

## Tests

Added idevice_debug_test.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*