### PR TITLE
Updated references to obsolete Material button classes in benchmarks/test_apps/stocks

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -25,7 +25,7 @@ class _NotImplementedDialog extends StatelessWidget {
       title: const Text('Not Implemented'),
       content: const Text('This feature has not yet been implemented.'),
       actions: <Widget>[
-        FlatButton(
+        TextButton(
           onPressed: debugDumpApp,
           child: Row(
             children: <Widget>[
@@ -40,7 +40,7 @@ class _NotImplementedDialog extends StatelessWidget {
             ],
           ),
         ),
-        FlatButton(
+        TextButton(
           onPressed: () {
             Navigator.pop(context, false);
           },

--- a/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
@@ -72,13 +72,13 @@ class StockSettingsState extends State<StockSettings> {
               title: const Text('Change mode?'),
               content: const Text('Optimistic mode means everything is awesome. Are you sure you can handle that?'),
               actions: <Widget>[
-                FlatButton(
+                TextButton(
                   child: const Text('NO THANKS'),
                   onPressed: () {
                     Navigator.pop(context, false);
                   },
                 ),
-                FlatButton(
+                TextButton(
                   child: const Text('AGREE'),
                   onPressed: () {
                     Navigator.pop(context, true);


### PR DESCRIPTION
Replaced (4) uses of FlatButton with TextButton in benchmarks/test_apps/stocks per #59702.