### PR TITLE
Deprecate VelocityTracker default constructor and added VelocityTracker.withKind constructor

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
@@ -20,7 +20,7 @@ void main() {
   assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
   final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
   final List<TrackerBenchmark> benchmarks = <TrackerBenchmark>[
-    TrackerBenchmark(name: 'velocity_tracker_iteration', tracker: VelocityTracker(PointerDeviceKind.touch)),
+    TrackerBenchmark(name: 'velocity_tracker_iteration', tracker: VelocityTracker.withKind(PointerDeviceKind.touch)),
     TrackerBenchmark(name: 'velocity_tracker_iteration_ios_fling', tracker: IOSScrollViewFlingVelocityTracker(PointerDeviceKind.touch)),
   ];
   final Stopwatch watch = Stopwatch();

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -376,7 +376,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   void handlePrimaryPointer(PointerEvent event) {
     if (!event.synthesized) {
       if (event is PointerDownEvent) {
-        _velocityTracker = VelocityTracker(event.kind);
+        _velocityTracker = VelocityTracker.withKind(event.kind);
         _velocityTracker!.addPosition(event.timeStamp, event.localPosition);
       }
       if (event is PointerMoveEvent) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,7 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }) : assert(dragStartBehavior != null),
        super(debugOwner: debugOwner, kind: kind);
 
-  static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker(event.kind);
+  static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker.withKind(event.kind);
   /// Configure the behavior of offsets sent to [onStart].
   ///
   /// If set to [DragStartBehavior.start], the [onStart] callback will be called

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -30,7 +30,7 @@ abstract class MultiDragPointerState {
   /// The [initialPosition] argument must not be null.
   MultiDragPointerState(this.initialPosition, this.kind)
     : assert(initialPosition != null),
-      _velocityTracker = VelocityTracker(kind);
+      _velocityTracker = VelocityTracker.withKind(kind);
 
   /// The global coordinates of the pointer when the pointer contacted the screen.
   final Offset initialPosition;

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -286,7 +286,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   void addAllowedPointer(PointerEvent event) {
     startTrackingPointer(event.pointer, event.transform);
-    _velocityTrackers[event.pointer] = VelocityTracker(event.kind);
+    _velocityTrackers[event.pointer] = VelocityTracker.withKind(event.kind);
     if (_state == _ScaleState.ready) {
       _state = _ScaleState.possible;
       _initialSpan = 0.0;

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -151,7 +151,7 @@ class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
     'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked '
-    'This feature was deprecated after 1.22.0-12.1.pre .'
+    'This feature was deprecated after v1.22.0-12.1.pre .'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -150,7 +150,7 @@ class _PointAtTime {
 class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
-    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked '
+    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked. '
     'This feature was deprecated after v1.22.0-12.1.pre.'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -150,8 +150,8 @@ class _PointAtTime {
 class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
-    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked.'
-    'This feature was deprecated after 1.22.0.'
+    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked '
+    'This feature was deprecated after v1.22.0.'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -149,7 +149,15 @@ class _PointAtTime {
 /// have been received.
 class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
-  VelocityTracker(this.kind);
+  @Deprecated(
+    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated '
+    'with the gesture being tracked.'
+    'This feature was deprecated after 1.22.0'
+  )
+  VelocityTracker([this.kind = PointerDeviceKind.touch]);
+
+  /// Create a new velocity tracker for a pointer [kind].
+  VelocityTracker.withKind(this.kind);
 
   static const int _assumePointerMoveStoppedMilliseconds = 40;
   static const int _historySize = 20;
@@ -281,7 +289,7 @@ class VelocityTracker {
 ///   the iOS method that reports the fling velocity when the touch is released.
 class IOSScrollViewFlingVelocityTracker extends VelocityTracker {
   /// Create a new IOSScrollViewFlingVelocityTracker.
-  IOSScrollViewFlingVelocityTracker(PointerDeviceKind kind) : super(kind);
+  IOSScrollViewFlingVelocityTracker(PointerDeviceKind kind) : super.withKind(kind);
 
   /// The velocity estimation uses at most 4 `_PointAtTime` samples. The extra
   /// samples are there to make the `VelocityEstimate.offset` sufficiently large

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -151,7 +151,7 @@ class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
     'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked '
-    'This feature was deprecated after v1.22.0-12.1.pre .'
+    'This feature was deprecated after v1.22.0-12.1.pre.'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -150,9 +150,8 @@ class _PointAtTime {
 class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
-    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated '
-    'with the gesture being tracked.'
-    'This feature was deprecated after 1.22.0'
+    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked.'
+    'This feature was deprecated after 1.22.0.'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -151,7 +151,7 @@ class VelocityTracker {
   /// Create a new velocity tracker for a pointer [kind].
   @Deprecated(
     'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked '
-    'This feature was deprecated after v1.22.0.'
+    'This feature was deprecated after 1.22.0-12.1.pre .'
   )
   VelocityTracker([this.kind = PointerDeviceKind.touch]);
 

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -75,7 +75,7 @@ class ScrollBehavior {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return (PointerEvent event) => VelocityTracker(event.kind);
+        return (PointerEvent event) => VelocityTracker.withKind(event.kind);
     }
   }
 

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -38,7 +38,7 @@ void main() {
   ];
 
   test('Velocity tracker gives expected results', () {
-    final VelocityTracker tracker = VelocityTracker(PointerDeviceKind.touch);
+    final VelocityTracker tracker = VelocityTracker.withKind(PointerDeviceKind.touch);
     int i = 0;
     for (final PointerEvent event in velocityEventData) {
       if (event is PointerDownEvent || event is PointerMoveEvent)
@@ -64,7 +64,7 @@ void main() {
 
   test('Interrupted velocity estimation', () {
     // Regression test for https://github.com/flutter/flutter/pull/7510
-    final VelocityTracker tracker = VelocityTracker(PointerDeviceKind.touch);
+    final VelocityTracker tracker = VelocityTracker.withKind(PointerDeviceKind.touch);
     for (final PointerEvent event in interruptedVelocityEventData) {
       if (event is PointerDownEvent || event is PointerMoveEvent)
         tracker.addPosition(event.timeStamp, event.position);
@@ -75,7 +75,7 @@ void main() {
   });
 
   test('No data velocity estimation', () {
-    final VelocityTracker tracker = VelocityTracker(PointerDeviceKind.touch);
+    final VelocityTracker tracker = VelocityTracker.withKind(PointerDeviceKind.touch);
     expect(tracker.getVelocity(), Velocity.zero);
   });
 

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -310,7 +310,7 @@ class RangeMaintainingTestScrollBehavior extends ScrollBehavior {
 
   @override
   GestureVelocityTrackerBuilder velocityTrackerBuilder(BuildContext context) {
-    return (PointerEvent event) => VelocityTracker(event.kind);
+    return (PointerEvent event) => VelocityTracker.withKind(event.kind);
   }
 
   @override

--- a/packages/flutter/test/widgets/scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scroll_behavior_test.dart
@@ -27,7 +27,7 @@ class TestScrollBehavior extends ScrollBehavior {
   @override
   GestureVelocityTrackerBuilder velocityTrackerBuilder(BuildContext context) {
       lastCreatedBuilder = flag
-        ? (PointerEvent ev) => VelocityTracker(ev.kind)
+        ? (PointerEvent ev) => VelocityTracker.withKind(ev.kind)
         : (PointerEvent ev) => IOSScrollViewFlingVelocityTracker(ev.kind);
       return lastCreatedBuilder;
   }


### PR DESCRIPTION
## Description

We've gotten feedback that the VelocityTracker change was disruptive, though it did not break any of the flutter framework or customer tests. In order to make the change non-breaking, PointerDeviceKind parameter can be made optional.

Nevertheless, this parameter should be provided so that the existing touch handlers can use more accurate gestures on mouse/stylus inputs, so we can encourage this by deprecating the default constructor and pointing users towards the VelocityTracker.withKind constructor that takes a non-optional parameter