### PR TITLE
Check that header exists instead of contents of header in build iOS module test

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -234,10 +234,7 @@ Future<void> main() async {
       section("Check all modes' engine header");
 
       for (final String mode in <String>['Debug', 'Profile', 'Release']) {
-        checkFileContains(
-          <String>['#import "FlutterEngine.h"'],
-          path.join(outputPath, mode, 'Flutter.framework', 'Headers', 'Flutter.h'),
-        );
+        checkFileExists(path.join(outputPath, mode, 'Flutter.framework', 'Headers', 'Flutter.h'));
       }
 
       section('Check all modes have plugins');


### PR DESCRIPTION
## Description

https://github.com/flutter/engine/pull/21193 changed the import.  Check that the header exists, instead of checking the contents.  This will avoid a manual engine roll.

## Related Issues

https://github.com/flutter/flutter/issues/60025#issuecomment-693612293
