### PR TITLE
Inform user how to fix permissions when the observatory URL isn't found on iOS 14

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -310,6 +310,7 @@ class IOSDevice extends Device {
     bool prebuiltApplication = false,
     bool ipv6 = false,
     @visibleForTesting Duration fallbackPollingDelay,
+    @visibleForTesting Duration fallbackThrottleTimeout,
     String userIdentifier,
   }) async {
     String packageId;
@@ -402,6 +403,7 @@ class IOSDevice extends Device {
           hostPort: debuggingOptions.hostVmServicePort,
           devicePort: debuggingOptions.deviceVmServicePort,
           ipv6: ipv6,
+          throttleTimeout: fallbackThrottleTimeout ?? const Duration(seconds: 1),
         );
       }
       final int installationResult = await _iosDeploy.runApp(
@@ -441,6 +443,12 @@ class IOSDevice extends Device {
         packageName: FlutterProject.current().manifest.appName,
       );
       if (localUri == null) {
+        if (majorSdkVersion >= 14) {
+          _logger.printError('Failed to attach to the observatory.');
+          _logger.printError(
+              'Try accepting the local permissions popup, or enable "Settings > Privacy > Local Network" for your app.');
+          _logger.printError('For more information, see https://flutter.dev/docs/development/ios-14#debugging-flutter');
+        }
         return LaunchResult.failed();
       }
       return LaunchResult.succeeded(observatoryUri: localUri);

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -446,7 +446,7 @@ class IOSDevice extends Device {
         if (majorSdkVersion >= 14) {
           _logger.printError('Failed to attach to the observatory.');
           _logger.printError(
-              'Try accepting the local permissions popup, or enable "Settings > Privacy > Local Network" for your app.');
+              'Try accepting the local network permissions popup, or enable "Settings > Privacy > Local Network" for your app.');
           _logger.printError('For more information, see https://flutter.dev/docs/development/ios-14#debugging-flutter');
         }
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -18,6 +18,7 @@ class ProtocolDiscovery {
     this.serviceName, {
     this.portForwarder,
     this.throttleDuration,
+    this.throttleTimeout,
     this.hostPort,
     this.devicePort,
     this.ipv6,
@@ -34,6 +35,7 @@ class ProtocolDiscovery {
     DeviceLogReader logReader, {
     DevicePortForwarder portForwarder,
     Duration throttleDuration = const Duration(milliseconds: 200),
+    Duration throttleTimeout,
     @required int hostPort,
     @required int devicePort,
     @required bool ipv6,
@@ -44,6 +46,7 @@ class ProtocolDiscovery {
       kObservatoryService,
       portForwarder: portForwarder,
       throttleDuration: throttleDuration,
+      throttleTimeout: throttleTimeout,
       hostPort: hostPort,
       devicePort: devicePort,
       ipv6: ipv6,
@@ -59,6 +62,9 @@ class ProtocolDiscovery {
 
   /// The time to wait before forwarding a new observatory URIs from [logReader].
   final Duration throttleDuration;
+
+  /// The time between URIs are discovered before timing out when scraping the [logReader]. Optional.
+  final Duration throttleTimeout;
 
   StreamSubscription<String> _deviceLogSubscription;
   _BufferedStreamController<Uri> _uriStreamController;
@@ -81,15 +87,20 @@ class ProtocolDiscovery {
   ///
   /// When a new observatory URL: is available in [logReader],
   /// the URLs are forwarded at most once every [throttleDuration].
+  /// Returns when no event has been observed for [throttleTimeout].
   ///
   /// Port forwarding is only attempted when this is invoked,
   /// for each observatory URL in the stream.
   Stream<Uri> get uris {
-    return _uriStreamController.stream
+    Stream<Uri> uriStream = _uriStreamController.stream
       .transform(_throttle<Uri>(
         waitDuration: throttleDuration,
       ))
       .asyncMap<Uri>(_forwardPort);
+    if (throttleTimeout != null) {
+      uriStream = uriStream .timeout(throttleTimeout);
+    }
+    return uriStream;
   }
 
   Future<void> cancel() => _stopScrapingLogs();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -274,7 +274,7 @@ void main() {
         kDeployCommand,
         kLaunchDebugCommand,
       ]);
-      BufferLogger logger = BufferLogger.test();
+     final  BufferLogger logger = BufferLogger.test();
       final IOSDevice device = setUpIOSDevice(
         sdkVersion: '13.0',
         processManager: processManager,
@@ -310,7 +310,7 @@ void main() {
 
       expect(launchResult.started, false);
       expect(launchResult.hasObservatory, false);
-      expect(logger.errorText, contains('Settings > Privacy > Local Network'));
+      expect(logger.errorText, isEmpty);
     }, overrides: <Type, Generator>{
       MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
       Usage: () => MockUsage(),
@@ -323,7 +323,7 @@ void main() {
         kDeployCommand,
         kLaunchDebugCommand,
       ]);
-      BufferLogger logger = BufferLogger.test();
+      final BufferLogger logger = BufferLogger.test();
       final IOSDevice device = setUpIOSDevice(
         sdkVersion: '14.0',
         processManager: processManager,
@@ -359,7 +359,7 @@ void main() {
 
       expect(launchResult.started, false);
       expect(launchResult.hasObservatory, false);
-      expect(logger.errorText, isEmpty);
+      expect(logger.errorText, contains('Settings > Privacy > Local Network'));
     }, overrides: <Type, Generator>{
       MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
       Usage: () => MockUsage(),


### PR DESCRIPTION
## Description

When the observatory port isn't discovered on iOS 14, tell the user they may be able to fix it by accepting the local network permissions dialog box, or digging into settings.  Also link to https://flutter.dev/docs/development/ios-14#debugging-flutter.

![Screen Shot 2020-09-16 at 2 56 36 PM](https://user-images.githubusercontent.com/682784/93396863-40a51980-f82d-11ea-8b0a-b9c8004dc2ca.png)


## Related Issues

Tooling part of https://github.com/flutter/flutter/issues/60634
Website update mentioning the settings permissions: https://github.com/flutter/website/pull/4622

## Tests

I added the following tests:
ios_device_start_prebuilt_tests

Also add a limit to how long the log reader will scan.  It should find it very quickly (I pegged to one second) or not at all.  Realistically this is only an issue in testing since the log reader practically never works as is...
