### PR TITLE
Add retrieve named route and has named route functions

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3959,6 +3959,37 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     }());
   }
 
+  /// Searches for a route with the given [name] and returns it if found, otherwise
+  /// returns null.
+  ///
+  /// {@macro flutter.widgets.navigator.getNamedRoute}
+  Route<dynamic> retrieveNamedRoute(String name) {
+    assert(name != null);
+    assert(!_debugLocked);
+    assert(() {
+      _debugLocked = true;
+      return true;
+    }());
+
+    final _RouteEntry entry = _history.firstWhere(
+        (_RouteEntry entry) => entry.route.settings.name == name,
+        orElse: () => null);
+
+    assert(() {
+      _debugLocked = false;
+      return true;
+    }());
+
+    return entry?.route;
+  }
+
+  /// Simply checks if the result of [getNamedRoute] exists.
+  ///
+  /// {@macro flutter.widgets.navigator.hasNamedRoute}
+  bool hasNamedRoute(String name) {
+    return retrieveNamedRoute(name) != null;
+  }
+
   /// Complete the lifecycle for a route that has been popped off the navigator.
   ///
   /// When the navigator pops a route, the navigator retains a reference to the

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3962,7 +3962,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// Searches for a route with the given [name] and returns it if found, otherwise
   /// returns null.
   ///
-  /// {@macro flutter.widgets.navigator.getNamedRoute}
+  /// {@macro flutter.widgets.navigator.retrieveNamedRoute}
   Route<dynamic> retrieveNamedRoute(String name) {
     assert(name != null);
     assert(!_debugLocked);

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3254,6 +3254,36 @@ void main() {
       expect(observations[7].previous, isNull);
     });
   });
+
+  testWidgets('finds named route and returns it', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (_) => Container(),
+      '/second': (_) => Container(),
+      '/third': (_) => Container()
+    };
+
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(MaterialApp(
+      routes: routes,
+      navigatorKey: navKey,
+    ));
+
+    navKey.currentState..pushNamed('/second')..pushNamed('/third');
+
+    Route<dynamic> route = navKey.currentState.retrieveNamedRoute('/second');
+
+    expect(route.settings.name, '/second');
+    expect(route, isNotNull);
+
+    navKey.currentState.removeRoute(route);
+
+    await tester.pumpAndSettle();
+
+    route = navKey.currentState.retrieveNamedRoute('/second');
+
+    expect(route, isNull);
+  });
 }
 
 typedef AnnouncementCallBack = void Function(Route<dynamic>);


### PR DESCRIPTION
## Description

Add retrieve named route and has named route functions, to the navigator API.

## Related Issues

## Tests

I added the following tests:

test/widgets/navigator_test.dart

test name => finds named route and returns it

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
