### PR TITLE
[flutter_tools] exit with helpful message if where is missing on windows

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -4,11 +4,11 @@
 
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../globals.dart' as globals;
+import 'common.dart';
 import 'file_system.dart';
 import 'io.dart';
 import 'logger.dart';

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -292,7 +292,7 @@ class _WindowsUtils extends OperatingSystemUtils {
     // `where` always returns all matches, not just the first one.
     ProcessResult result;
     try {
-      _processManager.runSync(<String>['where', execName]);
+      result = _processManager.runSync(<String>['where', execName]);
     } on ArgumentError {
       // `where` could be missing if system32 is not on the PATH.
       throwToolExit(

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -4,6 +4,7 @@
 
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -289,7 +290,18 @@ class _WindowsUtils extends OperatingSystemUtils {
   @override
   List<File> _which(String execName, { bool all = false }) {
     // `where` always returns all matches, not just the first one.
-    final ProcessResult result = _processManager.runSync(<String>['where', execName]);
+    ProcessResult result;
+    try {
+      _processManager.runSync(<String>['where', execName]);
+    } on ArgumentError {
+      // `where` could be missing if system32 is not on the PATH.
+      throwToolExit(
+        'Cannot find the executable for `where`. This can happen if the System32 '
+        'folder (e.g. C:\\Windows\\System32 ) is removed from the PATH environment '
+        'variable. Ensure that this is present and then try again after restarting '
+        'the terminal and/or IDE.'
+      );
+    }
     if (result.exitCode != 0) {
       return const <File>[];
     }

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -62,6 +63,13 @@ void main() {
   });
 
   group('which on Windows', () {
+    testWithoutContext('throws tool exit if where throws an argument error', () async {
+      when(mockProcessManager.runSync(<String>['where', kExecutable]))
+          .thenThrow(ArgumentError('Cannot find executable for where'));
+      final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
+
+      expect(() => utils.which(kExecutable), throwsA(isA<ToolExit>()));
+    });
     testWithoutContext('returns null when executable does not exist', () async {
       when(mockProcessManager.runSync(<String>['where', kExecutable]))
           .thenReturn(ProcessResult(0, 1, null, null));


### PR DESCRIPTION
## Description

Currently crash logging shows that a non-trivial number of users are hitting this error on stable. While it is technically an error in the user's setup, we can still exit with a helpful message and avoid a mysterious stack trace.

https://github.com/flutter/flutter/issues/14887