### PR TITLE
Deprecated unused property [RectangularSliderTrackShape.disabledThumbGapWidth]

### DIFF
--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1498,7 +1498,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// the thumb and any part of the track when the slider is enabled. The
   /// Material spec defaults this gap width 2, which is half of the disabled
   /// thumb radius.
-  @Deprecated("No longer has any effect.")
+  @Deprecated("No longer has any effect")
   final double disabledThumbGapWidth;
 
   @override

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1499,7 +1499,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// Material spec defaults this gap width 2, which is half of the disabled
   /// thumb radius.
   @Deprecated(
-    'No longer has any effect.'
+    'It no longer has any effect because the thumb does not shrink when the slider is disabled now. '
     'This feature was deprecated after v1.5.7.'
   )
   final double disabledThumbGapWidth;

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1498,7 +1498,10 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// the thumb and any part of the track when the slider is enabled. The
   /// Material spec defaults this gap width 2, which is half of the disabled
   /// thumb radius.
-  @Deprecated("No longer has any effect")
+  @Deprecated(
+    'No longer has any effect. '
+    'This feature was deprecated after v1.5.7.'
+  )
   final double disabledThumbGapWidth;
 
   @override

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1498,6 +1498,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// the thumb and any part of the track when the slider is enabled. The
   /// Material spec defaults this gap width 2, which is half of the disabled
   /// thumb radius.
+  @Deprecated("No longer has any effect.")
   final double disabledThumbGapWidth;
 
   @override

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1499,7 +1499,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// Material spec defaults this gap width 2, which is half of the disabled
   /// thumb radius.
   @Deprecated(
-    'No longer has any effect. '
+    'No longer has any effect.'
     'This feature was deprecated after v1.5.7.'
   )
   final double disabledThumbGapWidth;


### PR DESCRIPTION
This property was deprecated via https://github.com/flutter/flutter/pull/30390

@HansMuller @clocksmith 