### PR TITLE
Fixed the sliver appbar to have a fixed traversal order

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -698,12 +698,20 @@ class _AppBarState extends State<AppBar> {
       appBar = Stack(
         fit: StackFit.passthrough,
         children: <Widget>[
-          widget.flexibleSpace,
-          // Creates a material widget to prevent the flexibleSpace from
-          // obscuring the ink splashes produced by appBar children.
-          Material(
-            type: MaterialType.transparency,
-            child: appBar,
+          Semantics(
+            sortKey: const OrdinalSortKey(1.0),
+            explicitChildNodes: true,
+            child: widget.flexibleSpace,
+          ),
+          Semantics(
+            sortKey: const OrdinalSortKey(0.0),
+            explicitChildNodes: true,
+            // Creates a material widget to prevent the flexibleSpace from
+            // obscuring the ink splashes produced by appBar children.
+            child: Material(
+              type: MaterialType.transparency,
+              child: appBar,
+            ),
           ),
         ],
       );

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1684,6 +1684,83 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('SliverAppBar with flexable space has correct semantics order', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/64922.
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              leading: Text('Leading'),
+              flexibleSpace: Text('Flexible space'),
+              actions: <Widget>[Text('Action 1')],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics(
+            textDirection: TextDirection.ltr,
+            children: <TestSemantics>[
+              TestSemantics(
+                children: <TestSemantics>[
+                  TestSemantics(
+                    flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                children: <TestSemantics>[
+                                  TestSemantics(
+                                    label: 'Leading',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                  TestSemantics(
+                                    label: 'Action 1',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                ],
+                              ),
+                              TestSemantics(
+                                children: <TestSemantics>[
+                                  TestSemantics(
+                                    flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+                                    label: 'Flexible space',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                          TestSemantics(
+                            flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      ignoreRect: true,
+      ignoreTransform: true,
+      ignoreId: true,
+    ));
+
+    semantics.dispose();
+  });
+
   testWidgets('AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
     final ThemeData darkTheme = ThemeData.dark();
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1649,13 +1649,18 @@ void main() {
                           TestSemantics(
                             children: <TestSemantics>[
                               TestSemantics(
-                                label: 'Leading',
-                                textDirection: TextDirection.ltr,
+                                children: <TestSemantics>[
+                                  TestSemantics(
+                                    label: 'Leading',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                  TestSemantics(
+                                    label: 'Action 1',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                ],
                               ),
-                              TestSemantics(
-                                label: 'Action 1',
-                                textDirection: TextDirection.ltr,
-                              ),
+                              TestSemantics(),
                             ],
                           ),
                           TestSemantics(

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -178,25 +178,37 @@ void main() {
                           rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 11,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isHeader,
-                                SemanticsFlag.namesRoute
+                              id: 12,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  id: 13,
+                                  rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isHeader,
+                                    SemanticsFlag.namesRoute
+                                  ],
+                                  label: 'Title',
+                                  textDirection: TextDirection.ltr,
+                                ),
                               ],
-                              label: 'Title',
-                              textDirection: TextDirection.ltr,
                             ),
                             TestSemantics(
                               id: 10,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
-                              label: 'Expanded title',
-                              textDirection: TextDirection.ltr,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  id: 11,
+                                  rect: const Rect.fromLTRB(0.0, 0.0, 800.0, expandedHeight),
+                                  label: 'Expanded title',
+                                  textDirection: TextDirection.ltr,
+                                ),
+                              ],
                             ),
                           ],
                         ),
                         TestSemantics(
-                          id: 12,
+                          id: 14,
                           flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                           rect: TestSemantics.fullScreen,
                           actions: <SemanticsAction>[SemanticsAction.scrollUp],
@@ -272,27 +284,39 @@ void main() {
                           rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
                           children: <TestSemantics>[
                             TestSemantics(
-                              id: 11,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isHeader,
-                                SemanticsFlag.namesRoute
+                              id: 12,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  id: 13,
+                                  rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 20.0),
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isHeader,
+                                    SemanticsFlag.namesRoute
+                                  ],
+                                  label: 'Title',
+                                  textDirection: TextDirection.ltr,
+                                ),
                               ],
-                              label: 'Title',
-                              textDirection: TextDirection.ltr,
                             ),
                             // The flexible space bar still persists in the
                             // semantic tree even if it is collapsed.
                             TestSemantics(
                               id: 10,
-                              rect: const Rect.fromLTRB(0.0, 36.0, 800.0, 92.0),
-                              label: 'Expanded title',
-                              textDirection: TextDirection.ltr,
+                              rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 56.0),
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  id: 11,
+                                  rect: const Rect.fromLTRB(0.0, 36.0, 800.0, 92.0),
+                                  label: 'Expanded title',
+                                  textDirection: TextDirection.ltr,
+                                ),
+                              ],
                             ),
                           ],
                         ),
                         TestSemantics(
-                          id: 12,
+                          id: 14,
                           flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                           rect: TestSemantics.fullScreen,
                           actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown],
@@ -324,20 +348,20 @@ void main() {
                               textDirection: TextDirection.ltr,
                             ),
                             TestSemantics(
-                              id: 13,
+                              id: 15,
                               rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                               label: 'Item 4',
                               textDirection: TextDirection.ltr,
                             ),
                             TestSemantics(
-                              id: 14,
+                              id: 16,
                               rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0),
                               flags: <SemanticsFlag>[SemanticsFlag.isHidden],
                               label: 'Item 5',
                               textDirection: TextDirection.ltr,
                             ),
                             TestSemantics(
-                              id: 15,
+                              id: 17,
                               rect: const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0),
                               flags: <SemanticsFlag>[SemanticsFlag.isHidden],
                               label: 'Item 6',

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -986,13 +986,18 @@ void _tests() {
                   TestSemantics(
                     tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
                     children: <TestSemantics>[
+                      TestSemantics(),
                       TestSemantics(
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.namesRoute,
-                          SemanticsFlag.isHeader,
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.namesRoute,
+                              SemanticsFlag.isHeader,
+                            ],
+                            label: 'Forward app bar',
+                            textDirection: TextDirection.ltr,
+                          ),
                         ],
-                        label: 'Forward app bar',
-                        textDirection: TextDirection.ltr,
                       ),
                     ],
                   ),
@@ -1096,13 +1101,18 @@ void _tests() {
                   TestSemantics(
                     tags: <SemanticsTag>[RenderViewport.excludeFromScrolling],
                     children: <TestSemantics>[
+                      TestSemantics(),
                       TestSemantics(
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.namesRoute,
-                          SemanticsFlag.isHeader,
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.namesRoute,
+                              SemanticsFlag.isHeader,
+                            ],
+                            label: 'Backward app bar',
+                            textDirection: TextDirection.ltr,
+                          ),
                         ],
-                        label: 'Backward app bar',
-                        textDirection: TextDirection.ltr,
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Description

The ios voiceover by default uses the center position of each semantics nodes to determine the focus traverse order.
When the flexible space collapsing and expanding, it changes its center position of it semantics node which cause it to have a different focus traverse order. This causes confusion to user that they may have different accessibility order when they traverse out the header when it is expanded and traverse back to the header after it is collapsed.

This pr add a fixed traversal order of the sliver app bar by using a sort key.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64922

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
