### PR TITLE
Add --device-timeout flag to device-related commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -102,6 +102,7 @@ class AttachCommand extends FlutterCommand {
       );
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addDdsOptions(verboseHelp: verboseHelp);
+    usesDeviceTimeoutOption();
     hotRunnerFactory ??= HotRunnerFactory();
   }
 

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -34,9 +34,21 @@ class DevicesCommand extends FlutterCommand {
   final String description = 'List all connected devices.';
 
   @override
+  Duration get deviceDiscoveryTimeout {
+    if (argResults['timeout'] != null) {
+      final int timeoutSeconds = int.tryParse(stringArg('timeout'));
+      if (timeoutSeconds == null) {
+        throwToolExit( 'Could not parse -t/--timeout argument. It must be an integer.');
+      }
+      return Duration(seconds: timeoutSeconds);
+    }
+    return super.deviceDiscoveryTimeout;
+  }
+
+  @override
   Future<void> validateCommand() {
     if (argResults['timeout'] != null) {
-      throwToolExit('--timeout has been deprecated, use --${FlutterOptions.kDeviceTimeout} instead');
+      globals.printError('--timeout has been deprecated, use --${FlutterOptions.kDeviceTimeout} instead');
     }
     return super.validateCommand();
   }

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -22,8 +22,9 @@ class DevicesCommand extends FlutterCommand {
       'timeout',
       abbr: 't',
       defaultsTo: null,
-      help: 'Time in seconds to wait for devices to attach. Longer timeouts may be necessary for networked devices.'
+      help: '(deprecated) Use --device-timeout instead',
     );
+    usesDeviceTimeoutOption();
   }
 
   @override
@@ -32,20 +33,13 @@ class DevicesCommand extends FlutterCommand {
   @override
   final String description = 'List all connected devices.';
 
-  Duration get timeout {
-    if (argResults['timeout'] == null) {
-      return null;
+  @override
+  Future<void> validateCommand() {
+    if (argResults['timeout'] != null) {
+      throwToolExit('--timeout has been deprecated, use --${FlutterOptions.kDeviceTimeout} instead');
     }
-    if (_timeout == null) {
-      final int timeoutSeconds = int.tryParse(stringArg('timeout'));
-      if (timeoutSeconds == null) {
-        throwToolExit( 'Could not parse -t/--timeout argument. It must be an integer.');
-      }
-      _timeout = Duration(seconds: timeoutSeconds);
-    }
-    return _timeout;
+    return super.validateCommand();
   }
-  Duration _timeout;
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -56,7 +50,7 @@ class DevicesCommand extends FlutterCommand {
         exitCode: 1);
     }
 
-    final List<Device> devices = await globals.deviceManager.refreshAllConnectedDevices(timeout: timeout);
+    final List<Device> devices = await globals.deviceManager.refreshAllConnectedDevices(timeout: deviceDiscoveryTimeout);
 
     if (boolArg('machine')) {
       await printDevicesAsJson(devices);
@@ -68,8 +62,8 @@ class DevicesCommand extends FlutterCommand {
         status.writeln('Run "flutter emulators" to list and start any available device emulators.');
         status.writeln();
         status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
-        if (timeout == null) {
-          status.write('You may also try increasing the time to wait for connected devices with the --timeout flag. ');
+        if (deviceDiscoveryTimeout == null) {
+          status.write('You may also try increasing the time to wait for connected devices with the --${FlutterOptions.kDeviceTimeout} flag. ');
         }
         status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
 

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -146,7 +146,7 @@ class DriveCommand extends RunCommandBase {
   @override
   Future<void> validateCommand() async {
     if (userIdentifier != null) {
-      final Device device = await findTargetDevice();
+      final Device device = await findTargetDevice(timeout: deviceDiscoveryTimeout);
       if (device is! AndroidDevice) {
         throwToolExit('--${FlutterOptions.kDeviceUser} is only supported for Android');
       }
@@ -161,7 +161,7 @@ class DriveCommand extends RunCommandBase {
       throwToolExit(null);
     }
 
-    _device = await findTargetDevice();
+    _device = await findTargetDevice(timeout: deviceDiscoveryTimeout);
     if (device == null) {
       throwToolExit(null);
     }
@@ -388,9 +388,9 @@ $ex
   }
 }
 
-Future<Device> findTargetDevice() async {
+Future<Device> findTargetDevice({ @required Duration timeout }) async {
   final DeviceManager deviceManager = globals.deviceManager;
-  final List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current());
+  final List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current(), timeout: timeout);
 
   if (deviceManager.hasSpecifiedDeviceId) {
     if (devices.isEmpty) {

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -16,6 +16,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   InstallCommand() {
     requiresPubspecYaml();
     usesDeviceUserOption();
+    usesDeviceTimeoutOption();
     argParser.addFlag('uninstall-only',
       negatable: true,
       defaultsTo: false,

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -18,6 +18,7 @@ class LogsCommand extends FlutterCommand {
       abbr: 'c',
       help: 'Clear log history before reading from logs.',
     );
+    usesDeviceTimeoutOption();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -75,6 +75,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     usesDeviceUserOption();
+    usesDeviceTimeoutOption();
   }
 
   bool get traceStartup => boolArg('trace-startup');

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -51,6 +51,7 @@ class ScreenshotCommand extends FlutterCommand {
       },
       defaultsTo: _kDeviceType,
     );
+    usesDeviceTimeoutOption();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -209,7 +209,12 @@ abstract class DeviceManager {
   /// * If the user did not specify a device id and there is more than one
   /// device connected, then filter out unsupported devices and prioritize
   /// ephemeral devices.
-  Future<List<Device>> findTargetDevices(FlutterProject flutterProject) async {
+  Future<List<Device>> findTargetDevices(FlutterProject flutterProject, { Duration timeout }) async {
+    if (timeout != null) {
+      // Reset the cache with the specified timeout.
+      await refreshAllConnectedDevices(timeout: timeout);
+    }
+
     List<Device> devices = await getDevices();
 
     // Always remove web and fuchsia devices from `--all`. This setting

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -113,6 +113,7 @@ class FlutterOptions {
   static const String kPerformanceMeasurementFile = 'performance-measurement-file';
   static const String kNullSafety = 'sound-null-safety';
   static const String kDeviceUser = 'device-user';
+  static const String kDeviceTimeout = 'device-timeout';
   static const String kAnalyzeSize = 'analyze-size';
   static const String kNullAssertions = 'null-assertions';
 }
@@ -403,6 +404,28 @@ abstract class FlutterCommand extends Command<void> {
       help: 'Identifier number for a user or work profile on Android only. Run "adb shell pm list users" for available identifiers.',
       valueHelp: '10');
   }
+
+  void usesDeviceTimeoutOption() {
+    argParser.addOption(
+      FlutterOptions.kDeviceTimeout,
+      help: 'Time in seconds to wait for devices to attach. Longer timeouts may be necessary for networked devices.',
+      valueHelp: '10'
+    );
+  }
+
+  Duration get deviceDiscoveryTimeout {
+    if (_deviceDiscoveryTimeout == null
+        && argResults.options.contains(FlutterOptions.kDeviceTimeout)
+        && argResults.wasParsed(FlutterOptions.kDeviceTimeout)) {
+      final int timeoutSeconds = int.tryParse(stringArg(FlutterOptions.kDeviceTimeout));
+      if (timeoutSeconds == null) {
+        throwToolExit( 'Could not parse --${FlutterOptions.kDeviceTimeout} argument. It must be an integer.');
+      }
+      _deviceDiscoveryTimeout = Duration(seconds: timeoutSeconds);
+    }
+    return _deviceDiscoveryTimeout;
+  }
+  Duration _deviceDiscoveryTimeout;
 
   void addBuildModeFlags({ bool defaultToRelease = true, bool verboseHelp = false, bool excludeDebug = false }) {
     // A release build must be the default if a debug build is not possible.
@@ -970,7 +993,7 @@ abstract class FlutterCommand extends Command<void> {
       return null;
     }
     final DeviceManager deviceManager = globals.deviceManager;
-    List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current());
+    List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current(), timeout: deviceDiscoveryTimeout);
 
     if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
       globals.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId));

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -342,6 +342,8 @@ void main() {
         '-v',
         '--device-user',
         '10',
+        '--device-timeout',
+        '15',
       ]);
       final VerificationResult verificationResult = verify(
         mockHotRunnerFactory.build(

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -281,7 +281,7 @@ void main() {
         when(mockDevice.name).thenReturn('specified-device');
         when(mockDevice.id).thenReturn('123');
 
-        final Device device = await findTargetDevice();
+        final Device device = await findTargetDevice(timeout: null);
         expect(device.name, 'specified-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -293,7 +293,7 @@ void main() {
       Platform platform() => FakePlatform(operatingSystem: operatingSystem);
 
       testUsingContext('returns null if no devices found', () async {
-        expect(await findTargetDevice(), isNull);
+        expect(await findTargetDevice(timeout: null), isNull);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -305,7 +305,7 @@ void main() {
         when(mockDevice.name).thenReturn('mock-android-device');
         testDeviceManager.addDevice(mockDevice);
 
-        final Device device = await findTargetDevice();
+        final Device device = await findTargetDevice(timeout: null);
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -337,7 +337,7 @@ void main() {
         testDeviceManager.addDevice(mockDevice);
         testDeviceManager.addDevice(mockUnsupportedDevice);
 
-        final Device device = await findTargetDevice();
+        final Device device = await findTargetDevice(timeout: null);
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -366,7 +366,7 @@ void main() {
         when(mockDevice.isLocalEmulator)
             .thenAnswer((Invocation invocation) => Future<bool>.value(true));
 
-        final Device device = await findTargetDevice();
+        final Device device = await findTargetDevice(timeout: null);
         expect(device.name, 'mock-simulator');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -178,7 +178,7 @@ void main() {
         when(mockDeviceManager.getDevices()).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(noDevices)
         );
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
+        when(mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout'))).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(noDevices)
         );
 
@@ -214,7 +214,7 @@ void main() {
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) async {
           return <Device>[device];
         });
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer((Invocation invocation) async {
+        when(mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout'))).thenAnswer((Invocation invocation) async {
           return <Device>[device];
         });
         when(mockDeviceManager.hasSpecifiedAllDevices).thenReturn(false);
@@ -254,7 +254,7 @@ void main() {
           ]);
         });
 
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
+        when(mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout'))).thenAnswer(
             (Invocation invocation) => Future<List<Device>>.value(<Device>[]),
         );
 
@@ -301,7 +301,8 @@ void main() {
         );
         // No devices are attached, we just want to verify update the cache
         // BEFORE checking for devices
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
+        const Duration timeout = Duration(seconds: 10);
+        when(mockDeviceManager.findTargetDevices(any, timeout: timeout)).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[])
         );
 
@@ -309,6 +310,8 @@ void main() {
           await createTestCommandRunner(command).run(<String>[
             'run',
             '--no-pub',
+            '--device-timeout',
+            '10',
           ]);
           fail('Exception expected');
         } on ToolExit catch (e) {
@@ -324,7 +327,7 @@ void main() {
           // as part of gathering `requiredArtifacts`
           mockDeviceManager.getDevices(),
           // in validateCommand()
-          mockDeviceManager.findTargetDevices(any),
+          mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout')),
         ]);
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
@@ -365,7 +368,7 @@ void main() {
           (Invocation invocation) => Future<List<Device>>.value(<Device>[mockDevice])
         );
 
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
+        when(mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout'))).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[mockDevice])
         );
 
@@ -434,7 +437,7 @@ void main() {
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
           return Future<List<Device>>.value(<Device>[fakeDevice]);
         });
-        when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
+        when(mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout'))).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[fakeDevice])
         );
       });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -248,7 +248,7 @@ class FakeDeviceManager implements DeviceManager {
   }
 
   @override
-  Future<List<Device>> findTargetDevices(FlutterProject flutterProject) async {
+  Future<List<Device>> findTargetDevices(FlutterProject flutterProject, { Duration timeout }) async {
     return devices;
   }
 }


### PR DESCRIPTION
## Description

Deprecate `devices` command [`--timeout` flag](https://github.com/flutter/flutter/pull/51678), replace with a command-level `--device-timeout` flag.  Also use in `flutter run`, `drive`, `attach`, `install`, `screenshot`, and `logs`.

## Related Issues

Another piece to https://github.com/flutter/flutter/issues/15072 to allow longer timeouts for networked devices.

This will allow devicelab tests to pass a longer timeout to [`flutter drive` for tests targeting slower iOS devices](https://github.com/flutter/flutter/issues/64753).

## Tests

Added does/does not `refreshes device cache with a timeout` tests.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*