### PR TITLE
[flutter_tools] handle archive exception from invalid zip signature

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:archive/archive.dart';
 import 'package:meta/meta.dart';
 
 import 'android/gradle_utils.dart';
@@ -1511,6 +1512,13 @@ class ArtifactUpdater {
       try {
         extractor(tempFile, location);
       } on ProcessException {
+        retries -= 1;
+        if (retries == 0) {
+          rethrow;
+        }
+        _deleteIgnoringErrors(tempFile);
+        continue;
+      } on ArchiveException {
         retries -= 1;
         if (retries == 0) {
           rethrow;


### PR DESCRIPTION
## Description

Like the ProcessException thrown from zip running on a bad file, the tool should catch the ArchiveException thrown from windows implementation using package:archive.