### PR TITLE
Eliminate need for part of and mockito for animated_icons_private_test

### DIFF
--- a/packages/flutter/lib/src/material/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons.dart
@@ -18,11 +18,12 @@ import 'package:flutter/widgets.dart';
 
 // Public API.
 part 'animated_icons/animated_icons.dart';
+
 // Provides a public interface for referring to the private icon
 // implementations.
 part 'animated_icons/animated_icons_data.dart';
 
-// Animated icons data files.
+// Generated animated icon data files.
 part 'animated_icons/data/add_event.g.dart';
 part 'animated_icons/data/arrow_menu.g.dart';
 part 'animated_icons/data/close_menu.g.dart';

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -279,17 +279,17 @@ class _PathClose extends _PathCommand {
   }
 }
 
-// Interpolates a value given a set of values equally spaced in time.
-//
-// [interpolator] is the interpolation function used to interpolate between 2
-// points of type T.
-//
-// This is currently done with linear interpolation between every 2 consecutive
-// points. Linear interpolation was smooth enough with the limited set of
-// animations we have tested, so we use it for simplicity. If we find this to
-// not be smooth enough we can try applying spline instead.
-//
-// [progress] is expected to be between 0.0 and 1.0.
+/// Interpolates a value given a set of values equally spaced in time.
+///
+/// [interpolator] is the interpolation function used to interpolate between 2
+/// points of type T.
+///
+/// This is currently done with linear interpolation between every 2 consecutive
+/// points. Linear interpolation was smooth enough with the limited set of
+/// animations we have tested, so we use it for simplicity. If we find this to
+/// not be smooth enough we can try applying spline instead.
+///
+/// [progress] is expected to be between 0.0 and 1.0.
 T _interpolate<T>(List<T> values, double progress, _Interpolator<T> interpolator) {
   assert(progress <= 1.0);
   assert(progress >= 0.0);
@@ -303,3 +303,129 @@ T _interpolate<T>(List<T> values, double progress, _Interpolator<T> interpolator
 }
 
 typedef _Interpolator<T> = T Function(T a, T b, double progress);
+
+/// A test harness for testing the internals of [AnimatedIcon].
+///
+/// May only be created by tests for [AnimatedIcon].
+class AnimatedIconPrivateTestHarness {
+  /// Constructor for [AnimatedIcon] test harness.
+  ///
+  /// Meant only to be called by tests.
+  @visibleForTesting
+  const AnimatedIconPrivateTestHarness();
+
+  /// A testing function to test a private interpolator for [AnimatedIcon].
+  @visibleForTesting
+  T interpolate<T>(List<T> values, double progress, _Interpolator<T> interpolator) {
+    return _interpolate(values, progress, interpolator);
+  }
+
+  /// A testing function to create a private painting class for [AnimatedIcon].
+  @visibleForTesting
+  _AnimatedIconPainter createAnimatedIconPainter({
+    AnimatedIconData paths,
+    Animation<double> progress,
+    Color color,
+    double scale,
+    bool shouldMirror,
+    _UiPathFactory uiPathFactory,
+  }) {
+    return _AnimatedIconPainter(
+      paths: paths == null ? const <_PathFrames>[] : (paths as _AnimatedIconData).paths,
+      progress: progress,
+      color: color,
+      scale: scale,
+      shouldMirror: shouldMirror,
+      uiPathFactory: uiPathFactory,
+    );
+  }
+
+  /// A test object for testing [AnimatedIcon].
+  @visibleForTesting
+  static const AnimatedIconData movingBar = _AnimatedIconData(
+      Size(48.0, 48.0),
+      <_PathFrames>[
+        _PathFrames(
+          opacities: <double>[1.0, 0.2],
+          commands: <_PathCommand>[
+            _PathMoveTo(
+              <Offset>[
+                Offset(0.0, 0.0),
+                Offset(0.0, 38.0),
+              ],
+            ),
+            _PathLineTo(
+              <Offset>[
+                Offset(48.0, 0.0),
+                Offset(48.0, 38.0),
+              ],
+            ),
+            _PathLineTo(
+              <Offset>[
+                Offset(48.0, 10.0),
+                Offset(48.0, 48.0),
+              ],
+            ),
+            _PathLineTo(
+              <Offset>[
+                Offset(0.0, 10.0),
+                Offset(0.0, 48.0),
+              ],
+            ),
+            _PathLineTo(
+              <Offset>[
+                Offset(0.0, 0.0),
+                Offset(0.0, 38.0),
+              ],
+            ),
+            _PathClose(),
+          ],
+        ),
+      ],
+    );
+
+  /// A test object for testing [AnimatedIcon].
+  @visibleForTesting
+  static const AnimatedIconData bow = _AnimatedIconData(
+      Size(48.0, 48.0),
+      <_PathFrames>[
+        _PathFrames(
+          opacities: <double>[1.0, 1.0],
+          commands: <_PathCommand>[
+            _PathMoveTo(
+              <Offset>[
+                Offset(0.0, 24.0),
+                Offset(0.0, 24.0),
+                Offset(0.0, 24.0),
+              ],
+            ),
+            _PathCubicTo(
+              <Offset>[
+                Offset(16.0, 24.0),
+                Offset(16.0, 10.0),
+                Offset(16.0, 48.0),
+              ],
+              <Offset>[
+                Offset(32.0, 24.0),
+                Offset(32.0, 10.0),
+                Offset(32.0, 48.0),
+              ],
+              <Offset>[
+                Offset(48.0, 24.0),
+                Offset(48.0, 24.0),
+                Offset(48.0, 24.0),
+              ],
+            ),
+            _PathLineTo(
+              <Offset>[
+                Offset(0.0, 24.0),
+                Offset(0.0, 24.0),
+                Offset(0.0, 24.0),
+              ],
+            ),
+            _PathClose(),
+          ],
+        ),
+      ],
+    );
+  }

--- a/packages/flutter/test/material/animated_icons_private_test.dart
+++ b/packages/flutter/test/material/animated_icons_private_test.dart
@@ -4,57 +4,34 @@
 
 // @dart = 2.8
 
-// This is the test for the private implementation of animated icons.
-// To make the private API accessible from the test we do not import the
-// material material_animated_icons library, but instead, this test file is an
-// implementation of that library, using some of the parts of the real
-// material_animated_icons, this give the test access to the private APIs.
-library material_animated_icons;
-
 import 'dart:math' as math show pi;
-import 'dart:ui' show lerpDouble;
-import 'dart:ui' as ui show Paint, Path, Canvas;
+import 'dart:ui' as ui;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/src/material/animated_icons.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
-import 'package:mockito/mockito.dart';
 
 import '../flutter_test_alternative.dart';
 
-part 'package:flutter/src/material/animated_icons/animated_icons.dart';
-part 'package:flutter/src/material/animated_icons/animated_icons_data.dart';
+void main() {
+  AnimatedIconPrivateTestHarness harness;
 
-// We have to import all the generated files in the material library to avoid
-// analysis errors (as the generated constants are all referenced in the
-// animated_icons library).
-part 'package:flutter/src/material/animated_icons/data/add_event.g.dart';
-part 'package:flutter/src/material/animated_icons/data/arrow_menu.g.dart';
-part 'package:flutter/src/material/animated_icons/data/close_menu.g.dart';
-part 'package:flutter/src/material/animated_icons/data/ellipsis_search.g.dart';
-part 'package:flutter/src/material/animated_icons/data/event_add.g.dart';
-part 'package:flutter/src/material/animated_icons/data/home_menu.g.dart';
-part 'package:flutter/src/material/animated_icons/data/list_view.g.dart';
-part 'package:flutter/src/material/animated_icons/data/menu_arrow.g.dart';
-part 'package:flutter/src/material/animated_icons/data/menu_close.g.dart';
-part 'package:flutter/src/material/animated_icons/data/menu_home.g.dart';
-part 'package:flutter/src/material/animated_icons/data/pause_play.g.dart';
-part 'package:flutter/src/material/animated_icons/data/play_pause.g.dart';
-part 'package:flutter/src/material/animated_icons/data/search_ellipsis.g.dart';
-part 'package:flutter/src/material/animated_icons/data/view_list.g.dart';
+  setUp(() {
+    harness = const AnimatedIconPrivateTestHarness();
+  });
 
-class MockCanvas extends Mock implements ui.Canvas {}
-class MockPath extends Mock implements ui.Path {}
+  tearDown(() {
+    harness = null;
+  });
 
-void main () {
   group('Interpolate points', () {
     test('- single point', () {
       const List<Offset> points = <Offset>[
         Offset(25.0, 1.0),
       ];
-      expect(_interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
-      expect(_interpolate(points, 0.5, Offset.lerp), const Offset(25.0, 1.0));
-      expect(_interpolate(points, 1.0, Offset.lerp), const Offset(25.0, 1.0));
+      expect(harness.interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
+      expect(harness.interpolate(points, 0.5, Offset.lerp), const Offset(25.0, 1.0));
+      expect(harness.interpolate(points, 1.0, Offset.lerp), const Offset(25.0, 1.0));
     });
 
     test('- two points', () {
@@ -62,9 +39,9 @@ void main () {
         Offset(25.0, 1.0),
         Offset(12.0, 12.0),
       ];
-      expect(_interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
-      expect(_interpolate(points, 0.5, Offset.lerp), const Offset(18.5, 6.5));
-      expect(_interpolate(points, 1.0, Offset.lerp), const Offset(12.0, 12.0));
+      expect(harness.interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
+      expect(harness.interpolate(points, 0.5, Offset.lerp), const Offset(18.5, 6.5));
+      expect(harness.interpolate(points, 1.0, Offset.lerp), const Offset(12.0, 12.0));
     });
 
     test('- three points', () {
@@ -73,31 +50,34 @@ void main () {
         Offset(12.0, 12.0),
         Offset(23.0, 9.0),
       ];
-      expect(_interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
-      expect(_interpolate(points, 0.25, Offset.lerp), const Offset(18.5, 6.5));
-      expect(_interpolate(points, 0.5, Offset.lerp), const Offset(12.0, 12.0));
-      expect(_interpolate(points, 0.75, Offset.lerp), const Offset(17.5, 10.5));
-      expect(_interpolate(points, 1.0, Offset.lerp), const Offset(23.0, 9.0));
+      expect(harness.interpolate(points, 0.0, Offset.lerp), const Offset(25.0, 1.0));
+      expect(harness.interpolate(points, 0.25, Offset.lerp), const Offset(18.5, 6.5));
+      expect(harness.interpolate(points, 0.5, Offset.lerp), const Offset(12.0, 12.0));
+      expect(harness.interpolate(points, 0.75, Offset.lerp), const Offset(17.5, 10.5));
+      expect(harness.interpolate(points, 1.0, Offset.lerp), const Offset(23.0, 9.0));
     });
   });
 
-  group('_AnimatedIconPainter', () {
+  group('AnimatedIconPainter', () {
     const Size size = Size(48.0, 48.0);
-    final MockCanvas mockCanvas = MockCanvas();
+    MockPath mockPath;
+    MockCanvas mockCanvas;
     List<MockPath> generatedPaths;
-    final _UiPathFactory pathFactory = () {
-      final MockPath path = MockPath();
-      generatedPaths.add(path);
-      return path;
-    };
+    _UiPathFactory pathFactory;
 
     setUp(() {
-      generatedPaths = <MockPath> [];
+      generatedPaths = <MockPath>[];
+      mockCanvas = MockCanvas();
+      mockPath = MockPath();
+      pathFactory = () {
+        generatedPaths.add(mockPath);
+        return mockPath;
+      };
     });
 
     test('progress 0', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -107,19 +87,19 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 0.0),
-        generatedPaths[0].lineTo(48.0, 0.0),
-        generatedPaths[0].lineTo(48.0, 10.0),
-        generatedPaths[0].lineTo(0.0, 10.0),
-        generatedPaths[0].lineTo(0.0, 0.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 0.0]),
+        MockCall('lineTo', <dynamic>[48.0, 0.0]),
+        MockCall('lineTo', <dynamic>[48.0, 10.0]),
+        MockCall('lineTo', <dynamic>[0.0, 10.0]),
+        MockCall('lineTo', <dynamic>[0.0, 0.0]),
+        MockCall('close'),
       ]);
     });
 
     test('progress 1', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(1.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -129,19 +109,19 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 38.0),
-        generatedPaths[0].lineTo(48.0, 38.0),
-        generatedPaths[0].lineTo(48.0, 48.0),
-        generatedPaths[0].lineTo(0.0, 48.0),
-        generatedPaths[0].lineTo(0.0, 38.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 38.0]),
+        MockCall('lineTo', <dynamic>[48.0, 38.0]),
+        MockCall('lineTo', <dynamic>[48.0, 48.0]),
+        MockCall('lineTo', <dynamic>[0.0, 48.0]),
+        MockCall('lineTo', <dynamic>[0.0, 38.0]),
+        MockCall('close'),
       ]);
     });
 
     test('clamped progress', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(1.5),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -151,19 +131,20 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 38.0),
-        generatedPaths[0].lineTo(48.0, 38.0),
-        generatedPaths[0].lineTo(48.0, 48.0),
-        generatedPaths[0].lineTo(0.0, 48.0),
-        generatedPaths[0].lineTo(0.0, 38.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 38.0]),
+        MockCall('lineTo', <dynamic>[48.0, 38.0]),
+        MockCall('lineTo', <dynamic>[48.0, 48.0]),
+        MockCall('lineTo', <dynamic>[0.0, 48.0]),
+        MockCall('lineTo', <dynamic>[0.0, 38.0]),
+        MockCall('close'),
       ]);
     });
 
     test('scale', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      expect(mockCanvas._calls, isEmpty);
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 0.5,
@@ -171,12 +152,15 @@ void main () {
         uiPathFactory: pathFactory,
       );
       painter.paint(mockCanvas, size);
-      verify(mockCanvas.scale(0.5, 0.5));
+      mockCanvas.verifyCallsInOrder(<MockCall>[
+        MockCall('scale', <dynamic>[0.5, 0.5]),
+        MockCall.any('drawPath'),
+      ]);
     });
 
     test('mirror', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -184,15 +168,17 @@ void main () {
         uiPathFactory: pathFactory,
       );
       painter.paint(mockCanvas, size);
-      verifyInOrder(<void>[
-        mockCanvas.rotate(math.pi),
-        mockCanvas.translate(-48.0, -48.0),
+      mockCanvas.verifyCallsInOrder(<MockCall>[
+        MockCall('scale', <dynamic>[1.0, 1.0]),
+        MockCall('rotate', <dynamic>[math.pi]),
+        MockCall('translate', <dynamic>[-48.0, -48.0]),
+        MockCall.any('drawPath'),
       ]);
     });
 
     test('interpolated frame', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.movingBar,
         progress: const AlwaysStoppedAnimation<double>(0.5),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -202,19 +188,19 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 19.0),
-        generatedPaths[0].lineTo(48.0, 19.0),
-        generatedPaths[0].lineTo(48.0, 29.0),
-        generatedPaths[0].lineTo(0.0, 29.0),
-        generatedPaths[0].lineTo(0.0, 19.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 19.0]),
+        MockCall('lineTo', <dynamic>[48.0, 19.0]),
+        MockCall('lineTo', <dynamic>[48.0, 29.0]),
+        MockCall('lineTo', <dynamic>[0.0, 29.0]),
+        MockCall('lineTo', <dynamic>[0.0, 19.0]),
+        MockCall('close'),
       ]);
     });
 
     test('curved frame', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(1.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -224,17 +210,17 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 24.0),
-        generatedPaths[0].cubicTo(16.0, 48.0, 32.0, 48.0, 48.0, 24.0),
-        generatedPaths[0].lineTo(0.0, 24.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 24.0]),
+        MockCall('cubicTo', <dynamic>[16.0, 48.0, 32.0, 48.0, 48.0, 24.0]),
+        MockCall('lineTo', <dynamic>[0.0, 24.0]),
+        MockCall('close'),
       ]);
     });
 
     test('interpolated curved frame', () {
-      final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.25),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -244,17 +230,17 @@ void main () {
       painter.paint(mockCanvas, size);
       expect(generatedPaths.length, 1);
 
-      verifyInOrder(<void>[
-        generatedPaths[0].moveTo(0.0, 24.0),
-        generatedPaths[0].cubicTo(16.0, 17.0, 32.0, 17.0, 48.0, 24.0),
-        generatedPaths[0].lineTo(0.0, 24.0),
-        generatedPaths[0].close(),
+      generatedPaths[0].verifyCallsInOrder(<MockCall>[
+        MockCall('moveTo', <dynamic>[0.0, 24.0]),
+        MockCall('cubicTo', <dynamic>[16.0, 17.0, 32.0, 17.0, 48.0, 24.0]),
+        MockCall('lineTo', <dynamic>[0.0, 24.0]),
+        MockCall('close', <dynamic>[]),
       ]);
     });
 
     test('should not repaint same values', () {
-      final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter1 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -262,8 +248,8 @@ void main () {
         uiPathFactory: pathFactory,
       );
 
-      final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter2 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -275,8 +261,8 @@ void main () {
     });
 
     test('should repaint on progress change', () {
-      final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter1 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -284,8 +270,8 @@ void main () {
         uiPathFactory: pathFactory,
       );
 
-      final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter2 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.1),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -297,8 +283,8 @@ void main () {
     });
 
     test('should repaint on color change', () {
-      final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter1 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -306,8 +292,8 @@ void main () {
         uiPathFactory: pathFactory,
       );
 
-      final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter2 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFFFF0000),
         scale: 1.0,
@@ -319,8 +305,8 @@ void main () {
     });
 
     test('should repaint on paths change', () {
-      final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+      final CustomPainter painter1 = harness.createAnimatedIconPainter(
+        paths: AnimatedIconPrivateTestHarness.bow,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF0000FF),
         scale: 1.0,
@@ -328,8 +314,8 @@ void main () {
         uiPathFactory: pathFactory,
       );
 
-      final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: const <_PathFrames> [],
+      final CustomPainter painter2 = harness.createAnimatedIconPainter(
+        paths: null,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF0000FF),
         scale: 1.0,
@@ -339,91 +325,82 @@ void main () {
 
       expect(painter1.shouldRepaint(painter2), true);
     });
-
   });
 }
 
-const _AnimatedIconData movingBar = _AnimatedIconData(
-  Size(48.0, 48.0),
-  <_PathFrames> [
-    _PathFrames(
-      opacities: <double> [1.0, 0.2],
-      commands: <_PathCommand> [
-        _PathMoveTo(
-          <Offset> [
-            Offset(0.0, 0.0),
-            Offset(0.0, 38.0),
-          ],
-        ),
-        _PathLineTo(
-          <Offset> [
-            Offset(48.0, 0.0),
-            Offset(48.0, 38.0),
-          ],
-        ),
-        _PathLineTo(
-          <Offset> [
-            Offset(48.0, 10.0),
-            Offset(48.0, 48.0),
-          ],
-        ),
-        _PathLineTo(
-          <Offset> [
-            Offset(0.0, 10.0),
-            Offset(0.0, 48.0),
-          ],
-        ),
-        _PathLineTo(
-          <Offset> [
-            Offset(0.0, 0.0),
-            Offset(0.0, 38.0),
-          ],
-        ),
-        _PathClose(),
-      ],
-    ),
-  ],
-);
+typedef _UiPathFactory = ui.Path Function();
 
-const _AnimatedIconData bow = _AnimatedIconData(
-  Size(48.0, 48.0),
-  <_PathFrames> [
-    _PathFrames(
-      opacities: <double> [1.0, 1.0],
-      commands: <_PathCommand> [
-        _PathMoveTo(
-          <Offset> [
-            Offset(0.0, 24.0),
-            Offset(0.0, 24.0),
-            Offset(0.0, 24.0),
-          ],
-        ),
-        _PathCubicTo(
-          <Offset> [
-            Offset(16.0, 24.0),
-            Offset(16.0, 10.0),
-            Offset(16.0, 48.0),
-          ],
-          <Offset> [
-            Offset(32.0, 24.0),
-            Offset(32.0, 10.0),
-            Offset(32.0, 48.0),
-          ],
-          <Offset> [
-            Offset(48.0, 24.0),
-            Offset(48.0, 24.0),
-            Offset(48.0, 24.0),
-          ],
-        ),
-        _PathLineTo(
-          <Offset> [
-            Offset(0.0, 24.0),
-            Offset(0.0, 24.0),
-            Offset(0.0, 24.0),
-          ],
-        ),
-        _PathClose(),
-      ],
-    ),
-  ],
-);
+// Contains the data from an invocation used for collection of calls and for
+// expectations in Mock class.
+class MockCall {
+  // Creates a mock call with optional positional arguments.
+  MockCall(String memberName, [this.positionalArguments, this.acceptAny = false])
+      : memberSymbol = Symbol(memberName);
+  MockCall.fromSymbol(this.memberSymbol, [this.positionalArguments, this.acceptAny = false]);
+  // Creates a mock call expectation that doesn't care about what the arguments were.
+  MockCall.any(String memberName)
+      : memberSymbol = Symbol(memberName),
+        acceptAny = true,
+        positionalArguments = null;
+
+  final Symbol memberSymbol;
+  String get memberName {
+    final RegExp symbolMatch = RegExp(r'Symbol\("(?<name>.*)"\)');
+    final RegExpMatch match = symbolMatch.firstMatch(memberSymbol.toString());
+    assert(match != null);
+    return match.namedGroup('name');
+  }
+  final List<dynamic> positionalArguments;
+  final bool acceptAny;
+
+  @override
+  String toString() {
+    return '$memberName(${positionalArguments?.join(', ') ?? ''})';
+  }
+}
+
+// A very simplified version of a Mock class.
+//
+// Only verifies positional arguments, and only can verify calls in order.
+class Mock {
+  final List<MockCall> _calls = <MockCall>[];
+
+  void addMockCall(Symbol symbol, [List<dynamic> args]) {
+    _calls.add(MockCall.fromSymbol(symbol, args));
+  }
+
+  // Verify that the given calls happened in the order given.
+  void verifyCallsInOrder(List<MockCall> expected) {
+    int count = 0;
+    expect(expected.length, equals(_calls.length),
+        reason: 'Incorrect number of calls received. '
+            'Expected ${expected.length} and received ${_calls.length}.\n'
+            '  Calls Received: $_calls\n'
+            '  Calls Expected: $expected');
+    for (final MockCall call in _calls) {
+      expect(call.memberSymbol, equals(expected[count].memberSymbol),
+          reason: 'Unexpected call to ${call.memberName}, expected a call to '
+              '${expected[count].memberName} instead.');
+      if (call.positionalArguments != null && !expected[count].acceptAny) {
+        int countArg = 0;
+        for (final dynamic arg in call.positionalArguments) {
+          expect(arg, equals(expected[count].positionalArguments[countArg]),
+              reason: 'Failed at call $count. Positional argument $countArg to ${call.memberName} '
+                  'not as expected. Expected ${expected[count].positionalArguments[countArg]} '
+                  'and received $arg');
+          countArg++;
+        }
+      }
+      count++;
+    }
+  }
+
+  @override
+  void noSuchMethod(Invocation invocation) {
+    addMockCall(invocation.memberName, invocation.positionalArguments);
+  }
+}
+
+class MockCanvas extends Mock implements ui.Canvas {}
+
+class MockPath extends Mock implements ui.Path {}


### PR DESCRIPTION
## Description

This removes the need to use a library and `part` directives in the test for animated icons, and eliminates its dependency upon the Mockito package. These attributes of the test were making it hard to migrate to NNBD (well, at least the mockito dependency), and the use of the part directive is discouraged, so it was good to eliminate it.

I'm not terribly happy with the exposure of a public class that has only `@visibleForTesting` methods, but that makes it possible to have a factory that can construct the private data. The test harness class should be tree-shaken away since nothing calls it, so there should be no size impact on production code.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.
