### PR TITLE
[flutter_tools] remove advice about running sdkmanager directly in favor of directing to flutter.dev

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -113,9 +113,7 @@ class UserMessages {
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
   String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
-      'To update using sdkmanager, run:\n'
-      '  "$managerPath" "platforms;android-$sdkMinVersion" "build-tools;$buildToolsMinVersion"\n'
-      'or visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
+      'To update the Android SDK visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
 
   // Messages used in AndroidStudioValidator
   String androidStudioVersion(String version) => 'version $version';


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/65414

the sdkmanager requires JDK 1.8 in order to run without crashing (compilation for Android itself can use newer versions). Usually this is provided via Android Studio, and when AS uses the sdkmanager is likely sets the JAVA_HOME so that the command is guaranteed to work. The advice to run from the command line is likely to fail if the user does not have JAVA_HOME already set to the AS JDK or another compatible JDK. 

Remove this advice in favor of directing users towards the existing documentation on using AS.