### PR TITLE
Mark large_image_changer tests as not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -872,14 +872,12 @@ tasks:
       Measures memory usage when rotating through a series of large images.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   large_image_changer_perf_ios:
     description: >
       Measures memory, cpu, and gpu usage when rotating through a series of large images.
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
-    flaky: true
 
   animated_placeholder_perf:
     description: >


### PR DESCRIPTION
They appear to be passing now.
