### PR TITLE
[web] Inform the engine when read-only flag is flipped

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -880,6 +880,11 @@ class TextInputConnection {
     TextInput._instance._requestAutofill();
   }
 
+  void updateConfig(TextInputConfiguration configuration) {
+    assert(attached);
+    TextInput._instance._updateConfig(configuration);
+  }
+
   /// Requests that the text input control change its internal state to match the given state.
   void setEditingState(TextEditingValue value) {
     assert(attached);
@@ -1209,6 +1214,14 @@ class TextInput {
     _channel.invokeMethod<void>('TextInput.clearClient');
     _currentConnection = null;
     _scheduleHide();
+  }
+
+  void _updateConfig(TextInputConfiguration configuration) {
+    assert(configuration != null);
+    _channel.invokeMethod<void>(
+      'TextInput.updateConfig',
+      configuration.toJson(),
+    );
   }
 
   void _setEditingState(TextEditingValue value) {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -880,6 +880,8 @@ class TextInputConnection {
     TextInput._instance._requestAutofill();
   }
 
+  /// Requests that the text input control update itself according to the new
+  /// [TextInputConfiguration].
   void updateConfig(TextInputConfiguration configuration) {
     assert(attached);
     TextInput._instance._updateConfig(configuration);

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1566,15 +1566,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       }
     }
 
-    if (kIsWeb && oldWidget.readOnly != widget.readOnly) {
-      _textInputConnection.updateConfig(textInputConfiguration);
+    if (kIsWeb && _hasInputConnection) {
+      if (oldWidget.readOnly != widget.readOnly) {
+        _textInputConnection!.updateConfig(textInputConfiguration);
+      }
     }
 
     if (widget.style != oldWidget.style) {
       final TextStyle style = widget.style;
       // The _textInputConnection will pick up the new style when it attaches in
       // _openInputConnection.
-      if (_textInputConnection != null && _textInputConnection!.attached) {
+      if (_hasInputConnection) {
         _textInputConnection!.setStyle(
           fontFamily: style.fontFamily,
           fontSize: style.fontSize,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1561,8 +1561,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (!_shouldCreateInputConnection) {
       _closeInputConnectionIfNeeded();
     } else {
-      if (oldWidget.readOnly && _hasFocus)
+      if (oldWidget.readOnly && _hasFocus) {
         _openInputConnection();
+      }
+    }
+
+    if (kIsWeb && oldWidget.readOnly != widget.readOnly) {
+      _textInputConnection.updateConfig(textInputConfiguration);
     }
 
     if (widget.style != oldWidget.style) {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1436,6 +1436,44 @@ void main() {
     }
   });
 
+  testWidgets('Sends "updateConfig" when read-only flag is flipped', (WidgetTester tester) async {
+    bool readOnly = true;
+    StateSetter setState;
+    final TextEditingController controller = TextEditingController(text: 'Lorem ipsum dolor sit amet');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(builder: (BuildContext context, StateSetter stateSetter) {
+          setState = stateSetter;
+          return EditableText(
+            readOnly: readOnly,
+            controller: controller,
+            backgroundCursorColor: Colors.grey,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+          );
+        }),
+      ),
+    );
+
+    // Interact with the field to establish the input connection.
+    final Offset topLeft = tester.getTopLeft(find.byType(EditableText));
+    await tester.tapAt(topLeft + const Offset(0.0, 5.0));
+    await tester.pump();
+
+    expect(tester.testTextInput.hasAnyClients, kIsWeb ? isTrue : isFalse);
+    if (kIsWeb) {
+      expect(tester.testTextInput.setClientArgs['readOnly'], isTrue);
+    }
+
+    setState(() { readOnly = false; });
+    await tester.pump();
+
+    expect(tester.testTextInput.hasAnyClients, isTrue);
+    expect(tester.testTextInput.setClientArgs['readOnly'], isFalse);
+  });
+
   testWidgets('Fires onChanged when text changes via TextSelectionOverlay', (WidgetTester tester) async {
     String changedValue;
     final Widget widget = MaterialApp(

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -98,6 +98,9 @@ class TestTextInput {
         _client = methodCall.arguments[0] as int;
         setClientArgs = methodCall.arguments[1] as Map<String, dynamic>;
         break;
+      case 'TextInput.updateConfig':
+        setClientArgs = methodCall.arguments as Map<String, dynamic>;
+        break;
       case 'TextInput.clearClient':
         _client = 0;
         _isVisible = false;


### PR DESCRIPTION
## Description

Text editing in Flutter sends input configuration to the engine when the connection is established, but it never updates it. Input configuration could change during the lifetime of the `EditableText` widget, but the engine will remain out-of-sync in this case.

So far, the only issue we received that's related to this is https://github.com/flutter/flutter/issues/64636 so I fixed it in this PR, but I expect other issues to pop up at some point in the future.

Depends on engine PR: https://github.com/flutter/engine/pull/21048

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64636

## Tests

I added the following tests:

- `test/widgets/editable_text_test.dart`.