### PR TITLE
Mark `platform_views_scroll_perf_ios__timeline_summary` as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -479,6 +479,7 @@ tasks:
       Measures the runtime performance of platform views in the Complex Layout sample app on iPhone 6.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
+    flaky: true
 
   flutter_gallery_ios32__start_up:
     description: >


### PR DESCRIPTION
Mark the test as flaky to unblock the tree.

https://github.com/flutter/flutter/issues/65556