### PR TITLE
Updated references to obsolete Material button classes in benchmarks/macrobenchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -67,105 +67,105 @@ class HomePage extends StatelessWidget {
       body: ListView(
         key: const Key(kScrollableName),
         children: <Widget>[
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kCullOpacityRouteName),
             child: const Text('Cull opacity'),
             onPressed: () {
               Navigator.pushNamed(context, kCullOpacityRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kCubicBezierRouteName),
             child: const Text('Cubic Bezier'),
             onPressed: () {
               Navigator.pushNamed(context, kCubicBezierRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kBackdropFilterRouteName),
             child: const Text('Backdrop Filter'),
             onPressed: () {
               Navigator.pushNamed(context, kBackdropFilterRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kPostBackdropFilterRouteName),
             child: const Text('Post Backdrop Filter'),
             onPressed: () {
               Navigator.pushNamed(context, kPostBackdropFilterRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kSimpleAnimationRouteName),
             child: const Text('Simple Animation'),
             onPressed: () {
               Navigator.pushNamed(context, kSimpleAnimationRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kPictureCacheRouteName),
             child: const Text('Picture Cache'),
             onPressed: () {
               Navigator.pushNamed(context, kPictureCacheRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kLargeImagesRouteName),
             child: const Text('Large Images'),
             onPressed: () {
               Navigator.pushNamed(context, kLargeImagesRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kTextRouteName),
             child: const Text('Text'),
             onPressed: () {
               Navigator.pushNamed(context, kTextRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kAnimatedPlaceholderRouteName),
             child: const Text('Animated Placeholder'),
             onPressed: () {
               Navigator.pushNamed(context, kAnimatedPlaceholderRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kColorFilterAndFadeRouteName),
             child: const Text('Color Filter and Fade'),
             onPressed: () {
               Navigator.pushNamed(context, kColorFilterAndFadeRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kFadingChildAnimationRouteName),
             child: const Text('Fading Child Animation'),
             onPressed: () {
               Navigator.pushNamed(context, kFadingChildAnimationRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kImageFilteredTransformAnimationRouteName),
             child: const Text('ImageFiltered Transform Animation'),
             onPressed: () {
               Navigator.pushNamed(context, kImageFilteredTransformAnimationRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kMultiWidgetConstructionRouteName),
             child: const Text('Widget Construction and Destruction'),
             onPressed: () {
               Navigator.pushNamed(context, kMultiWidgetConstructionRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kHeavyGridViewRouteName),
             child: const Text('Heavy Grid View'),
             onPressed: () {
               Navigator.pushNamed(context, kHeavyGridViewRouteName);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             key: const Key(kLargeImageChangerRouteName),
             child: const Text('Large Image Changer'),
             onPressed: () {


### PR DESCRIPTION
Replaced uses of RaisedButton with ElevatedButton in benchmarks/macrobenchmarks/lib/main.dart per #59702.