### PR TITLE
Divider with subheader example update

### DIFF
--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -36,37 +36,52 @@ import 'theme.dart';
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/divider.png)
 ///
 /// ```dart
-/// Widget build(BuildContext context) {
-///   return Center(
-///     child: Column(
-///       children: <Widget>[
-///         Expanded(
-///           child: Container(
-///             color: Colors.amber,
-///             child: const Center(
-///               child: Text('Above'),
+///   Widget build(BuildContext context) {
+///     return Center(
+///       child: Column(
+///         children: <Widget>[
+///           Expanded(
+///             child: Container(
+///               color: Colors.amber,
+///               child: const Center(
+///                 child: Text('Above'),
+///               ),
 ///             ),
 ///           ),
-///         ),
-///         const Divider(
-///           color: Colors.black,
-///           height: 20,
-///           thickness: 5,
-///           indent: 20,
-///           endIndent: 0,
-///         ),
-///         Expanded(
-///           child: Container(
-///             color: Colors.blue,
-///             child: const Center(
-///               child: Text('Below'),
+///           const Divider(
+///             color: Colors.black,
+///             height: 20,
+///             thickness: 5,
+///             indent: 20,
+///             endIndent: 0,
+///           ),
+///           // Subheader example from Material spec.
+///           // https://material.io/components/dividers#types
+///           Container(
+///             padding: EdgeInsets.only(left: 20),
+///             child: Align(
+///               alignment: Alignment.centerLeft,
+///               child: Text(
+///                 'Subheader',
+///                 style: Theme.of(context).textTheme.bodyText2.copyWith(
+///                     fontSize: 12.0,
+///                     color: Theme.of(context).textTheme.caption.color),
+///                 textAlign: TextAlign.start,
+///               ),
 ///             ),
 ///           ),
-///         ),
-///       ],
-///     ),
-///   );
-/// }
+///           Expanded(
+///             child: Container(
+///               color: Colors.blue,
+///               child: const Center(
+///                 child: Text('Below'),
+///               ),
+///             ),
+///           ),
+///         ],
+///       ),
+///     );
+///   }
 /// ```
 /// {@end-tool}
 /// See also:

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -37,51 +37,52 @@ import 'theme.dart';
 ///
 /// ```dart
 ///   Widget build(BuildContext context) {
-///     return Center(
-///       child: Column(
-///         children: <Widget>[
-///           Expanded(
-///             child: Container(
-///               color: Colors.amber,
-///               child: const Center(
-///                 child: Text('Above'),
-///               ),
-///             ),
-///           ),
-///           const Divider(
-///             color: Colors.black,
-///             height: 20,
-///             thickness: 5,
-///             indent: 20,
-///             endIndent: 0,
-///           ),
-///           // Subheader example from Material spec.
-///           // https://material.io/components/dividers#types
-///           Container(
-///             padding: EdgeInsets.only(left: 20),
-///             child: Align(
-///               alignment: Alignment.centerLeft,
-///               child: Text(
-///                 'Subheader',
-///                 style: Theme.of(context).textTheme.bodyText2.copyWith(
-///                     fontSize: 12.0,
-///                     color: Theme.of(context).textTheme.caption.color),
-///                 textAlign: TextAlign.start,
-///               ),
-///             ),
-///           ),
-///           Expanded(
-///             child: Container(
-///               color: Colors.blue,
-///               child: const Center(
-///                 child: Text('Below'),
-///               ),
-///             ),
-///           ),
-///         ],
-///       ),
-///     );
-///   }
+///    return Center(
+///      child: Column(
+///        children: <Widget>[
+///          Expanded(
+///            child: Container(
+///              color: Colors.amber,
+///              child: const Center(
+///                child: Text('Above'),
+///              ),
+///            ),
+///          ),
+///          const Divider(
+///            color: Colors.black,
+///            height: 20,
+///            thickness: 5,
+///            indent: 20,
+///            endIndent: 20,
+///          ),
+///          // Subheader example from Material spec.
+///          // https://material.io/components/dividers#types
+///          Container(
+///            padding: EdgeInsets.only(left: 20),
+///            child: Align(
+///              alignment: AlignmentDirectional.centerStart,
+///              child: Text(
+///                'Subheader',
+///                style: Theme.of(context).textTheme.bodyText2.copyWith(
+///                  fontSize: 12.0,
+///                  color: Theme.of(context).textTheme.caption.color,
+///                ),
+///                textAlign: TextAlign.start,
+///              ),
+///            ),
+///          ),
+///          Expanded(
+///            child: Container(
+///              color: Colors.blue,
+///              child: const Center(
+///                child: Text('Below'),
+///              ),
+///            ),
+///          ),
+///        ],
+///      ),
+///    );
+///  }
 /// ```
 /// {@end-tool}
 /// See also:

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -49,7 +49,6 @@ import 'theme.dart';
 ///            ),
 ///          ),
 ///          const Divider(
-///            color: Colors.black,
 ///            height: 20,
 ///            thickness: 5,
 ///            indent: 20,
@@ -63,17 +62,14 @@ import 'theme.dart';
 ///              alignment: AlignmentDirectional.centerStart,
 ///              child: Text(
 ///                'Subheader',
-///                style: Theme.of(context).textTheme.bodyText2.copyWith(
-///                  fontSize: 12.0,
-///                  color: Theme.of(context).textTheme.caption.color,
-///                ),
+///                style: Theme.of(context).textTheme.caption,
 ///                textAlign: TextAlign.start,
 ///              ),
 ///            ),
 ///          ),
 ///          Expanded(
 ///            child: Container(
-///              color: Colors.blue,
+///              color: Theme.of(context).colorScheme.primary,
 ///              child: const Center(
 ///                child: Text('Below'),
 ///              ),

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -36,49 +36,49 @@ import 'theme.dart';
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/divider.png)
 ///
 /// ```dart
-///   Widget build(BuildContext context) {
-///    return Center(
-///      child: Column(
-///        children: <Widget>[
-///          Expanded(
-///            child: Container(
-///              color: Colors.amber,
-///              child: const Center(
-///                child: Text('Above'),
-///              ),
-///            ),
-///          ),
-///          const Divider(
-///            height: 20,
-///            thickness: 5,
-///            indent: 20,
-///            endIndent: 20,
-///          ),
-///          // Subheader example from Material spec.
-///          // https://material.io/components/dividers#types
-///          Container(
-///            padding: EdgeInsets.only(left: 20),
-///            child: Align(
-///              alignment: AlignmentDirectional.centerStart,
-///              child: Text(
-///                'Subheader',
-///                style: Theme.of(context).textTheme.caption,
-///                textAlign: TextAlign.start,
-///              ),
-///            ),
-///          ),
-///          Expanded(
-///            child: Container(
-///              color: Theme.of(context).colorScheme.primary,
-///              child: const Center(
-///                child: Text('Below'),
-///              ),
-///            ),
-///          ),
-///        ],
-///      ),
-///    );
-///  }
+/// Widget build(BuildContext context) {
+///   return Center(
+///     child: Column(
+///       children: <Widget>[
+///         Expanded(
+///           child: Container(
+///             color: Colors.amber,
+///             child: const Center(
+///               child: Text('Above'),
+///             ),
+///           ),
+///         ),
+///         const Divider(
+///           height: 20,
+///           thickness: 5,
+///           indent: 20,
+///           endIndent: 20,
+///         ),
+///         // Subheader example from Material spec.
+///         // https://material.io/components/dividers#types
+///         Container(
+///           padding: const EdgeInsets.only(left: 20),
+///           child: Align(
+///             alignment: AlignmentDirectional.centerStart,
+///             child: Text(
+///               'Subheader',
+///               style: Theme.of(context).textTheme.caption,
+///               textAlign: TextAlign.start,
+///             ),
+///           ),
+///         ),
+///         Expanded(
+///           child: Container(
+///             color: Theme.of(context).colorScheme.primary,
+///             child: const Center(
+///               child: Text('Below'),
+///             ),
+///           ),
+///         ),
+///       ],
+///     ),
+///   );
+/// }
 /// ```
 /// {@end-tool}
 /// See also:


### PR DESCRIPTION
## Description

Improved divider snippet so it shows sub header text below it. Material divider uses divider and sub headers frequently. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
