### PR TITLE
Mark nonflaky tests as such

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -491,7 +491,6 @@ tasks:
       Measures the startup time of the Flutter Gallery app on 32-bit iOS (iPhone 4S).
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
-    flaky: true # https://github.com/flutter/flutter/issues/62633
 
   flutter_gallery_ios32__transition_perf:
     description: >
@@ -853,7 +852,6 @@ tasks:
       Measures the performance of the Crane page in the new Flutter Gallery on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   fast_scroll_large_images__memory:
     description: >


### PR DESCRIPTION
Those 2 tests have been green for the last 10 runs
