### PR TITLE
Add TextTheme.of(context) (#65410)

### DIFF
--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -7,6 +7,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
+import '../../widgets.dart';
+import 'theme.dart';
 import 'typography.dart';
 
 /// Material design text theme.
@@ -341,6 +343,17 @@ class TextTheme with Diagnosticable {
   )
   TextStyle get body1 => bodyText2;
 
+  /// Helper function for getting the [TextTheme] from the closest [Theme]
+  /// instance that encloses the given context.
+  ///
+  /// For more information see [Theme.of].
+  ///
+  /// See also:
+  ///
+  /// * [Theme.of]
+  static TextTheme of(BuildContext context, { bool shadowThemeOnly = false }) {
+    return Theme.of(context, shadowThemeOnly: shadowThemeOnly).textTheme;
+  }
 
   /// Creates a copy of this text theme but with the given fields replaced with
   /// the new values.

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -208,4 +208,28 @@ void main() {
     expect(lerped.subtitle2, null);
     expect(lerped.overline, null);
   });
+
+  testWidgets('TextTheme retrieved from Theme', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          textTheme: const TextTheme(
+            headline1: TextStyle(color: Colors.red),
+          ),
+        ),
+        home: Scaffold(
+          body: Builder(builder: (BuildContext context) {
+            return Text(
+              'text',
+              style: TextTheme.of(context).headline1,
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(
+        Theme.of(tester.element(find.text('text'))).textTheme.headline1.color,
+        equals(Colors.red));
+  });
 }


### PR DESCRIPTION
## Description

`Theme.of(context).textTheme` is quite a bit of boilerplate, having a `TextTheme.of(context)` would be a good addition.

## Related Issues

Fixes #65410.

## Tests

I added the following tests:

`TextTheme retrieved from Theme`.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
