### PR TITLE
Prefer moreOrLessEquals over closeTo

### DIFF
--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -261,17 +261,19 @@ void main() {
       startHandle: const Offset(0.0, -0.3),
       endHandle: const Offset(1.3, 1.3),
     );
-    expect(curve.transform(0.0).dx, closeTo(0.0, 1e-6));
-    expect(curve.transform(0.0).dy, closeTo(0.0, 1e-6));
-    expect(curve.transform(0.25).dx, closeTo(0.0966945, 1e-6));
-    expect(curve.transform(0.25).dy, closeTo(0.2626806, 1e-6));
-    expect(curve.transform(0.5).dx, closeTo(0.33, 1e-6));
-    expect(curve.transform(0.5).dy, closeTo(0.25, 1e-6));
-    expect(curve.transform(0.75).dx, closeTo(0.570260, 1e-6));
-    expect(curve.transform(0.75).dy, closeTo(0.883085, 1e-6));
-    expect(curve.transform(1.0).dx, closeTo(1.0, 1e-6));
-    expect(curve.transform(1.0).dy, closeTo(1.0, 1e-6));
+    const double tolerance = 1e-6;
+    expect(curve.transform(0.0).dx, moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.0).dy, moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.25).dx, moreOrLessEquals(0.0966945, epsilon: tolerance));
+    expect(curve.transform(0.25).dy, moreOrLessEquals(0.2626806, epsilon: tolerance));
+    expect(curve.transform(0.5).dx, moreOrLessEquals(0.33, epsilon: tolerance));
+    expect(curve.transform(0.5).dy, moreOrLessEquals(0.25, epsilon: tolerance));
+    expect(curve.transform(0.75).dx, moreOrLessEquals(0.570260, epsilon: tolerance));
+    expect(curve.transform(0.75).dy, moreOrLessEquals(0.883085, epsilon: tolerance));
+    expect(curve.transform(1.0).dx, moreOrLessEquals(1.0, epsilon: tolerance));
+    expect(curve.transform(1.0).dy, moreOrLessEquals(1.0, epsilon: tolerance));
   });
+
   test('CatmullRomSpline enforces contract', () {
     expect(() {
       CatmullRomSpline(null);
@@ -295,6 +297,7 @@ void main() {
       CatmullRomSpline(const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero], tension: 2.0);
     }, throwsAssertionError);
   });
+
   test('CatmullRomSpline interpolates values properly when precomputed', () {
     final CatmullRomSpline curve = CatmullRomSpline.precompute(
       const <Offset>[
@@ -310,17 +313,19 @@ void main() {
       startHandle: const Offset(0.0, -0.3),
       endHandle: const Offset(1.3, 1.3),
     );
-    expect(curve.transform(0.0).dx, closeTo(0.0, 1e-6));
-    expect(curve.transform(0.0).dy, closeTo(0.0, 1e-6));
-    expect(curve.transform(0.25).dx, closeTo(0.0966945, 1e-6));
-    expect(curve.transform(0.25).dy, closeTo(0.2626806, 1e-6));
-    expect(curve.transform(0.5).dx, closeTo(0.33, 1e-6));
-    expect(curve.transform(0.5).dy, closeTo(0.25, 1e-6));
-    expect(curve.transform(0.75).dx, closeTo(0.570260, 1e-6));
-    expect(curve.transform(0.75).dy, closeTo(0.883085, 1e-6));
-    expect(curve.transform(1.0).dx, closeTo(1.0, 1e-6));
-    expect(curve.transform(1.0).dy, closeTo(1.0, 1e-6));
+    const double tolerance = 1e-6;
+    expect(curve.transform(0.0).dx, moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.0).dy, moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.25).dx, moreOrLessEquals(0.0966945, epsilon: tolerance));
+    expect(curve.transform(0.25).dy, moreOrLessEquals(0.2626806, epsilon: tolerance));
+    expect(curve.transform(0.5).dx, moreOrLessEquals(0.33, epsilon: tolerance));
+    expect(curve.transform(0.5).dy, moreOrLessEquals(0.25, epsilon: tolerance));
+    expect(curve.transform(0.75).dx, moreOrLessEquals(0.570260, epsilon: tolerance));
+    expect(curve.transform(0.75).dy, moreOrLessEquals(0.883085, epsilon: tolerance));
+    expect(curve.transform(1.0).dx, moreOrLessEquals(1.0, epsilon: tolerance));
+    expect(curve.transform(1.0).dy, moreOrLessEquals(1.0, epsilon: tolerance));
   });
+
   test('CatmullRomSpline enforces contract when precomputed', () {
     expect(() {
       CatmullRomSpline.precompute(null);
@@ -344,6 +349,7 @@ void main() {
       CatmullRomSpline.precompute(const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero], tension: 2.0);
     }, throwsAssertionError);
   });
+
   test('CatmullRomCurve interpolates given points correctly', () {
     final CatmullRomCurve curve = CatmullRomCurve(
       const <Offset>[
@@ -356,15 +362,16 @@ void main() {
 
     // These values are approximations.
     const double tolerance = 1e-6;
-    expect(curve.transform(0.0), closeTo(0.0, tolerance));
-    expect(curve.transform(0.01), closeTo(0.012874734350170863, tolerance));
-    expect(curve.transform(0.2), closeTo(0.24989646045277542, tolerance));
-    expect(curve.transform(0.33), closeTo(0.250037698527661, tolerance));
-    expect(curve.transform(0.5), closeTo(0.9999057323235939, tolerance));
-    expect(curve.transform(0.6), closeTo(0.9357294964536621, tolerance));
-    expect(curve.transform(0.8), closeTo(0.7500423402378034, tolerance));
-    expect(curve.transform(1.0), closeTo(1.0, tolerance));
+    expect(curve.transform(0.0), moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.01), moreOrLessEquals(0.012874734350170863, epsilon: tolerance));
+    expect(curve.transform(0.2), moreOrLessEquals(0.24989646045277542, epsilon: tolerance));
+    expect(curve.transform(0.33), moreOrLessEquals(0.250037698527661, epsilon: tolerance));
+    expect(curve.transform(0.5), moreOrLessEquals(0.9999057323235939, epsilon: tolerance));
+    expect(curve.transform(0.6), moreOrLessEquals(0.9357294964536621, epsilon: tolerance));
+    expect(curve.transform(0.8), moreOrLessEquals(0.7500423402378034, epsilon: tolerance));
+    expect(curve.transform(1.0), moreOrLessEquals(1.0, epsilon: tolerance));
   });
+
   test('CatmullRomCurve interpolates given points correctly when precomputed', () {
     final CatmullRomCurve curve = CatmullRomCurve.precompute(
       const <Offset>[
@@ -377,15 +384,16 @@ void main() {
 
     // These values are approximations.
     const double tolerance = 1e-6;
-    expect(curve.transform(0.0), closeTo(0.0, tolerance));
-    expect(curve.transform(0.01), closeTo(0.012874734350170863, tolerance));
-    expect(curve.transform(0.2), closeTo(0.24989646045277542, tolerance));
-    expect(curve.transform(0.33), closeTo(0.250037698527661, tolerance));
-    expect(curve.transform(0.5), closeTo(0.9999057323235939, tolerance));
-    expect(curve.transform(0.6), closeTo(0.9357294964536621, tolerance));
-    expect(curve.transform(0.8), closeTo(0.7500423402378034, tolerance));
-    expect(curve.transform(1.0), closeTo(1.0, tolerance));
+    expect(curve.transform(0.0), moreOrLessEquals(0.0, epsilon: tolerance));
+    expect(curve.transform(0.01), moreOrLessEquals(0.012874734350170863, epsilon: tolerance));
+    expect(curve.transform(0.2), moreOrLessEquals(0.24989646045277542, epsilon: tolerance));
+    expect(curve.transform(0.33), moreOrLessEquals(0.250037698527661, epsilon: tolerance));
+    expect(curve.transform(0.5), moreOrLessEquals(0.9999057323235939, epsilon: tolerance));
+    expect(curve.transform(0.6), moreOrLessEquals(0.9357294964536621, epsilon: tolerance));
+    expect(curve.transform(0.8), moreOrLessEquals(0.7500423402378034, epsilon: tolerance));
+    expect(curve.transform(1.0), moreOrLessEquals(1.0, epsilon: tolerance));
   });
+
   test('CatmullRomCurve enforces contract', () {
     expect(() {
       CatmullRomCurve(null);
@@ -507,6 +515,7 @@ void main() {
       );
     }, throwsAssertionError);
   });
+
   test('CatmullRomCurve enforces contract when precomputed', () {
     expect(() {
       CatmullRomCurve.precompute(null);

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -782,46 +782,46 @@ void main() {
     expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, 600.0);
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(470.0, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(470.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(374.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(374.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(337.1, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(337.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(325.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(325.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(320.8, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(320.8, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(319.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(319.3, epsilon: 0.1));
 
     // Action sheet has reached final height
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(319.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(319.3, epsilon: 0.1));
 
     // Exit animation
     await tester.tapAt(const Offset(20.0, 20.0));
     await tester.pump();
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(319.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(319.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(449.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(449.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(544.9, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(544.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(582.1, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(582.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(593.9, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(593.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(598.5, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(598.5, epsilon: 0.1));
 
     // Action sheet has disappeared
     await tester.pump(const Duration(milliseconds: 60));
@@ -859,23 +859,23 @@ void main() {
     expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, 600.0);
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(470.0, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(470.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(374.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(374.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(337.1, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(337.1, epsilon: 0.1));
 
     // Exit animation
     await tester.tapAt(const Offset(20.0, 20.0));
     await tester.pump(const Duration(milliseconds: 60));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(374.3, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(374.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, closeTo(470.0, 0.1));
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(470.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 60));
     expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, 600.0);

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -961,31 +961,31 @@ void main() {
     // Enter animation.
     await tester.pump();
     Transform transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.3, 0.01));
+    expect(transform.transform[0], moreOrLessEquals(1.3, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.145, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.145, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.044, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.044, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.013, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.013, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.003, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.003, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.000, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.000, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 50));
     transform = tester.widget(find.byType(Transform));
-    expect(transform.transform[0], closeTo(1.000, 0.001));
+    expect(transform.transform[0], moreOrLessEquals(1.000, epsilon: 0.001));
 
     await tester.tap(find.text('Delete'));
 
@@ -1042,50 +1042,50 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, closeTo(0.40, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.40, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, closeTo(0.437, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.437, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, closeTo(0.55, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.55, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, closeTo(0.737, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.737, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, closeTo(1.0, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(1.0, epsilon: 0.001));
 
     await tester.tap(find.text('Delete'));
 
     // Exit animation, look at reverse FadeTransition.
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.500, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.500, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.332, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.332, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.188, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.188, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.081, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.081, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.019, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.019, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, closeTo(0.0, 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.0, epsilon: 0.001));
   });
 
   testWidgets('Actions are accessible by key', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/page_test.dart
+++ b/packages/flutter/test/cupertino/page_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(widget2TopLeft.dx, greaterThan(widget1InitialTopLeft.dx));
 
     // Will need to be changed if the animation curve or duration changes.
-    expect(widget1TransientTopLeft.dx, closeTo(130, 1.0));
+    expect(widget1TransientTopLeft.dx, moreOrLessEquals(130, epsilon: 1.0));
 
     await tester.pumpAndSettle();
 
@@ -68,7 +68,7 @@ void main() {
     expect(widget2TopLeft.dx, greaterThan(widget1InitialTopLeft.dx));
 
     // Will need to be changed if the animation curve or duration changes.
-    expect(widget1TransientTopLeft.dx, closeTo(249, 1.0));
+    expect(widget1TransientTopLeft.dx, moreOrLessEquals(249, epsilon: 1.0));
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -438,68 +438,68 @@ void main() {
     // entire screen.
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(443.7, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(443.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(291.9, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(291.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(168.2, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(168.2, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(89.5, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(89.5, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(48.1, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(48.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(26.1, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(26.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(14.3, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(14.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(7.41, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(7.41, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(3.0, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(3.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(0.0, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(0.0, epsilon: 0.1));
 
     // Exit animation
     await tester.tap(find.text('Close'));
     await tester.pump();
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(156.3, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(156.3, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(308.1, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(308.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(431.7, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(431.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(510.4, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(510.4, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(551.8, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(551.8, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(573.8, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(573.8, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(585.6, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(585.6, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(592.6, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(592.6, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(596.9, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(596.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dy, closeTo(600.0, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(600.0, epsilon: 0.1));
   });
 
   Future<void> testParallax(WidgetTester tester, {@required bool fromFullscreenDialog}) async {
@@ -536,51 +536,51 @@ void main() {
 
     // Enter animation.
     await tester.tap(find.text('Button'));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(0.0, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(0.0, epsilon: 0.1));
     await tester.pump();
 
     // We use a higher number of intervals since the animation has to scale the
     // entire screen.
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-70.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-70.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-137.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-137.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-192.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-192.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-227.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-227.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-246.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-246.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-255.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-255.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-260.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-260.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-264.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-264.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-266.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-266.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-267.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-267.0, epsilon: 1.0));
 
     // Exit animation
     await tester.tap(find.text('Button'));
     await tester.pump();
 
     await tester.pump(const Duration(milliseconds: 40));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-198.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-198.0, epsilon: 1.0));
 
     await tester.pump(const Duration(milliseconds: 360));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(-0.0, 1.0));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-0.0, epsilon: 1.0));
   }
 
   testWidgets('CupertinoPageRoute has parallax when non fullscreenDialog route is pushed on top', (WidgetTester tester) async {
@@ -625,7 +625,7 @@ void main() {
 
     // Enter animation.
     await tester.tap(find.text('Button'));
-    expect(tester.getTopLeft(find.byType(Placeholder)).dx, closeTo(0.0, 0.1));
+    expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(0.0, epsilon: 0.1));
     await tester.pump();
 
     // We use a higher number of intervals since the animation has to scale the

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -3462,8 +3462,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is at the top.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(206.0, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(206.0, epsilon: .0001));
       });
 
       testWidgets('align center', (WidgetTester tester) async {
@@ -3510,8 +3510,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is at the center.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(291.5, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(291.5, epsilon: .0001));
       });
 
       testWidgets('align bottom', (WidgetTester tester) async {
@@ -3558,8 +3558,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is at the bottom.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(377.0, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(377.0, epsilon: .0001));
       });
 
       testWidgets('align as a double', (WidgetTester tester) async {
@@ -3606,8 +3606,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is near the bottom.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(355.625, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(355.625, epsilon: .0001));
       });
     });
 
@@ -3660,8 +3660,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is at the center. Same as without prefix.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(291.5, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(291.5, epsilon: .0001));
       });
 
       testWidgets('align top', (WidgetTester tester) async {
@@ -3714,8 +3714,8 @@ void main() {
 
         // The prefix is at the top, and the EditableText is centered within its
         // height.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(241.5, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(241.5, epsilon: .0001));
       });
 
       testWidgets('align bottom', (WidgetTester tester) async {
@@ -3768,8 +3768,8 @@ void main() {
 
         // The prefix is at the bottom, and the EditableText is centered within
         // its height.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(341.5, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(341.5, epsilon: .0001));
       });
 
       testWidgets('align as a double', (WidgetTester tester) async {
@@ -3821,8 +3821,8 @@ void main() {
         expect(focusNode.hasFocus, true);
 
         // The EditableText is near the bottom.
-        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, closeTo(size.height, .0001));
-        expect(tester.getTopLeft(find.byType(EditableText)).dy, closeTo(329.0, .0001));
+        expect(tester.getTopLeft(find.byType(CupertinoTextField)).dy, moreOrLessEquals(size.height, epsilon: .0001));
+        expect(tester.getTopLeft(find.byType(EditableText)).dy, moreOrLessEquals(329.0, epsilon: .0001));
       });
     });
 

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -24,7 +24,7 @@ void main() {
     final double dyDelta2 = thirdPosition.dy - secondPosition.dy;
 
     // If the animation were linear, these two values would be the same.
-    expect(dyDelta1, isNot(closeTo(dyDelta2, 0.1)));
+    expect(dyDelta1, isNot(moreOrLessEquals(dyDelta2, epsilon: 0.1)));
   }
 
   testWidgets('Tapping on a modal BottomSheet should not dismiss it', (WidgetTester tester) async {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -808,28 +808,28 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 20));
     // Avatar drawer should start expanding.
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(81.2, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(81.2, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-18.8, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(13.2, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-18.8, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(13.2, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(86.7, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(86.7, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-13.3, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(18.6, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-13.3, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(18.6, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(94.7, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(94.7, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-5.3, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(26.7, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-5.3, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(26.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(99.5, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(99.5, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-0.5, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(31.5, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-0.5, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(31.5, epsilon: 0.1));
 
     // Wait for being done with animation, and make sure it didn't change
     // height.
@@ -849,28 +849,28 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 20));
     // Avatar drawer should start contracting.
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(102.9, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(102.9, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(2.9, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(34.9, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(2.9, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(34.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(98.0, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(98.0, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-2.0, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(30.0, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-2.0, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(30.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(84.1, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(84.1, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-15.9, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(16.1, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-15.9, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(16.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(80.0, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(80.0, epsilon: 0.1));
     expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, closeTo(-20.0, 0.1));
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx, closeTo(12.0, 0.1));
+    expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-20.0, epsilon: 0.1));
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(12.0, epsilon: 0.1));
 
     // Wait for being done with animation, make sure it didn't change
     // height, and make sure that the avatar is no longer drawn.
@@ -923,25 +923,25 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 20));
     // Delete button drawer should start expanding.
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(81.2, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(81.2, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(53.2, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(53.2, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(86.7, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(86.7, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(58.7, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(58.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(94.7, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(94.7, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(66.7, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(66.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(99.5, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(99.5, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(71.5, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(71.5, epsilon: 0.1));
 
     // Wait for being done with animation, and make sure it didn't change
     // height.
@@ -968,25 +968,25 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 20));
     // Delete button drawer should start contracting.
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(103.8, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(103.8, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(75.8, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(75.8, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(102.9, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(102.9, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(74.9, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(74.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(101.0, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(101.0, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(73.0, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(73.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
-    expect(tester.getSize(find.byType(RawChip)).width, closeTo(97.5, 0.1));
+    expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(97.5, epsilon: 0.1));
     expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
-    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, closeTo(69.5, 0.1));
+    expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(69.5, epsilon: 0.1));
 
     // Wait for being done with animation, make sure it didn't change
     // height, and make sure that the delete button is no longer drawn.
@@ -1244,11 +1244,11 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.002, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.002, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.54, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.54, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 100));
@@ -1262,11 +1262,11 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 20));
-    expect(getSelectProgress(tester), closeTo(0.875, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.875, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 20));
-    expect(getSelectProgress(tester), closeTo(0.13, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.13, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 100));
@@ -1320,12 +1320,12 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.002, 0.01));
-    expect(getAvatarDrawerProgress(tester), closeTo(0.459, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.002, epsilon: 0.01));
+    expect(getAvatarDrawerProgress(tester), moreOrLessEquals(0.459, epsilon: 0.01));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.54, 0.01));
-    expect(getAvatarDrawerProgress(tester), closeTo(0.92, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.54, epsilon: 0.01));
+    expect(getAvatarDrawerProgress(tester), moreOrLessEquals(0.92, epsilon: 0.01));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 100));
     expect(getSelectProgress(tester), equals(1.0));
@@ -1338,12 +1338,12 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 20));
-    expect(getSelectProgress(tester), closeTo(0.875, 0.01));
-    expect(getAvatarDrawerProgress(tester), closeTo(0.96, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.875, epsilon: 0.01));
+    expect(getAvatarDrawerProgress(tester), moreOrLessEquals(0.96, epsilon: 0.01));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 20));
-    expect(getSelectProgress(tester), closeTo(0.13, 0.01));
-    expect(getAvatarDrawerProgress(tester), closeTo(0.75, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.13, epsilon: 0.01));
+    expect(getAvatarDrawerProgress(tester), moreOrLessEquals(0.75, epsilon: 0.01));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 100));
     expect(getSelectProgress(tester), equals(0.0));
@@ -1395,11 +1395,11 @@ void main() {
     expect(SchedulerBinding.instance.transientCallbackCount, equals(2));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.002, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.002, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 50));
-    expect(getSelectProgress(tester), closeTo(0.54, 0.01));
+    expect(getSelectProgress(tester), moreOrLessEquals(0.54, epsilon: 0.01));
     expect(getAvatarDrawerProgress(tester), equals(1.0));
     expect(getDeleteDrawerProgress(tester), equals(0.0));
     await tester.pump(const Duration(milliseconds: 100));

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -684,11 +684,11 @@ void main() {
     }) {
       expect(
         tester.getTopLeft(dialogFinder).dx,
-        closeTo(tester.getTopLeft(finder).dx - unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getTopLeft(finder).dx - unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
       expect(
         tester.getBottomLeft(dialogFinder).dx,
-        closeTo(tester.getBottomLeft(finder).dx - unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getBottomLeft(finder).dx - unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
     }
 
@@ -700,11 +700,11 @@ void main() {
     }) {
       expect(
         tester.getTopRight(dialogFinder).dx,
-        closeTo(tester.getTopRight(finder).dx + unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getTopRight(finder).dx + unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
       expect(
         tester.getBottomRight(dialogFinder).dx,
-        closeTo(tester.getBottomRight(finder).dx + unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getBottomRight(finder).dx + unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
     }
 
@@ -716,11 +716,11 @@ void main() {
     }) {
       expect(
         tester.getTopLeft(dialogFinder).dy,
-        closeTo(tester.getTopLeft(finder).dy - unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getTopLeft(finder).dy - unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
       expect(
         tester.getTopRight(dialogFinder).dy,
-        closeTo(tester.getTopRight(finder).dy - unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getTopRight(finder).dy - unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
     }
 
@@ -732,11 +732,11 @@ void main() {
     }) {
       expect(
         tester.getBottomLeft(dialogFinder).dy,
-        closeTo(tester.getBottomRight(finder).dy + unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getBottomRight(finder).dy + unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
       expect(
         tester.getBottomRight(dialogFinder).dy,
-        closeTo(tester.getBottomRight(finder).dy + unscaledValue * paddingScaleFactors[textScaleFactor], 1e-6),
+        moreOrLessEquals(tester.getBottomRight(finder).dy + unscaledValue * paddingScaleFactors[textScaleFactor]),
       );
     }
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1353,10 +1353,10 @@ void main() {
     //   12 - bottom padding
 
     expect(tester.getSize(find.byType(InputDecorator)).width, 800.0);
-    expect(tester.getSize(find.byType(InputDecorator)).height, closeTo(128.0, .0001));
+    expect(tester.getSize(find.byType(InputDecorator)).height, moreOrLessEquals(128.0, epsilon: .0001));
     expect(tester.getSize(find.text('text')).height, 20.0);
     expect(tester.getSize(find.byKey(pKey)).height, 100.0);
-    expect(tester.getTopLeft(find.text('text')).dy, closeTo(96, .0001)); // 12 + 100 - 16
+    expect(tester.getTopLeft(find.text('text')).dy, moreOrLessEquals(96, epsilon: .0001)); // 12 + 100 - 16
     expect(tester.getTopLeft(find.byKey(pKey)).dy, 12.0);
 
     // layout is a row: [prefix text suffix]
@@ -1403,10 +1403,10 @@ void main() {
     // positioned at 19, and the text is at 19+100-16=103.
 
     expect(tester.getSize(find.byType(InputDecorator)).width, 800.0);
-    expect(tester.getSize(find.byType(InputDecorator)).height, closeTo(144, .0001));
+    expect(tester.getSize(find.byType(InputDecorator)).height, moreOrLessEquals(144, epsilon: .0001));
     expect(tester.getSize(find.text('text')).height, 20.0);
     expect(tester.getSize(find.byKey(pKey)).height, 100.0);
-    expect(tester.getTopLeft(find.text('text')).dy, closeTo(103, .0001));
+    expect(tester.getTopLeft(find.text('text')).dy, moreOrLessEquals(103, epsilon: .0001));
     expect(tester.getTopLeft(find.byKey(pKey)).dy, 19.0);
 
     // layout is a row: [prefix text suffix]
@@ -1745,7 +1745,7 @@ void main() {
         );
 
         // Same as the default case above.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(12.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(12.0, epsilon: .0001));
       });
 
       testWidgets('align center', (WidgetTester tester) async {
@@ -1768,7 +1768,7 @@ void main() {
         );
 
         // Below the top aligned case.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(290.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(290.0, epsilon: .0001));
       });
 
       testWidgets('align bottom', (WidgetTester tester) async {
@@ -1791,7 +1791,7 @@ void main() {
         );
 
         // Below the center aligned case.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(568.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(568.0, epsilon: .0001));
       });
 
       testWidgets('align as a double', (WidgetTester tester) async {
@@ -1814,7 +1814,7 @@ void main() {
         );
 
         // In between the center and bottom aligned cases.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(498.5, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(498.5, epsilon: .0001));
       });
     });
 
@@ -1841,7 +1841,7 @@ void main() {
 
         // Similar to the case without a border, but with a little extra room at
         // the top to make room for the border.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(24.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(24.0, epsilon: .0001));
       });
 
       testWidgets('align center (default)', (WidgetTester tester) async {
@@ -1865,7 +1865,7 @@ void main() {
         );
 
         // Below the top aligned case.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(289.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(289.0, epsilon: .0001));
       });
 
       testWidgets('align bottom', (WidgetTester tester) async {
@@ -1889,7 +1889,7 @@ void main() {
         );
 
         // Below the center aligned case.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(564.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(564.0, epsilon: .0001));
       });
     });
 
@@ -1919,7 +1919,7 @@ void main() {
         );
 
         // Same as the default case above.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(96, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(96, epsilon: .0001));
         expect(tester.getTopLeft(find.byKey(pKey)).dy, 12.0);
       });
 
@@ -1948,7 +1948,7 @@ void main() {
         );
 
         // Same as the default case above.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(96.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(96.0, epsilon: .0001));
         expect(tester.getTopLeft(find.byKey(pKey)).dy, 12.0);
       });
 
@@ -1977,7 +1977,7 @@ void main() {
         );
 
         // Top of the input + 100 prefix height - overlap
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(96.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(96.0, epsilon: .0001));
         expect(tester.getTopLeft(find.byKey(pKey)).dy, 12.0);
       });
     });
@@ -2010,8 +2010,8 @@ void main() {
         );
 
         // In the middle of the expanded InputDecorator.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(331.0, .0001));
-        expect(tester.getTopLeft(find.byKey(pKey)).dy, closeTo(247.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(331.0, epsilon: .0001));
+        expect(tester.getTopLeft(find.byKey(pKey)).dy, moreOrLessEquals(247.0, epsilon: .0001));
       });
 
       testWidgets('InputDecorator tall prefix with border align top', (WidgetTester tester) async {
@@ -2041,7 +2041,7 @@ void main() {
         );
 
         // Above the center example.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(108.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(108.0, epsilon: .0001));
         // The prefix is positioned at the top of the input, so this value is
         // the same as the top aligned test without a prefix.
         expect(tester.getTopLeft(find.byKey(pKey)).dy, 24.0);
@@ -2074,8 +2074,8 @@ void main() {
         );
 
         // Below the center example.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(564.0, .0001));
-        expect(tester.getTopLeft(find.byKey(pKey)).dy, closeTo(480.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(564.0, epsilon: .0001));
+        expect(tester.getTopLeft(find.byKey(pKey)).dy, moreOrLessEquals(480.0, epsilon: .0001));
       });
 
       testWidgets('InputDecorator tall prefix with border align double', (WidgetTester tester) async {
@@ -2105,8 +2105,8 @@ void main() {
         );
 
         // Between the top and center examples.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(354.3, .0001));
-        expect(tester.getTopLeft(find.byKey(pKey)).dy, closeTo(270.3, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(354.3, epsilon: .0001));
+        expect(tester.getTopLeft(find.byKey(pKey)).dy, moreOrLessEquals(270.3, epsilon: .0001));
       });
     });
 
@@ -2133,7 +2133,7 @@ void main() {
 
         // The label causes the text to start slightly lower than it would
         // otherwise.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(28.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(28.0, epsilon: .0001));
       });
 
       testWidgets('align center', (WidgetTester tester) async {
@@ -2158,7 +2158,7 @@ void main() {
 
         // The label reduces the amount of space available for text, so the
         // center is slightly lower.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(298.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(298.0, epsilon: .0001));
       });
 
       testWidgets('align bottom', (WidgetTester tester) async {
@@ -2183,7 +2183,7 @@ void main() {
 
         // The label reduces the amount of space available for text, but the
         // bottom line is still in the same place.
-        expect(tester.getTopLeft(find.text(text)).dy, closeTo(568.0, .0001));
+        expect(tester.getTopLeft(find.text(text)).dy, moreOrLessEquals(568.0, epsilon: .0001));
       });
     });
   });

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -185,11 +185,11 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 1));
     final RenderPhysicalShape modelC = getModel(tester);
-    expect(modelC.elevation, closeTo(0.0, 0.001));
+    expect(modelC.elevation, moreOrLessEquals(0.0, epsilon: 0.001));
 
     await tester.pump(kThemeChangeDuration ~/ 2);
     final RenderPhysicalShape modelD = getModel(tester);
-    expect(modelD.elevation, isNot(closeTo(0.0, 0.001)));
+    expect(modelD.elevation, isNot(moreOrLessEquals(0.0, epsilon: 0.001)));
 
     await tester.pump(kThemeChangeDuration);
     final RenderPhysicalShape modelE = getModel(tester);

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -20,7 +20,7 @@ void main() {
     final double dyDelta2 = thirdPosition.dy - secondPosition.dy;
 
     // If the animation were linear, these two values would be the same.
-    expect(dyDelta1, isNot(closeTo(dyDelta2, 0.1)));
+    expect(dyDelta1, isNot(moreOrLessEquals(dyDelta2, epsilon: 0.1)));
   }
 
   testWidgets('Verify that a BottomSheet can be rebuilt with ScaffoldFeatureController.setState()', (WidgetTester tester) async {

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -61,15 +61,15 @@ void main() {
     // The start thumb is selected when tapping the left inactive track.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.1;
     await tester.tapAt(leftTarget);
-    expect(values.start, closeTo(0.1, 0.01));
+    expect(values.start, moreOrLessEquals(0.1, epsilon: 0.01));
     expect(values.end, equals(0.7));
 
     // The end thumb is selected when tapping the right inactive track.
     await tester.pump();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.9;
     await tester.tapAt(rightTarget);
-    expect(values.start, closeTo(0.1, 0.01));
-    expect(values.end, closeTo(0.9, 0.01));
+    expect(values.start, moreOrLessEquals(0.1, epsilon: 0.01));
+    expect(values.end, moreOrLessEquals(0.9, epsilon: 0.01));
   });
 
   testWidgets('Range Slider can move when tapped (continuous RTL)', (WidgetTester tester) async {
@@ -119,14 +119,14 @@ void main() {
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.1;
     await tester.tapAt(leftTarget);
     expect(values.start, 0.3);
-    expect(values.end, closeTo(0.9, 0.01));
+    expect(values.end, moreOrLessEquals(0.9, epsilon: 0.01));
 
     // The start thumb is selected when tapping the right inactive track.
     await tester.pump();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.9;
     await tester.tapAt(rightTarget);
-    expect(values.start, closeTo(0.1, 0.01));
-    expect(values.end, closeTo(0.9, 0.01));
+    expect(values.start, moreOrLessEquals(0.1, epsilon: 0.01));
+    expect(values.end, moreOrLessEquals(0.9, epsilon: 0.01));
   });
 
   testWidgets('Range Slider can move when tapped (discrete LTR)', (WidgetTester tester) async {
@@ -486,18 +486,18 @@ void main() {
     // Drag the start thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.start, closeTo(0.5, 0.05));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the end thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.end, closeTo(0.5, 0.05));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the start thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, -(bottomRight - topLeft) * 0.3);
-    expect(values.start, closeTo(0.2, 0.05));
+    expect(values.start, moreOrLessEquals(0.2, epsilon: 0.05));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (continuous RTL)', (WidgetTester tester) async {
@@ -539,18 +539,18 @@ void main() {
     // Drag the end thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.end, closeTo(0.5, 0.05));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the start thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.start, closeTo(0.5, 0.05));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the start thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, (bottomRight - topLeft) * 0.3);
-    expect(values.start, closeTo(0.2, 0.05));
+    expect(values.start, moreOrLessEquals(0.2, epsilon: 0.05));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (discrete LTR)', (WidgetTester tester) async {
@@ -595,18 +595,18 @@ void main() {
     // Drag the start thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.start, closeTo(50, 0.01));
+    expect(values.start, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the end thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.end, closeTo(50, 0.01));
+    expect(values.end, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the start thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, -(bottomRight - topLeft) * 0.3);
-    expect(values.start, closeTo(20, 0.01));
+    expect(values.start, moreOrLessEquals(20, epsilon: 0.01));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (discrete RTL)', (WidgetTester tester) async {
@@ -651,18 +651,18 @@ void main() {
     // Drag the end thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.end, closeTo(50, 0.01));
+    expect(values.end, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the start thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.start, closeTo(50, 0.01));
+    expect(values.start, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the start thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, (bottomRight - topLeft) * 0.3);
-    expect(values.start, closeTo(20, 0.01));
+    expect(values.start, moreOrLessEquals(20, epsilon: 0.01));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continuous LTR)', (WidgetTester tester) async {
@@ -704,18 +704,18 @@ void main() {
     // Drag the start thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.start, closeTo(0.5, 0.05));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the end thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.end, closeTo(0.5, 0.05));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the end thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, (bottomRight - topLeft) * 0.3);
-    expect(values.end, closeTo(0.8, 0.05));
+    expect(values.end, moreOrLessEquals(0.8, epsilon: 0.05));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continuous RTL)', (WidgetTester tester) async {
@@ -757,18 +757,18 @@ void main() {
     // Drag the end thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.end, closeTo(0.5, 0.05));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the start thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.start, closeTo(0.5, 0.05));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.05));
 
     // Drag the end thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, -(bottomRight - topLeft) * 0.3);
-    expect(values.end, closeTo(0.8, 0.05));
+    expect(values.end, moreOrLessEquals(0.8, epsilon: 0.05));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (discrete LTR)', (WidgetTester tester) async {
@@ -813,18 +813,18 @@ void main() {
     // Drag the start thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.start, closeTo(50, 0.01));
+    expect(values.start, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the end thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.end, closeTo(50, 0.01));
+    expect(values.end, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the end thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, (bottomRight - topLeft) * 0.3);
-    expect(values.end, closeTo(80, 0.01));
+    expect(values.end, moreOrLessEquals(80, epsilon: 0.01));
   });
 
   testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (discrete RTL)', (WidgetTester tester) async {
@@ -869,18 +869,18 @@ void main() {
     // Drag the end thumb towards the center.
     final Offset leftTarget = topLeft + (bottomRight - topLeft) * 0.3;
     await tester.dragFrom(leftTarget, middle - leftTarget);
-    expect(values.end, closeTo(50, 0.01));
+    expect(values.end, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the start thumb towards the center.
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.start, closeTo(50, 0.01));
+    expect(values.start, moreOrLessEquals(50, epsilon: 0.01));
 
     // Drag the end thumb apart.
     await tester.pumpAndSettle();
     await tester.dragFrom(middle, -(bottomRight - topLeft) * 0.3);
-    expect(values.end, closeTo(80, 0.01));
+    expect(values.end, moreOrLessEquals(80, epsilon: 0.01));
   });
 
   testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by tap', (WidgetTester tester) async {
@@ -933,12 +933,12 @@ void main() {
     expect(startValues, null);
     expect(endValues, null);
     await tester.dragFrom(leftTarget, (bottomRight - topLeft) * 0.2);
-    expect(startValues.start, closeTo(30, 1));
-    expect(startValues.end, closeTo(70, 1));
-    expect(values.start, closeTo(50, 1));
-    expect(values.end, closeTo(70, 1));
-    expect(endValues.start, closeTo(50, 1));
-    expect(endValues.end, closeTo(70, 1));
+    expect(startValues.start, moreOrLessEquals(30, epsilon: 1));
+    expect(startValues.end, moreOrLessEquals(70, epsilon: 1));
+    expect(values.start, moreOrLessEquals(50, epsilon: 1));
+    expect(values.end, moreOrLessEquals(70, epsilon: 1));
+    expect(endValues.start, moreOrLessEquals(50, epsilon: 1));
+    expect(endValues.end, moreOrLessEquals(70, epsilon: 1));
   });
 
   testWidgets('Range Slider onChangeEnd and onChangeStart are called on an interaction initiated by drag', (WidgetTester tester) async {
@@ -993,17 +993,17 @@ void main() {
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, (bottomRight - topLeft) * -0.2);
     await tester.pumpAndSettle();
-    expect(values.start, closeTo(50, 1));
-    expect(values.end, closeTo(51, 1));
+    expect(values.start, moreOrLessEquals(50, epsilon: 1));
+    expect(values.end, moreOrLessEquals(51, epsilon: 1));
 
     // Drag the end thumb to the right.
     final Offset middleTarget = topLeft + (bottomRight - topLeft) * 0.5;
     await tester.dragFrom(middleTarget, (bottomRight - topLeft) * 0.4);
     await tester.pumpAndSettle();
-    expect(startValues.start, closeTo(50, 1));
-    expect(startValues.end, closeTo(51, 1));
-    expect(endValues.start, closeTo(50, 1));
-    expect(endValues.end, closeTo(90, 1));
+    expect(startValues.start, moreOrLessEquals(50, epsilon: 1));
+    expect(startValues.end, moreOrLessEquals(51, epsilon: 1));
+    expect(endValues.start, moreOrLessEquals(50, epsilon: 1));
+    expect(endValues.end, moreOrLessEquals(90, epsilon: 1));
   });
 
   ThemeData _buildTheme() {
@@ -1499,8 +1499,8 @@ void main() {
     await tester.pumpAndSettle();
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
-    expect(values.start, closeTo(0.5, 0.03));
-    expect(values.end, closeTo(0.5, 0.03));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.03));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.03));
     await tester.pumpAndSettle();
 
     expect(
@@ -1572,8 +1572,8 @@ void main() {
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
     await tester.pumpAndSettle();
-    expect(values.start, closeTo(0.5, 0.03));
-    expect(values.end, closeTo(0.5, 0.03));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.03));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.03));
     final TestGesture gesture = await tester.startGesture(middle);
     await tester.pumpAndSettle();
 
@@ -1647,8 +1647,8 @@ void main() {
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
     await tester.pumpAndSettle();
-    expect(values.start, closeTo(0.5, 0.03));
-    expect(values.end, closeTo(0.5, 0.03));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.03));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.03));
     final TestGesture gesture = await tester.startGesture(middle);
     await tester.pumpAndSettle();
 
@@ -1716,8 +1716,8 @@ void main() {
     final Offset rightTarget = topLeft + (bottomRight - topLeft) * 0.7;
     await tester.dragFrom(rightTarget, middle - rightTarget);
     await tester.pumpAndSettle();
-    expect(values.start, closeTo(0.5, 0.03));
-    expect(values.end, closeTo(0.5, 0.03));
+    expect(values.start, moreOrLessEquals(0.5, epsilon: 0.03));
+    expect(values.end, moreOrLessEquals(0.5, epsilon: 0.03));
     final TestGesture gesture = await tester.startGesture(middle);
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -129,9 +129,9 @@ void main() {
 
     final Offset target = topLeft + (bottomRight - topLeft) / 4.0;
     await tester.tapAt(target);
-    expect(value, closeTo(0.25, 0.05));
+    expect(value, moreOrLessEquals(0.25, epsilon: 0.05));
     expect(startValue, equals(0.5));
-    expect(endValue, closeTo(0.25, 0.05));
+    expect(endValue, moreOrLessEquals(0.25, epsilon: 0.05));
     await tester.pump(); // No animation should start.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
@@ -179,7 +179,7 @@ void main() {
 
     final Offset target = topLeft + (bottomRight - topLeft) / 4.0;
     await tester.tapAt(target);
-    expect(value, closeTo(0.75, 0.05));
+    expect(value, moreOrLessEquals(0.75, epsilon: 0.05));
     await tester.pump(); // No animation should start.
     expect(SchedulerBinding.instance.transientCallbackCount, equals(0));
   });
@@ -352,20 +352,20 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 5);
-    expect(log.last.dx, closeTo(386.6, 0.1));
+    expect(log.last.dx, moreOrLessEquals(386.6, epsilon: 0.1));
     // With no more gesture or value changes, the thumb position should still
     // be redrawn in the animated position.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 7);
-    expect(log.last.dx, closeTo(344.5, 0.1));
+    expect(log.last.dx, moreOrLessEquals(344.5, epsilon: 0.1));
     // Final position.
     await tester.pump(const Duration(milliseconds: 80));
     expectedLog.add(const Offset(24.0, 300.0));
     expect(value, equals(0.0));
     expect(log.length, 8);
-    expect(log.last.dx, closeTo(24.0, 0.1));
+    expect(log.last.dx, moreOrLessEquals(24.0, epsilon: 0.1));
     await gesture.up();
   });
 
@@ -467,20 +467,20 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 5);
-    expect(log.last.dx, closeTo(386.6, 0.1));
+    expect(log.last.dx, moreOrLessEquals(386.6, epsilon: 0.1));
     // With no more gesture or value changes, the thumb position should still
     // be redrawn in the animated position.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
     expect(log.length, 7);
-    expect(log.last.dx, closeTo(344.5, 0.1));
+    expect(log.last.dx, moreOrLessEquals(344.5, epsilon: 0.1));
     // Final position.
     await tester.pump(const Duration(milliseconds: 80));
     expectedLog.add(const Offset(24.0, 300.0));
     expect(value, equals(0.0));
     expect(log.length, 8);
-    expect(log.last.dx, closeTo(24.0, 0.1));
+    expect(log.last.dx, moreOrLessEquals(24.0, epsilon: 0.1));
     await gesture.up();
   });
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -399,7 +399,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.index, 5);
     // The center of the FFFFFF item is now at the TabBar's center
-    expect(tester.getCenter(find.text('FFFFFF')).dx, closeTo(400.0, 1.0));
+    expect(tester.getCenter(find.text('FFFFFF')).dx, moreOrLessEquals(400.0, epsilon: 1.0));
   });
 
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3411,7 +3411,7 @@ void main() {
     // line text field).
     final double lineHeight = findRenderEditable(tester).preferredLineHeight;
     scrollableState = tester.firstState(find.byType(Scrollable));
-    expect(scrollableState.position.pixels, closeTo(lineHeight, 0.1));
+    expect(scrollableState.position.pixels, moreOrLessEquals(lineHeight, epsilon: 0.1));
   });
 
   testWidgets('haptic feedback', (WidgetTester tester) async {
@@ -4758,8 +4758,8 @@ void main() {
     //  ---------   rowBottomY
 
     final double rowBottomY = tester.getBottomLeft(find.byType(Row)).dy;
-    expect(tester.getBottomLeft(find.byKey(keyA)).dy, closeTo(rowBottomY - 4.0, 0.001));
-    expect(tester.getBottomLeft(find.text('abc')).dy, closeTo(rowBottomY - 2.0, 0.001));
+    expect(tester.getBottomLeft(find.byKey(keyA)).dy, moreOrLessEquals(rowBottomY - 4.0, epsilon: 0.001));
+    expect(tester.getBottomLeft(find.text('abc')).dy, moreOrLessEquals(rowBottomY - 2.0, epsilon: 0.001));
     expect(tester.getBottomLeft(find.byKey(keyB)).dy, rowBottomY);
   });
 
@@ -4810,8 +4810,8 @@ void main() {
 
     final double rowBottomY = tester.getBottomLeft(find.byType(Row)).dy;
     // The values here should match the version with strut disabled ('TextField baseline alignment no-strut')
-    expect(tester.getBottomLeft(find.byKey(keyA)).dy, closeTo(rowBottomY - 4.0, 0.001));
-    expect(tester.getBottomLeft(find.text('abc')).dy, closeTo(rowBottomY - 2.0, 0.001));
+    expect(tester.getBottomLeft(find.byKey(keyA)).dy, moreOrLessEquals(rowBottomY - 4.0, epsilon: 0.001));
+    expect(tester.getBottomLeft(find.text('abc')).dy, moreOrLessEquals(rowBottomY - 2.0, epsilon: 0.001));
     expect(tester.getBottomLeft(find.byKey(keyB)).dy, rowBottomY);
   });
 

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1310,8 +1310,8 @@ void main() {
     final double textDy = tester.getBottomLeft(find.text('Text')).dy;
 
     expect(firstToggleButtonDy, secondToggleButtonDy);
-    expect(firstToggleButtonDy, closeTo(materialButtonDy - 2.0, 0.001));
-    expect(firstToggleButtonDy, closeTo(textDy - 4.0, 0.001));
+    expect(firstToggleButtonDy, moreOrLessEquals(materialButtonDy - 2.0, epsilon: 0.001));
+    expect(firstToggleButtonDy, moreOrLessEquals(textDy - 4.0, epsilon: 0.001));
   });
 
   testWidgets('Directionality test', (WidgetTester tester) async {

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -315,53 +315,53 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     offset = 1;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     offset = 2;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     offset = 3;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * offset, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * offset, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
 
     // For explicit newlines, getOffsetForCaret places the caret at the location
     // indicated by offset regardless of affinity.
@@ -373,40 +373,40 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     offset = 1;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     offset = 2;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.0001));
 
     // getOffsetForCaret in an unwrapped string with explicit newlines is the
     // same for either affinity.
@@ -418,27 +418,27 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     offset = 1;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
 
     // When text wraps on its own, getOffsetForCaret disambiguates between the
     // end of one line and start of next using affinity.
@@ -450,15 +450,15 @@ void main() {
       ui.Rect.zero,
     );
     // When affinity is downstream, cursor is at beginning of second line
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: text.length - 1, affinity: ui.TextAffinity.upstream),
       ui.Rect.zero,
     );
     // When affinity is upstream, cursor is at end of first line
-    expect(caretOffset.dx, closeTo(98.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(98.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
 
     // When given a string with a newline at the end, getOffsetForCaret puts
     // the cursor at the start of the next line regardless of affinity
@@ -469,15 +469,15 @@ void main() {
       ui.TextPosition(offset: text.length),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     offset = text.length;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
 
     // Given a one-line right aligned string, positioning the cursor at offset 0
     // means that it appears at the "end" of the string, after the character
@@ -491,8 +491,8 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     painter.textAlign = TextAlign.left;
 
     // When given an offset after a newline in the middle of a string,
@@ -506,14 +506,14 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
 
     // When given a string with multiple trailing newlines, places the caret
     // in the position given by offset regardless of affinity.
@@ -523,14 +523,14 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * 3, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(SIZE_OF_A * 3, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
 
     offset = 4;
     painter.text = TextSpan(text: text);
@@ -539,43 +539,43 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
 
     offset = 5;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.0001));
 
     offset = 6;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 3, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
 
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 3, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
 
     // When given a string with multiple leading newlines, places the caret in
     // the position given by offset regardless of affinity.
@@ -587,56 +587,56 @@ void main() {
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 3, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 3, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 3, epsilon: 0.0001));
 
     offset = 2;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A * 2, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A * 2, epsilon: 0.0001));
 
     offset = 1;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy,closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy,moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(SIZE_OF_A, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(SIZE_OF_A, epsilon: 0.0001));
 
     offset = 0;
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
     caretOffset = painter.getOffsetForCaret(
       ui.TextPosition(offset: offset, affinity: TextAffinity.upstream),
       ui.Rect.zero,
     );
-    expect(caretOffset.dx, closeTo(0.0, 0.0001));
-    expect(caretOffset.dy, closeTo(0.0, 0.0001));
+    expect(caretOffset.dx, moreOrLessEquals(0.0, epsilon: 0.0001));
+    expect(caretOffset.dy, moreOrLessEquals(0.0, epsilon: 0.0001));
   });
 
   test('TextPainter widget span', () {

--- a/packages/flutter/test/physics/friction_simulation_test.dart
+++ b/packages/flutter/test/physics/friction_simulation_test.dart
@@ -5,25 +5,23 @@
 import 'package:flutter/physics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-const double _kEpsilon = .00001;
-
 void main() {
   test('Friction simulation positive velocity', () {
     final FrictionSimulation friction = FrictionSimulation(0.135, 100.0, 100.0);
 
-    expect(friction.x(0.0), closeTo(100.0, _kEpsilon));
-    expect(friction.dx(0.0), closeTo(100.0, _kEpsilon));
+    expect(friction.x(0.0), moreOrLessEquals(100.0));
+    expect(friction.dx(0.0), moreOrLessEquals(100.0));
 
-    expect(friction.x(0.1), closeTo(110.0, 1.0));
-    expect(friction.x(0.5), closeTo(131.0, 1.0));
-    expect(friction.x(2.0), closeTo(149.0, 1.0));
+    expect(friction.x(0.1), moreOrLessEquals(110.0, epsilon: 1.0));
+    expect(friction.x(0.5), moreOrLessEquals(131.0, epsilon: 1.0));
+    expect(friction.x(2.0), moreOrLessEquals(149.0, epsilon: 1.0));
 
-    expect(friction.finalX, closeTo(149.0, 1.0));
+    expect(friction.finalX, moreOrLessEquals(149.0, epsilon: 1.0));
 
     expect(friction.timeAtX(100.0), 0.0);
-    expect(friction.timeAtX(friction.x(0.1)), closeTo(0.1, _kEpsilon));
-    expect(friction.timeAtX(friction.x(0.5)), closeTo(0.5, _kEpsilon));
-    expect(friction.timeAtX(friction.x(2.0)), closeTo(2.0, _kEpsilon));
+    expect(friction.timeAtX(friction.x(0.1)), moreOrLessEquals(0.1));
+    expect(friction.timeAtX(friction.x(0.5)), moreOrLessEquals(0.5));
+    expect(friction.timeAtX(friction.x(2.0)), moreOrLessEquals(2.0));
 
     expect(friction.timeAtX(-1.0), double.infinity);
     expect(friction.timeAtX(200.0), double.infinity);
@@ -32,19 +30,19 @@ void main() {
   test('Friction simulation negative velocity', () {
     final FrictionSimulation friction = FrictionSimulation(0.135, 100.0, -100.0);
 
-    expect(friction.x(0.0), closeTo(100.0, _kEpsilon));
-    expect(friction.dx(0.0), closeTo(-100.0, _kEpsilon));
+    expect(friction.x(0.0), moreOrLessEquals(100.0));
+    expect(friction.dx(0.0), moreOrLessEquals(-100.0));
 
-    expect(friction.x(0.1), closeTo(91.0, 1.0));
-    expect(friction.x(0.5), closeTo(68.0, 1.0));
-    expect(friction.x(2.0), closeTo(51.0, 1.0));
+    expect(friction.x(0.1), moreOrLessEquals(91.0, epsilon: 1.0));
+    expect(friction.x(0.5), moreOrLessEquals(68.0, epsilon: 1.0));
+    expect(friction.x(2.0), moreOrLessEquals(51.0, epsilon: 1.0));
 
-    expect(friction.finalX, closeTo(50, 1.0));
+    expect(friction.finalX, moreOrLessEquals(50, epsilon: 1.0));
 
     expect(friction.timeAtX(100.0), 0.0);
-    expect(friction.timeAtX(friction.x(0.1)), closeTo(0.1, _kEpsilon));
-    expect(friction.timeAtX(friction.x(0.5)), closeTo(0.5, _kEpsilon));
-    expect(friction.timeAtX(friction.x(2.0)), closeTo(2.0, _kEpsilon));
+    expect(friction.timeAtX(friction.x(0.1)), moreOrLessEquals(0.1));
+    expect(friction.timeAtX(friction.x(0.5)), moreOrLessEquals(0.5));
+    expect(friction.timeAtX(friction.x(2.0)), moreOrLessEquals(2.0));
 
     expect(friction.timeAtX(101.0), double.infinity);
     expect(friction.timeAtX(40.0), double.infinity);

--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/widgets.dart';
 
-import '../flutter_test_alternative.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('test_friction', () {
@@ -21,7 +22,7 @@ void main() {
 
     expect(friction.dx(1.0), 120.0);
     expect(friction.dx(2.0), 36.0);
-    expect(friction.dx(3.0), closeTo(10.8, 0.00001));
+    expect(friction.dx(3.0), moreOrLessEquals(10.8));
     expect(friction.dx(4.0) < 3.5, true);
 
     expect(friction.isDone(5.0), true);
@@ -48,10 +49,9 @@ void main() {
     expect(friction.x(0.0), 10.0);
     expect(friction.dx(0.0), 600.0);
 
-    const double epsilon = 1e-4;
-    expect(friction.isDone(1.0 + epsilon), true);
-    expect(friction.x(1.0), closeTo(endPosition, epsilon));
-    expect(friction.dx(1.0), closeTo(endVelocity, epsilon));
+    expect(friction.isDone(1.0 + precisionErrorTolerance), true);
+    expect(friction.x(1.0), moreOrLessEquals(endPosition));
+    expect(friction.dx(1.0), moreOrLessEquals(endVelocity));
 
     // Same scenario as above except that the velocities are
     // are negative.
@@ -65,9 +65,9 @@ void main() {
 
     friction = FrictionSimulation.through(
         startPosition, endPosition, startVelocity, endVelocity);
-    expect(friction.isDone(1.0 + epsilon), true);
-    expect(friction.x(1.0), closeTo(endPosition, epsilon));
-    expect(friction.dx(1.0), closeTo(endVelocity, epsilon));
+    expect(friction.isDone(1.0 + precisionErrorTolerance), true);
+    expect(friction.x(1.0), moreOrLessEquals(endPosition));
+    expect(friction.dx(1.0), moreOrLessEquals(endVelocity));
   });
 
   test('BoundedFrictionSimulation control test', () {
@@ -248,14 +248,14 @@ void main() {
     expect(scroll.x(0.0), 100);
     expect(scroll.dx(0.0), 400.0);
 
-    expect(scroll.x(1.0), closeTo(272.0, 1.0));
+    expect(scroll.x(1.0), moreOrLessEquals(272.0, epsilon: 1.0));
 
-    expect(scroll.dx(1.0), closeTo(54.0, 1.0));
-    expect(scroll.dx(2.0), closeTo(7.0, 1.0));
+    expect(scroll.dx(1.0), moreOrLessEquals(54.0, epsilon: 1.0));
+    expect(scroll.dx(2.0), moreOrLessEquals(7.0, epsilon: 1.0));
     expect(scroll.dx(3.0), lessThan(1.0));
 
     expect(scroll.isDone(5.0), true);
-    expect(scroll.x(5.0), closeTo(300.0, 1.0));
+    expect(scroll.x(5.0), moreOrLessEquals(300.0, epsilon: 1.0));
   });
 
   test('over/under scroll spring', () {
@@ -270,33 +270,33 @@ void main() {
     scroll.tolerance = const Tolerance(velocity: 45.0, distance: 1.5);
 
     expect(scroll.isDone(0.0), false);
-    expect(scroll.x(0.0), closeTo(500.0, .0001));
-    expect(scroll.dx(0.0), closeTo(-7500.0, .0001));
+    expect(scroll.x(0.0), moreOrLessEquals(500.0));
+    expect(scroll.dx(0.0), moreOrLessEquals(-7500.0));
 
     // Expect to reach 0.0 at about t=.07 at which point the simulation will
     // switch from friction to the spring
     expect(scroll.isDone(0.065), false);
-    expect(scroll.x(0.065), closeTo(42.0, 1.0));
-    expect(scroll.dx(0.065), closeTo(-6584.0, 1.0));
+    expect(scroll.x(0.065), moreOrLessEquals(42.0, epsilon: 1.0));
+    expect(scroll.dx(0.065), moreOrLessEquals(-6584.0, epsilon: 1.0));
 
     // We've overscrolled (0.1 > 0.07). Trigger the underscroll
     // simulation, and reverse direction
     expect(scroll.isDone(0.1), false);
-    expect(scroll.x(0.1), closeTo(-123.0, 1.0));
-    expect(scroll.dx(0.1), closeTo(-2613.0, 1.0));
+    expect(scroll.x(0.1), moreOrLessEquals(-123.0, epsilon: 1.0));
+    expect(scroll.dx(0.1), moreOrLessEquals(-2613.0, epsilon: 1.0));
 
     // Headed back towards 0.0 and slowing down.
     expect(scroll.isDone(0.5), false);
-    expect(scroll.x(0.5), closeTo(-15.0, 1.0));
-    expect(scroll.dx(0.5), closeTo(124.0, 1.0));
+    expect(scroll.x(0.5), moreOrLessEquals(-15.0, epsilon: 1.0));
+    expect(scroll.dx(0.5), moreOrLessEquals(124.0, epsilon: 1.0));
 
     // Now jump back to the beginning, because we can.
     expect(scroll.isDone(0.0), false);
-    expect(scroll.x(0.0), closeTo(500.0, .0001));
-    expect(scroll.dx(0.0), closeTo(-7500.0, .0001));
+    expect(scroll.x(0.0), moreOrLessEquals(500.0));
+    expect(scroll.dx(0.0), moreOrLessEquals(-7500.0));
 
     expect(scroll.isDone(2.0), true);
     expect(scroll.x(2.0), 0.0);
-    expect(scroll.dx(2.0), closeTo(0.0, 1.0));
+    expect(scroll.dx(2.0), moreOrLessEquals(0.0, epsilon: 1.0));
   });
 }

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -274,13 +274,13 @@ void main() {
     // rendering widths in tests.
     // TODO(gspencergoog): Figure out why this is, and fix it. https://github.com/flutter/flutter/issues/12357
     expect(boxes[0].toRect().width, anyOf(14.0, 13.0));
-    expect(boxes[0].toRect().height, closeTo(13.0, 0.0001));
+    expect(boxes[0].toRect().height, moreOrLessEquals(13.0, epsilon: 0.0001));
     expect(boxes[1].toRect().width, anyOf(27.0, 26.0));
-    expect(boxes[1].toRect().height, closeTo(26.0, 0.0001));
+    expect(boxes[1].toRect().height, moreOrLessEquals(26.0, epsilon: 0.0001));
     expect(boxes[2].toRect().width, anyOf(27.0, 26.0));
-    expect(boxes[2].toRect().height, closeTo(26.0, 0.0001));
+    expect(boxes[2].toRect().height, moreOrLessEquals(26.0, epsilon: 0.0001));
     expect(boxes[3].toRect().width, anyOf(14.0, 13.0));
-    expect(boxes[3].toRect().height, closeTo(13.0, 0.0001));
+    expect(boxes[3].toRect().height, moreOrLessEquals(13.0, epsilon: 0.0001));
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61016
 
   test('toStringDeep', () {

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -50,11 +50,11 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 10));
     transition = tester.widget(find.byType(FadeTransition).at(0));
-    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.01));
     transition = tester.widget(find.byType(FadeTransition).at(1));
-    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.01));
     transition = tester.widget(find.byType(FadeTransition).at(2));
-    expect(transition.opacity.value, closeTo(0.1, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.1, epsilon: 0.01));
     await tester.pumpAndSettle();
   });
 
@@ -338,11 +338,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(StatefulTestState.generation, equals(3));
     transition = tester.widget(find.byType(FadeTransition).at(0));
-    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.01));
     transition = tester.widget(find.byType(FadeTransition).at(1));
-    expect(transition.opacity.value, closeTo(0.4, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.01));
     transition = tester.widget(find.byType(FadeTransition).at(2));
-    expect(transition.opacity.value, closeTo(0.1, 0.01));
+    expect(transition.opacity.value, moreOrLessEquals(0.1, epsilon: 0.01));
     await tester.pumpAndSettle();
     expect(StatefulTestState.generation, equals(3));
   });

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -263,11 +263,11 @@ void main() {
       final double belowBaseline = math.max(belowBaseline1, belowBaseline2);
       expect(rowBox.size.height, greaterThan(textBox1.size.height));
       expect(rowBox.size.height, greaterThan(textBox2.size.height));
-      expect(rowBox.size.height, closeTo(aboveBaseline + belowBaseline, .001));
+      expect(rowBox.size.height, moreOrLessEquals(aboveBaseline + belowBaseline, epsilon: .001));
       expect(tester.getTopLeft(find.byKey(key1)).dy, 0);
       expect(
         tester.getTopLeft(find.byKey(key2)).dy,
-        closeTo(aboveBaseline1 - aboveBaseline2, .001),
+        moreOrLessEquals(aboveBaseline1 - aboveBaseline2, epsilon: .001),
       );
     });
 
@@ -321,7 +321,7 @@ void main() {
       expect(tester.getTopLeft(find.byKey(key1)).dy, 0);
       expect(
         tester.getTopLeft(find.byKey(key2)).dy,
-        closeTo(aboveBaseline1 - aboveBaseline2, .001),
+        moreOrLessEquals(aboveBaseline1 - aboveBaseline2, epsilon: .001),
       );
     });
   });

--- a/packages/flutter/test/widgets/ensure_visible_test.dart
+++ b/packages/flutter/test/widgets/ensure_visible_test.dart
@@ -218,11 +218,11 @@ void main() {
 
       Scrollable.ensureVisible(findContext(0));
       await tester.pump();
-      expect(tester.getBottomRight(findKey(0)).dy, closeTo(100.0, 0.1));
+      expect(tester.getBottomRight(findKey(0)).dy, moreOrLessEquals(100.0, epsilon: 0.1));
 
       Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
-      expect(tester.getTopLeft(findKey(0)).dy, closeTo(500.0, 0.1));
+      expect(tester.getTopLeft(findKey(0)).dy, moreOrLessEquals(500.0, epsilon: 0.1));
     });
   });
 
@@ -474,11 +474,11 @@ void main() {
       await prepare(321.0);
       Scrollable.ensureVisible(findContext(0));
       await tester.pump();
-      expect(tester.getBottomRight(findKey(0)).dy, closeTo(100.0, 0.1));
+      expect(tester.getBottomRight(findKey(0)).dy, moreOrLessEquals(100.0, epsilon: 0.1));
 
       Scrollable.ensureVisible(findContext(0), alignment: 1.0);
       await tester.pump();
-      expect(tester.getTopLeft(findKey(0)).dy, closeTo(500.0, 0.1));
+      expect(tester.getTopLeft(findKey(0)).dy, moreOrLessEquals(500.0, epsilon: 0.1));
     });
   });
 

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -467,25 +467,25 @@ Future<void> main() async {
     await tester.pump(duration * 0.25);
     expect(
       tester.getSize(find.byKey(secondKey)).height,
-      closeTo(curve.transform(0.25) * deltaHeight + initialHeight, epsilon),
+      moreOrLessEquals(curve.transform(0.25) * deltaHeight + initialHeight, epsilon: epsilon),
     );
 
     await tester.pump(duration * 0.25);
     expect(
       tester.getSize(find.byKey(secondKey)).height,
-      closeTo(curve.transform(0.50) * deltaHeight + initialHeight, epsilon),
+      moreOrLessEquals(curve.transform(0.50) * deltaHeight + initialHeight, epsilon: epsilon),
     );
 
     await tester.pump(duration * 0.25);
     expect(
       tester.getSize(find.byKey(secondKey)).height,
-      closeTo(curve.transform(0.75) * deltaHeight + initialHeight, epsilon),
+      moreOrLessEquals(curve.transform(0.75) * deltaHeight + initialHeight, epsilon: epsilon),
     );
 
     await tester.pump(duration * 0.25);
     expect(
       tester.getSize(find.byKey(secondKey)).height,
-      closeTo(curve.transform(1.0) * deltaHeight + initialHeight, epsilon),
+      moreOrLessEquals(curve.transform(1.0) * deltaHeight + initialHeight, epsilon: epsilon),
     );
   });
 
@@ -720,7 +720,7 @@ Future<void> main() async {
     // 150ms so we should be just about back to where Hero 'a' started.
     const double epsilon = 0.001;
     await tester.pump(const Duration(milliseconds: 99));
-    closeTo(tester.getSize(find.byKey(secondKey)).height - initialHeight, epsilon);
+    moreOrLessEquals(tester.getSize(find.byKey(secondKey)).height - initialHeight, epsilon: epsilon);
 
     // The flight is finished. We're back to where we started.
     await tester.pump(const Duration(milliseconds: 300));
@@ -790,7 +790,7 @@ Future<void> main() async {
     // 150ms so we should be just about back to where Hero 'a' started.
     const double epsilon = 0.001;
     await tester.pump(const Duration(milliseconds: 99));
-    closeTo(tester.getSize(find.byKey(firstKey)).height - initialHeight, epsilon);
+    moreOrLessEquals(tester.getSize(find.byKey(firstKey)).height - initialHeight, epsilon: epsilon);
 
     // The flight is finished. We're back to where we started.
     await tester.pump(const Duration(milliseconds: 300));
@@ -1571,19 +1571,19 @@ Future<void> main() async {
     // pop, and it should end up where the push started.
 
     await tester.pump();
-    expect(tester.getTopLeft(find.byKey(secondKey)).dx, closeTo(x4, epsilon));
+    expect(tester.getTopLeft(find.byKey(secondKey)).dx, moreOrLessEquals(x4, epsilon: epsilon));
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(secondKey)).dx, closeTo(x3, epsilon));
+    expect(tester.getTopLeft(find.byKey(secondKey)).dx, moreOrLessEquals(x3, epsilon: epsilon));
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(secondKey)).dx, closeTo(x2, epsilon));
+    expect(tester.getTopLeft(find.byKey(secondKey)).dx, moreOrLessEquals(x2, epsilon: epsilon));
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(secondKey)).dx, closeTo(x1, epsilon));
+    expect(tester.getTopLeft(find.byKey(secondKey)).dx, moreOrLessEquals(x1, epsilon: epsilon));
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(secondKey)).dx, closeTo(x0, epsilon));
+    expect(tester.getTopLeft(find.byKey(secondKey)).dx, moreOrLessEquals(x0, epsilon: epsilon));
 
     // Below: show that a different pop Hero path is in fact taken after
     // a completed push transition.
@@ -1612,10 +1612,10 @@ Future<void> main() async {
     await tester.pump(duration * 0.6);
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(firstKey)).dx, isNot(closeTo(x4, epsilon)));
+    expect(tester.getTopLeft(find.byKey(firstKey)).dx, isNot(moreOrLessEquals(x4, epsilon: epsilon)));
 
     await tester.pump(duration * 0.1);
-    expect(tester.getTopLeft(find.byKey(firstKey)).dx, isNot(closeTo(x3, epsilon)));
+    expect(tester.getTopLeft(find.byKey(firstKey)).dx, isNot(moreOrLessEquals(x3, epsilon: epsilon)));
 
     // At this point the flight path arcs do start to get pretty close so
     // there's no point in comparing them.

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -383,22 +383,22 @@ void main() {
       // It hits the boundary in the x direction first.
       await tester.pump(const Duration(milliseconds: 60));
       translation = transformationController.value.getTranslation();
-      expect(translation.x, closeTo(boundaryMargin, .000000001));
+      expect(translation.x, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
       expect(translation.y, lessThan(boundaryMargin));
       final double yWhenXHits = translation.y;
 
       // x is held to the boundary while y slides along.
       await tester.pump(const Duration(milliseconds: 50));
       translation = transformationController.value.getTranslation();
-      expect(translation.x, closeTo(boundaryMargin, .000000001));
+      expect(translation.x, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
       expect(translation.y, greaterThan(yWhenXHits));
       expect(translation.y, lessThan(boundaryMargin));
 
       // Eventually it ends up in the corner.
       await tester.pumpAndSettle();
       translation = transformationController.value.getTranslation();
-      expect(translation.x, closeTo(boundaryMargin, .000000001));
-      expect(translation.y, closeTo(boundaryMargin, .000000001));
+      expect(translation.x, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
+      expect(translation.y, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
     });
 
     testWidgets('Scaling automatically causes a centering translation', (WidgetTester tester) async {
@@ -430,8 +430,8 @@ void main() {
       await tester.flingFrom(childOffset, flingEnd, 1000.0);
       await tester.pumpAndSettle();
       translation = transformationController.value.getTranslation();
-      expect(translation.x, closeTo(boundaryMargin, .000000001));
-      expect(translation.y, closeTo(boundaryMargin, .000000001));
+      expect(translation.x, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
+      expect(translation.y, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
 
       // Zoom out so the entire child is visible. The child will also be
       // translated in order to keep it inside the boundaries.
@@ -457,7 +457,7 @@ void main() {
       expect(translation.y, lessThan(boundaryMargin));
       expect(translation.x, greaterThan(0.0));
       expect(translation.y, greaterThan(0.0));
-      expect(translation.x, closeTo(translation.y, .000000001));
+      expect(translation.x, moreOrLessEquals(translation.y, epsilon: 1e-9));
 
       // Zoom in on a point that's not the center, and see that it remains at
       // roughly the same location in the viewport after the zoom.
@@ -482,8 +482,8 @@ void main() {
       await gesture2.up();
       await tester.pumpAndSettle();
       final Offset newSceneFocalPoint = transformationController.toScene(viewportFocalPoint);
-      expect(newSceneFocalPoint.dx, closeTo(sceneFocalPoint.dx, 1.0));
-      expect(newSceneFocalPoint.dy, closeTo(sceneFocalPoint.dy, 1.0));
+      expect(newSceneFocalPoint.dx, moreOrLessEquals(sceneFocalPoint.dx, epsilon: 1.0));
+      expect(newSceneFocalPoint.dy, moreOrLessEquals(sceneFocalPoint.dy, epsilon: 1.0));
     });
 
     testWidgets('Scaling automatically causes a centering translation even when alignPanAxis is set', (WidgetTester tester) async {
@@ -522,8 +522,8 @@ void main() {
       await tester.flingFrom(childOffset2, flingEnd2, 1000.0);
       await tester.pumpAndSettle();
       translation = transformationController.value.getTranslation();
-      expect(translation.x, closeTo(boundaryMargin, .000000001));
-      expect(translation.y, closeTo(boundaryMargin, .000000001));
+      expect(translation.x, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
+      expect(translation.y, moreOrLessEquals(boundaryMargin, epsilon: 1e-9));
 
       // Zoom out so the entire child is visible. The child will also be
       // translated in order to keep it inside the boundaries.
@@ -549,7 +549,7 @@ void main() {
       expect(translation.y, lessThan(boundaryMargin));
       expect(translation.x, greaterThan(0.0));
       expect(translation.y, greaterThan(0.0));
-      expect(translation.x, closeTo(translation.y, .000000001));
+      expect(translation.x, moreOrLessEquals(translation.y, epsilon: 1e-9));
 
       // Zoom in on a point that's not the center, and see that it remains at
       // roughly the same location in the viewport after the zoom.
@@ -574,8 +574,8 @@ void main() {
       await gesture2.up();
       await tester.pumpAndSettle();
       final Offset newSceneFocalPoint = transformationController.toScene(viewportFocalPoint);
-      expect(newSceneFocalPoint.dx, closeTo(sceneFocalPoint.dx, 1.0));
-      expect(newSceneFocalPoint.dy, closeTo(sceneFocalPoint.dy, 1.0));
+      expect(newSceneFocalPoint.dx, moreOrLessEquals(sceneFocalPoint.dx, epsilon: 1.0));
+      expect(newSceneFocalPoint.dy, moreOrLessEquals(sceneFocalPoint.dy, epsilon: 1.0));
     });
 
     testWidgets('Can scale with mouse', (WidgetTester tester) async {
@@ -784,8 +784,8 @@ void main() {
 
       final Vector3 closestPoint = InteractiveViewer.getNearestPointOnLine(point, a , b);
 
-      expect(closestPoint.x, closeTo(-356.8, 0.1));
-      expect(closestPoint.y, closeTo(205.8, 0.1));
+      expect(closestPoint.x, moreOrLessEquals(-356.8, epsilon: 0.1));
+      expect(closestPoint.y, moreOrLessEquals(205.8, epsilon: 0.1));
     });
   });
 
@@ -933,8 +933,8 @@ void main() {
 
       final Vector3 nearestPoint = InteractiveViewer.getNearestPointInside(point, quad);
 
-      expect(nearestPoint.x, closeTo(5.8, 0.1));
-      expect(nearestPoint.y, closeTo(10.8, 0.1));
+      expect(nearestPoint.x, moreOrLessEquals(5.8, epsilon: 0.1));
+      expect(nearestPoint.y, moreOrLessEquals(10.8, epsilon: 0.1));
     });
   });
 }

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1465,21 +1465,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1),
       );
 
       await tester.pumpAndSettle();
@@ -1528,21 +1528,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1),
       );
 
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -411,7 +411,7 @@ void main() {
       AxisDirection.down,
     );
     p.paint(testCanvas, size);
-    expect(captureRect().height, closeTo(fullThumbExtent, .000001));
+    expect(captureRect().height, moreOrLessEquals(fullThumbExtent, epsilon: 1e-6));
 
     // Scrolling just to the very end also gives a full sized thumb.
     p.update(
@@ -421,7 +421,7 @@ void main() {
       AxisDirection.down,
     );
     p.paint(testCanvas, size);
-    expect(captureRect().height, closeTo(fullThumbExtent, .000001));
+    expect(captureRect().height, moreOrLessEquals(fullThumbExtent, epsilon: 1e-6));
 
     // Scrolling just past the end shrinks the thumb slightly.
     p.update(
@@ -431,7 +431,7 @@ void main() {
       AxisDirection.down,
     );
     p.paint(testCanvas, size);
-    expect(captureRect().height, closeTo(fullThumbExtent, 2.0));
+    expect(captureRect().height, moreOrLessEquals(fullThumbExtent, epsilon: 2.0));
 
     // Scrolling way past the end shrinks the thumb to minimum.
     p.update(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1777,8 +1777,8 @@ void main() {
     //  ---------   rowBottomY
 
     final double rowBottomY = tester.getBottomLeft(find.byType(Row)).dy;
-    expect(tester.getBottomLeft(find.byKey(keyA)).dy, closeTo(rowBottomY - 4.0, 0.001));
-    expect(tester.getBottomLeft(find.text('abc')).dy, closeTo(rowBottomY - 2.0, 0.001));
+    expect(tester.getBottomLeft(find.byKey(keyA)).dy, moreOrLessEquals(rowBottomY - 4.0, epsilon: 1e-3));
+    expect(tester.getBottomLeft(find.text('abc')).dy, moreOrLessEquals(rowBottomY - 2.0, epsilon: 1e-3));
     expect(tester.getBottomLeft(find.byKey(keyB)).dy, rowBottomY);
   });
 
@@ -1824,8 +1824,8 @@ void main() {
     //  ---------   rowBottomY
 
     final double rowBottomY = tester.getBottomLeft(find.byType(Row)).dy;
-    expect(tester.getBottomLeft(find.byKey(keyA)).dy, closeTo(rowBottomY - 4.0, 0.001));
-    expect(tester.getBottomLeft(find.text('abc')).dy, closeTo(rowBottomY - 2.0, 0.001));
+    expect(tester.getBottomLeft(find.byKey(keyA)).dy, moreOrLessEquals(rowBottomY - 4.0, epsilon: 1e-3));
+    expect(tester.getBottomLeft(find.text('abc')).dy, moreOrLessEquals(rowBottomY - 2.0, epsilon: 1e-3));
     expect(tester.getBottomLeft(find.byKey(keyB)).dy, rowBottomY);
   });
 

--- a/packages/flutter/test/widgets/spacer_test.dart
+++ b/packages/flutter/test/widgets/spacer_test.dart
@@ -45,14 +45,14 @@ void main() {
     final Rect spacer3Rect = tester.getRect(find.byType(Spacer).at(2));
     final Rect spacer4Rect = tester.getRect(find.byType(Spacer).at(3));
     expect(spacer1Rect.size.height, 0.0);
-    expect(spacer1Rect.size.width, closeTo(93.8, 0.1));
-    expect(spacer1Rect.left, closeTo(696.3, 0.1));
-    expect(spacer2Rect.size.width, closeTo(93.8, 0.1));
-    expect(spacer2Rect.left, closeTo(592.5, 0.1));
+    expect(spacer1Rect.size.width, moreOrLessEquals(93.8, epsilon: 0.1));
+    expect(spacer1Rect.left, moreOrLessEquals(696.3, epsilon: 0.1));
+    expect(spacer2Rect.size.width, moreOrLessEquals(93.8, epsilon: 0.1));
+    expect(spacer2Rect.left, moreOrLessEquals(592.5, epsilon: 0.1));
     expect(spacer3Rect.size.width, spacer2Rect.size.width * 2.0);
-    expect(spacer3Rect.left, closeTo(395.0, 0.1));
+    expect(spacer3Rect.left, moreOrLessEquals(395.0, epsilon: 0.1));
     expect(spacer4Rect.size.width, spacer3Rect.size.width * 2.0);
-    expect(spacer4Rect.left, closeTo(10.0, 0.1));
+    expect(spacer4Rect.left, moreOrLessEquals(10.0, epsilon: 0.1));
   });
 
   testWidgets('Spacer takes up space.', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/transitions_test.dart
+++ b/packages/flutter/test/widgets/transitions_test.dart
@@ -141,13 +141,13 @@ void main() {
       expect(actualDecoration.color, const Color(0xFF505050));
       expect(actualDecoration.border, isA<Border>());
       final Border border = actualDecoration.border as Border;
-      expect(border.left.width, closeTo(1.9, 0.1));
+      expect(border.left.width, moreOrLessEquals(1.9, epsilon: 0.1));
       expect(border.left.style, BorderStyle.solid);
       expect(border.left.color, const Color(0xFF151515));
-      expect(actualDecoration.borderRadius.resolve(TextDirection.ltr).topLeft.x, closeTo(6.8, 0.1));
+      expect(actualDecoration.borderRadius.resolve(TextDirection.ltr).topLeft.x, moreOrLessEquals(6.8, epsilon: 0.1));
       expect(actualDecoration.shape, BoxShape.rectangle);
-      expect(actualDecoration.boxShadow[0].blurRadius, closeTo(3.1, 0.1));
-      expect(actualDecoration.boxShadow[0].spreadRadius, closeTo(1.2, 0.1));
+      expect(actualDecoration.boxShadow[0].blurRadius, moreOrLessEquals(3.1, epsilon: 0.1));
+      expect(actualDecoration.boxShadow[0].spreadRadius, moreOrLessEquals(1.2, epsilon: 0.1));
       // Scaling a shadow doesn't change the color.
       expect(actualDecoration.boxShadow[0].color, const Color(0x66000000));
     });


### PR DESCRIPTION
## Description

Flutter's `moreOrLessEquals` has a few advantages over `closeTo` from the `matcher` package:

   * It emits the epsilon value in the test result on failure.
   * It uses a named parameter for epsilon, which improves readability at the call site.
   * It has a reasonable default for epsilon in cases where something more specific isn't required.

Using it also has the nice property that it aids in its own discovery when when people go looking for such functionality in new tests.

This change also migrates the physics tests to use the default value of epsilon, and includes a couple unrelated whitespace formatting cleanups.

## Related changes
This is a followup patch to #64914, which migrated uses of `closeTo` that used the default value for epsilon. This change covers cases where values other than the default value are used. 