### PR TITLE
*.properties added in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Miscellaneous
 *.class
 *.lock
+*.properties
 *.log
 *.pyc
 *.swp


### PR DESCRIPTION
## Description

local.properties file contains information specific to your local configuration.
Location of the SDK. This is only used by Gradle. 

## Related Issues

It creates multiple warnings while working in collaboration also may create some error regarding SDK location. Every system has there owned SDK location and different configuration. 