### PR TITLE
fix the bug of DropdownButton popup widget position error

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1178,8 +1178,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   TextStyle get _textStyle => widget.style ?? Theme.of(context).textTheme.subtitle1;
 
   void _handleTap() {
+    final RenderBox overlayBox = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final Offset overlayOffset = overlayBox.localToGlobal(Offset.zero);
     final RenderBox itemBox = context.findRenderObject() as RenderBox;
-    final Rect itemRect = itemBox.localToGlobal(Offset.zero) & itemBox.size;
+    final Rect itemGlobalRect = itemBox.localToGlobal(Offset.zero) & itemBox.size;
+    final Rect itemRect = itemGlobalRect.translate(-overlayOffset.dx, -overlayOffset.dy);
     final TextDirection textDirection = Directionality.of(context);
     final EdgeInsetsGeometry menuMargin = ButtonTheme.of(context).alignedDropdown
       ? _kAlignedMenuMargin

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1178,7 +1178,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   TextStyle get _textStyle => widget.style ?? Theme.of(context).textTheme.subtitle1;
 
   void _handleTap() {
-    final RenderBox overlayBox = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final RenderBox overlayBox = Navigator.of(context).overlay.context.findRenderObject() as RenderBox;
     final Offset overlayOffset = overlayBox.localToGlobal(Offset.zero);
     final RenderBox itemBox = context.findRenderObject() as RenderBox;
     final Rect itemGlobalRect = itemBox.localToGlobal(Offset.zero) & itemBox.size;

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2612,4 +2612,120 @@ void main() {
     expect(value, equals('two'));
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
+
+  testWidgets('DropdownButton positioning inside nested Overlay', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
+      .map<DropdownMenuItem<String>>((String value) {
+        return DropdownMenuItem<String>(
+          key: ValueKey<String>(value),
+          value: value,
+          child: Text(value),
+        );
+      }).toList();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Example')),
+          body: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Overlay(
+              initialEntries: <OverlayEntry>[
+                OverlayEntry(
+                  builder: (_) => Center(
+                    child: DropdownButton<String>(
+                      key: buttonKey,
+                      value: 'c',
+                      isDense: true,
+                      onChanged: (String newValue) {},
+                      items: itemsWithDuplicateValues,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder buttonFinder = find.byKey(buttonKey).last;
+    final Finder popupFinder = find.byKey(const ValueKey<String>('c')).last;
+    await tester.tap(buttonFinder);
+    await tester.pumpAndSettle();
+
+    final Offset buttonCenter = tester.getCenter(buttonFinder);
+    final Rect buttonRect = tester.getRect(buttonFinder);
+
+    final Offset popupCenter = tester.getCenter(popupFinder);
+    final Rect popupRect = tester.getRect(popupFinder);
+
+    expect(buttonRect.left, popupRect.left);
+    expect(buttonCenter.dy, popupCenter.dy);
+  });
+
+  testWidgets('DropdownButton positioning inside nested Navigator', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
+      .map<DropdownMenuItem<String>>((String value) {
+        return DropdownMenuItem<String>(
+          key: ValueKey<String>(value),
+          value: value,
+          child: Text(value),
+        );
+      }).toList();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          // appBar: AppBar(title: const Text('Example')),
+          body: Padding(
+            padding: const EdgeInsets.all(80.0),
+            child: Navigator(
+              onGenerateRoute: (RouteSettings settings) {
+                return MaterialPageRoute<dynamic>(
+                  builder: (BuildContext context) {
+                    return Container(
+                      child: Column(
+                        children: <Widget>[
+                          const SizedBox(
+                            height: 300.0,
+                          ),
+                          Container(
+                            width: 100.0,
+                            child: DropdownButton<String>(
+                              isDense: true,
+                              key: buttonKey,
+                              value: 'c',
+                              onChanged: (String newValue) {},
+                              items: itemsWithDuplicateValues,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder buttonFinder = find.byKey(buttonKey).last;
+    final Finder popupFinder = find.byKey(const ValueKey<String>('c')).last;
+    await tester.tap(buttonFinder);
+    await tester.pumpAndSettle();
+
+    final Offset buttonCenter = tester.getCenter(buttonFinder);
+    final Rect buttonRect = tester.getRect(buttonFinder);
+
+    final Offset popupCenter = tester.getCenter(popupFinder);
+    final Rect popupRect = tester.getRect(popupFinder);
+
+    expect(buttonRect.left, popupRect.left);
+    expect(buttonCenter.dy, popupCenter.dy);
+  });
 }


### PR DESCRIPTION
## Description

This bug will happen when the Navigator is not full screen, the code:

```dart
Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      body: Row(
        children: [
          SizedBox(
            width: 200.0,
          ),
          SizedBox(
            width: 800.0,
            child: Navigator(
              initialRoute: '/',
              onGenerateRoute: ((settings) {
                return MaterialPageRoute(builder: (context) {
                  return Container(
                    color: Colors.red,
                    child: Column(
                      children: [
                        Container(
                          width: 500.0,
                          child: DropdownButton<String>(
                            value: '1',
                            // underline: Container(height: 0),
                            isExpanded: true,
                            onChanged: (value) => setState(() => 1),
                            items: [
                              DropdownMenuItem(
                                value: '1',
                                child: Text('boy'),
                              ),
                              DropdownMenuItem(
                                value: '2',
                                child: Text('girl'),
                              )
                            ],
                          ),
                        ),
                      ],
                    ),
                  );
                });
              }),
            ),
          )
        ],
      ), 
    );
```


## Tests

above code ok

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


