### PR TITLE
[fuchsia] Tests wait for device to be up after pave

### DIFF
--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -77,6 +77,13 @@ ssh-keygen -y -f $pkey > key.pub
 fuchsia_ctl pave -i $1 --public-key "key.pub"
 echo "$(date) END:PAVING --------------------------------------------"
 
+echo "$(date) START:WAIT_DEVICE_READY -------------------------------"
+for i in {1..10}; do
+  fuchsia_ctl ssh \
+      --identity-file $pkey \
+      -c "echo up" && break || sleep 15;
+done
+echo "$(date) END:WAIT_DEVICE_READY ---------------------------------"
 
 echo "$(date) START:PUSH_PACKAGES -------------------------------"
 fuchsia_ctl push-packages \


### PR DESCRIPTION
## Description

- After pave, wait for the device to be up before continuing the script
  - This already existed in the engine script and just needed to be copied over


## Related Issues

https://github.com/flutter/flutter/issues/57044

https://chromium-swarm.appspot.com/task?id=4e4f462c5557f510 shows that fuchsia_ctl is failing to find the device, so it fails to push packages necessary to run the test.


## Tests

This is a bash script to run tests from the SDK against Fuchsia.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
