### PR TITLE
Fix bug when updating the `divisions` and `value` of the slider at the same time

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -729,8 +729,11 @@ class _RangeSliderRenderObjectWidget extends LeafRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, _RenderRangeSlider renderObject) {
     renderObject
-      ..values = values
+      // We should update the `divisions` ahead of `values`, because the `values`
+      // setter dependent on the `divisions`.
+      // https://github.com/flutter/flutter/issues/65943
       ..divisions = divisions
+      ..values = values
       ..labels = labels
       ..sliderTheme = sliderTheme
       ..theme = Theme.of(context)

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -731,7 +731,6 @@ class _RangeSliderRenderObjectWidget extends LeafRenderObjectWidget {
     renderObject
       // We should update the `divisions` ahead of `values`, because the `values`
       // setter dependent on the `divisions`.
-      // https://github.com/flutter/flutter/issues/65943
       ..divisions = divisions
       ..values = values
       ..labels = labels

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -837,8 +837,11 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, _RenderSlider renderObject) {
     renderObject
-      ..value = value
+      // We should update the `divisions` ahead of `value`, because the `value`
+      // setter dependent on the `divisions`.
+      // https://github.com/flutter/flutter/issues/65943
       ..divisions = divisions
+      ..value = value
       ..label = label
       ..sliderTheme = sliderTheme
       ..theme = Theme.of(context)

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -839,7 +839,6 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
     renderObject
       // We should update the `divisions` ahead of `value`, because the `value`
       // setter dependent on the `divisions`.
-      // https://github.com/flutter/flutter/issues/65943
       ..divisions = divisions
       ..value = value
       ..label = label

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2499,17 +2499,17 @@ void main() {
     await tester.pumpWidget(buildFrame(15));
     await tester.pumpAndSettle(); // Finish the animation.
 
-    RRect leftActiveTrackRRect;
-    RRect rightActiveTrackRRect;
+    RRect leftInactiveTrackRRect;
+    RRect rightInactiveTrackRRect;
     int index = 0;
     expect(renderObject, paints..something((Symbol method, List<dynamic> arguments) {
       if (method != #drawRRect)
         return false;
       if (index == 0) {
-        leftActiveTrackRRect = arguments[0] as RRect;
+        leftInactiveTrackRRect = arguments[0] as RRect;
         index++;
       } else {
-        rightActiveTrackRRect = arguments[0] as RRect;
+        rightInactiveTrackRRect = arguments[0] as RRect;
         index++;
       }
       if (index == 2) {
@@ -2524,7 +2524,7 @@ void main() {
     // The right of the left active track shape is the position of the 1st thumb.
     // The left of the right active track shape is the position of the 2nd thumb.
     // 24.0 is the default margin, (800.0 - 24.0 - 24.0) is the slider's width.
-    expect(nearEqual(leftActiveTrackRRect.right, (800.0 - 24.0 - 24.0) * (5 / 15) + 24.0, 0.01), true);
-    expect(nearEqual(rightActiveTrackRRect.left, (800.0 - 24.0 - 24.0) * (8 / 15) + 24.0, 0.01), true);
+    expect(nearEqual(leftInactiveTrackRRect.right, (800.0 - 24.0 - 24.0) * (5 / 15) + 24.0, 0.01), true);
+    expect(nearEqual(rightInactiveTrackRRect.left, (800.0 - 24.0 - 24.0) * (8 / 15) + 24.0, 0.01), true);
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2435,7 +2435,7 @@ void main() {
 
   testWidgets('Update the divisions and value at the same time for Slider', (WidgetTester tester) async {
     // Regress test for https://github.com/flutter/flutter/issues/65943
-    Widget buildFrame(double  maxValue) {
+    Widget buildFrame(double maxValue) {
       return MaterialApp(
         home: Material(
           child: Center(
@@ -2471,60 +2471,5 @@ void main() {
     // The right of the active track shape is the position of the thumb.
     // 24.0 is the default margin, (800.0 - 24.0 - 24.0) is the slider's width.
     expect(nearEqual(activeTrackRRect.right, (800.0 - 24.0 - 24.0) * (5 / 15) + 24.0, 0.01), true);
-  });
-
-  testWidgets('Update the divisions and values at the same time for RangeSlider', (WidgetTester tester) async {
-    // Regress test for https://github.com/flutter/flutter/issues/65943
-    Widget buildFrame(double  maxValue) {
-      return MaterialApp(
-        home: Material(
-          child: Center(
-            child: RangeSlider(
-              values: const RangeValues(5, 8),
-              max: maxValue,
-              divisions: maxValue.toInt(),
-              onChanged: (RangeValues newValue) {},
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildFrame(10));
-
-    // _RenderRangeSlider is the last render object in the tree.
-    final RenderObject renderObject = tester.allRenderObjects.last;
-
-    // Update the divisions from 10 to 15, the thumbs should be paint at the correct position.
-    await tester.pumpWidget(buildFrame(15));
-    await tester.pumpAndSettle(); // Finish the animation.
-
-    RRect leftInactiveTrackRRect;
-    RRect rightInactiveTrackRRect;
-    int index = 0;
-    expect(renderObject, paints..something((Symbol method, List<dynamic> arguments) {
-      if (method != #drawRRect)
-        return false;
-      if (index == 0) {
-        leftInactiveTrackRRect = arguments[0] as RRect;
-        index++;
-      } else {
-        rightInactiveTrackRRect = arguments[0] as RRect;
-        index++;
-      }
-      if (index == 2) {
-        return true;
-      } else {
-        return false;
-      }
-    }));
-
-    // The 1st thumb should at one-third(5 / 15) of the Slider.
-    // The 2nd thumb should at (8 / 15) of the Slider.
-    // The right of the left active track shape is the position of the 1st thumb.
-    // The left of the right active track shape is the position of the 2nd thumb.
-    // 24.0 is the default margin, (800.0 - 24.0 - 24.0) is the slider's width.
-    expect(nearEqual(leftInactiveTrackRRect.right, (800.0 - 24.0 - 24.0) * (5 / 15) + 24.0, 0.01), true);
-    expect(nearEqual(rightInactiveTrackRRect.left, (800.0 - 24.0 - 24.0) * (8 / 15) + 24.0, 0.01), true);
   });
 }


### PR DESCRIPTION
## Description

When updating the `divisions` and `value` of the slider at the same time, the position of the thumb is wrong because the old `divisions` value is used.

## Related Issues

Fixes #65943 

## Tests

See files.