### PR TITLE
Match lerped values using moreOrLessEquals

### DIFF
--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -934,7 +934,7 @@ void main() {
     expect(bottomLargeTitle.text.style.color, const Color(0xff00050a));
     expect(bottomLargeTitle.text.style.fontWeight, FontWeight.w700);
     expect(bottomLargeTitle.text.style.fontFamily, '.SF Pro Display');
-    expect(bottomLargeTitle.text.style.letterSpacing, 0.374765625);
+    expect(bottomLargeTitle.text.style.letterSpacing, moreOrLessEquals(0.374765625));
 
     // The top back label is styled exactly the same way.
     final RenderParagraph topBackLabel =
@@ -942,19 +942,19 @@ void main() {
     expect(topBackLabel.text.style.color, const Color(0xff00050a));
     expect(topBackLabel.text.style.fontWeight, FontWeight.w700);
     expect(topBackLabel.text.style.fontFamily, '.SF Pro Display');
-    expect(topBackLabel.text.style.letterSpacing, 0.374765625);
+    expect(topBackLabel.text.style.letterSpacing, moreOrLessEquals(0.374765625));
 
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomLargeTitle.text.style.color, const Color(0xff006de4));
     expect(bottomLargeTitle.text.style.fontWeight, FontWeight.w400);
     expect(bottomLargeTitle.text.style.fontFamily, '.SF Pro Text');
-    expect(bottomLargeTitle.text.style.letterSpacing, -0.32379547566175454);
+    expect(bottomLargeTitle.text.style.letterSpacing, moreOrLessEquals(-0.32379547566175454));
 
     expect(topBackLabel.text.style.color, const Color(0xff006de4));
     expect(topBackLabel.text.style.fontWeight, FontWeight.w400);
     expect(topBackLabel.text.style.fontFamily, '.SF Pro Text');
-    expect(topBackLabel.text.style.letterSpacing, -0.32379547566175454);
+    expect(topBackLabel.text.style.letterSpacing, moreOrLessEquals(-0.32379547566175454));
   });
 
   testWidgets('Top middle fades in and slides in from the right', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -26,11 +26,11 @@ void main() {
     expect(color.toColor(), const Color(0xb399816b));
 
     final HSVColor result = HSVColor.lerp(color, const HSVColor.fromAHSV(0.3, 128.0, 0.7, 0.2), 0.25);
-    expect(result.alpha, 0.6);
-    expect(result.hue, 53.0);
+    expect(result.alpha, moreOrLessEquals(0.6));
+    expect(result.hue, moreOrLessEquals(53.0));
     expect(result.saturation, greaterThan(0.3999));
     expect(result.saturation, lessThan(0.4001));
-    expect(result.value, 0.5);
+    expect(result.value, moreOrLessEquals(0.5));
   });
 
   test('HSVColor hue sweep test', () {
@@ -222,11 +222,11 @@ void main() {
     expect(color.toColor(), const Color(0xb3b8977a));
 
     final HSLColor result = HSLColor.lerp(color, const HSLColor.fromAHSL(0.3, 128.0, 0.7, 0.2), 0.25);
-    expect(result.alpha, 0.6);
-    expect(result.hue, 53.0);
+    expect(result.alpha, moreOrLessEquals(0.6));
+    expect(result.hue, moreOrLessEquals(53.0));
     expect(result.saturation, greaterThan(0.3999));
     expect(result.saturation, lessThan(0.4001));
-    expect(result.lightness, 0.5);
+    expect(result.lightness, moreOrLessEquals(0.5));
   });
 
   test('HSLColor hue sweep test', () {

--- a/packages/flutter/test/rendering/box_constraints_test.dart
+++ b/packages/flutter/test/rendering/box_constraints_test.dart
@@ -71,25 +71,25 @@ void main() {
       maxHeight: 17.0,
     );
     BoxConstraints copy = BoxConstraints.lerp(null, constraints, 0.5);
-    expect(copy.minWidth, 1.5);
-    expect(copy.maxWidth, 3.5);
-    expect(copy.minHeight, 5.5);
-    expect(copy.maxHeight, 8.5);
+    expect(copy.minWidth, moreOrLessEquals(1.5));
+    expect(copy.maxWidth, moreOrLessEquals(3.5));
+    expect(copy.minHeight, moreOrLessEquals(5.5));
+    expect(copy.maxHeight, moreOrLessEquals(8.5));
     copy = BoxConstraints.lerp(constraints, null, 0.5);
-    expect(copy.minWidth, 1.5);
-    expect(copy.maxWidth, 3.5);
-    expect(copy.minHeight, 5.5);
-    expect(copy.maxHeight, 8.5);
+    expect(copy.minWidth, moreOrLessEquals(1.5));
+    expect(copy.maxWidth, moreOrLessEquals(3.5));
+    expect(copy.minHeight, moreOrLessEquals(5.5));
+    expect(copy.maxHeight, moreOrLessEquals(8.5));
     copy = BoxConstraints.lerp(const BoxConstraints(
       minWidth: 13.0,
       maxWidth: 17.0,
       minHeight: 111.0,
       maxHeight: 117.0,
     ), constraints, 0.2);
-    expect(copy.minWidth, 11.0);
-    expect(copy.maxWidth, 15.0);
-    expect(copy.minHeight, 91.0);
-    expect(copy.maxHeight, 97.0);
+    expect(copy.minWidth, moreOrLessEquals(11.0));
+    expect(copy.maxWidth, moreOrLessEquals(15.0));
+    expect(copy.minHeight, moreOrLessEquals(91.0));
+    expect(copy.maxHeight, moreOrLessEquals(97.0));
   });
 
   test('BoxConstraints lerp with unbounded width', () {


### PR DESCRIPTION
## Description

Several of our tests make use of numbers without an exact floating point representation (frequently 0.x where x!=5) which, when scaled, also scale the error. The end result is that some of these tests currently implicitly rely on an implementation detail of floating point math and are sensitive to differences in the ~15th decimal place.

This patch reduces the sensitivity of some of these tests, checking values up to the `precisionErrorTolerance` from the foundation layer rather than requiring en exact match.

## Related patches
flutter/engine#20879 fixes a bug in `lerpDouble` such that when the `a`, `b` endpoint parameters differ significantly in value, 0.0 is always returned rather than an intermediate value. As part of that patch, we change the implementation of the calculation to an algebraically-equivalent form which reduces the floating point error, but which produces small differences in the least-significant bits of the double representation, particularly when the arguments in the test have no exact floating-point representation (such as 0.2, 0.3, 0.6, 0.8 in several of these particular tests).