### PR TITLE
Updated references to obsolete Material button classes in examples

### DIFF
--- a/examples/layers/widgets/spinning_mixed.dart
+++ b/examples/layers/widgets/spinning_mixed.dart
@@ -50,7 +50,7 @@ void attachWidgetTreeToRenderTree(RenderProxyBox container) {
                 margin: const EdgeInsets.all(10.0),
                 child: Row(
                   children: <Widget>[
-                    RaisedButton(
+                    ElevatedButton(
                       child: Row(
                         children: <Widget>[
                           Image.network('https://flutter.dev/images/favicon.png'),

--- a/examples/platform_channel/lib/main.dart
+++ b/examples/platform_channel/lib/main.dart
@@ -65,7 +65,7 @@ class _PlatformChannelState extends State<PlatformChannel> {
               Text(_batteryLevel, key: const Key('Battery level label')),
               Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: const Text('Refresh'),
                   onPressed: _getBatteryLevel,
                 ),

--- a/examples/platform_channel_swift/lib/main.dart
+++ b/examples/platform_channel_swift/lib/main.dart
@@ -65,7 +65,7 @@ class _PlatformChannelState extends State<PlatformChannel> {
               Text(_batteryLevel, key: const Key('Battery level label')),
               Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: const Text('Refresh'),
                   onPressed: _getBatteryLevel,
                 ),


### PR DESCRIPTION
Replaced uses of RaisedButton with ElevatedButton in the examples directory per #59702.