### PR TITLE
Update Windows system font change handling

### DIFF
--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
@@ -53,5 +53,12 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
       return *result;
     }
   }
+
+  switch (message) {
+    case WM_FONTCHANGE:
+      flutter_controller_->engine()->ReloadSystemFonts();
+      break;
+  }
+
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);
 }

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
@@ -187,11 +187,6 @@ Win32Window::MessageHandler(HWND hwnd,
         SetFocus(child_content_);
       }
       return 0;
-
-    // Messages that are directly forwarded to embedding.
-    case WM_FONTCHANGE:
-      SendMessage(child_content_, WM_FONTCHANGE, NULL, NULL);
-      return 0;
   }
 
   return DefWindowProc(window_handle_, message, wparam, lparam);


### PR DESCRIPTION
## Description

The engine now has an explicit API for system font changes, rather than
expecting the WM_FONTCHANGE message to be forwarded to the Flutter view.

## Related Issues

https://github.com/flutter/flutter/issues/52748

## Tests

I added the following tests: None; end-to-end testing of Windows applications doesn't exist yet.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
