### PR TITLE
Remove invalid assert in daemon

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1251,7 +1251,6 @@ class AppRunLogger extends Logger {
     bool multilineOutput = false,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
-    assert(timeout != null);
     final int id = _nextProgressId++;
 
     _sendProgressEvent(<String, dynamic>{


### PR DESCRIPTION
This assert fires if you run with asserts enabled with no cached artifacts, because there is code that passes `null`, for example:

https://github.com/flutter/flutter/blob/09a9671ed3e3b9887f314cac224256513cd8f87a/packages/flutter_tools/lib/src/cache.dart#L1469-L1472

As far as I can tell, it's allowed to passed null - nothing else fails, and the code this timeout is passed into seems to also handle null, for example:

https://github.com/flutter/flutter/blob/eadc35f62bf24d3746357eba4c34828f7c93fc84/packages/flutter_tools/lib/src/base/logger.dart#L600-L609