### PR TITLE
TextField constrained layout bug

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1032,11 +1032,12 @@ class _RenderDecoration extends RenderBox {
       counterHeight,
       helperErrorHeight,
     );
+    final Offset densityOffset = decoration.visualDensity.baseSizeAdjustment;
     boxToBaseline[input] = _layoutLineBox(
       input,
       boxConstraints.deflate(EdgeInsets.only(
-        top: contentPadding.top + topHeight,
-        bottom: contentPadding.bottom + bottomHeight,
+        top: contentPadding.top + topHeight + densityOffset.dy / 2,
+        bottom: contentPadding.bottom + bottomHeight + densityOffset.dy / 2,
       )).copyWith(
         minWidth: inputWidth,
         maxWidth: inputWidth,
@@ -1071,7 +1072,6 @@ class _RenderDecoration extends RenderBox {
     );
 
     // Calculate the height of the input text container.
-    final Offset densityOffset = decoration.visualDensity.baseSizeAdjustment;
     final double prefixIconHeight = prefixIcon == null ? 0 : prefixIcon.size.height;
     final double suffixIconHeight = suffixIcon == null ? 0 : suffixIcon.size.height;
     final double fixIconHeight = math.max(prefixIconHeight, suffixIconHeight);
@@ -1087,8 +1087,8 @@ class _RenderDecoration extends RenderBox {
     );
     final double minContainerHeight = decoration.isDense || decoration.isCollapsed || expands
       ? 0.0
-      : kMinInteractiveDimension + densityOffset.dy;
-    final double maxContainerHeight = boxConstraints.maxHeight - bottomHeight + densityOffset.dy;
+      : kMinInteractiveDimension;
+    final double maxContainerHeight = boxConstraints.maxHeight - bottomHeight;
     final double containerHeight = expands
       ? maxContainerHeight
       : math.min(math.max(contentHeight, minContainerHeight), maxContainerHeight);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1065,7 +1065,7 @@ class _RenderDecoration extends RenderBox {
       prefixHeight - boxToBaseline[prefix],
       suffixHeight - boxToBaseline[suffix],
     );
-    final double fixBelowInput = math.max(
+    final double fixBelowInput = fixBelowBaseline <= 0.0 ? 0.0 : math.max(
       0,
       fixBelowBaseline - (inputHeight - inputInternalBaseline),
     );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4235,4 +4235,55 @@ void main() {
     expect(tester.getSize(find.text(labelText)).width, labelWidth);
     expect(getOpacity(tester, prefixText), 1.0);
   });
+
+  testWidgets('given enough space, constrained and unconstrained heights result in the same size widget', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/65572
+    final UniqueKey keyUnconstrained = UniqueKey();
+    final UniqueKey keyConstrained = UniqueKey();
+
+    Widget getInputDecorator(VisualDensity visualDensity) {
+      return MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return Theme(
+                data: Theme.of(context).copyWith(visualDensity: visualDensity),
+                child: Center(
+                  child: Row(
+                    children: <Widget>[
+                      SizedBox(
+                        width: 35.0,
+                        child: TextField(
+                          key: keyUnconstrained,
+                        ),
+                      ),
+                      SizedBox(
+                        width: 35.0,
+                        // 48 is the height that this TextField would take when
+                        // laid out with no constraints.
+                        height: 48.0,
+                        child: TextField(
+                          key: keyConstrained,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(getInputDecorator(VisualDensity.standard));
+    final double constrainedHeight = tester.getSize(find.byKey(keyConstrained)).height;
+    final double unConstrainedHeight = tester.getSize(find.byKey(keyUnconstrained)).height;
+    expect(constrainedHeight, equals(unConstrainedHeight));
+
+    await tester.pumpWidget(getInputDecorator(VisualDensity.compact));
+    final double constrainedHeightCompact = tester.getSize(find.byKey(keyConstrained)).height;
+    final double unConstrainedHeightCompact = tester.getSize(find.byKey(keyUnconstrained)).height;
+    expect(constrainedHeightCompact, equals(unConstrainedHeightCompact));
+  });
 }


### PR DESCRIPTION
## Description

A TextField with constraints, but enough space to fully size itself, was sometimes sized differently than one with infinite space.

![screenshot of problem](https://user-images.githubusercontent.com/15253456/92781343-e6054c80-f358-11ea-8d40-396a6167a6c8.png)

See the issue for an in-depth description of the problem.

## Related Issues

Closes https://github.com/flutter/flutter/issues/65572

## Tests

I added the following tests:

  * Render a constrained and unconstrained TextField and verify they're the same height.