### PR TITLE
[flutter_tools] adjust index.html caching and insert cache busting URL in to main.dart.js/sw request

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -301,7 +301,9 @@ class WebReleaseBundle extends Target {
         outputFile.parent.createSync(recursive: true);
       }
       outputResourcesFiles.add(outputFile);
-      // insert a random hash into the requests for main.dart.js and service_worker.js
+      // insert a random hash into the requests for main.dart.js and service_worker.js. This is
+      // not a content hash, because it would need to be the hash for the entire bundle and not
+      // just the resource in question.
       if (environment.fileSystem.path.basename(inputFile.path) == 'index.html') {
         final String randomHash = Random().nextInt(10000000).toString();
         final String resultString = inputFile.readAsStringSync()

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -305,7 +305,7 @@ class WebReleaseBundle extends Target {
       // not a content hash, because it would need to be the hash for the entire bundle and not
       // just the resource in question.
       if (environment.fileSystem.path.basename(inputFile.path) == 'index.html') {
-        final String randomHash = Random().nextInt(10000000).toString();
+        final String randomHash = Random().nextInt(4294967296).toString();
         final String resultString = inputFile.readAsStringSync()
           .replaceFirst(
             '<script src="main.dart.js" type="application/javascript"></script>',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -96,7 +96,15 @@ void main() {
     environment.defines[kBuildMode] = 'release';
     final Directory webResources = environment.projectDir.childDirectory('web');
     webResources.childFile('index.html')
-      .createSync(recursive: true);
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+<html>
+  <script src="main.dart.js" type="application/javascript"></script>
+  <script>
+    navigator.serviceWorker.register('flutter_service_worker.js');
+  </script>
+</html>
+''');
     webResources.childFile('foo.txt')
       .writeAsStringSync('A');
     environment.buildDir.childFile('main.dart.js').createSync();
@@ -117,6 +125,11 @@ void main() {
 
     expect(environment.outputDir.childFile('foo.txt')
       .readAsStringSync(), 'B');
+    // Appends number to requests for service worker and main.dart.js
+    expect(environment.outputDir.childFile('index.html').readAsStringSync(), allOf(
+      contains('<script src="main.dart.js?v='),
+      contains('flutter_service_worker.js?v='),
+    ));
   }));
 
   test('WebEntrypointTarget generates an entrypoint for a file outside of main', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Attempt to bypass aggressive CDN by requesting main.dart.js/sw.js with a query param and defaulting index.html to online first. This will not stop aggressive CDN caching of the index.html

https://github.com/flutter/flutter/issues/64968