### PR TITLE
[flutter] elide semantic information from certain widget spans

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -918,16 +918,18 @@ class RenderParagraph extends RenderBox
       );
 
       if (info.isPlaceholder) {
-        final SemanticsNode childNode = children.elementAt(placeholderIndex++);
-        final TextParentData parentData = child!.parentData as TextParentData;
-        childNode.rect = Rect.fromLTWH(
-          childNode.rect.left,
-          childNode.rect.top,
-          childNode.rect.width * parentData.scale!,
-          childNode.rect.height * parentData.scale!,
-        );
-        newChildren.add(childNode);
-        child = childAfter(child);
+        if (children.isNotEmpty) {
+          final SemanticsNode childNode = children.elementAt(placeholderIndex++);
+          final TextParentData parentData = child!.parentData as TextParentData;
+          childNode.rect = Rect.fromLTWH(
+            childNode.rect.left,
+            childNode.rect.top,
+            childNode.rect.width * parentData.scale!,
+            childNode.rect.height * parentData.scale!,
+          );
+          newChildren.add(childNode);
+          child = childAfter(child);
+        }
       } else {
         final SemanticsConfiguration configuration = SemanticsConfiguration()
           ..sortKey = OrdinalSortKey(ordinal++)

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1004,7 +1004,7 @@ void main() {
         ),
       ],
     )));
-  }, semanticsEnabled: true);
+  }, semanticsEnabled: true, skip: isBrowser); // Browser semantics have different sizes.
 }
 
 Future<void> _pumpTextWidget({ WidgetTester tester, String text, TextOverflow overflow }) {


### PR DESCRIPTION
## Description

If a widget span has no children, avoid reading them which causes a RangeError crash.

Fixes https://github.com/flutter/flutter/issues/65818