### PR TITLE
[flutter_tools] remove unused zip verification

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -93,13 +93,7 @@ abstract class OperatingSystemUtils {
 
   void unzip(File file, Directory targetDirectory);
 
-  /// Returns true if the ZIP is not corrupt.
-  bool verifyZip(File file);
-
   void unpack(File gzippedTarFile, Directory targetDirectory);
-
-  /// Returns true if the gzip is not corrupt (does not check tar).
-  bool verifyGzip(File gzippedFile);
 
   /// Compresses a stream using gzip level 1 (faster but larger).
   Stream<List<int>> gzipLevel1Stream(Stream<List<int>> stream) {
@@ -230,10 +224,6 @@ class _PosixUtils extends OperatingSystemUtils {
     );
   }
 
-  @override
-  bool verifyZip(File zipFile) =>
-    _processUtils.exitsHappySync(<String>['unzip', '-t', '-qq', zipFile.path]);
-
   // tar -xzf tarball -C dest
   @override
   void unpack(File gzippedTarFile, Directory targetDirectory) {
@@ -242,10 +232,6 @@ class _PosixUtils extends OperatingSystemUtils {
       throwOnError: true,
     );
   }
-
-  @override
-  bool verifyGzip(File gzippedFile) =>
-    _processUtils.exitsHappySync(<String>['gzip', '-t', gzippedFile.path]);
 
   @override
   File makePipe(String path) {
@@ -336,37 +322,11 @@ class _WindowsUtils extends OperatingSystemUtils {
   }
 
   @override
-  bool verifyZip(File zipFile) {
-    try {
-      ZipDecoder().decodeBytes(zipFile.readAsBytesSync(), verify: true);
-    } on FileSystemException catch (_) {
-      return false;
-    } on ArchiveException catch (_) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
   void unpack(File gzippedTarFile, Directory targetDirectory) {
     final Archive archive = TarDecoder().decodeBytes(
       GZipDecoder().decodeBytes(gzippedTarFile.readAsBytesSync()),
     );
     _unpackArchive(archive, targetDirectory);
-  }
-
-  @override
-  bool verifyGzip(File gzipFile) {
-    try {
-      GZipDecoder().decodeBytes(gzipFile.readAsBytesSync(), verify: true);
-    } on FileSystemException catch (_) {
-      return false;
-    } on ArchiveException catch (_) {
-      return false;
-    } on RangeError catch (_) {
-      return false;
-    }
-    return true;
   }
 
   void _unpackArchive(Archive archive, Directory targetDirectory) {

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:typed_data';
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -112,59 +110,6 @@ void main() {
       () => osUtils.unzip(mockFile, mockDirectory),
       throwsProcessException(message: exceptionMessage),
     );
-  });
-
-  group('gzip on Windows:', () {
-    testWithoutContext('verifyGzip returns false on a FileSystemException', () {
-      final MockFileSystem fileSystem = MockFileSystem();
-      final MockFile mockFile = MockFile();
-      when(fileSystem.file(any)).thenReturn(mockFile);
-      when(mockFile.readAsBytesSync()).thenThrow(
-        const FileSystemException('error'),
-      );
-      final OperatingSystemUtils osUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'windows'),
-        processManager: mockProcessManager,
-      );
-
-      expect(osUtils.verifyGzip(mockFile), isFalse);
-    });
-
-    testWithoutContext('verifyGzip returns false on an ArchiveException', () {
-      final MockFileSystem fileSystem = MockFileSystem();
-      final MockFile mockFile = MockFile();
-      when(fileSystem.file(any)).thenReturn(mockFile);
-      when(mockFile.readAsBytesSync()).thenReturn(Uint8List.fromList(<int>[
-        // Anything other than the magic header: 0x1f, 0x8b.
-        0x01,
-        0x02,
-      ]));
-      final OperatingSystemUtils osUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'windows'),
-        processManager: mockProcessManager,
-      );
-
-      expect(osUtils.verifyGzip(mockFile), isFalse);
-    });
-
-    testWithoutContext('verifyGzip returns false on an empty file', () {
-      final MockFileSystem fileSystem = MockFileSystem();
-      final MockFile mockFile = MockFile();
-      when(fileSystem.file(any)).thenReturn(mockFile);
-      when(mockFile.readAsBytesSync()).thenReturn(Uint8List(0));
-      final OperatingSystemUtils osUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'windows'),
-        processManager: mockProcessManager,
-      );
-
-      expect(osUtils.verifyGzip(mockFile), isFalse);
-    });
   });
 
   testWithoutContext('stream compression level', () {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -313,13 +313,7 @@ class FakeOperatingSystemUtils implements OperatingSystemUtils {
   void unzip(File file, Directory targetDirectory) { }
 
   @override
-  bool verifyZip(File file) => true;
-
-  @override
   void unpack(File gzippedTarFile, Directory targetDirectory) { }
-
-  @override
-  bool verifyGzip(File gzippedFile) => true;
 
   @override
   Stream<List<int>> gzipLevel1Stream(Stream<List<int>> stream) => stream;


### PR DESCRIPTION
## Description

This is no longer used, in favor of just attempting to unzip and handling the exception.