### PR TITLE
Revert "Roll new gallery to help flaky Crane test"

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = '9eb1ff89a0cd5fd4333215fc62d735becf74da4a';
+const String galleryVersion = 'a208eac6e6e8336ae9820e54c572c099231f1da2';


### PR DESCRIPTION
Reverts flutter/flutter#64676

A few device lab tests consistently red after this landed.

new_gallery_ios__transition_perf
ios_app_with_extensions_test
new_gallery_transition_perf