### PR TITLE
Move the registration of the restoration channel to binding initialization

### DIFF
--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -97,6 +97,25 @@ typedef _BucketVisitor = void Function(RestorationBucket bucket);
 ///  * [RestorationMixin], which uses [RestorationBucket]s behind the scenes
 ///    to make [State] objects of [StatefulWidget]s restorable.
 class RestorationManager extends ChangeNotifier {
+  /// Construct the restoration manager and set up the communications channels
+  /// with the engine to get restoration messages (by calling [initChannels]).
+  RestorationManager() {
+    initChannels();
+  }
+
+  /// Sets up the method call handler for [SystemChannels.restoration].
+  ///
+  /// This is called by the constructor to configure the communications channel
+  /// with the Flutter engine to get restoration messages.
+  ///
+  /// Subclasses (especially in tests) can override this to avoid setting up
+  /// that communications channel, or to set it up differently, as necessary.
+  @protected
+  void initChannels() {
+    assert(!SystemChannels.restoration.checkMethodCallHandler(_methodHandler));
+    SystemChannels.restoration.setMethodCallHandler(_methodHandler);
+  }
+
   /// The root of the [RestorationBucket] hierarchy containing the restoration
   /// data.
   ///
@@ -128,9 +147,6 @@ class RestorationManager extends ChangeNotifier {
   ///  * [RootRestorationScope], which makes the root bucket available in the
   ///    [Widget] tree.
   Future<RestorationBucket?> get rootBucket {
-    if (!SystemChannels.restoration.checkMethodCallHandler(_methodHandler)) {
-      SystemChannels.restoration.setMethodCallHandler(_methodHandler);
-    }
     if (_rootBucketIsValid) {
       return SynchronousFuture<RestorationBucket?>(_rootBucket);
     }

--- a/packages/flutter/test/services/channel_buffers_test.dart
+++ b/packages/flutter/test/services/channel_buffers_test.dart
@@ -15,8 +15,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestChannelBuffersFlutterBinding extends BindingBase with SchedulerBinding, ServicesBinding {
-}
+class TestChannelBuffersFlutterBinding extends BindingBase with SchedulerBinding, ServicesBinding { }
 
 void main() {
   ByteData _makeByteData(String str) {

--- a/packages/flutter/test/services/restoration.dart
+++ b/packages/flutter/test/services/restoration.dart
@@ -10,10 +10,20 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class MockRestorationManager extends TestRestorationManager {
+  MockRestorationManager({ this.enableChannels = false });
+
   bool get updateScheduled => _updateScheduled;
   bool _updateScheduled = false;
 
   final List<RestorationBucket> _buckets = <RestorationBucket>[];
+
+  final bool enableChannels;
+
+  @override
+  void initChannels() {
+    if (enableChannels)
+      super.initChannels();
+  }
 
   @override
   void scheduleSerializationFor(RestorationBucket bucket) {


### PR DESCRIPTION
Having side-effects in a getter is surprising and unintuitive. This reduces the side-effects caused by RestorationManager.rootBucket.

Also, https://github.com/flutter/engine/pull/21062 is planning on making the message queue draining asynchronous, so we need to make sure that we subscribe to messages before the build phase is scheduled, otherwise we will be delaying the first frame by one cycle.
