### PR TITLE
Fix minor comment formatting issues

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -893,10 +893,10 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   /// ```dart
   /// FlutterError.demangleStackTrace = (StackTrace stackTrace) {
   ///   if (stack is stack_trace.Trace)
-  //      return stack.vmTrace;
-  //    if (stack is stack_trace.Chain)
-  //      return stack.toTrace().vmTrace;
-  //    return stack;
+  ///     return stack.vmTrace;
+  ///   if (stack is stack_trace.Chain)
+  ///     return stack.toTrace().vmTrace;
+  ///   return stack;
   /// };
   /// ```
   static StackTraceDemangler demangleStackTrace = (StackTrace stackTrace) => stackTrace;

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -194,7 +194,7 @@ class _ZoomPageTransition extends StatelessWidget {
   /// See also:
   ///
   ///  * [TransitionRoute.secondaryAnimation], which is the value given to this
-  //     property when the [_ZoomPageTransition] is used as a page transition.
+  ///    property when the [_ZoomPageTransition] is used as a page transition.
   final Animation<double> secondaryAnimation;
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/lib/src/rendering/error.dart
+++ b/packages/flutter/lib/src/rendering/error.dart
@@ -91,7 +91,7 @@ class RenderErrorBox extends RenderBox {
   /// See also:
   ///
   ///  * [minimumWidth], which controls how wide the box must be before the
-  //     horizontal padding is applied.
+  ///    horizontal padding is applied.
   static EdgeInsets padding = const EdgeInsets.fromLTRB(64.0, 96.0, 64.0, 12.0);
 
   /// The width below which the horizontal padding is not applied.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3491,7 +3491,7 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
   ///  * [SemanticsNode.parentPaintClipRect] for the source and definition
   ///    of the `parentPaintClipRect` argument.
   ///  * [SemanticsNode.elevationAdjustment] for the source and definition
-  ///   of the `elevationAdjustment` argument.
+  ///    of the `elevationAdjustment` argument.
   void compileChildren({
     required Rect? parentSemanticsClipRect,
     required Rect? parentPaintClipRect,

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3489,9 +3489,9 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
   ///  * [SemanticsNode.parentSemanticsClipRect] for the source and definition
   ///    of the `parentSemanticsClipRect` argument.
   ///  * [SemanticsNode.parentPaintClipRect] for the source and definition
-  //     of the `parentPaintClipRect` argument.
+  ///    of the `parentPaintClipRect` argument.
   ///  * [SemanticsNode.elevationAdjustment] for the source and definition
-  //    of the `elevationAdjustment` argument.
+  ///   of the `elevationAdjustment` argument.
   void compileChildren({
     required Rect? parentSemanticsClipRect,
     required Rect? parentPaintClipRect,

--- a/packages/flutter/test/material/page_selector_test.dart
+++ b/packages/flutter/test/material/page_selector_test.dart
@@ -92,7 +92,7 @@ void main() {
     tabController.animateTo(1, duration: const Duration(milliseconds: 200));
     await tester.pump();
     // Verify that indicator 0's color is becoming increasingly transparent,
-    /// and indicator 1's color is becoming increasingly opaque during the
+    // and indicator 1's color is becoming increasingly opaque during the
     // 200ms animation. Indicator 2 remains transparent throughout.
     await tester.pump(const Duration(milliseconds: 10));
     List<Color> colors = indicatorColors(tester);


### PR DESCRIPTION
This PR fixes some minor formatting issues with comments throughout the framework.

Mostly comments that misplaced `///` with `//`.