### PR TITLE
Find text containing in tests

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -36,17 +36,19 @@ class CommonFinders {
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder text(String text, { bool skipOffstage = true }) => _TextFinder(text, skipOffstage: skipOffstage);
 
-  /// Finds [Text] and [EditableText] widgets which contain the `text` argument.
+  /// Finds [Text] and [EditableText] widgets which contain the given
+  /// `pattern` argument.
   ///
   /// ## Sample code
   ///
   /// ```dart
   /// expect(find.textContain('Back'), findsOneWidget);
+  /// expect(find.textContain(RegExp(r'(\w+)')), findsOneWidget);
   /// ```
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
-  Finder textContaining(String text, { bool skipOffstage = true }) => _TextContainingFinder(text, skipOffstage: skipOffstage);
+  Finder textContaining(Pattern pattern, { bool skipOffstage = true }) => _TextContainingFinder(pattern, skipOffstage: skipOffstage);
 
   /// Looks for widgets that contain a [Text] descendant with `text`
   /// in it.
@@ -569,23 +571,23 @@ class _TextFinder extends MatchFinder {
 }
 
 class _TextContainingFinder extends MatchFinder {
-  _TextContainingFinder(this.text, {bool skipOffstage = true})
+  _TextContainingFinder(this.pattern, {bool skipOffstage = true})
       : super(skipOffstage: skipOffstage);
 
-  final String text;
+  final Pattern pattern;
 
   @override
-  String get description => 'text containing "$text"';
+  String get description => 'text containing $pattern';
 
   @override
   bool matches(Element candidate) {
     final Widget widget = candidate.widget;
     if (widget is Text) {
       if (widget.data != null)
-        return widget.data.contains(text);
-      return widget.textSpan.toPlainText().contains(text);
+        return widget.data.contains(pattern);
+      return widget.textSpan.toPlainText().contains(pattern);
     } else if (widget is EditableText) {
-      return widget.controller.text.contains(text);
+      return widget.controller.text.contains(pattern);
     }
     return false;
   }

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -36,6 +36,18 @@ class CommonFinders {
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder text(String text, { bool skipOffstage = true }) => _TextFinder(text, skipOffstage: skipOffstage);
 
+  /// Finds [Text] and [EditableText] widgets which contain the `text` argument.
+  ///
+  /// ## Sample code
+  ///
+  /// ```dart
+  /// expect(find.textContain('Back'), findsOneWidget);
+  /// ```
+  ///
+  /// If the `skipOffstage` argument is true (the default), then this skips
+  /// nodes that are [Offstage] or that are from inactive [Route]s.
+  Finder textContaining(String text, { bool skipOffstage = true }) => _TextContainingFinder(text, skipOffstage: skipOffstage);
+
   /// Looks for widgets that contain a [Text] descendant with `text`
   /// in it.
   ///
@@ -551,6 +563,29 @@ class _TextFinder extends MatchFinder {
       return widget.textSpan.toPlainText() == text;
     } else if (widget is EditableText) {
       return widget.controller.text == text;
+    }
+    return false;
+  }
+}
+
+class _TextContainingFinder extends MatchFinder {
+  _TextContainingFinder(this.text, {bool skipOffstage = true})
+      : super(skipOffstage: skipOffstage);
+
+  final String text;
+
+  @override
+  String get description => 'text containing "$text"';
+
+  @override
+  bool matches(Element candidate) {
+    final Widget widget = candidate.widget;
+    if (widget is Text) {
+      if (widget.data != null)
+        return widget.data.contains(text);
+      return widget.textSpan.toPlainText().contains(text);
+    } else if (widget is EditableText) {
+      return widget.controller.text.contains(text);
     }
     return false;
   }

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -35,6 +35,7 @@ void main() {
       await tester.pumpWidget(_boilerplate(
         const Text('this is a test'),
       ));
+      expect(find.textContaining(RegExp(r'test')), findsOneWidget);
       expect(find.textContaining('test'), findsOneWidget);
       expect(find.textContaining('a'), findsOneWidget);
       expect(find.textContaining('s'), findsOneWidget);
@@ -51,6 +52,7 @@ void main() {
             ),
           )));
 
+      expect(find.textContaining(RegExp(r'isatest')), findsOneWidget);
       expect(find.textContaining('isatest'), findsOneWidget);
     });
 
@@ -63,6 +65,7 @@ void main() {
         ),
       ));
 
+      expect(find.textContaining(RegExp(r'test')), findsOneWidget);
       expect(find.textContaining('test'), findsOneWidget);
     });
   });

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -53,6 +53,18 @@ void main() {
 
       expect(find.textContaining('isatest'), findsOneWidget);
     });
+    
+    testWidgets('finds EditableText widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: _boilerplate(TextField(
+            controller: TextEditingController()..text = 'this is test',
+          )),
+        ),
+      ));
+
+      expect(find.textContaining('test'), findsOneWidget);
+    });
   });
 
   group('semantics', () {

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -18,15 +18,40 @@ void main() {
 
     testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
       await tester.pumpWidget(_boilerplate(
-        const Text.rich(
-          TextSpan(text: 't', children: <TextSpan>[
-            TextSpan(text: 'e'),
-            TextSpan(text: 'st'),
-          ],
-        ),
-      )));
+          const Text.rich(
+            TextSpan(text: 't', children: <TextSpan>[
+              TextSpan(text: 'e'),
+              TextSpan(text: 'st'),
+            ],
+            ),
+          )));
 
       expect(find.text('test'), findsOneWidget);
+    });
+  });
+
+  group('textContaining', () {
+    testWidgets('finds Text widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+        const Text('this is a test'),
+      ));
+      expect(find.textContaining('test'), findsOneWidget);
+      expect(find.textContaining('a'), findsOneWidget);
+      expect(find.textContaining('s'), findsOneWidget);
+    });
+
+    testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+          const Text.rich(
+            TextSpan(text: 'this', children: <TextSpan>[
+              TextSpan(text: 'is'),
+              TextSpan(text: 'a'),
+              TextSpan(text: 'test'),
+            ],
+            ),
+          )));
+
+      expect(find.textContaining('isatest'), findsOneWidget);
     });
   });
 

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       expect(find.textContaining('isatest'), findsOneWidget);
     });
-    
+
     testWidgets('finds EditableText widgets', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -18,13 +18,13 @@ void main() {
 
     testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
       await tester.pumpWidget(_boilerplate(
-          const Text.rich(
-            TextSpan(text: 't', children: <TextSpan>[
-              TextSpan(text: 'e'),
-              TextSpan(text: 'st'),
-            ],
-            ),
-          )));
+        const Text.rich(
+          TextSpan(text: 't', children: <TextSpan>[
+            TextSpan(text: 'e'),
+            TextSpan(text: 'st'),
+          ],
+        ),
+      )));
 
       expect(find.text('test'), findsOneWidget);
     });


### PR DESCRIPTION
## Description

This PR adds a new finder to find text widgets that contain a specified text. This is useful when you have longer dynamic texts and just want to verify a given sentence or word is there.

Usage in tests:
```
// Text('this is a test')
expect(find.textContaining('test'), findsOneWidget);
```

The same applies for EditableText widgets.

## Related Issues

#65070

## Tests

I added the following tests:

- Test to ensure finds Text widgets containg a string
- Test to ensure finds Text.rich widgets containg a string
- Test to ensure finds EditableText widgets containg a string

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
