### PR TITLE
Revert "always adds alert label for alert dialog in Android"

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -413,11 +413,9 @@ class AlertDialog extends StatelessWidget {
   /// The semantic label of the dialog used by accessibility frameworks to
   /// announce screen transitions when the dialog is opened and closed.
   ///
-  /// In iOS, if this label is not provided, a semantic label will be inferred
-  /// from the [title] if it is not null.
-  ///
-  /// In Android, if this label is not provided, the dialog will use the
-  /// [MaterialLocalizations.alertDialogLabel] as its label.
+  /// If this label is not provided, a semantic label will be inferred from the
+  /// [title] if it is not null.  If there is no title, the label will be taken
+  /// from [MaterialLocalizations.alertDialogLabel].
   ///
   /// See also:
   ///
@@ -457,15 +455,18 @@ class AlertDialog extends StatelessWidget {
     final DialogTheme dialogTheme = DialogTheme.of(context);
 
     String label = semanticLabel;
-    switch (theme.platform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        break;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        label ??= MaterialLocalizations.of(context)?.alertDialogLabel;
+    if (title == null) {
+      switch (theme.platform) {
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          label = semanticLabel;
+          break;
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          label = semanticLabel ?? MaterialLocalizations.of(context)?.alertDialogLabel;
+      }
     }
 
     // The paddingScaleFactor is used to adjust the padding of Dialog's
@@ -490,7 +491,7 @@ class AlertDialog extends StatelessWidget {
           style: titleTextStyle ?? dialogTheme.titleTextStyle ?? theme.textTheme.headline6,
           child: Semantics(
             child: title,
-            namesRoute: label == null,
+            namesRoute: true,
             container: true,
           ),
         ),
@@ -568,8 +569,6 @@ class AlertDialog extends StatelessWidget {
 
     if (label != null)
       dialogChild = Semantics(
-        scopesRoute: true,
-        explicitChildNodes: true,
         namesRoute: true,
         label: label,
         child: dialogChild,

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -1275,12 +1275,10 @@ void main() {
         ));
   });
 
-  testWidgets('AlertDialog widget contains route semantics from title for iOS', (WidgetTester tester) async {
+  testWidgets('Dialog widget contains route semantics from title', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
-
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.iOS),
         home: Material(
           child: Builder(
             builder: (BuildContext context) {
@@ -1318,62 +1316,6 @@ void main() {
     expect(semantics, includesNodeWith(
       label: 'Title',
       flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
-    ));
-
-    semantics.dispose();
-  });
-
-    testWidgets('AlertDialog widget always contains alert route semantics for android', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.android),
-        home: Material(
-          child: Builder(
-            builder: (BuildContext context) {
-              return Center(
-                child: ElevatedButton(
-                  child: const Text('X'),
-                  onPressed: () {
-                    showDialog<void>(
-                      context: context,
-                      builder: (BuildContext context) {
-                        return const AlertDialog(
-                          title: Text('Title'),
-                          content: Text('Y'),
-                          actions: <Widget>[],
-                        );
-                      },
-                    );
-                  },
-                ),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-
-    expect(semantics, isNot(includesNodeWith(
-      label: 'Title',
-      flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
-    )));
-    expect(semantics, isNot(includesNodeWith(
-      label: 'Alert',
-      flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
-    )));
-
-    await tester.tap(find.text('X'));
-    await tester.pumpAndSettle();
-    // It does not use 'Title' as route semantics
-    expect(semantics, isNot(includesNodeWith(
-      label: 'Title',
-      flags: <SemanticsFlag>[SemanticsFlag.namesRoute],
-    )));
-    expect(semantics, includesNodeWith(
-      label: 'Alert',
-      flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
     ));
 
     semantics.dispose();


### PR DESCRIPTION
Reverts flutter/flutter#65973

Breaks android semantics integration test:


```
2020-09-16T18:49:33.953383: stdout: [+11309 ms] 00:32 [32m+8[0m: AccessibilityBridge Popup Controls Modal alert dialog has correct Android semantics[0m
2020-09-16T18:49:35.841076: stdout: [+1887 ms] 00:34 [32m+8[0m[31m -1[0m: AccessibilityBridge Popup Controls Modal alert dialog has correct Android semantics [1m[31m[E][0m[0m
2020-09-16T18:49:35.841274: stdout: [        ]   Expected: AndroidSemanticsNode with className: android.view.View with actions: [AndroidSemanticsAction.accessibilityFocus] with flag isChecked: false with flag isEnabled: true with flag isFocusable: true
2020-09-16T18:49:35.841512: stdout: [        ]     Actual: AndroidSemanticsNode:<{flags: {isEditable: false, isEnabled: true, isDismissable: false, isCheckable: false, isChecked: false, isFocused: false, isLongClickable: false, isFocusable: true, isPassword: false}, id: 94, text: null, rect: {height: 69, width: 696, bottom: 258.6666564941406, top: 235.6666717529297, left: 64.0, right: 296.0}, actions: [128], className: android.view.View, liveRegion: 0, contentDescription: Title text}>
2020-09-16T18:49:35.841761: stdout: [        ]      Which: Expected actions: [AndroidSemanticsAction.accessibilityFocus]
2020-09-16T18:49:35.842043: stdout: [        ]             Actual actions: [AndroidSemanticsAction.clearAccessibilityFocus]
2020-09-16T18:49:35.842284: stdout: [        ]             Unexpected: {AndroidSemanticsAction.clearAccessibilityFocus}
2020-09-16T18:49:35.842473: stdout: [        ]             Missing: {AndroidSemanticsAction.accessibilityFocus}
2020-09-16T18:49:35.842720: stdout: [        ]   Alert Title button doesn't have the right semantics
2020-09-16T18:49:35.867026: stdout: [  +24 ms]   package:test_api/src/frontend/expect.dart 155:31               fail
2020-09-16T18:49:35.867608: stdout: [        ]   package:test_api/src/frontend/expect.dart 150:3                _expect
stdout: [        ]   package:test_api/src/frontend/expect.dart 59:3                 expect
stdout: [        ]   test_driver/main_test.dart 607:13                              main.<fn>.<fn>.<fn>
2020-09-16T18:49:35.868270: stdout: [        ]   ===== asynchronous gap ===========================
stdout: [        ]   dart:async/zone.dart 1129:19                                   _CustomZone.registerBinaryCallback
stdout: [        ]   dart:async-patch/async_patch.dart 94:8                         _asyncErrorWrapperHelper
2020-09-16T18:49:35.868676: stdout: [        ]   package:test_api/src/backend/invoker.dart                      Invoker.waitForOutstandingCallbacks.<fn>
stdout: [        ]   dart:async/zone.dart 1190:13                                   _rootRun
2020-09-16T18:49:35.869146: stdout: [        ]   dart:async/zone.dart 1093:19                                   _CustomZone.run
stdout: [        ]   dart:async/zone.dart 1630:10                                   _runZoned
2020-09-16T18:49:35.869698: stdout: [        ]   dart:async/zone.dart 1550:10                                   runZoned
stdout: [        ]   package:test_api/src/backend/invoker.dart 228:5                Invoker.waitForOutstandingCallbacks
```

FYI @chunhtai 