### PR TITLE
Make sure all isolates start during flutter driver tests.

### DIFF
--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -72,6 +72,10 @@ void main() {
         connectionLog.add('streamListen');
         return null;
       });
+      when(mockPeer.sendRequest('setFlag', any)).thenAnswer((Invocation invocation) {
+        connectionLog.add('setFlag');
+        return null;
+      });
       when(mockIsolate.pauseEvent).thenReturn(MockVMPauseStartEvent());
       when(mockIsolate.resume()).thenAnswer((Invocation invocation) {
         connectionLog.add('resume');
@@ -85,8 +89,25 @@ void main() {
       final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is paused at start');
-      expect(connectionLog, <String>['resume', 'streamListen', 'onExtensionAdded']);
+      expect(connectionLog, <String>['setFlag', 'resume', 'streamListen', 'onExtensionAdded']);
     });
+
+    test('ignores setFlag failure', () async {
+      when(mockPeer.sendRequest('setFlag', any)).thenThrow(Exception('setFlag failed'));
+      when(mockIsolate.pauseEvent).thenReturn(MockVMPauseStartEvent());
+      when(mockIsolate.resume()).thenAnswer((Invocation invocation) {
+        return Future<dynamic>.value(null);
+      });
+      when(mockIsolate.onExtensionAdded).thenAnswer((Invocation invocation) {
+        return Stream<String>.fromIterable(<String>['ext.flutter.driver']);
+      });
+
+      final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
+      expectLogContains('Failed to set pause_isolates_on_start=false, proceeding. '
+                        'Error: Exception: setFlag failed');
+      expect(driver, isNotNull);
+    });
+
 
     test('connects to isolate paused mid-flight', () async {
       when(mockIsolate.pauseEvent).thenReturn(MockVMPauseBreakpointEvent());


### PR DESCRIPTION
## Description

Fixes #24703.

Flutter driver has problems when flutter apps use more than a single isolate. The other isolates don't start, so apps malfunction. This PR fixes the problem by telling the dart VM to let new isolates start automatically. This only happens if the first isolate is found paused; otherwise we don't mess with the flag.

There have been two previous attempts at fixing this bug.

https://github.com/flutter/flutter/pull/61841 was reverted because it broke a fragile test app.
https://github.com/flutter/flutter/pull/64432 because of timing issues when a hot reload/hot restart occurred while flutter driver was connected with the app.

Thanks to tvolkert@ for pointing out an alternate approach that uses a dart VM feature to keep flutter driver code simpler. Hopefully this approach is more stable, but given history this one might get rolled back too.

## Related Issues

24703

## Tests

I added the following tests:

* Added unit tests in flutter_driver_test.dart to verify that all isolates have resume() invoked.
* Ran devicelab tests for the flutter gallery app, verifying that the bug that caused this change to be reverted last time (#62239) doesn't reoccur.
* Added a new example app that uses isolates, and tested it on several platfoms: macos, android simulator and physical devices, ios simulator and physical devices.
* Manually tested against an app that uses isolates started from native plugins.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.