### PR TITLE
Expose 3 new methods with text metrics in RenderParagraph

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -784,7 +784,9 @@ class TextPainter {
     return _caretMetrics.offset;
   }
 
-  /// Returns the tight bounded height of the glyph at the given [position].
+  /// {@template flutter.painting.textPainter.getFullHeightForCaret}
+  /// Returns the strut bounded height of the glyph at the given `position`.
+  /// {@endtemplate}
   ///
   /// Valid only after [layout] has been called.
   double? getFullHeightForCaret(TextPosition position, Rect caretPrototype) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -735,6 +735,11 @@ class RenderParagraph extends RenderBox
     }
   }
 
+  /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
+  /// This does not required the layout to be updated.
+  double get preferredLineHeight => _textPainter.preferredLineHeight;
+
+
   /// Returns the offset at which to paint the caret.
   ///
   /// Valid only after [layout].
@@ -742,6 +747,15 @@ class RenderParagraph extends RenderBox
     assert(!debugNeedsLayout);
     _layoutTextWithConstraints(constraints);
     return _textPainter.getOffsetForCaret(position, caretPrototype);
+  }
+
+  /// Returns the tight bounded height of the glyph at the given [position].
+  ///
+  /// Valid only after [layout].
+  double? getFullHeightForCaret(TextPosition position, Rect caretPrototype) {
+    assert(!debugNeedsLayout);
+    _layoutTextWithConstraints(constraints);
+    return _textPainter.getFullHeightForCaret(position, caretPrototype);
   }
 
   /// Returns a list of rects that bound the given selection.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -735,11 +735,6 @@ class RenderParagraph extends RenderBox
     }
   }
 
-  /// An estimate of the height of a line in the text. See [TextPainter.preferredLineHeight].
-  /// This does not required the layout to be updated.
-  double get preferredLineHeight => _textPainter.preferredLineHeight;
-
-
   /// Returns the offset at which to paint the caret.
   ///
   /// Valid only after [layout].
@@ -749,7 +744,7 @@ class RenderParagraph extends RenderBox
     return _textPainter.getOffsetForCaret(position, caretPrototype);
   }
 
-  /// Returns the tight bounded height of the glyph at the given [position].
+  /// {@macro flutter.painting.textPainter.getFullHeightForCaret}
   ///
   /// Valid only after [layout].
   double? getFullHeightForCaret(TextPosition position, Rect caretPrototype) {
@@ -793,17 +788,6 @@ class RenderParagraph extends RenderBox
     assert(!debugNeedsLayout);
     _layoutTextWithConstraints(constraints);
     return _textPainter.getWordBoundary(position);
-  }
-
-  /// Returns the text range of the line at the given offset.
-  ///
-  /// The newline, if any, is included in the range.
-  ///
-  /// Valid only after [layout].
-  TextRange getLineBoundary(TextPosition position) {
-    assert(!debugNeedsLayout);
-    _layoutTextWithConstraints(constraints);
-    return _textPainter.getLineBoundary(position);
   }
 
   /// Returns the size of the text as laid out.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -795,6 +795,17 @@ class RenderParagraph extends RenderBox
     return _textPainter.getWordBoundary(position);
   }
 
+  /// Returns the text range of the line at the given offset.
+  ///
+  /// The newline, if any, is included in the range.
+  ///
+  /// Valid only after [layout].
+  TextRange getLineBoundary(TextPosition position) {
+    assert(!debugNeedsLayout);
+    _layoutTextWithConstraints(constraints);
+    return _textPainter.getLineBoundary(position);
+  }
+
   /// Returns the size of the text as laid out.
   ///
   /// This can differ from [size] if the text overflowed or if the [constraints]

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -747,10 +747,10 @@ class RenderParagraph extends RenderBox
   /// {@macro flutter.painting.textPainter.getFullHeightForCaret}
   ///
   /// Valid only after [layout].
-  double? getFullHeightForCaret(TextPosition position, Rect caretPrototype) {
+  double? getFullHeightForCaret(TextPosition position) {
     assert(!debugNeedsLayout);
     _layoutTextWithConstraints(constraints);
-    return _textPainter.getFullHeightForCaret(position, caretPrototype);
+    return _textPainter.getFullHeightForCaret(position, Rect.zero);
   }
 
   /// Returns a list of rects that bound the given selection.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -43,9 +43,7 @@ void main() {
     );
     layout(paragraph);
 
-    const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
-
-    final double height5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5), caret);
+    final double height5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5));
     expect(height5, equals(10.0));
   });
 

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -36,6 +36,15 @@ void main() {
     expect(offset50.dy, greaterThan(offset5.dy));
   });
 
+  test('preferredLineHeight control test', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(text: _kText),
+      textDirection: TextDirection.ltr,
+    );
+
+    expect(paragraph.preferredLineHeight, greaterThan(0.0));
+  });
+
   test('getFullHeightForCaret control test', () {
     final RenderParagraph paragraph = RenderParagraph(
       const TextSpan(text: _kText),
@@ -47,6 +56,20 @@ void main() {
 
     final double offset5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5), caret);
     expect(offset5, greaterThan(0.0));
+  });
+
+  test('getLineBoundary control test', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(text: _kText),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph);
+
+    final TextRange range5 = paragraph.getLineBoundary(const TextPosition(offset: 5));
+    expect(range5.textInside(_kText), equals('I polished up that handle so carefullee'));
+
+    final TextRange range50 = paragraph.getLineBoundary(const TextPosition(offset: 50));
+    expect(range50.textInside(_kText), equals("That now I am the Ruler of the Queen's Navee!"));
   });
 
   test('getPositionForOffset control test', () {

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -36,6 +36,19 @@ void main() {
     expect(offset50.dy, greaterThan(offset5.dy));
   });
 
+  test('getFullHeightForCaret control test', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(text: _kText),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph);
+
+    const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
+
+    final double offset5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5), caret);
+    expect(offset5, greaterThan(0.0));
+  });
+
   test('getPositionForOffset control test', () {
     final RenderParagraph paragraph = RenderParagraph(
       const TextSpan(text: _kText),

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -36,40 +36,17 @@ void main() {
     expect(offset50.dy, greaterThan(offset5.dy));
   });
 
-  test('preferredLineHeight control test', () {
-    final RenderParagraph paragraph = RenderParagraph(
-      const TextSpan(text: _kText),
-      textDirection: TextDirection.ltr,
-    );
-
-    expect(paragraph.preferredLineHeight, greaterThan(0.0));
-  });
-
   test('getFullHeightForCaret control test', () {
     final RenderParagraph paragraph = RenderParagraph(
-      const TextSpan(text: _kText),
+      const TextSpan(text: _kText,style: TextStyle(fontSize: 10.0)),
       textDirection: TextDirection.ltr,
     );
     layout(paragraph);
 
     const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
 
-    final double offset5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5), caret);
-    expect(offset5, greaterThan(0.0));
-  });
-
-  test('getLineBoundary control test', () {
-    final RenderParagraph paragraph = RenderParagraph(
-      const TextSpan(text: _kText),
-      textDirection: TextDirection.ltr,
-    );
-    layout(paragraph);
-
-    final TextRange range5 = paragraph.getLineBoundary(const TextPosition(offset: 5));
-    expect(range5.textInside(_kText), equals('I polished up that handle so carefullee'));
-
-    final TextRange range50 = paragraph.getLineBoundary(const TextPosition(offset: 50));
-    expect(range50.textInside(_kText), equals("That now I am the Ruler of the Queen's Navee!"));
+    final double height5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5), caret);
+    expect(height5, equals(10.0));
   });
 
   test('getPositionForOffset control test', () {


### PR DESCRIPTION
## Description

Exposes `preferredLineHeight`, `getFullHeightForCaret` and `getLineBoundary` on `RenderParagraph`.

## Use case

I've created a [rich text editor](https://github.com/memspace/zefyr) for Flutter and currently work on cleaning up and refactoring its rendering layer.

In the editor I'm taking advantage of the built-in `RenderParagraph` to represent a single paragraph in a document.
Since I'm using it in an editable context I need it to provide a few more metrics related to handling of editing cursor:

* `preferredLineHeight`
* `getFullHeightForCaret`
* `getLineBoundary`

These methods would be proxying to the underlying `TextPainter` instance. Right now I have implemented a workaround for `preferredLineHeight` but it doesn't seem like I can create one for `getFullHeightForCaret` or `getLineBoundary`.

I noticed that `RenderParagraph` already exposes some editing-specific methods (`getOffsetForCaret` and `getBoxesForSelection`) so it doesn't seem like it'd go against certain design goals for this class.

## Related Issues

* Fixes https://github.com/flutter/flutter/issues/65069

## Tests

Added the following tests in `packages/flutter/test/rendering/paragraph_test.dart`:

* `preferredLineHeight control test`
* `getFullHeightForCaret control test`
* `getLineBoundary control test`


## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
