### PR TITLE
Fix FormFieldState value not in sync with the onChanged value from TextFormField.

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -232,10 +232,10 @@ class TextFormField extends FormField<String> {
          final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
              .applyDefaults(Theme.of(field.context).inputDecorationTheme);
          void onChangedHandler(String value) {
+           field.didChange(value);
            if (onChanged != null) {
              onChanged(value);
            }
-           field.didChange(value);
          }
          return TextField(
            controller: state._effectiveController,

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -431,6 +431,28 @@ void main() {
     expect(find.text('changedValue'), findsOneWidget);
   });
 
+  testWidgets('onChanged callbacks value and FormFieldState.value are sync', (WidgetTester tester) async {
+    FormFieldState<String> state;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              onChanged: (String value) {
+                expect(value, state.value);
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    state = tester.state<FormFieldState<String>>(find.byType(TextFormField));
+
+    await tester.enterText(find.byType(TextField), 'Soup');
+  });
+
   testWidgets('autofillHints is passed to super', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -432,6 +432,8 @@ void main() {
   });
 
   testWidgets('onChanged callbacks value and FormFieldState.value are sync', (WidgetTester tester) async {
+    bool _called = false;
+
     FormFieldState<String> state;
 
     await tester.pumpWidget(
@@ -440,6 +442,7 @@ void main() {
           child: Center(
             child: TextFormField(
               onChanged: (String value) {
+                _called = true;
                 expect(value, state.value);
               },
             ),
@@ -451,6 +454,8 @@ void main() {
     state = tester.state<FormFieldState<String>>(find.byType(TextFormField));
 
     await tester.enterText(find.byType(TextField), 'Soup');
+
+    expect(_called, true);
   });
 
   testWidgets('autofillHints is passed to super', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fix FormFieldState value not in sync with the onChanged value from TextFormField.

example:

```dart
import 'package:flutter/material.dart';

void main() => runApp(MaterialApp(home: MyApp()));

class MyApp extends StatefulWidget {
  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  final key = GlobalKey<FormFieldState>();

  @override
  Widget build(BuildContext context) {
    return SafeArea(
      child: Scaffold(
        body: TextFormField (
            key: key,
            onChanged: (value) {
              print('onChanged: $value');
              print('currentState.value: ${key.currentState.value}');
            }),
      ),
    );
  }
}
```

input foo before log:

```
flutter: onChanged: f
flutter: currentState.value:
flutter: onChanged: fo
flutter: currentState.value: f
flutter: onChanged: foo
flutter: currentState.value: fo
```

after:
```
flutter: onChanged: f
flutter: currentState.value: f
flutter: onChanged: fo
flutter: currentState.value: fo
flutter: onChanged: foo
flutter: currentState.value: foo
```

## Related Issues

#36543


## Tests

I added the following tests:

add onChanged callbacks value and FormFieldState.value are sync for text_form_field_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
