### PR TITLE
Don't use flock on MacOS because it's not compatible

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -42,9 +42,9 @@ function _rmlock () {
 # Determines which lock method to use, based on what is available on the system.
 # Returns a non-zero value if the lock was not acquired, zero if acquired.
 #
-# There is macOS version of flock but it's not compatible: 1) it doesn't support 
+# There is macOS version of flock but it's not compatible: 1) it doesn't support
 # `exclusive` option and 2) it doesn't support `--` option format. We can't use
-# flock even if it's installed on macOS, otherwise this function will fail and 
+# flock even if it's installed on macOS, otherwise this function will fail and
 # flutter command will be blocked by it.
 # by this.
 function _lock () {

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -43,12 +43,10 @@ function _rmlock () {
 # Returns a non-zero value if the lock was not acquired, zero if acquired.
 #
 # There is macOS version of flock but it's not compatible: 1) it doesn't support
-# `exclusive` option and 2) it doesn't support `--` option format. We can't use
-# flock even if it's installed on macOS, otherwise this function will fail and
-# flutter command will be blocked by it.
-# by this.
+# `exclusive` option and 2) it doesn't support `--` option format. Do not use
+# flock on macOS, otherwise this function will fail and the script will stall.
 function _lock () {
-  if ! [[ $OS =~ Darwin.* ]] && hash flock 2>/dev/null; then
+  if ! [[ $(uname -s) =~ Darwin.* ]] && hash flock 2>/dev/null; then
     flock --nonblock --exclusive 7 2>/dev/null
   elif hash shlock 2>/dev/null; then
     shlock -f "$1" -p $$

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -42,7 +42,7 @@ function _rmlock () {
 # Determines which lock method to use, based on what is available on the system.
 # Returns a non-zero value if the lock was not acquired, zero if acquired.
 function _lock () {
-  if hash flock 2>/dev/null; then
+  if ! [[ $OS =~ Darwin.* ]] && hash flock 2>/dev/null; then
     flock --nonblock --exclusive 7 2>/dev/null
   elif hash shlock 2>/dev/null; then
     shlock -f "$1" -p $$

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -41,6 +41,12 @@ function _rmlock () {
 
 # Determines which lock method to use, based on what is available on the system.
 # Returns a non-zero value if the lock was not acquired, zero if acquired.
+#
+# There is macOS version of flock but it's not compatible: 1) it doesn't support 
+# `exclusive` option and 2) it doesn't support `--` option format. We can't use
+# flock even if it's installed on macOS, otherwise this function will fail and 
+# flutter command will be blocked by it.
+# by this.
 function _lock () {
   if ! [[ $OS =~ Darwin.* ]] && hash flock 2>/dev/null; then
     flock --nonblock --exclusive 7 2>/dev/null


### PR DESCRIPTION
## Description

There's an issue in the `shared.sh` that flutter command is blocked by `Waiting for another flutter command to release the startup lock...` on macOS if `flock` is installed. 

Root cause of the issue: There is macOS version of `flock` but it's not compatible: 1) it doesn't support `exclusive` option and 2) it doesn't support `--` option format. We can't use flock even if it's installed on macOS, otherwise the `lock` function will fail and flutter command will be blocked by it.

Propose solution: Check OS in `lock` function and skip using `flock` even if it exists on macOS.

## Related Issues

https://github.com/flutter/flutter/issues/65807

## Tests

I added the following tests:

I've manually tested it on macOS with flock installed.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
