### PR TITLE
Assert goldctl is present in luci builds

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -270,6 +270,11 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
       && cirrusBranch == 'master'
       && platform.environment.containsKey('GOLD_SERVICE_ACCOUNT');
 
+    if (platform.environment.containsKey('SWARMING_TASK_ID')) {
+      // If this is a luci environment, goldctl should be present.
+      assert(platform.environment.containsKey('GOLDCTL'));
+    }
+
     final bool luciPostSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
       // Luci tryjob environments contain this value to inform the [FlutterPreSubmitComparator].
@@ -391,6 +396,11 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
     final bool cirrusPreSubmit = platform.environment.containsKey('CIRRUS_CI')
       && cirrusPR.isNotEmpty
       && platform.environment.containsKey('GOLD_SERVICE_ACCOUNT');
+
+    if (platform.environment.containsKey('SWARMING_TASK_ID')) {
+      // If this is a luci environment, goldctl should be present.
+      assert(platform.environment.containsKey('GOLDCTL'));
+    }
 
     final bool luciPreSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -608,6 +608,21 @@ void main() {
         );
       });
 
+      test('Asserts goldctl is present on luci', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+            'SWARMING_TASK_ID' : '12345678990',
+            'GOLD_TRYJOB' : 'git/ref/12345/head'
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          () => FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+          throwsAssertionError,
+        );
+      });
+
       group('correctly determines testing environment', () {
         test('returns true for Luci', () {
           platform = FakePlatform(
@@ -711,6 +726,21 @@ void main() {
     group('Pre-Submit', () {
       FlutterGoldenFileComparator comparator;
       final MockSkiaGoldClient mockSkiaClient = MockSkiaGoldClient();
+
+      test('Asserts goldctl is present on luci', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+            'SWARMING_TASK_ID' : '12345678990',
+            'GOLD_TRYJOB' : 'git/ref/12345/head'
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          () =>FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+          throwsAssertionError,
+        );
+      });
 
       group('correctly determines testing environment', () {
         test('returns true for Cirrus', () {


### PR DESCRIPTION
## Description

This will assert goldctl is present for all luci builds.

## Related Issues

https://github.com/flutter/flutter/issues/64969 - needs to land first

## Tests

Tested assertion for pre and post submit.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
