### PR TITLE
Always use POSIX paths for generated CMake files

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -929,20 +929,30 @@ Future<void> _writeIOSPluginRegistrant(FlutterProject project, List<Plugin> plug
   }
 }
 
+/// The relative path from a project's main CMake file to the plugin symlink
+/// directory to use in the generated plugin CMake file.
+///
+/// Because the generated file is checked in, it can't use absolute paths. It is
+/// designed to be included by the main CMakeLists.txt, so it relative to
+/// that file, rather than the generated file.
+String _cmakeRelativePluginSymlinkDirectoryPath(CmakeBasedProject project) {
+  final String makefileDirPath = project.cmakeFile.parent.absolute.path;
+  // CMake alway uses posix-style path separators, regardless of the platform.
+  final path.Context cmakePathContext = path.Context(style: path.Style.posix);
+  final List<String> relativePathComponents = globals.fs.path.split(globals.fs.path.relative(
+    project.pluginSymlinkDirectory.absolute.path,
+    from: makefileDirPath,
+  ));
+  return cmakePathContext.joinAll(relativePathComponents);
+}
+
 Future<void> _writeLinuxPluginFiles(FlutterProject project, List<Plugin> plugins) async {
   final List<Plugin>nativePlugins = _filterNativePlugins(plugins, LinuxPlugin.kConfigKey);
   final List<Map<String, dynamic>> linuxPlugins = _extractPlatformMaps(nativePlugins, LinuxPlugin.kConfigKey);
-  // The generated file is checked in, so can't use absolute paths. It is
-  // included by the main CMakeLists.txt, so relative paths must be relative to
-  // that file's directory.
-  final String makefileDirPath = project.linux.cmakeFile.parent.absolute.path;
   final Map<String, dynamic> context = <String, dynamic>{
     'os': 'linux',
     'plugins': linuxPlugins,
-    'pluginsDir': globals.fs.path.relative(
-      project.linux.pluginSymlinkDirectory.absolute.path,
-      from: makefileDirPath,
-    ),
+    'pluginsDir': _cmakeRelativePluginSymlinkDirectoryPath(project.linux),
   };
   await _writeLinuxPluginRegistrant(project.linux.managedDirectory, context);
   await _writePluginCmakefile(project.linux.generatedPluginCmakeFile, context);
@@ -1005,19 +1015,10 @@ List<Plugin> _filterNativePlugins(List<Plugin> plugins, String platformKey) {
 Future<void> _writeWindowsPluginFiles(FlutterProject project, List<Plugin> plugins) async {
   final List<Plugin>nativePlugins = _filterNativePlugins(plugins, WindowsPlugin.kConfigKey);
   final List<Map<String, dynamic>> windowsPlugins = _extractPlatformMaps(nativePlugins, WindowsPlugin.kConfigKey);
-  // The generated file is checked in, so can't use absolute paths. It is
-  // included by the main CMakeLists.txt, so relative paths must be relative to
-  // that file's directory.
-  final String makefileDirPath = project.windows.cmakeFile.parent.absolute.path;
-  final path.Context cmakePathContext = path.Context(style: path.Style.posix);
-  final List<String> relativePathComponents = globals.fs.path.split(globals.fs.path.relative(
-    project.windows.pluginSymlinkDirectory.absolute.path,
-    from: makefileDirPath,
-  ));
   final Map<String, dynamic> context = <String, dynamic>{
     'os': 'windows',
     'plugins': windowsPlugins,
-    'pluginsDir': cmakePathContext.joinAll(relativePathComponents),
+    'pluginsDir': _cmakeRelativePluginSymlinkDirectoryPath(project.windows),
   };
   await _writeCppPluginRegistrant(project.windows.managedDirectory, context);
   await _writePluginCmakefile(project.windows.generatedPluginCmakeFile, context);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -336,6 +336,9 @@ abstract class CmakeBasedProject {
 
   /// Includable CMake with rules and variables for plugin builds.
   File get generatedPluginCmakeFile;
+
+  /// The directory to write plugin symlinks.
+  Directory get pluginSymlinkDirectory;
 }
 
 /// Represents the iOS sub-project of a Flutter project.
@@ -1043,6 +1046,9 @@ class WindowsProject extends FlutterProjectPlatform implements CmakeBasedProject
   @override
   File get generatedPluginCmakeFile => managedDirectory.childFile('generated_plugins.cmake');
 
+  @override
+  Directory get pluginSymlinkDirectory => ephemeralDirectory.childDirectory('.plugin_symlinks');
+
   Directory get _editableDirectory => parent.directory.childDirectory('windows');
 
   /// The directory in the project that is managed by Flutter. As much as
@@ -1054,9 +1060,6 @@ class WindowsProject extends FlutterProjectPlatform implements CmakeBasedProject
   /// generated on the fly. All generated files that are not intended to be
   /// checked in should live here.
   Directory get ephemeralDirectory => managedDirectory.childDirectory('ephemeral');
-
-  /// The directory to write plugin symlinks.
-  Directory get pluginSymlinkDirectory => ephemeralDirectory.childDirectory('.plugin_symlinks');
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {}
 }
@@ -1097,7 +1100,7 @@ class LinuxProject extends FlutterProjectPlatform implements CmakeBasedProject {
   @override
   File get generatedPluginCmakeFile => managedDirectory.childFile('generated_plugins.cmake');
 
-  /// The directory to write plugin symlinks.
+  @override
   Directory get pluginSymlinkDirectory => ephemeralDirectory.childDirectory('.plugin_symlinks');
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {}


### PR DESCRIPTION
## Description

The Windows plugin CMake generation had code to ensure that the paths
written to it used POSIX separators, but the Linux version didn't; that
meant that plugin updates run on Windows machines would corrupt the
generated (but checked in) Linux CMake file.

This change shares that code so that both will use POSIX paths
regardless of what OS they are generated on.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64591

## Tests

I added the following tests: Ensures that both Windows and Linux files have the correct separators when run with a Windows-style filesystem.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
