### PR TITLE
Sort generated plugin file content by plugin name

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -1161,6 +1161,8 @@ Future<void> refreshPluginsList(FlutterProject project, {bool checkProjects = fa
 /// Assumes [refreshPluginsList] has been called since last change to `pubspec.yaml`.
 Future<void> injectPlugins(FlutterProject project, {bool checkProjects = false}) async {
   final List<Plugin> plugins = await findPlugins(project);
+  // Sort the plugins by name to keep ordering stable in generated files.
+  plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
   if ((checkProjects && project.android.existsSync()) || !checkProjects) {
     await _writeAndroidPluginRegistrant(project, plugins);
   }

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/time.dart';
+import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -122,37 +123,57 @@ void main() {
       );
     });
 
-    const String _pluginYaml = '''
+    // Makes fake plugin packages for each plugin, adds them to flutterProject,
+    // and returns their directories.
+    //
+    // If an entry contains a path separator, it will be treated as a path for
+    // the location of the package, with the name being the last component.
+    // Otherwise it will be treated as a name, and put in a default location
+    // (a fake pub cache).
+    List<Directory> createFakePlugins(FileSystem fileSystem, List<String> pluginNamesOrPaths) {
+      const String pluginYamlTemplate = '''
   flutter:
     plugin:
       platforms:
         ios:
-          pluginClass: SomePlugin
+          pluginClass: PLUGIN_CLASS
         macos:
-          pluginClass: SomePlugin
+          pluginClass: PLUGIN_CLASS
         windows:
-          pluginClass: SomePlugin
+          pluginClass: PLUGIN_CLASS
         linux:
-          pluginClass: SomePlugin
+          pluginClass: PLUGIN_CLASS
         web:
-          pluginClass: SomePlugin
-          fileName: lib/SomeFile.dart
+          pluginClass: PLUGIN_CLASS
+          fileName: lib/PLUGIN_CLASS.dart
         android:
-          pluginClass: SomePlugin
+          pluginClass: PLUGIN_CLASS
           package: AndroidPackage
   ''';
 
+      final List<Directory> directories = <Directory>[];
+      final Directory fakePubCache = fileSystem.systemTempDirectory.childDirectory('cache');
+      final File packagesFile = flutterProject.directory.childFile('.packages')
+            ..createSync(recursive: true);
+      for (final String nameOrPath in pluginNamesOrPaths) {
+        final String name = fileSystem.path.basename(nameOrPath);
+        final Directory pluginDirectory = (nameOrPath == name)
+            ? fakePubCache.childDirectory(name)
+            : fileSystem.directory(nameOrPath);
+        packagesFile.writeAsStringSync(
+            '$name:file://${pluginDirectory.childFile('lib').uri}\n',
+            mode: FileMode.writeOnlyAppend);
+        pluginDirectory.childFile('pubspec.yaml')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(pluginYamlTemplate.replaceAll('PLUGIN_CLASS', toTitleCase(camelCase(name))));
+        directories.add(pluginDirectory);
+      }
+      return directories;
+    }
+
     // Makes a fake plugin package, adds it to flutterProject, and returns its directory.
     Directory createFakePlugin(FileSystem fileSystem) {
-      const String name = 'apackage';
-      final Directory packageDirectory = fileSystem.systemTempDirectory.childDirectory('cache').childDirectory(name);
-      flutterProject.directory.childFile('.packages')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('$name:file://${packageDirectory.childFile('lib').uri}\n');
-      packageDirectory.childFile('pubspec.yaml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(_pluginYaml);
-      return packageDirectory;
+      return createFakePlugins(fileSystem, <String>['some_plugin'])[0];
     }
 
     void createNewJavaPlugin1() {
@@ -1034,7 +1055,7 @@ flutter:
 
         expect(pluginMakefile.existsSync(), isTrue);
         final String contents = pluginMakefile.readAsStringSync();
-        expect(contents, contains('apackage'));
+        expect(contents, contains('some_plugin'));
         expect(contents, contains('target_link_libraries(\${BINARY_NAME} PRIVATE \${plugin}_plugin)'));
         expect(contents, contains('list(APPEND PLUGIN_BUNDLED_LIBRARIES \$<TARGET_FILE:\${plugin}_plugin>)'));
         expect(contents, contains('list(APPEND PLUGIN_BUNDLED_LIBRARIES \${\${plugin}_bundled_libraries})'));
@@ -1044,6 +1065,32 @@ flutter:
         FeatureFlags: () => featureFlags,
       });
 
+      testUsingContext('Generated Linux plugin files sorts by plugin name', () async {
+        when(linuxProject.existsSync()).thenReturn(true);
+        when(featureFlags.isLinuxEnabled).thenReturn(true);
+        when(flutterProject.isModule).thenReturn(false);
+        createFakePlugins(fs, <String>[
+          'plugin_d',
+          'plugin_a',
+          '/local_plugins/plugin_c',
+          '/local_plugins/plugin_b'
+        ]);
+
+        await injectPlugins(flutterProject, checkProjects: true);
+
+        final File pluginCmakeFile = linuxProject.generatedPluginCmakeFile;
+        final File pluginRegistrant = linuxProject.managedDirectory.childFile('generated_plugin_registrant.cc');
+        for (final File file in <File>[pluginCmakeFile, pluginRegistrant]) {
+          final String contents = file.readAsStringSync();
+          expect(contents.indexOf('plugin_a'), lessThan(contents.indexOf('plugin_b')));
+          expect(contents.indexOf('plugin_b'), lessThan(contents.indexOf('plugin_c')));
+          expect(contents.indexOf('plugin_c'), lessThan(contents.indexOf('plugin_d')));
+        }
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+      });
 
       testUsingContext('Injecting creates generated Windows registrant', () async {
         when(windowsProject.existsSync()).thenReturn(true);
@@ -1119,22 +1166,27 @@ flutter:
         FeatureFlags: () => featureFlags,
       });
 
-      testUsingContext('Injecting creates generated Windows plugin CMake file', () async {
+      testUsingContext('Generated Windows plugin files sorts by plugin name', () async {
         when(windowsProject.existsSync()).thenReturn(true);
         when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
-        createFakePlugin(fs);
+        createFakePlugins(fs, <String>[
+          'plugin_d',
+          'plugin_a',
+          '/local_plugins/plugin_c',
+          '/local_plugins/plugin_b'
+        ]);
 
         await injectPlugins(flutterProject, checkProjects: true);
 
-        final File pluginMakefile = windowsProject.generatedPluginCmakeFile;
-
-        expect(pluginMakefile.existsSync(), isTrue);
-        final String contents = pluginMakefile.readAsStringSync();
-        expect(contents, contains('apackage'));
-        expect(contents, contains('target_link_libraries(\${BINARY_NAME} PRIVATE \${plugin}_plugin)'));
-        expect(contents, contains('list(APPEND PLUGIN_BUNDLED_LIBRARIES \$<TARGET_FILE:\${plugin}_plugin>)'));
-        expect(contents, contains('list(APPEND PLUGIN_BUNDLED_LIBRARIES \${\${plugin}_bundled_libraries})'));
+        final File pluginCmakeFile = windowsProject.generatedPluginCmakeFile;
+        final File pluginRegistrant = windowsProject.managedDirectory.childFile('generated_plugin_registrant.cc');
+        for (final File file in <File>[pluginCmakeFile, pluginRegistrant]) {
+          final String contents = file.readAsStringSync();
+          expect(contents.indexOf('plugin_a'), lessThan(contents.indexOf('plugin_b')));
+          expect(contents.indexOf('plugin_b'), lessThan(contents.indexOf('plugin_c')));
+          expect(contents.indexOf('plugin_c'), lessThan(contents.indexOf('plugin_d')));
+        }
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -1183,7 +1235,7 @@ flutter:
         // refreshPluginsList should call createPluginSymlinks.
         await refreshPluginsList(flutterProject);
 
-        expect(linuxProject.pluginSymlinkDirectory.childLink('apackage').existsSync(), true);
+        expect(linuxProject.pluginSymlinkDirectory.childLink('some_plugin').existsSync(), true);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -1196,7 +1248,7 @@ flutter:
         // refreshPluginsList should call createPluginSymlinks.
         await refreshPluginsList(flutterProject);
 
-        expect(windowsProject.pluginSymlinkDirectory.childLink('apackage').existsSync(), true);
+        expect(windowsProject.pluginSymlinkDirectory.childLink('some_plugin').existsSync(), true);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -1282,8 +1334,8 @@ flutter:
         await refreshPluginsList(flutterProject);
 
         final List<Link> links = <Link>[
-          linuxProject.pluginSymlinkDirectory.childLink('apackage'),
-          windowsProject.pluginSymlinkDirectory.childLink('apackage'),
+          linuxProject.pluginSymlinkDirectory.childLink('some_plugin'),
+          windowsProject.pluginSymlinkDirectory.childLink('some_plugin'),
         ];
         for (final Link link in links) {
           link.deleteSync();
@@ -1318,7 +1370,26 @@ flutter:
       }
 
       test('validatePubspecForPlugin works', () async {
-        _createPubspecFile(_pluginYaml);
+        const String pluginYaml = '''
+  flutter:
+    plugin:
+      platforms:
+        ios:
+          pluginClass: SomePlugin
+        macos:
+          pluginClass: SomePlugin
+        windows:
+          pluginClass: SomePlugin
+        linux:
+          pluginClass: SomePlugin
+        web:
+          pluginClass: SomePlugin
+          fileName: lib/SomeFile.dart
+        android:
+          pluginClass: SomePlugin
+          package: AndroidPackage
+  ''';
+        _createPubspecFile(pluginYaml);
         validatePubspecForPlugin(projectDir: projectDir.absolute.path, pluginClass: 'SomePlugin', expectedPlatforms: <String>[
           'ios', 'macos', 'windows', 'linux', 'android', 'web'
         ], androidIdentifier: 'AndroidPackage', webFileName: 'lib/SomeFile.dart');


### PR DESCRIPTION
## Description

Plugins in generated files are currently using whatever order they have
from lower layers of the code; in practice it seems to be sorted based
on file path, but there's nothing obviously guaranteeing that. That can
also lead to some odd ordering when a project includes local plugins.

This sorts the plugins by plugin name before generating files from them,
ensuring that there is a stable (which avoids churn, given that these
are files that developers check in) and intuitive order in the generated
files.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55899

## Tests

I added the following tests: Verifies ordering in the generated plugin files on Windows and Linux. (macOS tests would require a way of bypassing the pod steps in the tests, which doesn't seem to exist in the test fixtures currently.)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
