### PR TITLE
[flutter_tools] only lock if an upgrade/download will be performed (linux/macos) and output building messages to stderr

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -27,11 +27,11 @@ IF NOT EXIST "%flutter_root%\.git" (
   ECHO        The flutter tool requires Git in order to operate properly;
   ECHO        to set up Flutter, run the following command:
   ECHO        git clone -b stable https://github.com/flutter/flutter.git
-  EXIT /B 1
+  EXIT 1
 )
 
 REM Include shared scripts in shared.bat
-SET shared_bin=%FLUTTER_ROOT%/bin/internal/shared.bat
+SET shared_bin=%FLUTTER_ROOT%\bin\internal\shared.bat
 CALL "%shared_bin%"
 
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -142,7 +142,7 @@ GOTO :after_subroutine
         GOTO :retry_pub_upgrade
       :upgrade_retries_exhausted
         SET exit_code=%ERRORLEVEL%
-        ECHO Error: 'pub upgrade' still failing after %total_tries% tries, giving up. 1>&2
+        ECHO Error: 'pub upgrade' still failing after %total_tries% tries. 1>&2
         GOTO final_exit
       :upgrade_succeeded
     ENDLOCAL

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -95,8 +95,6 @@ GOTO :after_subroutine
     REM PowerShell command must have exit code set in order to prevent all non-zero exit codes from being translated
     REM into 1. The exit code 2 is used to detect the case where the major version is incorrect and there should be
     REM no subsequent retries.
-    REM PowerShell redirects all output streams to stdout by default, redirect these to stderr to avoid breaking
-    REM machine mode that parses stdout as structured data.
     ECHO Downloading Dart SDK from Flutter engine %dart_required_version%... 1>&2
     %powershell_executable% -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'; exit $LASTEXITCODE;"
     IF "%ERRORLEVEL%" EQU "2" (

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -22,13 +22,13 @@ function retry_upgrade {
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
     (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY" --no-precompile) && break
-    echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
     return 1
   fi
   return 0
@@ -94,14 +94,14 @@ function _wait_for_lock () {
       # Print with a return so that if the Dart code also prints this message
       # when it does its own lock, the message won't appear twice. Be sure that
       # the clearing printf below has the same number of space characters.
-      printf "Waiting for another flutter command to release the startup lock...\r";
+      printf "Waiting for another flutter command to release the startup lock...\r" >&2;
       waiting_message_displayed="true"
     fi
     sleep .1;
   done
   if [[ $waiting_message_displayed == "true" ]]; then
     # Clear the waiting message so it doesn't overlap any following text.
-    printf "                                                                  \r";
+    printf "                                                                  \r" >&2;
   fi
   unset waiting_message_displayed
   # If the lock file is acquired, make sure that it is removed on exit.
@@ -138,7 +138,7 @@ function upgrade_flutter () (
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
     VERBOSITY="--verbosity=error"
 
-    echo Building flutter tool...
+    >&2 echo Building flutter tool...
     if [[ "$CI" == "true" || "$BOT" == "true" || "$CONTINUOUS_INTEGRATION" == "true" || "$CHROME_HEADLESS" == "1" ]]; then
       PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
       VERBOSITY="--verbosity=normal"
@@ -186,24 +186,24 @@ function shared::execute() {
 
   # Test if running as superuser – but don't warn if running within Docker
   if [[ "$EUID" == "0" && ! -f /.dockerenv ]]; then
-    echo "   Woah! You appear to be trying to run flutter as root."
-    echo "   We strongly recommend running the flutter tool without superuser privileges."
-    echo "  /"
-    echo "📎"
+    >&2 echo "   Woah! You appear to be trying to run flutter as root."
+    >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
+    >&2 echo "  /"
+    >&2 echo "📎"
   fi
 
   # Test if Git is available on the Host
   if ! hash git 2>/dev/null; then
-    echo "Error: Unable to find git in your PATH."
+    >&2 echo "Error: Unable to find git in your PATH."
     exit 1
   fi
   # Test if the flutter directory is a git clone (otherwise git rev-parse HEAD
   # would fail)
   if [[ ! -e "$FLUTTER_ROOT/.git" ]]; then
-    echo "Error: The Flutter directory is not a clone of the GitHub project."
-    echo "       The flutter tool requires Git in order to operate properly;"
-    echo "       to install Flutter, see the instructions at:"
-    echo "       https://flutter.dev/get-started"
+    >&2 echo "Error: The Flutter directory is not a clone of the GitHub project."
+    >&2 echo "       The flutter tool requires Git in order to operate properly;"
+    >&2 echo "       to install Flutter, see the instructions at:"
+    >&2 echo "       https://flutter.dev/get-started"
     exit 1
   fi
 
@@ -225,7 +225,7 @@ function shared::execute() {
       "$DART" "$@"
       ;;
     *)
-      echo "Error! Executable name $BIN_NAME not recognized!"
+      >&2 echo "Error! Executable name $BIN_NAME not recognized!"
       exit 1
       ;;
   esac

--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -38,7 +38,6 @@ if ((Test-Path $engineStamp) -and ($engineVersion -eq (Get-Content $engineStamp)
     return
 }
 
-Write-Host "Downloading Dart SDK from Flutter engine $engineVersion..."
 $dartSdkBaseUrl = $Env:FLUTTER_STORAGE_BASE_URL
 if (-not $dartSdkBaseUrl) {
     $dartSdkBaseUrl = "https://storage.googleapis.com"
@@ -71,7 +70,6 @@ Catch {
     $ProgressPreference = $OriginalProgressPreference
 }
 
-Write-Host "Unzipping Dart SDK..."
 If (Get-Command 7z -errorAction SilentlyContinue) {
     # The built-in unzippers are painfully slow. Use 7-Zip, if available.
     & 7z x $dartSdkZip "-o$cachePath" -bd | Out-Null

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -102,7 +102,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     >&2 echo
     >&2 echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
     >&2 echo "If you're located in China, please see this page:"
-    e>&2 cho "  https://flutter.dev/community/china"
+    >&2 echo "  https://flutter.dev/community/china"
     >&2 echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -23,25 +23,25 @@ ENGINE_VERSION=`cat "$FLUTTER_ROOT/bin/internal/engine.version"`
 
 if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; then
   command -v curl > /dev/null 2>&1 || {
-    echo
-    echo 'Missing "curl" tool. Unable to download Dart SDK.'
+    >&2 echo
+    >&2 echo 'Missing "curl" tool. Unable to download Dart SDK.'
     case "$(uname -s)" in
       Darwin)
-        echo 'Consider running "brew install curl".'
+        >&2 echo 'Consider running "brew install curl".'
         ;;
       Linux)
-        echo 'Consider running "sudo apt-get install curl".'
+        >&2 echo 'Consider running "sudo apt-get install curl".'
         ;;
       *)
-        echo "Please install curl."
+        >&2 echo "Please install curl."
         ;;
     esac
     echo
     exit 1
   }
   command -v unzip > /dev/null 2>&1 || {
-    echo
-    echo 'Missing "unzip" tool. Unable to extract Dart SDK.'
+    >&2 echo
+    >&2 echo 'Missing "unzip" tool. Unable to extract Dart SDK.'
     case "$(uname -s)" in
       Darwin)
         echo 'Consider running "brew install unzip".'
@@ -56,7 +56,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     echo
     exit 1
   }
-  echo "Downloading Dart SDK from Flutter engine $ENGINE_VERSION..."
+  >&2 echo "Downloading Dart SDK from Flutter engine $ENGINE_VERSION..."
 
   case "$(uname -s)" in
     Darwin)
@@ -99,20 +99,20 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   DART_SDK_ZIP="$FLUTTER_ROOT/bin/cache/$DART_ZIP_NAME"
 
   curl --retry 3 --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
-    echo
-    echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
-    echo "If you're located in China, please see this page:"
-    echo "  https://flutter.dev/community/china"
-    echo
+    >&2 echo
+    >&2 echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
+    >&2 echo "If you're located in China, please see this page:"
+    e>&2 cho "  https://flutter.dev/community/china"
+    >&2 echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1
   }
   unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
-    echo
-    echo "It appears that the downloaded file is corrupt; please try again."
-    echo "If this problem persists, please report the problem at:"
-    echo "  https://github.com/flutter/flutter/issues/new?template=ACTIVATION.md"
-    echo
+    >&2 echo
+    >&2 echo "It appears that the downloaded file is corrupt; please try again."
+    >&2 echo "If this problem persists, please report the problem at:"
+    >&2 echo "  https://github.com/flutter/flutter/issues/new?template=ACTIVATION.md"
+    >&2 echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1
   }

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -529,6 +529,10 @@ linter:
     );
     final List<String> stderr = result.stderr.toString().trim().split('\n');
     final List<String> stdout = result.stdout.toString().trim().split('\n');
+    // Remove output from building the flutter tool.
+    stderr.removeWhere((String line) {
+      return line.startsWith('Building flutter tool...');
+    });
     // Check out the stderr to see if the analyzer had it's own issues.
     if (stderr.isNotEmpty && (stderr.first.contains(' issues found. (ran in ') || stderr.first.contains(' issue found. (ran in '))) {
       // The "23 issues found" message goes onto stderr, which is concatenated first.

--- a/dev/bots/test/analyze-sample-code_test.dart
+++ b/dev/bots/test/analyze-sample-code_test.dart
@@ -14,7 +14,7 @@ void main() {
     );
     final List<String> stdoutLines = process.stdout.toString().split('\n');
     final List<String> stderrLines = process.stderr.toString().split('\n')
-      ..removeWhere((String line) => line.startsWith('Analyzer output:'));
+      ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
       'known_broken_documentation.dart:30:9: new Opacity(',


### PR DESCRIPTION
## Description

Currently an invocation of flutter/dart will always attempt to acquire a lock. This can pose problems for tools that attempt to run multiple dart/flutter instances.

Instead update the lock logic (on Linux/macOS) so that we only attempt to acquire it if an update/snapshot needs to be performed. To avoid repeatedly performing downloads/snapshots if multiple flutter/dart invocations are fired off concurrently when an update needs to be performed, do a second check of the download/snapshot condition after the lock is released.

Additionally, moves all of the building/debug output to stderr on both the bash and batch scripts. This allows machine mode consumption of the tool to ignore needing to parse/handle the rebuild messages.

fyi @devoncarew 
