### PR TITLE
Fab for search delegate  

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -9,9 +9,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../material.dart';
 import 'app_bar.dart';
 import 'colors.dart';
 import 'debug.dart';
+import 'floating_action_button.dart';
 import 'input_border.dart';
 import 'input_decorator.dart';
 import 'material_localizations.dart';
@@ -90,7 +92,6 @@ Future<T> showSearch<T>({
 /// call. Call [SearchDelegate.close] before re-using the same delegate instance
 /// for another [showSearch] call.
 abstract class SearchDelegate<T> {
-
   /// Constructor to be called by subclasses which may specify [searchFieldLabel], [keyboardType] and/or
   /// [textInputAction].
   ///
@@ -124,6 +125,11 @@ abstract class SearchDelegate<T> {
     this.searchFieldStyle,
     this.keyboardType,
     this.textInputAction = TextInputAction.search,
+    this.showFloatingActionButton = false,
+    this.floatingActionButtonSize = 56.0,
+    this.floatingActionButtonIconSize = 44.0,
+    this.floatingActionButtonResult,
+    this.elevation = 10.0,
   });
 
   /// Suggestions shown in the body of the search page while the user types a
@@ -261,6 +267,25 @@ abstract class SearchDelegate<T> {
       ..popUntil((Route<dynamic> route) => route == _route)
       ..pop(result);
   }
+
+  /// The value for the result in the [close] function to pop with the result.
+  /// Is null by default
+  final T floatingActionButtonResult;
+
+  /// The boolean for displaying Floating Action Button.
+  /// Initially set to false.
+  final bool showFloatingActionButton;
+
+  /// The Floating Action Button Size
+  /// It is defaulted to 56.0
+  final double floatingActionButtonSize;
+
+  /// The Icon size for the close Icon inside of the Floating Action Button.
+  /// The size is defaulted to 44.0
+  final double floatingActionButtonIconSize;
+
+  /// This is the elevation for the [FloatingActionButton]
+  final double elevation;
 
   /// The hint text that is shown in the search field when it is empty.
   ///
@@ -537,6 +562,22 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           ),
           actions: widget.delegate.buildActions(context),
         ),
+        floatingActionButton: widget.delegate.showFloatingActionButton
+            ? FloatingActionButton(
+                onPressed: () => widget.delegate
+                    .close(context, widget.delegate.floatingActionButtonResult),
+                isExtended: false,
+                backgroundColor: theme.primaryColor,
+                tooltip: 'exit',
+                splashColor: theme.splashColor,
+                elevation: widget.delegate.elevation,
+                child: Icon(
+                  Icons.arrow_back,
+                  size: widget.delegate.floatingActionButtonIconSize,
+                  color: theme.primaryIconTheme.color,
+                ),
+              )
+            : null,
         body: AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
           child: body,

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -693,6 +693,42 @@ void main() {
       semantics.dispose();
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
   });
+
+  testWidgets('Open Search delegate and then Close using Floating Action Button', (WidgetTester tester)async{
+    final _TestSearchDelegate delegate = _TestSearchDelegate();
+    final List<String> selectedResults = <String>[];
+
+    await tester.pumpWidget(TestHomePage(
+      delegate: delegate,
+      results: selectedResults,
+    ));
+
+    // We are on the homepage
+    expect(find.text('HomeBody'), findsOneWidget);
+    expect(find.text('HomeTitle'), findsOneWidget);
+    expect(find.text('Suggestions'), findsNothing);
+
+    // Open search
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HomeBody'), findsNothing);
+    expect(find.text('HomeTitle'), findsNothing);
+    expect(find.text('Suggestions'), findsOneWidget);
+    expect(selectedResults, hasLength(0));
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.focusNode.hasFocus, isTrue);
+
+    // Close  search using Floating action Button
+    await tester.tap(find.byTooltip('exit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('HomeBody'), findsOneWidget);
+    expect(find.text('HomeTitle'), findsOneWidget);
+    expect(find.text('Suggestions'), findsNothing);
+    expect(selectedResults, <String>['Result']);
+  });
 }
 
 class TestHomePage extends StatelessWidget {
@@ -754,7 +790,7 @@ class _TestSearchDelegate extends SearchDelegate<String> {
     TextStyle searchFieldStyle,
     String searchHint,
     TextInputAction textInputAction = TextInputAction.search,
-  }) : super(searchFieldLabel: searchHint, textInputAction: textInputAction, searchFieldStyle: searchFieldStyle);
+  }) : super(searchFieldLabel: searchHint, textInputAction: textInputAction, searchFieldStyle: searchFieldStyle,showFloatingActionButton: true,floatingActionButtonResult: result);
 
   final String suggestions;
   final String result;


### PR DESCRIPTION
## Description

FAB for SearchDelegate to only exit (navigate back) to the previous context.
Since due to unusual and large screen sizes an implementation of FAB to only exit the search delegate is required. 

The following code will add the FAB if the user makes 'showFloatingActionButton ' as true which is defaulted to false;
The FAB is also given a default size of 54.0 and Icon (Material Arrow -back icon) is given a default size of the size of 44.0.
The Icon colour follows the primary Icon theme colour. 
The FAB background colour follows the primary colour described in the theme.
The FAB has a default elevation of 10.0,

The FAB also pops with the result as specified by the user for the close function to return on pop context. 

## Related Issues

 #65309 

## Tests

I added the following tests:

- Added test to open the Search Delegate and then close using FAB.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
