### PR TITLE
Inset padding dialog

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -132,12 +132,12 @@ class Dialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final DialogTheme dialogTheme = DialogTheme.of(context);
     final EdgeInsets effectivePadding = MediaQuery.of(context).viewInsets + (insetPadding ?? const EdgeInsets.all(0.0));
-    double mindWidthSize = 280.0;
-    double mindHeightSize = 0.0;
+    double minWidthSize = 280.0;
+    double minHeightSize = 0.0;
 
     if (insetPadding != null) {
-      mindWidthSize = (insetPadding.right == 0.0 && insetPadding.left == 0.0) ? double.infinity : 280.0;
-      mindHeightSize = (insetPadding.top == 0.0 && insetPadding.bottom == 0.0) ? double.infinity : 0.0;
+      minWidthSize = (insetPadding.right == 0.0 && insetPadding.left == 0.0) ? double.infinity : 280.0;
+      minHeightSize = (insetPadding.top == 0.0 && insetPadding.bottom == 0.0) ? double.infinity : 0.0;
     }
     return AnimatedPadding(
       padding: effectivePadding,
@@ -151,7 +151,7 @@ class Dialog extends StatelessWidget {
         context: context,
         child: Center(
           child: ConstrainedBox(
-            constraints: BoxConstraints(minWidth: mindWidthSize, minHeight: mindHeightSize),
+            constraints: BoxConstraints(minWidth: minWidthSize, minHeight: minHeightSize),
             child: Material(
               color: backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor,
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -132,6 +132,13 @@ class Dialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final DialogTheme dialogTheme = DialogTheme.of(context);
     final EdgeInsets effectivePadding = MediaQuery.of(context).viewInsets + (insetPadding ?? const EdgeInsets.all(0.0));
+    double mindWidthSize = 280.0;
+    double mindHeightSize = 0.0;
+
+    if (insetPadding != null) {
+      mindWidthSize = (insetPadding.right == 0.0 && insetPadding.left == 0.0) ? double.infinity : 280.0;
+      mindHeightSize = (insetPadding.top == 0.0 && insetPadding.bottom == 0.0) ? double.infinity : 0.0;
+    }
     return AnimatedPadding(
       padding: effectivePadding,
       duration: insetAnimationDuration,
@@ -144,7 +151,7 @@ class Dialog extends StatelessWidget {
         context: context,
         child: Center(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 280.0),
+            constraints: BoxConstraints(minWidth: mindWidthSize, minHeight: mindHeightSize),
             child: Material(
               color: backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor,
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -1275,6 +1275,27 @@ void main() {
         ));
   });
 
+  testWidgets('Dialog check the width, height by insetPadding zero value', (WidgetTester tester) async {
+    // case without padding value
+    const AlertDialog dialog = AlertDialog(
+        content: Text('content'),
+        insetPadding: EdgeInsets.all(0.0)
+    );
+
+    await tester.pumpWidget(_buildAppWithDialog(dialog));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+
+    final ConstrainedBox box = tester.widget<ConstrainedBox>(
+        find.descendant(of: find.byType(AlertDialog), matching: find.byType(ConstrainedBox))
+    );
+
+    expect(box.constraints.minWidth, double.infinity);
+    expect(box.constraints.minHeight, double.infinity);
+  });
+
+
   testWidgets('Dialog widget contains route semantics from title', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(


### PR DESCRIPTION
## Description
InsetPadding not working correctly in AlertDialog / Dialog
```dart
 _showDialog() {
    showDialog(
      context: context,
      builder: (_) {
        return AlertDialog(
          insetPadding: EdgeInsets.all(0.0),
          content: Center(child: Text('asd')),
        );
      },
    );
  }
```
Despite EdgeInsets.all(0.0), `horizontal still has a padding value`

**solution** -> BoxConstraints minWidth

## Related Issues
#61154

## Tests
test case : checked Dialog width, height by insetPadding zero value
https://github.com/flutter/flutter/pull/64900/commits/fa64fe93ccedab4c244f5403978dda578fd345ce
## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
