### PR TITLE
[devicelab] Remove ~/.gradle after each devicelab task run

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -157,4 +157,8 @@ Future<void> cleanupSystem() async {
   } else {
     print('Could not determine JAVA_HOME; not shutting down Gradle.');
   }
+  // Removes the .gradle directory because sometimes gradle fails in updating
+  // itself and leaves corrupted zip archives, which could cause the next
+  // devicelab task to fail. https://github.com/flutter/flutter/issues/65277
+  rmTree(dir('${Platform.environment['HOME']}/.gradle'));
 }

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -157,8 +157,9 @@ Future<void> cleanupSystem() async {
   } else {
     print('Could not determine JAVA_HOME; not shutting down Gradle.');
   }
-  // Removes the .gradle directory because sometimes gradle fails in updating
-  // itself and leaves corrupted zip archives, which could cause the next
-  // devicelab task to fail. https://github.com/flutter/flutter/issues/65277
+  // Removes the .gradle directory because sometimes gradle fails in downloading
+  // a new version and leaves a corrupted zip archive, which could cause the
+  // next devicelab task to fail.
+  // https://github.com/flutter/flutter/issues/65277
   rmTree(dir('${Platform.environment['HOME']}/.gradle'));
 }


### PR DESCRIPTION
Bug: https://github.com/flutter/flutter/issues/65277

