### PR TITLE
Add CompositedTransformFollower.{followerAnchor, leaderAnchor} for custom anchoring

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2408,7 +2408,7 @@ class FollowerLayer extends ContainerLayer {
     // and layer offset (LeaderLayer._lastOffset).
     leader.applyTransform(null, forwardTransform);
     final Offset effectiveOrigin = _effectiveLinkedOffset;
-    forwardTransform.translate(effectiveOrigin.dx,effectiveOrigin.dy);
+    forwardTransform.translate(effectiveOrigin.dx, effectiveOrigin.dy);
 
     final Matrix4 inverseTransform = _collectTransformForLayerChain(inverseLayers);
 

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2027,7 +2027,7 @@ class LayerLink {
   LeaderLayer? get leader => _leader;
   LeaderLayer? _leader;
 
-  /// The total size of the contents of [leader].
+  /// The total size of [leader]'s contents.
   Size? leaderSize;
 
   @override
@@ -2215,7 +2215,6 @@ class FollowerLayer extends ContainerLayer {
   ///
   ///  * [unlinkedOffset], for when the layer is not linked.
   Offset? linkedOffset;
-
 
   Offset? _lastOffset;
   Matrix4? _lastTransform;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2028,6 +2028,11 @@ class LayerLink {
   LeaderLayer? _leader;
 
   /// The total size of [leader]'s contents.
+  ///
+  /// Generally this should be set by the [RenderObject] that paints on the
+  /// registered [leader] layer (for instance a [RenderLeaderLayer] that shares
+  /// this link with its followers). This size may be outdated before and during
+  /// layout.
   Size? leaderSize;
 
   @override

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4850,14 +4850,14 @@ class RenderLeaderLayer extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    link.leaderSize = size;
     if (layer == null) {
-      layer = LeaderLayer(link: link, offset: offset, size: size);
+      layer = LeaderLayer(link: link, offset: offset);
     } else {
       final LeaderLayer leaderLayer = layer as LeaderLayer;
       leaderLayer
         ..link = link
-        ..offset = offset
-        ..size = size;
+        ..offset = offset;
     }
     context.pushLayer(layer!, super.paint, Offset.zero);
     assert(layer != null);
@@ -4991,6 +4991,16 @@ class RenderFollowerLayer extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  Offset get _effectiveLinkedOffset {
+    final Size? leaderSize = link.leaderSize;
+    if (leaderSize == null) {
+      assert(leaderSize != null, 'the leader property of $link must not be null');
+      return Offset.zero;
+    }
+
+    return leaderAnchor.alongSize(leaderSize) - followerAnchor.alongSize(size) + offset;
+  }
+
   @override
   void detach() {
     layer = null;
@@ -5041,24 +5051,18 @@ class RenderFollowerLayer extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     assert(showWhenUnlinked != null);
     if (layer == null) {
-      layer = FollowerLayer.withAlignments(
+      layer = FollowerLayer(
         link: link,
         showWhenUnlinked: showWhenUnlinked,
-        linkedOffset: this.offset,
+        linkedOffset: _effectiveLinkedOffset,
         unlinkedOffset: offset,
-        leaderAnchor: leaderAnchor,
-        followerAnchor: followerAnchor,
-        size: size,
       );
     } else {
       layer
         ?..link = link
         ..showWhenUnlinked = showWhenUnlinked
-        ..linkedOffset = this.offset
-        ..unlinkedOffset = offset
-        ..leaderAnchor = leaderAnchor
-        ..followerAnchor = followerAnchor
-        ..size = size;
+        ..linkedOffset = _effectiveLinkedOffset
+        ..unlinkedOffset = offset;
     }
     context.pushLayer(
       layer!,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4947,6 +4947,18 @@ class RenderFollowerLayer extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  /// The anchor point on the linked [RenderLeaderLayer] that [followerAnchor]
+  /// will line up with.
+  ///
+  /// For example, when [leaderAnchor] and [followerAnchor] are both
+  /// [Alignment.topLeft], this [RenderFollowerLayer] will be top left aligned
+  /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
+  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
+  /// [RenderFollowerLayer] will be left aligned with the linked
+  /// [RenderLeaderlayer], and its top edge will line up with the
+  /// [RenderLeaderLayer]'s bottom edge.
+  ///
+  /// Defaults to [Alignment.topLeft].
   Alignment get leaderAnchor => _leaderAnchor;
   Alignment _leaderAnchor;
   set leaderAnchor(Alignment value) {
@@ -4957,6 +4969,18 @@ class RenderFollowerLayer extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  /// The point on this [RenderFollowerLayer] that will line up with
+  /// [followerAnchor] on the linked [RenderLeaderLayer].
+  ///
+  /// For example, when [leaderAnchor] and [followerAnchor] are both
+  /// [Alignment.topLeft], this [RenderFollowerLayer] will be top left aligned
+  /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
+  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
+  /// [RenderFollowerLayer] will be left aligned with the linked
+  /// [RenderLeaderlayer], and its top edge will line up with the
+  /// [RenderLeaderLayer]'s bottom edge.
+  ///
+  /// Defaults to [Alignment.topLeft].
   Alignment get followerAnchor => _followerAnchor;
   Alignment _followerAnchor;
   set followerAnchor(Alignment value) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4969,7 +4969,7 @@ class RenderFollowerLayer extends RenderProxyBox {
     markNeedsPaint();
   }
 
-  /// The point on this [RenderFollowerLayer] that will line up with
+  /// The anchor point on this [RenderFollowerLayer] that will line up with
   /// [followerAnchor] on the linked [RenderLeaderLayer].
   ///
   /// For example, when [leaderAnchor] and [followerAnchor] are both

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4963,7 +4963,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
   /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
   /// [RenderFollowerLayer] will be left aligned with the linked
-  /// [RenderLeaderlayer], and its top edge will line up with the
+  /// [RenderLeaderLayer], and its top edge will line up with the
   /// [RenderLeaderLayer]'s bottom edge.
   ///
   /// Defaults to [Alignment.topLeft].
@@ -4985,7 +4985,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
   /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
   /// [RenderFollowerLayer] will be left aligned with the linked
-  /// [RenderLeaderlayer], and its top edge will line up with the
+  /// [RenderLeaderLayer], and its top edge will line up with the
   /// [RenderLeaderLayer]'s bottom edge.
   ///
   /// Defaults to [Alignment.topLeft].

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4851,12 +4851,13 @@ class RenderLeaderLayer extends RenderProxyBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     if (layer == null) {
-      layer = LeaderLayer(link: link, offset: offset);
+      layer = LeaderLayer(link: link, offset: offset, size: size);
     } else {
       final LeaderLayer leaderLayer = layer as LeaderLayer;
       leaderLayer
         ..link = link
-        ..offset = offset;
+        ..offset = offset
+        ..size = size;
     }
     context.pushLayer(layer!, super.paint, Offset.zero);
     assert(layer != null);
@@ -4890,6 +4891,8 @@ class RenderFollowerLayer extends RenderProxyBox {
     required LayerLink link,
     bool showWhenUnlinked = true,
     Offset offset = Offset.zero,
+    Alignment leaderAnchor = Alignment.topLeft,
+    Alignment followerAnchor = Alignment.topLeft,
     RenderBox? child,
   }) : assert(link != null),
        assert(showWhenUnlinked != null),
@@ -4897,6 +4900,8 @@ class RenderFollowerLayer extends RenderProxyBox {
        _link = link,
        _showWhenUnlinked = showWhenUnlinked,
        _offset = offset,
+       _leaderAnchor = leaderAnchor,
+       _followerAnchor = followerAnchor,
        super(child);
 
   /// The link object that connects this [RenderFollowerLayer] with a
@@ -4939,6 +4944,26 @@ class RenderFollowerLayer extends RenderProxyBox {
     if (_offset == value)
       return;
     _offset = value;
+    markNeedsPaint();
+  }
+
+  Alignment get leaderAnchor => _leaderAnchor;
+  Alignment _leaderAnchor;
+  set leaderAnchor(Alignment value) {
+    assert(value != null);
+    if (_leaderAnchor == value)
+      return;
+    _leaderAnchor = value;
+    markNeedsPaint();
+  }
+
+  Alignment get followerAnchor => _followerAnchor;
+  Alignment _followerAnchor;
+  set followerAnchor(Alignment value) {
+    assert(value != null);
+    if (_followerAnchor == value)
+      return;
+    _followerAnchor = value;
     markNeedsPaint();
   }
 
@@ -4992,18 +5017,24 @@ class RenderFollowerLayer extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     assert(showWhenUnlinked != null);
     if (layer == null) {
-      layer = FollowerLayer(
+      layer = FollowerLayer.withAlignments(
         link: link,
         showWhenUnlinked: showWhenUnlinked,
         linkedOffset: this.offset,
         unlinkedOffset: offset,
+        leaderAnchor: leaderAnchor,
+        followerAnchor: followerAnchor,
+        size: size,
       );
     } else {
-      layer!
-        ..link = link
+      layer
+        ?..link = link
         ..showWhenUnlinked = showWhenUnlinked
         ..linkedOffset = this.offset
-        ..unlinkedOffset = offset;
+        ..unlinkedOffset = offset
+        ..leaderAnchor = leaderAnchor
+        ..followerAnchor = followerAnchor
+        ..size = size;
     }
     context.pushLayer(
       layer!,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4958,6 +4958,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// The anchor point on the linked [RenderLeaderLayer] that [followerAnchor]
   /// will line up with.
   ///
+  /// {@template flutter.rendering.followerLayer.anchor}
   /// For example, when [leaderAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this [RenderFollowerLayer] will be top left aligned
   /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
@@ -4965,6 +4966,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// [RenderFollowerLayer] will be left aligned with the linked
   /// [RenderLeaderLayer], and its top edge will line up with the
   /// [RenderLeaderLayer]'s bottom edge.
+  /// {@endtemplate}
   ///
   /// Defaults to [Alignment.topLeft].
   Alignment get leaderAnchor => _leaderAnchor;
@@ -4980,13 +4982,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// The anchor point on this [RenderFollowerLayer] that will line up with
   /// [followerAnchor] on the linked [RenderLeaderLayer].
   ///
-  /// For example, when [leaderAnchor] and [followerAnchor] are both
-  /// [Alignment.topLeft], this [RenderFollowerLayer] will be top left aligned
-  /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
-  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
-  /// [RenderFollowerLayer] will be left aligned with the linked
-  /// [RenderLeaderLayer], and its top edge will line up with the
-  /// [RenderLeaderLayer]'s bottom edge.
+  /// {@macro flutter.rendering.followerLayer.anchor}
   ///
   /// Defaults to [Alignment.topLeft].
   Alignment get followerAnchor => _followerAnchor;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1324,9 +1324,11 @@ class CompositedTransformTarget extends SingleChildRenderObjectWidget {
 ///
 /// When this widget is composited during the compositing phase (which comes
 /// after the paint phase, as described in [WidgetsBinding.drawFrame]), it
-/// applies a transformation that causes it to provide its child with a
-/// coordinate space that matches that of the linked [CompositedTransformTarget]
-/// widget, offset by [offset].
+/// applies a transformation that brings [targetAnchor] of the linked
+/// [CompositedTransformTarget] and [followerAnchor] of this widget together.
+/// The two anchor points will have the same global coordinates, unless [offset]
+/// is not [Offset.zero], in which case [followerAnchor] will be offset by
+/// [offset] in the linked [CompositedTransformTarget]'s coordinate space.
 ///
 /// The [LayerLink] object used as the [link] must be the same object as that
 /// provided to the matching [CompositedTransformTarget].
@@ -1385,11 +1387,37 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// hidden.
   final bool showWhenUnlinked;
 
+  /// The anchor point on the linked [CompositedTransformTarget] that
+  /// [followerAnchor] will line up with.
+  ///
+  /// For example, when [targetAnchor] and [followerAnchor] are both
+  /// [Alignment.topLeft], this widget will be top left aligned with the linked
+  /// [CompositedTransformTarget]. When [leaderAnchor] is
+  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
+  /// widget will be left aligned with the linked [CompositedTransformTarget],
+  /// and its top edge will line up with the [CompositedTransformTarget]'s
+  /// bottom edge.
+  ///
+  /// Defaults to [Alignment.topLeft].
   final Alignment targetAnchor;
+
+  /// The anchor point on this widget that will line up with [followerAnchor] on
+  /// the linked [CompositedTransformTarget].
+  ///
+  /// For example, when [targetAnchor] and [followerAnchor] are both
+  /// [Alignment.topLeft], this widget will be top left aligned with the linked
+  /// [CompositedTransformTarget]. When [leaderAnchor] is
+  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
+  /// widget will be left aligned with the linked [CompositedTransformTarget],
+  /// and its top edge will line up with the [CompositedTransformTarget]'s
+  /// bottom edge.
+  ///
+  /// Defaults to [Alignment.topLeft].
   final Alignment followerAnchor;
 
-  /// The offset to apply to the origin of the linked
-  /// [CompositedTransformTarget] to obtain this widget's origin.
+  /// The additional offset to apply to the [targetAnchor] of the linked
+  /// [CompositedTransformTarget] to obtain this widget's [followerAnchor]
+  /// position.
   final Offset offset;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1358,10 +1358,14 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
     @required this.link,
     this.showWhenUnlinked = true,
     this.offset = Offset.zero,
+    this.targetAnchor = Alignment.topLeft,
+    this.followerAnchor = Alignment.topLeft,
     Widget child,
   }) : assert(link != null),
        assert(showWhenUnlinked != null),
        assert(offset != null),
+       assert(targetAnchor != null),
+       assert(followerAnchor != null),
        super(key: key, child: child);
 
   /// The link object that connects this [CompositedTransformFollower] with a
@@ -1381,6 +1385,9 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// hidden.
   final bool showWhenUnlinked;
 
+  final Alignment targetAnchor;
+  final Alignment followerAnchor;
+
   /// The offset to apply to the origin of the linked
   /// [CompositedTransformTarget] to obtain this widget's origin.
   final Offset offset;
@@ -1391,6 +1398,8 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
       link: link,
       showWhenUnlinked: showWhenUnlinked,
       offset: offset,
+      leaderAnchor: targetAnchor,
+      followerAnchor: followerAnchor,
     );
   }
 
@@ -1399,7 +1408,9 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
     renderObject
       ..link = link
       ..showWhenUnlinked = showWhenUnlinked
-      ..offset = offset;
+      ..offset = offset
+      ..leaderAnchor = targetAnchor
+      ..followerAnchor = followerAnchor;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1390,6 +1390,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// The anchor point on the linked [CompositedTransformTarget] that
   /// [followerAnchor] will line up with.
   ///
+  /// {@template flutter.widgets.followerLayer.anchor}
   /// For example, when [targetAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this widget will be top left aligned with the linked
   /// [CompositedTransformTarget]. When [targetAnchor] is
@@ -1397,6 +1398,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// widget will be left aligned with the linked [CompositedTransformTarget],
   /// and its top edge will line up with the [CompositedTransformTarget]'s
   /// bottom edge.
+  /// {@endtemplate}
   ///
   /// Defaults to [Alignment.topLeft].
   final Alignment targetAnchor;
@@ -1404,13 +1406,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// The anchor point on this widget that will line up with [followerAnchor] on
   /// the linked [CompositedTransformTarget].
   ///
-  /// For example, when [targetAnchor] and [followerAnchor] are both
-  /// [Alignment.topLeft], this widget will be top left aligned with the linked
-  /// [CompositedTransformTarget]. When [targetAnchor] is
-  /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
-  /// widget will be left aligned with the linked [CompositedTransformTarget],
-  /// and its top edge will line up with the [CompositedTransformTarget]'s
-  /// bottom edge.
+  /// {@macro flutter.widgets.followerLayer.anchor}
   ///
   /// Defaults to [Alignment.topLeft].
   final Alignment followerAnchor;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1392,7 +1392,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   ///
   /// For example, when [targetAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this widget will be top left aligned with the linked
-  /// [CompositedTransformTarget]. When [leaderAnchor] is
+  /// [CompositedTransformTarget]. When [targetAnchor] is
   /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
   /// widget will be left aligned with the linked [CompositedTransformTarget],
   /// and its top edge will line up with the [CompositedTransformTarget]'s
@@ -1406,7 +1406,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   ///
   /// For example, when [targetAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this widget will be top left aligned with the linked
-  /// [CompositedTransformTarget]. When [leaderAnchor] is
+  /// [CompositedTransformTarget]. When [targetAnchor] is
   /// [Alignment.bottomLeft] and [followerAnchor] is [Alignment.topLeft], this
   /// widget will be left aligned with the linked [CompositedTransformTarget],
   /// and its top edge will line up with the [CompositedTransformTarget]'s

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -9,11 +9,12 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('Composited transforms - only offsets', (WidgetTester tester) async {
-    final LayerLink link = LayerLink();
+  final LayerLink link = LayerLink();
+  group('Composited transforms - only offsets', () {
     final GlobalKey key = GlobalKey();
-    await tester.pumpWidget(
-      Directionality(
+
+    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+      return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           children: <Widget>[
@@ -30,23 +31,41 @@ void main() {
               top: 343.0,
               child: CompositedTransformFollower(
                 link: link,
-                child: Container(key: key, height: 10.0, width: 10.0),
+                targetAnchor: targetAlignment,
+                followerAnchor: followerAlignment,
+                child: Container(key: key, height: 20.0, width: 20.0),
               ),
             ),
           ],
         ),
-      ),
-    );
-    final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
-    expect(box.localToGlobal(Offset.zero), const Offset(123.0, 456.0));
+      );
+    }
+
+    testWidgets('topLeft', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
+      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      expect(box.localToGlobal(Offset.zero), const Offset(123.0, 456.0));
+    });
+
+    testWidgets('center', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
+      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      expect(box.localToGlobal(Offset.zero), const Offset(118.0, 451.0));
+    });
+
+    testWidgets('bottomRight - topRight', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
+      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      expect(box.localToGlobal(Offset.zero), const Offset(113.0, 466.0));
+    });
   });
 
-  testWidgets('Composited transforms - with rotations', (WidgetTester tester) async {
-    final LayerLink link = LayerLink();
+  group('Composited transforms - with rotations', () {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
-    await tester.pumpWidget(
-      Directionality(
+
+    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+      return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           children: <Widget>[
@@ -57,7 +76,7 @@ void main() {
                 angle: 1.0, // radians
                 child: CompositedTransformTarget(
                   link: link,
-                  child: Container(key: key1, height: 10.0, width: 10.0),
+                  child: Container(key: key1, width: 80.0, height: 10.0),
                 ),
               ),
             ),
@@ -68,28 +87,50 @@ void main() {
                 angle: -0.3, // radians
                 child: CompositedTransformFollower(
                   link: link,
-                  child: Container(key: key2, height: 10.0, width: 10.0),
+                  targetAnchor: targetAlignment,
+                  followerAnchor: followerAlignment,
+                  child: Container(key: key2, width: 40.0, height: 20.0),
                 ),
               ),
             ),
           ],
         ),
-      ),
-    );
-    final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-    final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
-    final Offset position1 = box1.localToGlobal(Offset.zero);
-    final Offset position2 = box2.localToGlobal(Offset.zero);
-    expect(position1.dx, moreOrLessEquals(position2.dx));
-    expect(position1.dy, moreOrLessEquals(position2.dy));
+      );
+    }
+    testWidgets('topLeft', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(Offset.zero);
+      final Offset position2 = box2.localToGlobal(Offset.zero);
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
+
+    testWidgets('center', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(const Offset(40, 5));
+      final Offset position2 = box2.localToGlobal(const Offset(20, 10));
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
+
+    testWidgets('bottomRight - topRight', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(const Offset(80, 10));
+      final Offset position2 = box2.localToGlobal(const Offset(40, 0));
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
   });
 
-  testWidgets('Composited transforms - nested', (WidgetTester tester) async {
-    final LayerLink link = LayerLink();
+  group('Composited transforms - nested', () {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
-    await tester.pumpWidget(
-      Directionality(
+
+    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+      return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           children: <Widget>[
@@ -100,7 +141,7 @@ void main() {
                 angle: 1.0, // radians
                 child: CompositedTransformTarget(
                   link: link,
-                  child: Container(key: key1, height: 10.0, width: 10.0),
+                  child: Container(key: key1, width: 80.0, height: 10.0),
                 ),
               ),
             ),
@@ -119,7 +160,9 @@ void main() {
                         padding: const EdgeInsets.all(20.0),
                         child: CompositedTransformFollower(
                           link: link,
-                          child: Container(key: key2, height: 10.0, width: 10.0),
+                          targetAnchor: targetAlignment,
+                          followerAnchor: followerAlignment,
+                          child: Container(key: key2, width: 40.0, height: 20.0),
                         ),
                       ),
                     ),
@@ -129,24 +172,45 @@ void main() {
             ),
           ],
         ),
-      ),
-    );
-    final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-    final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
-    final Offset position1 = box1.localToGlobal(Offset.zero);
-    final Offset position2 = box2.localToGlobal(Offset.zero);
-    expect(position1.dx, moreOrLessEquals(position2.dx));
-    expect(position1.dy, moreOrLessEquals(position2.dy));
+      );
+    }
+    testWidgets('topLeft', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(Offset.zero);
+      final Offset position2 = box2.localToGlobal(Offset.zero);
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
+
+    testWidgets('center', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(Alignment.center.alongSize(const Size(80, 10)));
+      final Offset position2 = box2.localToGlobal(Alignment.center.alongSize(const Size(40, 20)));
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
+
+    testWidgets('bottomRight - topRight', (WidgetTester tester) async {
+      await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
+      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final Offset position1 = box1.localToGlobal(Alignment.bottomRight.alongSize(const Size(80, 10)));
+      final Offset position2 = box2.localToGlobal(Alignment.topRight.alongSize(const Size(40, 20)));
+      expect(position1, offsetMoreOrLessEquals(position2));
+    });
   });
 
-  testWidgets('Composited transforms - hit testing', (WidgetTester tester) async {
-    final LayerLink link = LayerLink();
+  group('Composited transforms - hit testing', () {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
     final GlobalKey key3 = GlobalKey();
-    bool _tapped = false;
-    await tester.pumpWidget(
-      Directionality(
+
+    bool tapped = false;
+
+    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+      return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           children: <Widget>[
@@ -163,18 +227,34 @@ void main() {
               child: GestureDetector(
                 key: key2,
                 behavior: HitTestBehavior.opaque,
-                onTap: () { _tapped = true; },
-                child: Container(key: key3, height: 10.0, width: 10.0),
+                onTap: () { tapped = true; },
+                child: Container(key: key3, height: 2.0, width: 2.0),
               ),
             ),
           ],
         ),
-      ),
-    );
-    final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
-    expect(box2.size, const Size(10.0, 10.0));
-    expect(_tapped, isFalse);
-    await tester.tap(find.byKey(key1));
-    expect(_tapped, isTrue);
+      );
+    }
+
+    const List<Alignment> alignments = <Alignment>[
+      Alignment.topLeft, Alignment.topRight,
+      Alignment.center,
+      Alignment.bottomLeft, Alignment.bottomRight,
+    ];
+
+    setUp(() { tapped = false; });
+
+    for (final Alignment targetAlignment in alignments) {
+      for (final Alignment followerAlignment in alignments) {
+        testWidgets('$targetAlignment - $followerAlignment', (WidgetTester tester) async{
+          await tester.pumpWidget(build(targetAlignment: targetAlignment, followerAlignment: followerAlignment));
+          final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+          expect(box2.size, const Size(2.0, 2.0));
+          expect(tapped, isFalse);
+          await tester.tap(find.byKey(key3));
+          expect(tapped, isTrue);
+        });
+      }
+    }
   });
 }


### PR DESCRIPTION
## Description

Added `followerAnchor` and `leaderAnchor` to `CompositedTransformFollower` to allow positioning the follower using other anchor points other than origin-to-origin. This should make positioning the autocomplete dropdown in #62927 a lot easier.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/57604

## Tests

I added the following tests:

Added variants for each existing test case.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
