### PR TITLE
Bug fix where MouseScrollWheel zoom in flutter-web does not execute onInteraction functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,4 +65,4 @@ CaiJingLong <cjl_spy@163.com>
 Alex Li <google@alexv525.com>
 Ram Navan <hiramprasad@gmail.com>
 meritozh <ah841814092@gmail.com>
-Terrence Addison Tandijono <terrenceaddison32@gmail.com>
+Terrence Addison Tandijono(flotilla) <terrenceaddison32@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ CaiJingLong <cjl_spy@163.com>
 Alex Li <google@alexv525.com>
 Ram Navan <hiramprasad@gmail.com>
 meritozh <ah841814092@gmail.com>
+Terrence Addison Tandijono <terrenceaddison32@gmail.com>

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -751,6 +751,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         rotation: details.rotation,
       ));
     }
+
     final Offset focalPointScene = _transformationController.toScene(
       details.localFocalPoint,
     );
@@ -923,7 +924,22 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _transformationController.value,
         focalPointSceneScaled - focalPointScene,
       );
+      final double scale = _transformationController.value.getMaxScaleOnAxis();
+      if (widget.onInteractionStart != null) {
+        widget.onInteractionStart(
+            ScaleStartDetails(focalPoint: focalPointSceneScaled));
+      }
+      if (widget.onInteractionUpdate != null) {
+        widget.onInteractionUpdate(ScaleUpdateDetails(
+          rotation: 0,
+          scale: scale,
+        ));
+      }
+      if (widget.onInteractionEnd != null) {
+        widget.onInteractionEnd(ScaleEndDetails());
+      }
     }
+
   }
 
   // Handle inertia drag animation.

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -924,22 +924,23 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _transformationController.value,
         focalPointSceneScaled - focalPointScene,
       );
-      final double scale = _transformationController.value.getMaxScaleOnAxis();
       if (widget.onInteractionStart != null) {
         widget.onInteractionStart(
-            ScaleStartDetails(focalPoint: focalPointSceneScaled));
+            ScaleStartDetails(focalPoint: focalPointSceneScaled)
+        );
       }
       if (widget.onInteractionUpdate != null) {
         widget.onInteractionUpdate(ScaleUpdateDetails(
-          rotation: 0,
-          scale: scale,
+          rotation: 0.0,
+          scale: scaleChange,
+          horizontalScale: 1.0,
+          verticalScale: 1.0,
         ));
       }
       if (widget.onInteractionEnd != null) {
         widget.onInteractionEnd(ScaleEndDetails());
       }
     }
-
   }
 
   // Handle inertia drag animation.

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -624,7 +624,7 @@ void main() {
     });
 
 
-testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
+    testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
       final TransformationController transformationController = TransformationController();
       double currentScale;
       Velocity currentVelocity;
@@ -634,13 +634,13 @@ testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester te
             body: Center(
               child: InteractiveViewer(
                 transformationController: transformationController,
-                onInteractionStart: (details){
-                  
+                onInteractionStart: (ScaleStartDetails details){
+
                 },
-                onInteractionUpdate: (details){
-                  currentScale = details.scale; 
+                onInteractionUpdate: (ScaleUpdateDetails details){
+                  currentScale = details.scale;
                 },
-                onInteractionEnd: (details){
+                onInteractionEnd: (ScaleEndDetails details){
                   currentVelocity = details.velocity;
                 },
                 child: Container(width: 200.0, height: 200.0),
@@ -653,9 +653,11 @@ testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester te
       final Offset center = tester.getCenter(find.byType(InteractiveViewer));
       await scrollAt(center, tester, const Offset(0.0, -20.0));
       await tester.pumpAndSettle();
+      const Velocity noMovement = Velocity(pixelsPerSecond: Offset(0,0));
+      final double afterScaling = transformationController.value.getMaxScaleOnAxis();
 
-      expect(transformationController.value.getMaxScaleOnAxis(),equals(currentScale));
-      expect(currentVelocity,equals(Velocity(pixelsPerSecond: Offset(0,0))));
+      expect(afterScaling,equals(currentScale));
+      expect(currentVelocity,equals(noMovement));
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -624,9 +624,10 @@ void main() {
     });
 
 
-    testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
+testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
       final TransformationController transformationController = TransformationController();
       double currentScale;
+      Velocity currentVelocity;
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -634,11 +635,13 @@ void main() {
               child: InteractiveViewer(
                 transformationController: transformationController,
                 onInteractionStart: (details){
+                  
                 },
                 onInteractionUpdate: (details){
                   currentScale = details.scale; 
                 },
                 onInteractionEnd: (details){
+                  currentVelocity = details.velocity;
                 },
                 child: Container(width: 200.0, height: 200.0),
               ),
@@ -652,6 +655,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(transformationController.value.getMaxScaleOnAxis(),equals(currentScale));
+      expect(currentVelocity,equals(Velocity(pixelsPerSecond: Offset(0,0))));
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -623,6 +623,37 @@ void main() {
       expect(transformationController.value.getMaxScaleOnAxis(), equals(1.0));
     });
 
+
+    testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
+      final TransformationController transformationController = TransformationController();
+      double currentScale;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                transformationController: transformationController,
+                onInteractionStart: (details){
+                },
+                onInteractionUpdate: (details){
+                  currentScale = details.scale; 
+                },
+                onInteractionEnd: (details){
+                },
+                child: Container(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byType(InteractiveViewer));
+      await scrollAt(center, tester, const Offset(0.0, -20.0));
+      await tester.pumpAndSettle();
+
+      expect(transformationController.value.getMaxScaleOnAxis(),equals(currentScale));
+    });
+
     testWidgets('viewport changes size', (WidgetTester tester) async {
       final TransformationController transformationController = TransformationController();
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -623,11 +623,11 @@ void main() {
       expect(transformationController.value.getMaxScaleOnAxis(), equals(1.0));
     });
 
-
-    testWidgets('Scale with mouse returns onInteraction properties',(WidgetTester tester) async{
+    testWidgets('Scale with mouse returns onInteraction properties', (WidgetTester tester) async{
       final TransformationController transformationController = TransformationController();
-      double currentScale;
+      double scaleChange;
       Velocity currentVelocity;
+      bool calledStart;
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -635,10 +635,10 @@ void main() {
               child: InteractiveViewer(
                 transformationController: transformationController,
                 onInteractionStart: (ScaleStartDetails details){
-
+                  calledStart = true;
                 },
                 onInteractionUpdate: (ScaleUpdateDetails details){
-                  currentScale = details.scale;
+                  scaleChange = details.scale;
                 },
                 onInteractionEnd: (ScaleEndDetails details){
                   currentVelocity = details.velocity;
@@ -656,8 +656,11 @@ void main() {
       const Velocity noMovement = Velocity(pixelsPerSecond: Offset(0,0));
       final double afterScaling = transformationController.value.getMaxScaleOnAxis();
 
-      expect(afterScaling,equals(currentScale));
-      expect(currentVelocity,equals(noMovement));
+      expect(scaleChange,greaterThan(1.0));
+      expect(afterScaling, isNot(equals(null)));
+      expect(afterScaling, isNot(equals(1.0)));
+      expect(currentVelocity, equals(noMovement));
+      expect(calledStart, equals(true));
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {


### PR DESCRIPTION
### Description
Previously using mouse scroll wheel to zoom on flutterweb in interactiveViewer will not execute the onInteraction functions. This PR fixes that and hooks up the MouseScrollWheel action with the onInteraction functions.

### Related 
Issue is linked [here](https://github.com/flutter/flutter/issues/64852)

### Tests
I added the following tests:
I added a test to make sure that when mousescrollwheel is used to zoom, details of the oninteractions can be collected.

### Checklist
Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes ([x]). This will ensure a smooth and quick review process.

[x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
[x] I signed the CLA.
[x] I read and followed the Flutter Style Guide, including Features we expect every widget to implement.
[x] I read the Tree Hygiene wiki page, which explains my responsibilities.
[x] I updated/added relevant documentation (doc comments with ///).
[x] All existing and new tests are passing.
[x]The analyzer (flutter analyze --flutter-repo) does not report any problems on my PR.
[x] I am willing to follow-up on review comments in a timely manner.
### Breaking Change
Did any tests fail when you ran them? Please read Handling breaking changes.

[x ] No, no existing tests failed, so this is not a breaking change.