### PR TITLE
Have the analyzer bot ignore .DS_Store files.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1141,6 +1141,8 @@ Iterable<File> _allFiles(String workingDirectory, String extension, { @required 
         continue;
       if (path.basename(entity.path) == 'gradlew.bat')
         continue;
+      if (path.basename(entity.path) == '.DS_Store')
+        continue;
       if (extension == null || path.extension(entity.path) == '.$extension') {
         matches += 1;
         yield entity;


### PR DESCRIPTION
## Description

The analyzer bot will currently choke on .DS_Store files (index files that appear on macos). This PR just ignores them when generating the list of files to analyze.

