### PR TITLE
Make ChangeNotifier.removeListener take constant time.

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -115,8 +115,8 @@ class ChangeNotifier implements Listenable {
     assert(() {
       if (_listeners == null) {
         throw FlutterError(
-            'A $runtimeType was used after being disposed.\n'
-                'Once you have called dispose() on a $runtimeType, it can no longer be used.'
+          'A $runtimeType was used after being disposed.\n'
+          'Once you have called dispose() on a $runtimeType, it can no longer be used.'
         );
       }
       return true;
@@ -183,8 +183,12 @@ class ChangeNotifier implements Listenable {
   void removeListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
     final List<_ListenerEntry>? links = _index![listener];
-    if (links != null && links.isNotEmpty)
-      links.removeAt(0).unlink();
+    if (links == null)
+      return;
+    assert(links.isNotEmpty);
+    links.removeAt(0).unlink();
+    if (links.isEmpty)
+      _index!.remove(listener);
   }
 
   /// Discards any resources used by the object. After this is called, the

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -157,7 +157,7 @@ class ChangeNotifier implements Listenable {
     _index!.update(
       listener,
       (ListQueue<_ListenerEntry> value) => value..add(entry),
-      ifAbsent: () => ListQueue.of(<_ListenerEntry>[entry]),
+      ifAbsent: () => ListQueue<_ListenerEntry>.of(<_ListenerEntry>[entry]),
     );
   }
 

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -109,7 +109,8 @@ class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
   LinkedList<_ListenerEntry>? _listeners = LinkedList<_ListenerEntry>();
-  Map<VoidCallback, List<_ListenerEntry>>? _index = <VoidCallback, List<_ListenerEntry>>{};
+  HashMap<VoidCallback, ListQueue<_ListenerEntry>>?
+    _index = HashMap<VoidCallback, ListQueue<_ListenerEntry>>();
 
   bool _debugAssertNotDisposed() {
     assert(() {
@@ -155,8 +156,8 @@ class ChangeNotifier implements Listenable {
     _listeners!.add(entry);
     _index!.update(
       listener,
-      (List<_ListenerEntry> value) => value..add(entry),
-      ifAbsent: () => <_ListenerEntry>[entry],
+      (ListQueue<_ListenerEntry> value) => value..add(entry),
+      ifAbsent: () => ListQueue.of(<_ListenerEntry>[entry]),
     );
   }
 
@@ -182,11 +183,11 @@ class ChangeNotifier implements Listenable {
   @override
   void removeListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
-    final List<_ListenerEntry>? links = _index![listener];
+    final ListQueue<_ListenerEntry>? links = _index![listener];
     if (links == null)
       return;
     assert(links.isNotEmpty);
-    links.removeAt(0).unlink();
+    links.removeFirst().unlink();
     if (links.isEmpty)
       _index!.remove(listener);
   }


### PR DESCRIPTION
## Description

This PR makes ConstantListener.removeListeners take constant time.

It achieves this by indexing all links to a callback and only removing the first link, without iterating through the whole list.

(I removed the O(n) part since it wasn't true. Dispatch is not bounded by the amount of listeners, but by how often listeners are added.)

## Related Issues

#64817

## Tests

I added no tests this PR is only meant to make removeListener faster.


## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No