### PR TITLE
[flutter_tools] fix failure to create ansi spinner if download needs to be retired

### DIFF
--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -81,7 +81,10 @@ class OutputPreferences {
 
 /// The command line terminal, if available.
 abstract class Terminal {
-  factory Terminal.test() = _TestTerminal;
+  /// Create a new test [Terminal].
+  ///
+  /// If not specified, [supportsColor] defaults to `false`.
+  factory Terminal.test({bool supportsColor}) = _TestTerminal;
 
   /// Whether the current terminal supports color escape codes.
   bool get supportsColor;
@@ -300,6 +303,8 @@ class AnsiTerminal implements Terminal {
 }
 
 class _TestTerminal implements Terminal {
+  _TestTerminal({this.supportsColor = false});
+
   @override
   bool usesTerminalUi;
 
@@ -329,7 +334,7 @@ class _TestTerminal implements Terminal {
   set singleCharMode(bool value) { }
 
   @override
-  bool get supportsColor => false;
+  final bool supportsColor;
 
   @override
   bool get supportsEmoji => false;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1466,13 +1466,14 @@ class ArtifactUpdater {
   ) async {
     final String downloadPath = flattenNameSubdirs(url, _fileSystem);
     final File tempFile = _createDownloadFile(downloadPath);
-    final Status status = _logger.startProgress(
-      message,
-      timeout: null, // This will take a variable amount of time based on network connectivity.
-    );
+    Status status;
     int retries = _kRetryCount;
 
     while (retries > 0) {
+      status = _logger.startProgress(
+        message,
+        timeout: null, // This will take a variable amount of time based on network connectivity.
+      );
       try {
         _ensureExists(tempFile.parent);
         final IOSink ioSink = tempFile.openWrite();


### PR DESCRIPTION
## Description

Because the Status spinner was only created on setup, the second stop would asset/crash.


Fixes https://github.com/flutter/flutter/issues/65449