### PR TITLE
Replaced reference to obsolete FlatButton button class in SnackBar

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -7,12 +7,14 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'button_theme.dart';
+import 'button_style.dart';
 import 'color_scheme.dart';
-import 'flat_button.dart';
 import 'material.dart';
+import 'material_state.dart';
 import 'scaffold.dart';
 import 'snack_bar_theme.dart';
+import 'text_button.dart';
+import 'text_button_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
@@ -128,15 +130,19 @@ class _SnackBarActionState extends State<SnackBarAction> {
 
   @override
   Widget build(BuildContext context) {
-    final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
-    final Color textColor = widget.textColor ?? snackBarTheme.actionTextColor;
-    final Color disabledTextColor = widget.disabledTextColor ?? snackBarTheme.disabledActionTextColor;
+    Color resolveForegroundColor(Set<MaterialState> states) {
+      final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
+      if (states.contains(MaterialState.disabled))
+        return widget.disabledTextColor ?? snackBarTheme.disabledActionTextColor;
+      return widget.textColor ?? snackBarTheme.actionTextColor;
+    }
 
-    return FlatButton(
+    return TextButton(
+      style: ButtonStyle(
+        foregroundColor: MaterialStateProperty.resolveWith<Color>(resolveForegroundColor),
+      ),
       onPressed: _haveTriggeredAction ? null : _handlePressed,
       child: Text(widget.label),
-      textColor: textColor,
-      disabledTextColor: disabledTextColor,
     );
   }
 }
@@ -385,6 +391,7 @@ class _SnackBarState extends State<SnackBar> {
     final ColorScheme colorScheme = theme.colorScheme;
     final SnackBarThemeData snackBarTheme = theme.snackBarTheme;
     final bool isThemeDark = theme.brightness == Brightness.dark;
+    final Color buttonColor = isThemeDark ? colorScheme.primaryVariant : colorScheme.secondary;
 
     // SnackBar uses a theme that is the opposite brightness from
     // the surrounding theme.
@@ -400,7 +407,7 @@ class _SnackBarState extends State<SnackBar> {
         primaryVariant: colorScheme.onPrimary,
         // For the button color, the spec says it should be primaryVariant, but for
         // backward compatibility on light themes we are leaving it as secondary.
-        secondary: isThemeDark ? colorScheme.primaryVariant : colorScheme.secondary,
+        secondary: buttonColor,
         secondaryVariant: colorScheme.onSecondary,
         surface: colorScheme.onSurface,
         background: themeBackgroundColor,
@@ -445,10 +452,13 @@ class _SnackBarState extends State<SnackBar> {
             ),
           ),
           if (widget.action != null)
-            ButtonTheme(
-              textTheme: ButtonTextTheme.accent,
-              minWidth: 64.0,
-              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            TextButtonTheme(
+              data: TextButtonThemeData(
+                style: TextButton.styleFrom(
+                  primary: buttonColor,
+                  padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                ),
+              ),
               child: widget.action,
             ),
         ],

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -101,6 +101,7 @@ void main() {
 
   testWidgets('SnackBar uses values from SnackBarThemeData', (WidgetTester tester) async {
     const String text = 'I am a snack bar.';
+    const String action = 'ACTION';
     final SnackBarThemeData snackBarTheme = _snackBarTheme();
 
     await tester.pumpWidget(MaterialApp(
@@ -113,7 +114,7 @@ void main() {
                   Scaffold.of(context).showSnackBar(SnackBar(
                     content: const Text(text),
                     duration: const Duration(seconds: 2),
-                    action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                    action: SnackBarAction(label: action, onPressed: () {}),
                   ));
                 },
                 child: const Text('X'),
@@ -128,20 +129,21 @@ void main() {
     await tester.pump(const Duration(milliseconds: 750));
 
     final Material material = _getSnackBarMaterial(tester);
-    final RawMaterialButton button = _getSnackBarButton(tester);
+    final RenderParagraph button = _getSnackBarActionTextRenderObject(tester, action);
     final RenderParagraph content = _getSnackBarTextRenderObject(tester, text);
 
     expect(content.text.style, snackBarTheme.contentTextStyle);
     expect(material.color, snackBarTheme.backgroundColor);
     expect(material.elevation, snackBarTheme.elevation);
     expect(material.shape, snackBarTheme.shape);
-    expect(button.textStyle.color, snackBarTheme.actionTextColor);
+    expect(button.text.style.color, snackBarTheme.actionTextColor);
   });
 
   testWidgets('SnackBar widget properties take priority over theme', (WidgetTester tester) async {
     const Color backgroundColor = Colors.purple;
     const Color textColor = Colors.pink;
     const double elevation = 7.0;
+    const String action = 'ACTION';
     const ShapeBorder shape = RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(9.0)),
     );
@@ -161,7 +163,7 @@ void main() {
                     duration: const Duration(seconds: 2),
                     action: SnackBarAction(
                       textColor: textColor,
-                      label: 'ACTION',
+                      label: action,
                       onPressed: () {},
                     ),
                   ));
@@ -178,12 +180,12 @@ void main() {
     await tester.pump(const Duration(milliseconds: 750));
 
     final Material material = _getSnackBarMaterial(tester);
-    final RawMaterialButton button = _getSnackBarButton(tester);
+    final RenderParagraph button = _getSnackBarActionTextRenderObject(tester, action);
 
     expect(material.color, backgroundColor);
     expect(material.elevation, elevation);
     expect(material.shape, shape);
-    expect(button.textStyle.color, textColor);
+    expect(button.text.style.color, textColor);
   });
 
   testWidgets('SnackBar theme behavior is correct for floating', (WidgetTester tester) async {
@@ -292,13 +294,11 @@ Material _getSnackBarMaterial(WidgetTester tester) {
   );
 }
 
-RawMaterialButton _getSnackBarButton(WidgetTester tester) {
-  return tester.widget<RawMaterialButton>(
-    find.descendant(
-      of: find.byType(SnackBar),
-      matching: find.byType(RawMaterialButton),
-    ).first,
-  );
+RenderParagraph _getSnackBarActionTextRenderObject(WidgetTester tester, String text) {
+  return tester.renderObject(find.descendant(
+    of: find.byType(TextButton),
+    matching: find.text(text),
+  ));
 }
 
 RenderParagraph _getSnackBarTextRenderObject(WidgetTester tester, String text) {


### PR DESCRIPTION
Replaced the one use of FlatButton with TextButton in SnackBar and removed its dependency on ButtonTheme per #59702.