### PR TITLE
[flutter_tools] handle terminals that do not support single char mode in Terminal.promptForCharInput

### DIFF
--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -275,7 +275,7 @@ class AnsiTerminal implements Terminal {
       assert(defaultChoiceIndex >= 0 && defaultChoiceIndex < acceptedCharacters.length);
       charactersToDisplay = List<String>.of(charactersToDisplay);
       charactersToDisplay[defaultChoiceIndex] = bolden(charactersToDisplay[defaultChoiceIndex]);
-      acceptedCharacters.add('\n');
+      acceptedCharacters.add('');
     }
     String choice;
     singleCharMode = true;
@@ -288,11 +288,11 @@ class AnsiTerminal implements Terminal {
         // prompt ends with ': '
         logger.printStatus(': ', emphasis: true, newline: false);
       }
-      choice = await keystrokes.first;
+      choice = (await keystrokes.first).trim();
       logger.printStatus(choice);
     }
     singleCharMode = false;
-    if (defaultChoiceIndex != null && choice == '\n') {
+    if (defaultChoiceIndex != null && choice == '') {
       choice = acceptedCharacters[defaultChoiceIndex];
     }
     return choice;

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -120,6 +120,9 @@ abstract class Terminal {
   /// will be the character in `acceptedCharacters` at the index given by
   /// `defaultChoiceIndex`.
   ///
+  /// The accepted characters must be a String with a length of 1, excluding any
+  /// whitespace characters such as `\t`, `\n`, or ` `.
+  ///
   /// If [usesTerminalUi] is false, throws a [StateError].
   Future<String> promptForCharInput(
     List<String> acceptedCharacters, {

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -143,7 +143,6 @@ void main() {
           bufferLogger.statusText,
           'Please choose something [a|b|c]: d\n'
           'Please choose something [a|b|c]: \n'
-          '\n'
           'Please choose something [a|b|c]: b\n');
     });
 
@@ -166,9 +165,9 @@ void main() {
 
       expect(choice, 'b');
       expect(
-          bufferLogger.statusText,
-          'Please choose something: \n'
-          '\n');
+        bufferLogger.statusText,
+        'Please choose something: \n'
+      );
     });
 
     testWithoutContext('Does not set single char mode when a terminal is not attached', () {


### PR DESCRIPTION
## Description

Some terminals stdin do not support single char mode (like an emacs terminal buffer apparently). If this is the case, then the presented choice values would always have an appended newline `\n` which would prevent us from finding the value in the listed index (or using it as a signal for the default choice). To fix, treat '' as the default choice and always trim the choice value.

While this has seemingly always been broken, it wasn't noticeable until the multi-device selection prompt was added a few months ago.

Fixes https://github.com/flutter/flutter/issues/65267