### PR TITLE
Updated androidMissingSdkInstructions error message

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -169,7 +169,7 @@ class AndroidValidator extends DoctorValidator {
       } else {
         // Instruct user to set [kAndroidSdkRoot] and not deprecated [kAndroidHome]
         // See https://github.com/flutter/flutter/issues/39301
-        messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(kAndroidSdkRoot, _platform)));
+        messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(_platform)));
       }
       return ValidationResult(ValidationType.missing, messages);
     }
@@ -200,7 +200,7 @@ class AndroidValidator extends DoctorValidator {
         _androidSdk.latestVersion.platformName,
         _androidSdk.latestVersion.buildToolsVersionName)));
     } else {
-      messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(kAndroidHome, _platform)));
+      messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(_platform)));
     }
 
     if (_platform.environment.containsKey(kAndroidHome)) {

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -169,7 +169,7 @@ class AndroidValidator extends DoctorValidator {
       } else {
         // Instruct user to set [kAndroidSdkRoot] and not deprecated [kAndroidHome]
         // See https://github.com/flutter/flutter/issues/39301
-        messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(_platform)));
+        messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(kAndroidSdkRoot, _platform)));
       }
       return ValidationResult(ValidationType.missing, messages);
     }
@@ -200,7 +200,7 @@ class AndroidValidator extends DoctorValidator {
         _androidSdk.latestVersion.platformName,
         _androidSdk.latestVersion.buildToolsVersionName)));
     } else {
-      messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(_platform)));
+      messages.add(ValidationMessage.error(_userMessages.androidMissingSdkInstructions(kAndroidHome, _platform)));
     }
 
     if (_platform.environment.containsKey(kAndroidHome)) {

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -14,8 +14,7 @@ class UserMessages {
       'Please report a bug at https://github.com/flutter/flutter/issues.';
 
   // Messages used in FlutterValidator
-  String flutterStatusInfo(
-          String channel, String version, String os, String locale) =>
+  String flutterStatusInfo(String channel, String version, String os, String locale) =>
       'Channel ${channel ?? 'unknown'}, ${version ?? 'Unknown'}, on $os, locale $locale';
   String flutterVersion(String version, String flutterRoot) =>
       'Flutter version $version at $flutterRoot';
@@ -35,8 +34,7 @@ class UserMessages {
 
   // Messages used in NoIdeValidator
   String get noIdeStatusInfo => 'No supported IDEs installed';
-  String get noIdeInstallationInfo =>
-      'IntelliJ - https://www.jetbrains.com/idea/';
+  String get noIdeInstallationInfo => 'IntelliJ - https://www.jetbrains.com/idea/';
 
   // Messages used in IntellijValidator
   String intellijStatusInfo(String version) => 'version $version';
@@ -48,20 +46,17 @@ class UserMessages {
   String intellijLocation(String installPath) => 'IntelliJ at $installPath';
 
   // Message used in IntellijValidatorOnMac
-  String get intellijMacUnknownResult =>
-      'Cannot determine if IntelliJ is installed';
+  String get intellijMacUnknownResult => 'Cannot determine if IntelliJ is installed';
 
   // Messages used in DeviceValidator
   String get devicesMissing => 'No devices available';
   String devicesAvailable(int devices) => '$devices available';
 
   // Messages used in AndroidValidator
-  String androidCantRunJavaBinary(String javaBinary) =>
-      'Cannot execute $javaBinary to determine the version';
+  String androidCantRunJavaBinary(String javaBinary) => 'Cannot execute $javaBinary to determine the version';
   String get androidUnknownJavaVersion => 'Could not determine java version';
   String androidJavaVersion(String javaVersion) => 'Java version $javaVersion';
-  String androidJavaMinimumVersion(String javaVersion) =>
-      'Java version $javaVersion is older than the minimum recommended version of 1.8';
+  String androidJavaMinimumVersion(String javaVersion) => 'Java version $javaVersion is older than the minimum recommended version of 1.8';
   String androidSdkLicenseOnly(String envKey) =>
       'Android SDK contains licenses only.\n'
       'Your first build of an Android application will take longer than usual, '
@@ -96,10 +91,8 @@ class UserMessages {
       'You can download the JDK from https://www.oracle.com/technetwork/java/javase/downloads/.';
   String androidJdkLocation(String location) => 'Java binary at: $location';
   String get androidLicensesAll => 'All Android licenses accepted.';
-  String get androidLicensesSome =>
-      'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
-  String get androidLicensesNone =>
-      'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+  String get androidLicensesSome => 'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+  String get androidLicensesNone => 'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
   String androidLicensesUnknown(Platform platform) =>
       'Android license status unknown.\n'
       'Run `flutter doctor --android-licenses` to accept the SDK licenses.\n'
@@ -107,29 +100,24 @@ class UserMessages {
   String androidSdkManagerOutdated(String managerPath) =>
       'A newer version of the Android SDK is required. To update, run:\n'
       '$managerPath --update\n';
-  String androidLicensesTimeout(String managerPath) =>
-      'Intentionally killing $managerPath';
+  String androidLicensesTimeout(String managerPath) => 'Intentionally killing $managerPath';
   String get androidSdkShort => 'Unable to locate Android SDK.';
   String androidMissingSdkManager(String sdkManagerPath, Platform platform) =>
       'Android sdkmanager tool not found ($sdkManagerPath).\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidCannotRunSdkManager(
-          String sdkManagerPath, String error, Platform platform) =>
+  String androidCannotRunSdkManager(String sdkManagerPath, String error, Platform platform) =>
       'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion,
-          String buildToolsMinVersion, Platform platform) =>
+  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
       'To update the Android SDK visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
 
   // Messages used in AndroidStudioValidator
   String androidStudioVersion(String version) => 'version $version';
-  String androidStudioLocation(String location) =>
-      'Android Studio at $location';
-  String get androidStudioNeedsUpdate =>
-      'Try updating or re-installing Android Studio.';
+  String androidStudioLocation(String location) => 'Android Studio at $location';
+  String get androidStudioNeedsUpdate => 'Try updating or re-installing Android Studio.';
   String get androidStudioResetDir =>
       'Consider removing your android-studio-dir setting by running:\n'
       'flutter config --android-studio-dir=';
@@ -149,8 +137,7 @@ class UserMessages {
   String xcodeOutdated(int versionMajor, int versionMinor, int versionPatch) =>
       'Flutter requires a minimum Xcode version of $versionMajor.$versionMinor.$versionPatch.\n'
       'Download the latest version or update via the Mac App Store.';
-  String get xcodeEula =>
-      "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
+  String get xcodeEula => "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
   String get xcodeMissingSimct =>
       'Xcode requires additional components to be installed in order to run.\n'
       'Launch Xcode and install additional required components when prompted or run:\n'
@@ -179,20 +166,17 @@ class UserMessages {
       '$consequence\n'
       'To install:\n'
       '$installInstructions';
-  String cocoaPodsUnknownVersion(
-          String consequence, String upgradeInstructions) =>
+  String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
       'Unknown CocoaPods version installed.\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';
-  String cocoaPodsOutdated(String currentVersion, String recVersion,
-          String consequence, String upgradeInstructions) =>
+  String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
       'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';
-  String cocoaPodsBrokenInstall(
-          String consequence, String reinstallInstructions) =>
+  String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
       'CocoaPods installed but not working.\n'
       '$consequence\n'
       'To re-install CocoaPods, run:\n'
@@ -201,17 +185,13 @@ class UserMessages {
   // Messages used in VsCodeValidator
   String vsCodeVersion(String version) => 'version $version';
   String vsCodeLocation(String location) => 'VS Code at $location';
-  String vsCodeFlutterExtensionMissing(String url) =>
-      'Flutter extension not installed; install from\n$url';
+  String vsCodeFlutterExtensionMissing(String url) => 'Flutter extension not installed; install from\n$url';
 
   // Messages used in VisualStudioValidator
-  String visualStudioVersion(String name, String version) =>
-      '$name version $version';
+  String visualStudioVersion(String name, String version) => '$name version $version';
   String visualStudioLocation(String location) => 'Visual Studio at $location';
-  String windows10SdkVersion(String version) =>
-      'Windows 10 SDK version $version';
-  String visualStudioMissingComponents(
-          String workload, List<String> components) =>
+  String windows10SdkVersion(String version) => 'Windows 10 SDK version $version';
+  String visualStudioMissingComponents(String workload, List<String> components) =>
       'Visual Studio is missing necessary components. Please re-run the '
       'Visual Studio installer for the "$workload" workload, and include these components:\n'
       '  ${components.join('\n  ')}\n'
@@ -226,67 +206,53 @@ class UserMessages {
       'Visual Studio $minimumVersion or later is required.\n'
       'Download at https://visualstudio.microsoft.com/downloads/.\n'
       'Please install the "$workload" workload, including all of its default components';
-  String get visualStudioIsPrerelease =>
-      'The current Visual Studio installation is a pre-release version. It may not be '
+  String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
       'supported by Flutter yet.';
   String get visualStudioNotLaunchable =>
       'The current Visual Studio installation is not launchable. Please reinstall Visual Studio.';
-  String get visualStudioIsIncomplete =>
-      'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
-  String get visualStudioRebootRequired =>
-      'Visual Studio requires a reboot of your system to complete installation.';
+  String get visualStudioIsIncomplete => 'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
+  String get visualStudioRebootRequired => 'Visual Studio requires a reboot of your system to complete installation.';
 
   // Messages used in LinuxDoctorValidator
   String get clangMissing => 'clang++ is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install clang), or '
       'can be downloaded from https://releases.llvm.org/';
-  String clangTooOld(String minimumVersion) =>
-      'clang++ $minimumVersion or later is required.';
+  String clangTooOld(String minimumVersion) => 'clang++ $minimumVersion or later is required.';
   String get cmakeMissing => 'CMake is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install cmake), or '
       'can be downloaded from https://cmake.org/download/';
-  String cmakeTooOld(String minimumVersion) =>
-      'cmake $minimumVersion or later is required.';
+  String cmakeTooOld(String minimumVersion) => 'cmake $minimumVersion or later is required.';
   String ninjaVersion(String version) => 'ninja version $version';
   String get ninjaMissing => 'ninja is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install ninja-build), or '
       'can be downloaded from https://github.com/ninja-build/ninja/releases';
-  String ninjaTooOld(String minimumVersion) =>
-      'ninja $minimumVersion or later is required.';
+  String ninjaTooOld(String minimumVersion) => 'ninja $minimumVersion or later is required.';
   String pkgConfigVersion(String version) => 'pkg-config version $version';
-  String get pkgConfigMissing =>
-      'pgk-config is required for Linux development.\n'
+  String get pkgConfigMissing => 'pgk-config is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install pkg-config), or '
       'can be downloaded from https://www.freedesktop.org/wiki/Software/pkg-config/';
-  String pkgConfigTooOld(String minimumVersion) =>
-      'pkg-config $minimumVersion or later is required.';
-  String get gtkLibrariesMissing =>
-      'GTK 3.0 development libraries are required for Linux development.\n'
+  String pkgConfigTooOld(String minimumVersion) => 'pkg-config $minimumVersion or later is required.';
+  String get gtkLibrariesMissing => 'GTK 3.0 development libraries are required for Linux development.\n'
       'They are likely available from your distribution (e.g.: apt install libgtk-3-dev)';
-  String get blkidLibraryMissing =>
-      'The blkid development library is required for Linux development.\n'
+  String get blkidLibraryMissing => 'The blkid development library is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install libblkid-dev)';
 
   // Messages used in FlutterCommand
-  String flutterElapsedTime(String name, String elapsedTime) =>
-      '"flutter $name" took $elapsedTime.';
+  String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';
   String get flutterNoDevelopmentDevice =>
       "Unable to locate a development device; please run 'flutter doctor' "
       'for information about installing additional components.';
-  String flutterNoMatchingDevice(String deviceId) =>
-      'No devices found with name or id '
+  String flutterNoMatchingDevice(String deviceId) => 'No devices found with name or id '
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProjects(List<String> unsupportedDevicesType) =>
       'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
-  String get flutterFoundButUnsupportedDevices =>
-      'The following devices were found, but are not supported by this project:';
+  String get flutterFoundButUnsupportedDevices => 'The following devices were found, but are not supported by this project:';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';
   String get flutterMultipleDevicesFound => 'Multiple devices found:';
-  String flutterChooseDevice(int option, String name, String deviceId) =>
-      '[$option]: $name ($deviceId)';
+  String flutterChooseDevice(int option, String name, String deviceId) => '[$option]: $name ($deviceId)';
   String get flutterChooseOne => 'Please choose one (To quit, press "q/Q")';
   String get flutterSpecifyDeviceWithAllOption =>
       'More than one device connected; please specify a device with '
@@ -295,17 +261,14 @@ class UserMessages {
       'More than one device connected; please specify a device with '
       "the '-d <deviceId>' flag.";
   String get flutterNoConnectedDevices => 'No connected devices.';
-  String get flutterNoPubspec => 'Error: No pubspec.yaml file found.\n'
+  String get flutterNoPubspec =>
+      'Error: No pubspec.yaml file found.\n'
       'This command should be run from the root of your Flutter project.\n'
       'Do not run this command from the root of your git clone of Flutter.';
-  String flutterTargetFileMissing(String path) =>
-      'Target file "$path" not found.';
-  String get flutterBasePatchFlagsExclusive =>
-      'Error: Only one of --baseline, --patch is allowed.';
-  String get flutterBaselineRequiresTraceFile =>
-      'Error: --baseline requires --compilation-trace-file to be specified.';
-  String get flutterPatchRequiresTraceFile =>
-      'Error: --patch requires --compilation-trace-file to be specified.';
+  String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
+  String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
+  String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';
+  String get flutterPatchRequiresTraceFile => 'Error: --patch requires --compilation-trace-file to be specified.';
 
   // Messages used in FlutterCommandRunner
   String runnerNoRoot(String error) => 'Unable to locate flutter root: $error';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -74,8 +74,7 @@ class UserMessages {
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set $envKey to that location.\n'
-      'You may also want to add it to your PATH environment variable.\n';
+      'If the Android SDK has been installed to a custom location, set set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -75,7 +75,6 @@ class UserMessages {
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
       'If the Android SDK has been installed to a custom location, please use\n'
-      '`flutter config --android-studio-dir` or\n'
       '`flutter config --android-sdk` to update to that location.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -14,7 +14,8 @@ class UserMessages {
       'Please report a bug at https://github.com/flutter/flutter/issues.';
 
   // Messages used in FlutterValidator
-  String flutterStatusInfo(String channel, String version, String os, String locale) =>
+  String flutterStatusInfo(
+          String channel, String version, String os, String locale) =>
       'Channel ${channel ?? 'unknown'}, ${version ?? 'Unknown'}, on $os, locale $locale';
   String flutterVersion(String version, String flutterRoot) =>
       'Flutter version $version at $flutterRoot';
@@ -34,7 +35,8 @@ class UserMessages {
 
   // Messages used in NoIdeValidator
   String get noIdeStatusInfo => 'No supported IDEs installed';
-  String get noIdeInstallationInfo => 'IntelliJ - https://www.jetbrains.com/idea/';
+  String get noIdeInstallationInfo =>
+      'IntelliJ - https://www.jetbrains.com/idea/';
 
   // Messages used in IntellijValidator
   String intellijStatusInfo(String version) => 'version $version';
@@ -46,17 +48,20 @@ class UserMessages {
   String intellijLocation(String installPath) => 'IntelliJ at $installPath';
 
   // Message used in IntellijValidatorOnMac
-  String get intellijMacUnknownResult => 'Cannot determine if IntelliJ is installed';
+  String get intellijMacUnknownResult =>
+      'Cannot determine if IntelliJ is installed';
 
   // Messages used in DeviceValidator
   String get devicesMissing => 'No devices available';
   String devicesAvailable(int devices) => '$devices available';
 
   // Messages used in AndroidValidator
-  String androidCantRunJavaBinary(String javaBinary) => 'Cannot execute $javaBinary to determine the version';
+  String androidCantRunJavaBinary(String javaBinary) =>
+      'Cannot execute $javaBinary to determine the version';
   String get androidUnknownJavaVersion => 'Could not determine java version';
   String androidJavaVersion(String javaVersion) => 'Java version $javaVersion';
-  String androidJavaMinimumVersion(String javaVersion) => 'Java version $javaVersion is older than the minimum recommended version of 1.8';
+  String androidJavaMinimumVersion(String javaVersion) =>
+      'Java version $javaVersion is older than the minimum recommended version of 1.8';
   String androidSdkLicenseOnly(String envKey) =>
       'Android SDK contains licenses only.\n'
       'Your first build of an Android application will take longer than usual, '
@@ -69,12 +74,12 @@ class UserMessages {
   String androidBadSdkDir(String envKey, String homeDir) =>
       '$envKey = $homeDir\n'
       'but Android SDK not found at this location.';
-  String androidMissingSdkInstructions(String envKey, Platform platform) =>
+  String androidMissingSdkInstructions(Platform platform) =>
       'Unable to locate Android SDK.\n'
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
+      'If the Android SDK has been installed to a custom location, set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';
@@ -91,8 +96,10 @@ class UserMessages {
       'You can download the JDK from https://www.oracle.com/technetwork/java/javase/downloads/.';
   String androidJdkLocation(String location) => 'Java binary at: $location';
   String get androidLicensesAll => 'All Android licenses accepted.';
-  String get androidLicensesSome => 'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
-  String get androidLicensesNone => 'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+  String get androidLicensesSome =>
+      'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+  String get androidLicensesNone =>
+      'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
   String androidLicensesUnknown(Platform platform) =>
       'Android license status unknown.\n'
       'Run `flutter doctor --android-licenses` to accept the SDK licenses.\n'
@@ -100,24 +107,29 @@ class UserMessages {
   String androidSdkManagerOutdated(String managerPath) =>
       'A newer version of the Android SDK is required. To update, run:\n'
       '$managerPath --update\n';
-  String androidLicensesTimeout(String managerPath) => 'Intentionally killing $managerPath';
+  String androidLicensesTimeout(String managerPath) =>
+      'Intentionally killing $managerPath';
   String get androidSdkShort => 'Unable to locate Android SDK.';
   String androidMissingSdkManager(String sdkManagerPath, Platform platform) =>
       'Android sdkmanager tool not found ($sdkManagerPath).\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidCannotRunSdkManager(String sdkManagerPath, String error, Platform platform) =>
+  String androidCannotRunSdkManager(
+          String sdkManagerPath, String error, Platform platform) =>
       'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
+  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion,
+          String buildToolsMinVersion, Platform platform) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
       'To update the Android SDK visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
 
   // Messages used in AndroidStudioValidator
   String androidStudioVersion(String version) => 'version $version';
-  String androidStudioLocation(String location) => 'Android Studio at $location';
-  String get androidStudioNeedsUpdate => 'Try updating or re-installing Android Studio.';
+  String androidStudioLocation(String location) =>
+      'Android Studio at $location';
+  String get androidStudioNeedsUpdate =>
+      'Try updating or re-installing Android Studio.';
   String get androidStudioResetDir =>
       'Consider removing your android-studio-dir setting by running:\n'
       'flutter config --android-studio-dir=';
@@ -137,7 +149,8 @@ class UserMessages {
   String xcodeOutdated(int versionMajor, int versionMinor, int versionPatch) =>
       'Flutter requires a minimum Xcode version of $versionMajor.$versionMinor.$versionPatch.\n'
       'Download the latest version or update via the Mac App Store.';
-  String get xcodeEula => "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
+  String get xcodeEula =>
+      "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
   String get xcodeMissingSimct =>
       'Xcode requires additional components to be installed in order to run.\n'
       'Launch Xcode and install additional required components when prompted or run:\n'
@@ -166,17 +179,20 @@ class UserMessages {
       '$consequence\n'
       'To install:\n'
       '$installInstructions';
-  String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
+  String cocoaPodsUnknownVersion(
+          String consequence, String upgradeInstructions) =>
       'Unknown CocoaPods version installed.\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';
-  String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
+  String cocoaPodsOutdated(String currentVersion, String recVersion,
+          String consequence, String upgradeInstructions) =>
       'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
       '$consequence\n'
       'To upgrade:\n'
       '$upgradeInstructions';
-  String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
+  String cocoaPodsBrokenInstall(
+          String consequence, String reinstallInstructions) =>
       'CocoaPods installed but not working.\n'
       '$consequence\n'
       'To re-install CocoaPods, run:\n'
@@ -185,13 +201,17 @@ class UserMessages {
   // Messages used in VsCodeValidator
   String vsCodeVersion(String version) => 'version $version';
   String vsCodeLocation(String location) => 'VS Code at $location';
-  String vsCodeFlutterExtensionMissing(String url) => 'Flutter extension not installed; install from\n$url';
+  String vsCodeFlutterExtensionMissing(String url) =>
+      'Flutter extension not installed; install from\n$url';
 
   // Messages used in VisualStudioValidator
-  String visualStudioVersion(String name, String version) => '$name version $version';
+  String visualStudioVersion(String name, String version) =>
+      '$name version $version';
   String visualStudioLocation(String location) => 'Visual Studio at $location';
-  String windows10SdkVersion(String version) => 'Windows 10 SDK version $version';
-  String visualStudioMissingComponents(String workload, List<String> components) =>
+  String windows10SdkVersion(String version) =>
+      'Windows 10 SDK version $version';
+  String visualStudioMissingComponents(
+          String workload, List<String> components) =>
       'Visual Studio is missing necessary components. Please re-run the '
       'Visual Studio installer for the "$workload" workload, and include these components:\n'
       '  ${components.join('\n  ')}\n'
@@ -206,53 +226,67 @@ class UserMessages {
       'Visual Studio $minimumVersion or later is required.\n'
       'Download at https://visualstudio.microsoft.com/downloads/.\n'
       'Please install the "$workload" workload, including all of its default components';
-  String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
+  String get visualStudioIsPrerelease =>
+      'The current Visual Studio installation is a pre-release version. It may not be '
       'supported by Flutter yet.';
   String get visualStudioNotLaunchable =>
       'The current Visual Studio installation is not launchable. Please reinstall Visual Studio.';
-  String get visualStudioIsIncomplete => 'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
-  String get visualStudioRebootRequired => 'Visual Studio requires a reboot of your system to complete installation.';
+  String get visualStudioIsIncomplete =>
+      'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
+  String get visualStudioRebootRequired =>
+      'Visual Studio requires a reboot of your system to complete installation.';
 
   // Messages used in LinuxDoctorValidator
   String get clangMissing => 'clang++ is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install clang), or '
       'can be downloaded from https://releases.llvm.org/';
-  String clangTooOld(String minimumVersion) => 'clang++ $minimumVersion or later is required.';
+  String clangTooOld(String minimumVersion) =>
+      'clang++ $minimumVersion or later is required.';
   String get cmakeMissing => 'CMake is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install cmake), or '
       'can be downloaded from https://cmake.org/download/';
-  String cmakeTooOld(String minimumVersion) => 'cmake $minimumVersion or later is required.';
+  String cmakeTooOld(String minimumVersion) =>
+      'cmake $minimumVersion or later is required.';
   String ninjaVersion(String version) => 'ninja version $version';
   String get ninjaMissing => 'ninja is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install ninja-build), or '
       'can be downloaded from https://github.com/ninja-build/ninja/releases';
-  String ninjaTooOld(String minimumVersion) => 'ninja $minimumVersion or later is required.';
+  String ninjaTooOld(String minimumVersion) =>
+      'ninja $minimumVersion or later is required.';
   String pkgConfigVersion(String version) => 'pkg-config version $version';
-  String get pkgConfigMissing => 'pgk-config is required for Linux development.\n'
+  String get pkgConfigMissing =>
+      'pgk-config is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install pkg-config), or '
       'can be downloaded from https://www.freedesktop.org/wiki/Software/pkg-config/';
-  String pkgConfigTooOld(String minimumVersion) => 'pkg-config $minimumVersion or later is required.';
-  String get gtkLibrariesMissing => 'GTK 3.0 development libraries are required for Linux development.\n'
+  String pkgConfigTooOld(String minimumVersion) =>
+      'pkg-config $minimumVersion or later is required.';
+  String get gtkLibrariesMissing =>
+      'GTK 3.0 development libraries are required for Linux development.\n'
       'They are likely available from your distribution (e.g.: apt install libgtk-3-dev)';
-  String get blkidLibraryMissing => 'The blkid development library is required for Linux development.\n'
+  String get blkidLibraryMissing =>
+      'The blkid development library is required for Linux development.\n'
       'It is likely available from your distribution (e.g.: apt install libblkid-dev)';
 
   // Messages used in FlutterCommand
-  String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';
+  String flutterElapsedTime(String name, String elapsedTime) =>
+      '"flutter $name" took $elapsedTime.';
   String get flutterNoDevelopmentDevice =>
       "Unable to locate a development device; please run 'flutter doctor' "
       'for information about installing additional components.';
-  String flutterNoMatchingDevice(String deviceId) => 'No devices found with name or id '
+  String flutterNoMatchingDevice(String deviceId) =>
+      'No devices found with name or id '
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProjects(List<String> unsupportedDevicesType) =>
       'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
-  String get flutterFoundButUnsupportedDevices => 'The following devices were found, but are not supported by this project:';
+  String get flutterFoundButUnsupportedDevices =>
+      'The following devices were found, but are not supported by this project:';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';
   String get flutterMultipleDevicesFound => 'Multiple devices found:';
-  String flutterChooseDevice(int option, String name, String deviceId) => '[$option]: $name ($deviceId)';
+  String flutterChooseDevice(int option, String name, String deviceId) =>
+      '[$option]: $name ($deviceId)';
   String get flutterChooseOne => 'Please choose one (To quit, press "q/Q")';
   String get flutterSpecifyDeviceWithAllOption =>
       'More than one device connected; please specify a device with '
@@ -261,14 +295,17 @@ class UserMessages {
       'More than one device connected; please specify a device with '
       "the '-d <deviceId>' flag.";
   String get flutterNoConnectedDevices => 'No connected devices.';
-  String get flutterNoPubspec =>
-      'Error: No pubspec.yaml file found.\n'
+  String get flutterNoPubspec => 'Error: No pubspec.yaml file found.\n'
       'This command should be run from the root of your Flutter project.\n'
       'Do not run this command from the root of your git clone of Flutter.';
-  String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
-  String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
-  String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';
-  String get flutterPatchRequiresTraceFile => 'Error: --patch requires --compilation-trace-file to be specified.';
+  String flutterTargetFileMissing(String path) =>
+      'Target file "$path" not found.';
+  String get flutterBasePatchFlagsExclusive =>
+      'Error: Only one of --baseline, --patch is allowed.';
+  String get flutterBaselineRequiresTraceFile =>
+      'Error: --baseline requires --compilation-trace-file to be specified.';
+  String get flutterPatchRequiresTraceFile =>
+      'Error: --patch requires --compilation-trace-file to be specified.';
 
   // Messages used in FlutterCommandRunner
   String runnerNoRoot(String error) => 'Unable to locate flutter root: $error';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -69,12 +69,12 @@ class UserMessages {
   String androidBadSdkDir(String envKey, String homeDir) =>
       '$envKey = $homeDir\n'
       'but Android SDK not found at this location.';
-  String androidMissingSdkInstructions(Platform platform) =>
+  String androidMissingSdkInstructions(String envKey, Platform platform) =>
       'Unable to locate Android SDK.\n'
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set the location with `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
+      'If the Android SDK has been installed to a custom location, please use `flutter config --android-studio-dir` or `flutter config --android-sdk` to set $envKey to that location.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -69,14 +69,14 @@ class UserMessages {
   String androidBadSdkDir(String envKey, String homeDir) =>
       '$envKey = $homeDir\n'
       'but Android SDK not found at this location.';
-  String androidMissingSdkInstructions(String envKey, Platform platform) =>
+  String androidMissingSdkInstructions(Platform platform) =>
       'Unable to locate Android SDK.\n'
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
       'If the Android SDK has been installed to a custom location, please use\n'
       '`flutter config --android-studio-dir` or\n'
-      '`flutter config --android-sdk` to set $envKey to that location.\n';
+      '`flutter config --android-sdk` to update to that location.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -74,7 +74,9 @@ class UserMessages {
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, please use `flutter config --android-studio-dir` or `flutter config --android-sdk` to set $envKey to that location.\n';
+      'If the Android SDK has been installed to a custom location, please use\n'
+      '`flutter config --android-studio-dir` or\n'
+      '`flutter config --android-sdk` to set $envKey to that location.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -74,7 +74,7 @@ class UserMessages {
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
+      'If the Android SDK has been installed to a custom location, set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -74,7 +74,7 @@ class UserMessages {
       'Install Android Studio from: https://developer.android.com/studio/index.html\n'
       'On first launch it will assist you in installing the Android SDK components.\n'
       '(or visit ${_androidSdkInstallUrl(platform)} for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
+      'If the Android SDK has been installed to a custom location, set the location with `flutter config --android-studio-dir` or `flutter config --android-sdk`.\n';
   String androidSdkLocation(String directory) => 'Android SDK at $directory';
   String androidSdkPlatformToolsVersion(String platform, String tools) =>
       'Platform $platform, build-tools $tools';

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -333,7 +333,7 @@ void main() {
     );
   });
 
-  testWithoutContext('Mentions `kAndroidSdkRoot if user has no AndroidSdk`', () async {
+  testWithoutContext('Mentions `flutter config --android-sdk if user has no AndroidSdk`', () async {
     final ValidationResult validationResult = await AndroidValidator(
       androidSdk: null,
       androidStudio: null,

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -345,7 +345,7 @@ void main() {
     ).validate();
     expect(
       validationResult.messages.any(
-        (ValidationMessage message) => message.message.contains(kAndroidSdkRoot)
+        (ValidationMessage message) => message.message.contains("flutter config --android-sdk")
       ),
       true,
     );

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -331,6 +331,12 @@ void main() {
       validationResult.messages.last.message,
       errorMessage,
     );
+    expect(
+      validationResult.messages.any(
+        (ValidationMessage message) => message.message.contains('Unable to locate Android SDK')
+      ),
+      false,
+    );
   });
 
   testWithoutContext('Mentions `flutter config --android-sdk if user has no AndroidSdk`', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -345,7 +345,7 @@ void main() {
     ).validate();
     expect(
       validationResult.messages.any(
-        (ValidationMessage message) => message.message.contains("flutter config --android-sdk")
+        (ValidationMessage message) => message.message.contains('flutter config --android-sdk')
       ),
       true,
     );

--- a/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   testWithoutContext('Android installation instructions', () {
     final UserMessages userMessages = UserMessages();
-    _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkInstructions('ANDROID_SDK_ROOT', platform));
+    _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkInstructions(platform));
     _checkInstallationURL((Platform platform) => userMessages.androidSdkInstallHelp(platform));
     _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkManager('/', platform));
     _checkInstallationURL((Platform platform) => userMessages.androidCannotRunSdkManager('/', '', platform));

--- a/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   testWithoutContext('Android installation instructions', () {
     final UserMessages userMessages = UserMessages();
-    _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkInstructions(platform));
+    _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkInstructions('ANDROID_SDK_ROOT', platform));
     _checkInstallationURL((Platform platform) => userMessages.androidSdkInstallHelp(platform));
     _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkManager('/', platform));
     _checkInstallationURL((Platform platform) => userMessages.androidCannotRunSdkManager('/', '', platform));


### PR DESCRIPTION
## Description

This addresses issue #5917: "Flutter Doctor should mention ANDROID_HOME when it can't find the android sdk as a possible reason why it can't find it"

xster mentioned:

> "Update, the current message does mention ANDROID_SDK_ROOT in the error message now in https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/base/user_messages.dart#L77.

> As pointed out above, it might want to mention setting flutter config --android-studio-dir or flutter config --android-sdk instead since it can cover more cases."

So in conclusion: I have updated the error message to tell the user to update the custom directory by using flutter config --android-studio-dir or flutter config --android-sdk. Am I doing this right? Please help

## Related Issues

Related #25221, #15114

## Tests

No tests were created. Tests are passing.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
