### PR TITLE
Update MergeableMaterial's default color to CardTheme.color

### DIFF
--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -539,7 +539,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
         widgets.add(
           Container(
             decoration: BoxDecoration(
-              color: Theme.of(context).cardColor,
+              color: Theme.of(context).cardTheme.color ?? Theme.of(context).cardColor,
               borderRadius: _borderRadius(i - 1, widgets.isEmpty, false),
               shape: BoxShape.rectangle,
             ),
@@ -611,7 +611,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
       widgets.add(
         Container(
           decoration: BoxDecoration(
-            color: Theme.of(context).cardColor,
+            color: Theme.of(context).cardTheme.color ?? Theme.of(context).cardColor,
             borderRadius: _borderRadius(i - 1, widgets.isEmpty, true),
             shape: BoxShape.rectangle,
           ),

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -539,7 +539,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
         widgets.add(
           Container(
             decoration: BoxDecoration(
-              color: Theme.of(context).cardTheme.color ?? Theme.of(context).cardColor,
+              color: Theme.of(context).cardTheme.color,
               borderRadius: _borderRadius(i - 1, widgets.isEmpty, false),
               shape: BoxShape.rectangle,
             ),
@@ -611,7 +611,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
       widgets.add(
         Container(
           decoration: BoxDecoration(
-            color: Theme.of(context).cardTheme.color ?? Theme.of(context).cardColor,
+            color: Theme.of(context).cardTheme.color,
             borderRadius: _borderRadius(i - 1, widgets.isEmpty, true),
             shape: BoxShape.rectangle,
           ),

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -1203,4 +1203,36 @@ void main() {
     // Since we are getting the last DecoratedBox, it will have a Border.top.
     expect(decoration.border.top.color, dividerColor);
   });
+
+  testWidgets('MergeableMaterial respects CardTheme.color prior to ThemeData.cardColor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          cardTheme: const CardTheme(
+            color: Colors.red
+          ),
+          cardColor: Colors.green,
+        ),
+        home: const Scaffold(
+          body: SingleChildScrollView(
+            child: MergeableMaterial(
+              children: <MergeableMaterialItem>[
+                MaterialSlice(
+                  key: ValueKey<String>('A'),
+                  child: SizedBox(
+                    width: 100.0,
+                    height: 100.0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox));
+    final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
+    expect(decoration.color, Colors.red);
+  });
 }

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -1204,7 +1204,7 @@ void main() {
     expect(decoration.border.top.color, dividerColor);
   });
 
-  testWidgets('MergeableMaterial respects CardTheme.color prior to ThemeData.cardColor', (WidgetTester tester) async {
+  testWidgets('MergeableMaterial\'s default color is set by CardTheme.color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(


### PR DESCRIPTION
## Description

Currently the `CardTheme.color` is ignored and `ThemeData.cardColor` is used in `MergeableMaterial`.
This pull request updates `MergeableMaterial`'s default color to `CardTheme.color`.
<details>

  <summary>Reproducible code sample</summary>

  ```dart
  import 'package:flutter/material.dart';

  void main() => runApp(MyApp());

  class MyApp extends StatelessWidget {

    @override
    Widget build(BuildContext context) {
      return MaterialApp(
        theme: ThemeData(
          cardTheme: CardTheme(
            color: Colors.red
          ),
          cardColor: Colors.green,
        ),
        home: Scaffold(
          appBar: AppBar(
            title: Text('Flutter Demo'),
          ),
          body: SingleChildScrollView(
            child: MergeableMaterial(
              children: <MergeableMaterialItem>[
                MaterialSlice(
                  key: ValueKey<String>('A'),
                  child: SizedBox(
                    width: 100.0,
                    height: 100.0,
                  ),
                ),
              ],
            ),
          ),
        ),
      );
    }
  }
  ```

</details>

| Before (`ThemeData.cardColor` is used as default) | After (`CardTheme.color` is used as default) | After (When `CardTheme.color` is not specified |
|---|---|---|
| <img src="https://user-images.githubusercontent.com/33684401/91881913-2f9cca00-ecbd-11ea-970e-9fc31b1749e8.png"> | <img src="https://user-images.githubusercontent.com/33684401/91881863-1e53bd80-ecbd-11ea-8f2a-2f885334b069.png"> | <img src="https://user-images.githubusercontent.com/33684401/91944443-0ae63800-ed39-11ea-9a11-7ee748d5ec0c.png">


## Related Issues

Fixes https://github.com/flutter/flutter/issues/63398

## Tests

I added the following tests:

- `mergeable_material_test.dart`
Added a test to verify that the color of `MaterialSlice` is applied by `CardTheme.color`. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
   - [ ] I wrote a design doc: 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
