### PR TITLE
[flutter_tools] prevent creation of android devices if adb is not located

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -58,13 +58,18 @@ class AndroidWorkflow implements Workflow {
   bool get appliesToHostPlatform => _featureFlags.isAndroidEnabled;
 
   @override
-  bool get canListDevices => _androidSdk != null && _androidSdk.adbPath != null;
+  bool get canListDevices => _androidSdk != null
+    && _androidSdk.adbPath != null;
 
   @override
-  bool get canLaunchDevices => _androidSdk != null && _androidSdk.validateSdkWellFormed().isEmpty;
+  bool get canLaunchDevices => _androidSdk != null
+    && _androidSdk.adbPath != null
+    && _androidSdk.validateSdkWellFormed().isEmpty;
 
   @override
-  bool get canListEmulators => _androidSdk != null && _androidSdk.emulatorPath != null;
+  bool get canListEmulators => _androidSdk != null
+    && _androidSdk.adbPath != null
+    && _androidSdk.emulatorPath != null;
 }
 
 class AndroidValidator extends DoctorValidator {

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -68,6 +68,20 @@ void main() {
     expect(androidWorkflow.canListEmulators, false);
   });
 
+  testWithoutContext('AndroidWorkflow handles a null adb', () {
+    final MockAndroidSdk androidSdk = MockAndroidSdk();
+    when(androidSdk.adbPath).thenReturn(null);
+    final AndroidWorkflow androidWorkflow = AndroidWorkflow(
+      featureFlags: TestFeatureFlags(),
+      androidSdk: androidSdk,
+    );
+
+    expect(androidWorkflow.canLaunchDevices, false);
+    expect(androidWorkflow.canListDevices, false);
+    expect(androidWorkflow.canListEmulators, false);
+  });
+
+
   testUsingContext('licensesAccepted returns LicensesAccepted.unknown if cannot find sdkmanager', () async {
     processManager.canRunSucceeds = false;
     when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -58,6 +58,7 @@ void main() {
     when(mockSdk.avdManagerPath).thenReturn('avdmanager');
     when(mockSdk.getAvdManagerPath()).thenReturn('avdmanager');
     when(mockSdk.emulatorPath).thenReturn('emulator');
+    when(mockSdk.adbPath).thenReturn('adb');
   });
 
   group('EmulatorManager', () {


### PR DESCRIPTION
## Description

More work to prevent current #2 crash issue on stable. If adb is not located do not list/create android devices.