### PR TITLE
Buttons animate elevation changes before changing background color

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -222,8 +222,9 @@ class ElevatedButton extends ButtonStyleButton {
   /// * `shadowColor` - Theme.shadowColor
   /// * `elevation`
   ///   * disabled - 0
-  ///   * hovered or focused - 2
-  ///   * pressed - 6
+  ///   * default - 2
+  ///   * hovered or focused - 4
+  ///   * pressed - 8
   /// * `padding`
   ///   * textScaleFactor <= 1 - horizontal(16)
   ///   * `1 < textScaleFactor <= 2` - lerp(horizontal(16), horizontal(8))

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -13,53 +13,6 @@ import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('Elevated buttons animate elevation before color on disable', (WidgetTester tester) async {
-    // This is a regression test for https://github.com/flutter/flutter/issues/387
-
-    const ColorScheme colorScheme = ColorScheme.light();
-    final Color backgroundColor = colorScheme.primary;
-    final Color disabledBackgroundColor = colorScheme.onSurface.withOpacity(0.12);
-
-    Widget buildFrame({ bool enabled }) {
-      return MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
-        home: Center(
-          child: ElevatedButton(
-            onPressed: enabled ? () { } : null,
-            child: const Text('button'),
-          ),
-        ),
-      );
-    }
-
-    PhysicalShape physicalShape() {
-      return tester.widget<PhysicalShape>(
-        find.descendant(
-          of: find.byType(ElevatedButton),
-          matching: find.byType(PhysicalShape),
-        ),
-      );
-    }
-
-    // Default elevation is 2, background color is primary.
-    await tester.pumpWidget(buildFrame(enabled: true));
-    expect(physicalShape().elevation, 2);
-    expect(physicalShape().color, backgroundColor);
-
-    // Disabled elevation animates to 0 over 200ms, THEN the background
-    // color changes to onSurface.withOpacity(0.12)
-    await tester.pumpWidget(buildFrame(enabled: false));
-    await tester.pump(const Duration(milliseconds: 50));
-    expect(physicalShape().elevation, lessThan(2));
-    expect(physicalShape().color, backgroundColor);
-    await tester.pump(const Duration(milliseconds: 150));
-    expect(physicalShape().elevation, 0);
-    expect(physicalShape().color, backgroundColor);
-    await tester.pumpAndSettle();
-    expect(physicalShape().elevation, 0);
-    expect(physicalShape().color, disabledBackgroundColor);
-  });
-
   testWidgets('ElevatedButton defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
 
@@ -976,6 +929,53 @@ void main() {
       ),
     );
     expect(paddingWidget.padding, const EdgeInsets.all(22));
+  });
+
+  testWidgets('Elevated buttons animate elevation before color on disable', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/387
+
+    const ColorScheme colorScheme = ColorScheme.light();
+    final Color backgroundColor = colorScheme.primary;
+    final Color disabledBackgroundColor = colorScheme.onSurface.withOpacity(0.12);
+
+    Widget buildFrame({ bool enabled }) {
+      return MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme),
+        home: Center(
+          child: ElevatedButton(
+            onPressed: enabled ? () { } : null,
+            child: const Text('button'),
+          ),
+        ),
+      );
+    }
+
+    PhysicalShape physicalShape() {
+      return tester.widget<PhysicalShape>(
+        find.descendant(
+          of: find.byType(ElevatedButton),
+          matching: find.byType(PhysicalShape),
+        ),
+      );
+    }
+
+    // Default elevation is 2, background color is primary.
+    await tester.pumpWidget(buildFrame(enabled: true));
+    expect(physicalShape().elevation, 2);
+    expect(physicalShape().color, backgroundColor);
+
+    // Disabled elevation animates to 0 over 200ms, THEN the background
+    // color changes to onSurface.withOpacity(0.12)
+    await tester.pumpWidget(buildFrame(enabled: false));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(physicalShape().elevation, lessThan(2));
+    expect(physicalShape().color, backgroundColor);
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(physicalShape().elevation, 0);
+    expect(physicalShape().color, backgroundColor);
+    await tester.pumpAndSettle();
+    expect(physicalShape().elevation, 0);
+    expect(physicalShape().color, disabledBackgroundColor);
   });
 }
 

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -13,12 +13,54 @@ import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('ElevatedButton defaults', (WidgetTester tester) async {
-    final Finder rawButtonMaterial = find.descendant(
-      of: find.byType(ElevatedButton),
-      matching: find.byType(Material),
-    );
+  testWidgets('Elevated buttons animate elevation before color on disable', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/387
 
+    const ColorScheme colorScheme = ColorScheme.light();
+    final Color backgroundColor = colorScheme.primary;
+    final Color disabledBackgroundColor = colorScheme.onSurface.withOpacity(0.12);
+
+    Widget buildFrame({ bool enabled }) {
+      return MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme),
+        home: Center(
+          child: ElevatedButton(
+            onPressed: enabled ? () { } : null,
+            child: const Text('button'),
+          ),
+        ),
+      );
+    }
+
+    PhysicalShape physicalShape() {
+      return tester.widget<PhysicalShape>(
+        find.descendant(
+          of: find.byType(ElevatedButton),
+          matching: find.byType(PhysicalShape),
+        ),
+      );
+    }
+
+    // Default elevation is 2, background color is primary.
+    await tester.pumpWidget(buildFrame(enabled: true));
+    expect(physicalShape().elevation, 2);
+    expect(physicalShape().color, backgroundColor);
+
+    // Disabled elevation animates to 0 over 200ms, THEN the background
+    // color changes to onSurface.withOpacity(0.12)
+    await tester.pumpWidget(buildFrame(enabled: false));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(physicalShape().elevation, lessThan(2));
+    expect(physicalShape().color, backgroundColor);
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(physicalShape().elevation, 0);
+    expect(physicalShape().color, backgroundColor);
+    await tester.pumpAndSettle();
+    expect(physicalShape().elevation, 0);
+    expect(physicalShape().color, disabledBackgroundColor);
+  });
+
+  testWidgets('ElevatedButton defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
 
     // Enabled ElevatedButton
@@ -33,6 +75,12 @@ void main() {
         ),
       ),
     );
+
+    final Finder rawButtonMaterial = find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(Material),
+    );
+
 
     Material material = tester.widget<Material>(rawButtonMaterial);
     expect(material.animationDuration, const Duration(milliseconds: 200));
@@ -87,6 +135,9 @@ void main() {
         ),
       ),
     );
+
+    // Finish the elevation animation, final background color change.
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(rawButtonMaterial);
     expect(material.animationDuration, const Duration(milliseconds: 200));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/387

To avoid the background "flashing" problem outlined here https://github.com/flutter/flutter/issues/387#issuecomment-683160342, TextButton, ElevatedButton, and OutlinedButton will handle simultaneous changes to their elevation and background color by animating the elevation change first, and then changing the background color.  This transition most commonly occurs when and ElevatedButton is disabled.

This change doesn't affect any other aspect of the buttons' appearance. Each button's underlying Material widget does not animate its background color but it does animate its elevation.

Note also: the issue addressed by this change, #387, is the 7th oldest open issue. It's 5 years old. UGH.