### PR TITLE
Update create templates to 1.0.0

### DIFF
--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -92,8 +92,20 @@ TaskFunction createFlutterCreateOfflineTest() {
   return () async {
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_create_test.');
     String output;
+    // The default create template has an actual online dependency against
+    // a pub package. Make sure it's available in pub cache first before
+    // trying to resolve it offline.
     await inDirectory(tempDir, () async {
-      output = await eval(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>['create', '--offline', 'flutter_create_test']);
+      output = await eval(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        <String>['pub', 'cache', 'add', 'cupertino_icons', '--version', '1.0.0'],
+      );
+    });
+    await inDirectory(tempDir, () async {
+      output = await eval(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        <String>['create', '--offline', 'flutter_create_test'],
+      );
     });
     if (output.contains(RegExp('building flutter tool', caseSensitive: false))) {
       return TaskResult.failure('`flutter create --offline` should not rebuild flutter tool');

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -38,7 +38,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -26,7 +26,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0
 
 dev_dependencies:
   flutter_test:
@@ -45,7 +45,7 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
-  # To add Flutter specific assets to your application, add an assets section, 
+  # To add Flutter specific assets to your application, add an assets section,
   # like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/65087 might turn out hard to merge. Need to update flutter gallery to update packages to add new icons to integration tests to write a golden test, but flutter gallery's breaking luci on head. 

Pull out the more urgent parts to check in before 1.22 branch cut. 