### PR TITLE
Turn pinned sliver header temporarily to floating pinned sliver header when showOnScreen is called.

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -479,29 +479,6 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverFloatingPe
    );
   }
 
-  //@override
-  //void performLayout() {
-  //  final SliverConstraints constraints = this.constraints;
-  //  final double maxExtent = this.maxExtent;
-  //  final bool overlapsContent = constraints.overlap > 0.0;
-  //  layoutChild(constraints.scrollOffset, maxExtent, overlapsContent: overlapsContent);
-  //  final double effectiveRemainingPaintExtent = math.max(0, constraints.remainingPaintExtent - constraints.overlap);
-  //  final double layoutExtent = (maxExtent - constraints.scrollOffset).clamp(0.0, effectiveRemainingPaintExtent);
-  //  final double stretchOffset = stretchConfiguration != null ?
-  //    constraints.overlap.abs() :
-  //    0.0;
-  //  geometry = SliverGeometry(
-  //    scrollExtent: maxExtent,
-  //    paintOrigin: constraints.overlap,
-  //    paintExtent: math.min(childExtent, effectiveRemainingPaintExtent),
-  //    layoutExtent: layoutExtent,
-  //    maxPaintExtent: maxExtent + stretchOffset,
-  //    maxScrollObstructionExtent: minExtent,
-  //    cacheExtent: layoutExtent > 0.0 ? -constraints.cacheOrigin + layoutExtent : layoutExtent,
-  //    hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
-  //  );
-  //}
-
   @override
   double childMainAxisPosition(RenderBox child) => 0.0;
 
@@ -663,14 +640,14 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     return stretchOffset > 0 ? 0.0 : math.min(0.0, paintExtent - childExtent);
   }
 
-  // endValue: the target scrollOffset when the animation finishes.
+  // endValue: the target scrollOffset when the animation ends.
   void _updateAnimation(Duration duration, double endValue, Curve curve) {
     assert(duration != null);
     assert(endValue != null);
     assert(curve != null);
     assert(
       vsync != null,
-      'vsync must not be null if the floating header changes size animatedly.',
+      'vsync must not be null if the persistent header snaps or reveals with animation.',
     );
 
     final AnimationController effectiveController =

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -334,6 +334,11 @@ class _SliverScrollingPersistentHeader extends _SliverPersistentHeaderRenderObje
       stretchConfiguration: delegate.stretchConfiguration
     );
   }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverScrollingPersistentHeaderForWidgets renderObject) {
+    renderObject.stretchConfiguration = delegate.stretchConfiguration;
+  }
 }
 
 class _RenderSliverScrollingPersistentHeaderForWidgets extends RenderSliverScrollingPersistentHeader
@@ -359,9 +364,20 @@ class _SliverPinnedPersistentHeader extends _SliverPersistentHeaderRenderObjectW
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin createRenderObject(BuildContext context) {
     return _RenderSliverPinnedPersistentHeaderForWidgets(
+      vsync: delegate.vsync,
+      snapConfiguration: delegate.snapConfiguration,
       stretchConfiguration: delegate.stretchConfiguration,
       showOnScreenConfiguration: delegate.showOnScreenConfiguration,
     );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverPinnedPersistentHeaderForWidgets renderObject) {
+    renderObject
+      ..vsync = delegate.vsync
+      ..snapConfiguration = delegate.snapConfiguration
+      ..stretchConfiguration = delegate.stretchConfiguration
+      ..showOnScreenConfiguration = delegate.showOnScreenConfiguration;
   }
 }
 
@@ -369,10 +385,14 @@ class _RenderSliverPinnedPersistentHeaderForWidgets extends RenderSliverPinnedPe
   with _RenderSliverPersistentHeaderForWidgetsMixin {
   _RenderSliverPinnedPersistentHeaderForWidgets({
     RenderBox child,
+    @required TickerProvider vsync,
+    FloatingHeaderSnapConfiguration snapConfiguration,
     OverScrollHeaderStretchConfiguration stretchConfiguration,
     PersistentHeaderShowOnScreenConfiguration showOnScreenConfiguration,
   }) : super(
+    vsync: vsync,
     child: child,
+    snapConfiguration: snapConfiguration,
     stretchConfiguration: stretchConfiguration,
     showOnScreenConfiguration: showOnScreenConfiguration,
   );

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2038,6 +2038,102 @@ void main() {
     await buildAndVerifyConfig();
   });
 
+  testWidgets('SliverAppBar basic showOnScreen test: no snapping', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          controller: controller,
+          slivers: const <Widget>[
+            SliverAppBar(
+              title: Text('Jumbo'),
+              pinned: true,
+              showOnScreenConfiguration: PersistentHeaderShowOnScreenConfiguration.maxExpansion,
+              expandedHeight: 500,
+            ),
+            SliverPadding(padding: EdgeInsets.only(top: 1000)),
+          ],
+        ),
+      ),
+    );
+
+    controller.jumpTo(800);
+    await tester.pump();
+
+    final RenderSliverPinnedPersistentHeader pinnedHeader = tester
+      .renderObject<RenderSliverPinnedPersistentHeader>(find.byType(SliverPersistentHeader, skipOffstage: false));
+
+    // Ensure the header is minimized.
+    assert(pinnedHeader.child.size.height == pinnedHeader.minExtent);
+    pinnedHeader.showOnScreen();
+    await tester.pump();
+
+    expect(pinnedHeader.child.size.height, greaterThan(pinnedHeader.minExtent));
+    expect(pinnedHeader.child.size.height, pinnedHeader.maxExtent);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, 10));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    // SliverAppBar does not shrink as we're scrolling towards the wrong direction;
+    expect(pinnedHeader.child.size.height, pinnedHeader.maxExtent);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -10));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(pinnedHeader.child.size.height, pinnedHeader.maxExtent - 10);
+  });
+
+  testWidgets('SliverAppBar basic showOnScreen test: with snapping', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          controller: controller,
+          slivers: const <Widget>[
+            SliverAppBar(
+              title: Text('Jumbo'),
+              pinned: true,
+              snap: true,
+              showOnScreenConfiguration: PersistentHeaderShowOnScreenConfiguration.maxExpansion,
+              expandedHeight: 500,
+            ),
+            SliverPadding(padding: EdgeInsets.only(top: 1000)),
+          ],
+        ),
+      ),
+    );
+
+    controller.jumpTo(800);
+    await tester.pump();
+
+    final RenderSliverPinnedPersistentHeader pinnedHeader = tester
+      .renderObject<RenderSliverPinnedPersistentHeader>(find.byType(SliverPersistentHeader, skipOffstage: false));
+
+    // Ensure the header is minimized.
+    assert(pinnedHeader.child.size.height == pinnedHeader.minExtent);
+    pinnedHeader.showOnScreen();
+    await tester.pump();
+
+    expect(pinnedHeader.child.size.height, greaterThan(pinnedHeader.minExtent));
+    expect(pinnedHeader.child.size.height, pinnedHeader.maxExtent);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, 10));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    // SliverAppBar does not shrink as we're scrolling towards the wrong direction;
+    expect(pinnedHeader.child.size.height, pinnedHeader.maxExtent);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -10));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    // Snaps to minExtent.
+    expect(pinnedHeader.child.size.height, pinnedHeader.minExtent);
+  });
+
   testWidgets('AppBar respects toolbarHeight', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

Still need to update the docs. Running on frob to see how much of a breaking change this is.

With this change, a pinned non-floating header can temporarily turn itself into a pinned floating header when `showOnScreen` is called. This is to prevent the showOnScreen call from scrolling the content to the top, in an effort to reveal the contents of the header.
Also `snap` is allowed for pinned headers and will snap the header back to its normal state when it's currently in a "floating" state.

### Example

```dart
void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  // This widget is the root of your application.
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      home: Scaffold(
        body: MyHomePage(),
      ),
    );
  }
}

class MyHomePage extends StatefulWidget {
  @override
  State<StatefulWidget> createState() => PageState();
}

class PageState extends State<MyHomePage> {
  final Key centerKey = const Key('center');
  @override
  Widget build(BuildContext context) {
    return CustomScrollView(
      // center: centerKey,
      // reverse: true,
      slivers: <Widget>[
        SliverAppBar(
          pinned: true,
          //floating: true,
          title: const Text('YAY'),
          expandedHeight: 500,
          showOnScreenConfiguration: PersistentHeaderShowOnScreenConfiguration.maxExpansion,
          flexibleSpace: FlexibleSpaceBar(title: ColoredBox(color: Colors.red, child: TextField(scrollPadding: EdgeInsets.only(top: 200)))),
        ),
         SliverAppBar(
          pinned: true,
          //floating: true,
          title: const Text('YAY'),
          expandedHeight: 500,
          showOnScreenConfiguration: PersistentHeaderShowOnScreenConfiguration.maxExpansion,
          snap: true,
          flexibleSpace: FlexibleSpaceBar(title: ColoredBox(color: Colors.red, child: TextField(scrollPadding: EdgeInsets.only(top: 200)))),
        ),
         SliverAppBar(
          pinned: true,
          //floating: true,
          title: const Text('YAY'),
          expandedHeight: 500,
          showOnScreenConfiguration: PersistentHeaderShowOnScreenConfiguration.maxExpansion,
          flexibleSpace: FlexibleSpaceBar(title: ColoredBox(color: Colors.red, child: TextField(scrollPadding: EdgeInsets.only(top: 200)))),
        ),
        ...List<Widget>.generate(20, (int i) {
            final Widget sliver = SliverToBoxAdapter(
              child: Container(
                color: Colors.red,
                height: 100.0,
                child: Text('Tile $i'),
              ),
            );
            return SliverPadding(
              key: i == 19 ? centerKey : null,
              padding: const EdgeInsets.only(top: 2.0, bottom: 100.0),
              sliver: sliver,
            );
        })
      ] ,
    );
  }
}
```

![untitled](https://user-images.githubusercontent.com/31859944/92984117-cce5c400-f45c-11ea-86db-b5dc31fe53e3.gif)

## Related Issues

- https://github.com/flutter/flutter/issues/64973

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
