### PR TITLE
Allow creating blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: I want help writing my application
     url: https://stackoverflow.com/tags/flutter


### PR DESCRIPTION
Many new issues were created mistakenly with "team: infra" issue, the hypothesis is users just scrolled to the bottom and clicked lowest issue template, which is the infra one. 

This PR will re-enable the option of opening a blank issue to mitigate the problem.

<img width="1202" alt="Screen Shot 2020-08-28 at 16 42 17" src="https://user-images.githubusercontent.com/6259181/91622741-71401480-e94d-11ea-840a-f8c3af63e11f.png">
