### PR TITLE
[ReorderableListView] remove extra margin added after picking up the item

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -206,9 +206,6 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
   // the currently dragging widget, such as when it first builds.
   static const double _defaultDropAreaExtent = 100.0;
 
-  // The additional margin to place around a computed drop area.
-  static const double _dropAreaMargin = 0.0;
-
   // How long an animation to reorder an element in the list takes.
   static const Duration _reorderAnimationDuration = Duration(milliseconds: 200);
 
@@ -264,7 +261,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         dropAreaWithoutMargin = _draggingFeedbackSize.height;
         break;
     }
-    return dropAreaWithoutMargin + _dropAreaMargin;
+    return dropAreaWithoutMargin;
   }
 
   @override

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -207,7 +207,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
   static const double _defaultDropAreaExtent = 100.0;
 
   // The additional margin to place around a computed drop area.
-  static const double _dropAreaMargin = 8.0;
+  static const double _dropAreaMargin = 0.0;
 
   // How long an animation to reorder an element in the list takes.
   static const Duration _reorderAnimationDuration = Duration(milliseconds: 200);

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -215,19 +215,19 @@ void main() {
         final Widget reorderableListView = ReorderableListView(
           children: <Widget>[
             Container(
-              key: Key('pink'),
+              key: const Key('pink'),
               width: double.infinity,
               height: itemHeight,
               color: Colors.pink,
             ),
             Container(
-              key: Key('blue'),
+              key: const Key('blue'),
               width: double.infinity,
               height: itemHeight,
               color: Colors.blue,
             ),
             Container(
-              key: Key('green'),
+              key: const Key('green'),
               width: double.infinity,
               height: itemHeight,
               color: Colors.green,
@@ -243,11 +243,11 @@ void main() {
           ),
         ));
 
-        await tester.startGesture(tester.getCenter(find.byKey(Key('blue'))));
+        await tester.startGesture(tester.getCenter(find.byKey(const Key('blue'))));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
         await expectLater(
-          find.byKey(Key('blue')),
+          find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.vertical.drop_area.png'),
         );
       });
@@ -769,19 +769,19 @@ void main() {
         final Widget reorderableListView = ReorderableListView(
           children: <Widget>[
             Container(
-              key: Key('pink'),
+              key: const Key('pink'),
               height: double.infinity,
               width: itemHeight,
               color: Colors.pink,
             ),
             Container(
-              key: Key('blue'),
+              key: const Key('blue'),
               height: double.infinity,
               width: itemHeight,
               color: Colors.blue,
             ),
             Container(
-              key: Key('green'),
+              key: const Key('green'),
               height: double.infinity,
               width: itemHeight,
               color: Colors.green,
@@ -797,11 +797,11 @@ void main() {
           ),
         ));
 
-        await tester.startGesture(tester.getCenter(find.byKey(Key('blue'))));
+        await tester.startGesture(tester.getCenter(find.byKey(const Key('blue'))));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
         await expectLater(
-          find.byKey(Key('blue')),
+          find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.horizontal.drop_area.png'),
         );
       });

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -178,8 +178,8 @@ void main() {
         }
 
         const double kNonDraggingListHeight = 292.0;
-        // The list view pads the drop area by 8dp.
-        const double kDraggingListHeight = 300.0;
+        // The list view pads the drop area by 0dp.
+        const double kDraggingListHeight = 292.0;
         // Drag a normal text item
         expect(getContentElement().size.height, kNonDraggingListHeight);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));
@@ -693,8 +693,8 @@ void main() {
         }
 
         const double kNonDraggingListWidth = 292.0;
-        // The list view pads the drop area by 8dp.
-        const double kDraggingListWidth = 300.0;
+        // The list view pads the drop area by 0dp.
+        const double kDraggingListWidth = 292.0;
         // Drag a normal text item
         expect(getContentElement().size.width, kNonDraggingListWidth);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -177,11 +177,9 @@ void main() {
           return contentElement;
         }
 
-        const double kNonDraggingListHeight = 292.0;
-        // The list view pads the drop area by 0dp.
         const double kDraggingListHeight = 292.0;
         // Drag a normal text item
-        expect(getContentElement().size.height, kNonDraggingListHeight);
+        expect(getContentElement().size.height, kDraggingListHeight);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
@@ -195,7 +193,7 @@ void main() {
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size.height, kNonDraggingListHeight);
+        expect(getContentElement().size.height, kDraggingListHeight);
 
         // Drag a tall item
         drag = await tester.startGesture(tester.getCenter(find.text('Tall item')));
@@ -210,7 +208,7 @@ void main() {
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size.height, kNonDraggingListHeight);
+        expect(getContentElement().size.height, kDraggingListHeight);
       });
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
@@ -692,11 +690,9 @@ void main() {
           return contentElement;
         }
 
-        const double kNonDraggingListWidth = 292.0;
-        // The list view pads the drop area by 0dp.
         const double kDraggingListWidth = 292.0;
         // Drag a normal text item
-        expect(getContentElement().size.width, kNonDraggingListWidth);
+        expect(getContentElement().size.width, kDraggingListWidth);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
@@ -710,7 +706,7 @@ void main() {
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size.width, kNonDraggingListWidth);
+        expect(getContentElement().size.width, kDraggingListWidth);
 
         // Drag a tall item
         drag = await tester.startGesture(tester.getCenter(find.text('Tall item')));
@@ -725,7 +721,7 @@ void main() {
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size.width, kNonDraggingListWidth);
+        expect(getContentElement().size.width, kDraggingListWidth);
       });
 
 

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -211,6 +211,47 @@ void main() {
         expect(getContentElement().size.height, kDraggingListHeight);
       });
 
+      testWidgets('Vertical drop area golden', (WidgetTester tester) async {
+        final Widget reorderableListView = ReorderableListView(
+          children: <Widget>[
+            Container(
+              key: Key('pink'),
+              width: double.infinity,
+              height: itemHeight,
+              color: Colors.pink,
+            ),
+            Container(
+              key: Key('blue'),
+              width: double.infinity,
+              height: itemHeight,
+              color: Colors.blue,
+            ),
+            Container(
+              key: Key('green'),
+              width: double.infinity,
+              height: itemHeight,
+              color: Colors.green,
+            ),
+          ],
+          scrollDirection: Axis.vertical,
+          onReorder: (int oldIndex, int newIndex) { },
+        );
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: itemHeight * 3,
+            child: reorderableListView,
+          ),
+        ));
+
+        await tester.startGesture(tester.getCenter(find.byKey(Key('blue'))));
+        await tester.pump(kLongPressTimeout + kPressTimeout);
+        await tester.pumpAndSettle();
+        await expectLater(
+          find.byKey(Key('blue')),
+          matchesGoldenFile('reorderable_list_test.vertical.drop_area.png'),
+        );
+      });
+
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {
           return find.byElementPredicate((Element element) => element.findAncestorWidgetOfExactType<_Stateful>()?.key == key)
@@ -724,6 +765,46 @@ void main() {
         expect(getContentElement().size.width, kDraggingListWidth);
       });
 
+      testWidgets('Horizontal drop area golden', (WidgetTester tester) async {
+        final Widget reorderableListView = ReorderableListView(
+          children: <Widget>[
+            Container(
+              key: Key('pink'),
+              height: double.infinity,
+              width: itemHeight,
+              color: Colors.pink,
+            ),
+            Container(
+              key: Key('blue'),
+              height: double.infinity,
+              width: itemHeight,
+              color: Colors.blue,
+            ),
+            Container(
+              key: Key('green'),
+              height: double.infinity,
+              width: itemHeight,
+              color: Colors.green,
+            ),
+          ],
+          scrollDirection: Axis.horizontal,
+          onReorder: (int oldIndex, int newIndex) { },
+        );
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            width: itemHeight * 3,
+            child: reorderableListView,
+          ),
+        ));
+
+        await tester.startGesture(tester.getCenter(find.byKey(Key('blue'))));
+        await tester.pump(kLongPressTimeout + kPressTimeout);
+        await tester.pumpAndSettle();
+        await expectLater(
+          find.byKey(Key('blue')),
+          matchesGoldenFile('reorderable_list_test.horizontal.drop_area.png'),
+        );
+      });
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {


### PR DESCRIPTION
## Description
As you can see under the gif when picking up an item in `ReorderableListView`, the others below the item move slightly downward. this is because the extra margin is added to the selected item after lifting. So I removed the extra margin and modified the related test.

|before|after|
|:--:|:--:|
|![before](https://user-images.githubusercontent.com/26322627/91946550-433a4600-ed3a-11ea-8342-28950d77740e.gif)|![after](https://user-images.githubusercontent.com/26322627/91946420-39b0de00-ed3a-11ea-8424-c286e133ab2f.gif)|

### Golden test image
|reorderable_list_test.vertical.drop_area.png|reorderable_list_test.horizontal.drop_area.png|
|:--:|:--:|
|![reorderable_list_test vertical drop_area](https://user-images.githubusercontent.com/26322627/92949779-9cbb1700-f496-11ea-9b0a-e6d3f82af3b2.png)|![reorderable_list_test horizontal drop_area](https://user-images.githubusercontent.com/26322627/92949775-9b89ea00-f496-11ea-8d47-e4414310b1fb.png)|

## Related Issues
Fixes https://github.com/flutter/flutter/issues/58411

## Tests

I modified the following tests: 
- [properly determines the vertical drop area extents](https://github.com/flutter/flutter/blob/780f5f99044ce7fcbcd868e2cf6878da02022db5/packages/flutter/test/material/reorderable_list_test.dart#L144)
- [properly determines the horizontal drop area extents](https://github.com/flutter/flutter/blob/780f5f99044ce7fcbcd868e2cf6878da02022db5/packages/flutter/test/material/reorderable_list_test.dart#L659)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
