### PR TITLE
Update hintColor value for Material

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -330,7 +330,7 @@ class ThemeData with Diagnosticable {
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;
     indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
-    hintColor ??= isDark ? const Color(0x80FFFFFF) : const Color(0x8A000000);
+    hintColor ??= isDark ? Colors.white60 : Colors.black.withOpacity(0.6);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
     pageTransitionsTheme ??= const PageTransitionsTheme();


### PR DESCRIPTION
## Description

Updated `hintColor` value for Material.

Both [Dark mode documentation](https://material.io/design/color/dark-theme.html#ui-application) and [Light mode documentation](https://material.io/design/color/text-legibility.html#text-backgrounds) states that
> Medium-emphasis text and hint text have opacities of 60%

This pull request updates `hintColor` value in dark mode to `Colors.white60`(corresponds to 60% opacity).
For light mode, updates value to `Colors.black.withOpacity(0.6)` since there's no constant for black60.  

### For golden file changes:
| input_decorator.outline_icon_label.ltr.png |
|---|
| ![input_decorator outline_icon_label ltr](https://user-images.githubusercontent.com/33684401/91904130-5966e880-ecdf-11ea-860e-5fad99aaf79b.png) |

| input_decorator.outline_icon_label.rtl.png |
|---|
| ![input_decorator outline_icon_label rtl](https://user-images.githubusercontent.com/33684401/91904133-59ff7f00-ecdf-11ea-9a95-be4811271b26.png) |


## Related Issues

Fixes https://github.com/flutter/flutter/issues/55329

## Tests

None. Only color values changed.
If I need to add a test for this, please let me know. :)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
