### PR TITLE
Fix Semi Hidden helpText in showDatePicker

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_picker_header.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_header.dart
@@ -142,7 +142,7 @@ class DatePickerHeader extends StatelessWidget {
                  children: <Widget>[
                    const SizedBox(height: 16),
                    Flexible(child: help),
-                   const SizedBox(height: 30),
+                   const Flexible(child: SizedBox(height: 38)),
                    Row(
                      children: <Widget>[
                        Expanded(child: title),

--- a/packages/flutter/lib/src/material/pickers/date_picker_header.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_header.dart
@@ -142,7 +142,7 @@ class DatePickerHeader extends StatelessWidget {
                  children: <Widget>[
                    const SizedBox(height: 16),
                    Flexible(child: help),
-                   const SizedBox(height: 38),
+                   const SizedBox(height: 30),
                    Row(
                      children: <Widget>[
                        Expanded(child: title),

--- a/packages/flutter/lib/src/material/pickers/date_picker_header.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_header.dart
@@ -141,7 +141,7 @@ class DatePickerHeader extends StatelessWidget {
                  crossAxisAlignment: CrossAxisAlignment.start,
                  children: <Widget>[
                    const SizedBox(height: 16),
-                   Flexible(child: help),
+                   help,
                    const Flexible(child: SizedBox(height: 38)),
                    Row(
                      children: <Widget>[


### PR DESCRIPTION
## Description

- Fix Semi Hidden helpText in showDatePicker

### Before : 
![image](https://user-images.githubusercontent.com/32666446/91840554-c5e2d880-ec48-11ea-93e4-b0e3c08fa947.png)
### After
![image](https://user-images.githubusercontent.com/32666446/92700211-74bc9e00-f346-11ea-9f2c-e41f006dab36.png)


## Related Issues

https://github.com/flutter/flutter/issues/64893


## Tests

I added the following tests: Tests already exists

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
