### PR TITLE
InteractiveViewer onInteractionUpdate focalPoint

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -733,13 +733,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // handled with GestureDetector's scale gesture.
   void _onScaleUpdate(ScaleUpdateDetails details) {
     final double scale = _transformationController!.value.getMaxScaleOnAxis();
-    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
-      focalPoint: details.focalPoint,
-      localFocalPoint: details.localFocalPoint,
-      scale: details.scale,
-      rotation: details.rotation,
-    ));
-
     final Offset focalPointScene = _transformationController!.toScene(
       details.localFocalPoint,
     );
@@ -793,7 +786,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         if (_round(_referenceFocalPoint!) != _round(focalPointSceneCheck)) {
           _referenceFocalPoint = focalPointSceneCheck;
         }
-        return;
+        break;
 
       case _GestureType.rotate:
         if (details.rotation == 0.0) {
@@ -806,7 +799,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
           details.localFocalPoint,
         );
         _currentRotation = desiredRotation;
-        return;
+        break;
 
       case _GestureType.pan:
         assert(_referenceFocalPoint != null);
@@ -827,8 +820,14 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _referenceFocalPoint = _transformationController!.toScene(
           details.localFocalPoint,
         );
-        return;
+        break;
     }
+    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
+      focalPoint: details.focalPoint,
+      localFocalPoint: details.localFocalPoint,
+      scale: details.scale,
+      rotation: details.rotation,
+    ));
   }
 
   // Handle the end of a gesture of _GestureType. All of pan, scale, and rotate
@@ -911,7 +910,10 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         focalPointSceneScaled - focalPointScene,
       );
       widget.onInteractionStart?.call(
-        ScaleStartDetails(focalPoint: focalPointSceneScaled)
+        ScaleStartDetails(
+          focalPoint: event.position,
+          localFocalPoint: event.localPosition,
+        ),
       );
       widget.onInteractionUpdate?.call(ScaleUpdateDetails(
         focalPoint: event.position,

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -220,6 +220,9 @@ class InteractiveViewer extends StatefulWidget {
 
   /// Called when the user ends a pan or scale gesture on the widget.
   ///
+  /// At the time this is called, the [TransformationController] will have
+  /// already been updated to reflect the change caused by the interaction.
+  ///
   /// {@template flutter.widgets.interactiveViewer.onInteraction}
   /// Will be called even if the interaction is disabled with
   /// [panEnabled] or [scaleEnabled].
@@ -229,10 +232,6 @@ class InteractiveViewer extends StatefulWidget {
   /// [GestureDetector.onScaleEnd]. Use [onInteractionStart],
   /// [onInteractionUpdate], and [onInteractionEnd] to respond to those
   /// gestures.
-  ///
-  /// The coordinates returned in the details are viewport coordinates relative
-  /// to the parent. See [TransformationController.toScene] for how to
-  /// convert the coordinates to scene coordinates relative to the child.
   /// {@endtemplate}
   ///
   /// See also:
@@ -243,7 +242,16 @@ class InteractiveViewer extends StatefulWidget {
 
   /// Called when the user begins a pan or scale gesture on the widget.
   ///
+  /// At the time this is called, the [TransformationController] will not have
+  /// changed due to this interaction.
+  ///
   /// {@macro flutter.widgets.interactiveViewer.onInteraction}
+  ///
+  /// The coordinates provided in the details' `focalPoint` and
+  /// `localFocalPoint` are normal Flutter event coordinates, not
+  /// InteractiveViewer scene coordinates. See
+  /// [TransformationController.toScene] for how to convert these coordinates to
+  /// scene coordinates relative to the child.
   ///
   /// See also:
   ///
@@ -253,7 +261,16 @@ class InteractiveViewer extends StatefulWidget {
 
   /// Called when the user updates a pan or scale gesture on the widget.
   ///
+  /// At the time this is called, the [TransformationController] will have
+  /// already been updated to reflect the change caused by the interaction.
+  ///
   /// {@macro flutter.widgets.interactiveViewer.onInteraction}
+  ///
+  /// The coordinates provided in the details' `focalPoint` and
+  /// `localFocalPoint` are normal Flutter event coordinates, not
+  /// InteractiveViewer scene coordinates. See
+  /// [TransformationController.toScene] for how to convert these coordinates to
+  /// scene coordinates relative to the child.
   ///
   /// See also:
   ///
@@ -882,10 +899,17 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
   // Handle mousewheel scroll events.
   void _receivedPointerSignal(PointerSignalEvent event) {
-    if (!_gestureIsSupported(_GestureType.scale)) {
-      return;
-    }
     if (event is PointerScrollEvent) {
+      widget.onInteractionStart?.call(
+        ScaleStartDetails(
+          focalPoint: event.position,
+          localFocalPoint: event.localPosition,
+        ),
+      );
+      if (!_gestureIsSupported(_GestureType.scale)) {
+        widget.onInteractionEnd?.call(ScaleEndDetails());
+        return;
+      }
       final RenderBox childRenderBox = _childKey.currentContext!.findRenderObject() as RenderBox;
       final Size childSize = childRenderBox.size;
       final double scaleChange = 1.0 - event.scrollDelta.dy / childSize.height;
@@ -895,6 +919,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       final Offset focalPointScene = _transformationController!.toScene(
         event.localPosition,
       );
+
       _transformationController!.value = _matrixScale(
         _transformationController!.value,
         scaleChange,
@@ -909,12 +934,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _transformationController!.value,
         focalPointSceneScaled - focalPointScene,
       );
-      widget.onInteractionStart?.call(
-        ScaleStartDetails(
-          focalPoint: event.position,
-          localFocalPoint: event.localPosition,
-        ),
-      );
+
       widget.onInteractionUpdate?.call(ScaleUpdateDetails(
         focalPoint: event.position,
         localFocalPoint: event.localPosition,

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -711,9 +711,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // Handle the start of a gesture. All of pan, scale, and rotate are handled
   // with GestureDetector's scale gesture.
   void _onScaleStart(ScaleStartDetails details) {
-    if (widget.onInteractionStart != null) {
-      widget.onInteractionStart!(details);
-    }
+    widget.onInteractionStart?.call(details);
 
     if (_controller.isAnimating) {
       _controller.stop();
@@ -735,14 +733,12 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // handled with GestureDetector's scale gesture.
   void _onScaleUpdate(ScaleUpdateDetails details) {
     final double scale = _transformationController!.value.getMaxScaleOnAxis();
-    if (widget.onInteractionUpdate != null) {
-      widget.onInteractionUpdate!(ScaleUpdateDetails(
-        focalPoint: details.focalPoint,
-        localFocalPoint: details.localFocalPoint,
-        scale: details.scale,
-        rotation: details.rotation,
-      ));
-    }
+    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
+      focalPoint: details.focalPoint,
+      localFocalPoint: details.localFocalPoint,
+      scale: details.scale,
+      rotation: details.rotation,
+    ));
 
     final Offset focalPointScene = _transformationController!.toScene(
       details.localFocalPoint,
@@ -838,9 +834,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // Handle the end of a gesture of _GestureType. All of pan, scale, and rotate
   // are handled with GestureDetector's scale gesture.
   void _onScaleEnd(ScaleEndDetails details) {
-    if (widget.onInteractionEnd != null) {
-      widget.onInteractionEnd!(details);
-    }
+    widget.onInteractionEnd?.call(details);
     _scaleStart = null;
     _rotationStart = null;
     _referenceFocalPoint = null;
@@ -916,24 +910,18 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _transformationController!.value,
         focalPointSceneScaled - focalPointScene,
       );
-      if (widget.onInteractionStart != null) {
-        widget.onInteractionStart!(
-            ScaleStartDetails(focalPoint: focalPointSceneScaled)
-        );
-      }
-      if (widget.onInteractionUpdate != null) {
-        widget.onInteractionUpdate!(ScaleUpdateDetails(
-          focalPoint: event.position,
-          localFocalPoint: event.localPosition,
-          rotation: 0.0,
-          scale: scaleChange,
-          horizontalScale: 1.0,
-          verticalScale: 1.0,
-        ));
-      }
-      if (widget.onInteractionEnd != null) {
-        widget.onInteractionEnd!(ScaleEndDetails());
-      }
+      widget.onInteractionStart?.call(
+        ScaleStartDetails(focalPoint: focalPointSceneScaled)
+      );
+      widget.onInteractionUpdate?.call(ScaleUpdateDetails(
+        focalPoint: event.position,
+        localFocalPoint: event.localPosition,
+        rotation: 0.0,
+        scale: scaleChange,
+        horizontalScale: 1.0,
+        verticalScale: 1.0,
+      ));
+      widget.onInteractionEnd?.call(ScaleEndDetails());
     }
   }
 

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -924,6 +924,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       }
       if (widget.onInteractionUpdate != null) {
         widget.onInteractionUpdate!(ScaleUpdateDetails(
+          focalPoint: _transformationController!.toScene(event.localPosition),
           rotation: 0.0,
           scale: scaleChange,
           horizontalScale: 1.0,

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -737,9 +737,8 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     final double scale = _transformationController!.value.getMaxScaleOnAxis();
     if (widget.onInteractionUpdate != null) {
       widget.onInteractionUpdate!(ScaleUpdateDetails(
-        focalPoint: _transformationController!.toScene(
-          details.localFocalPoint,
-        ),
+        focalPoint: details.focalPoint,
+        localFocalPoint: details.localFocalPoint,
         scale: details.scale,
         rotation: details.rotation,
       ));
@@ -924,7 +923,8 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       }
       if (widget.onInteractionUpdate != null) {
         widget.onInteractionUpdate!(ScaleUpdateDetails(
-          focalPoint: _transformationController!.toScene(event.localPosition),
+          focalPoint: event.position,
+          localFocalPoint: event.localPosition,
           rotation: 0.0,
           scale: scaleChange,
           horizontalScale: 1.0,

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -626,6 +626,7 @@ void main() {
     testWidgets('Scale with mouse returns onInteraction properties', (WidgetTester tester) async{
       final TransformationController transformationController = TransformationController();
       Offset focalPoint;
+      Offset localFocalPoint;
       double scaleChange;
       Velocity currentVelocity;
       bool calledStart;
@@ -641,6 +642,7 @@ void main() {
                 onInteractionUpdate: (ScaleUpdateDetails details){
                   scaleChange = details.scale;
                   focalPoint = details.focalPoint;
+                  localFocalPoint = details.localFocalPoint;
                 },
                 onInteractionEnd: (ScaleEndDetails details){
                   currentVelocity = details.velocity;
@@ -663,7 +665,10 @@ void main() {
       expect(afterScaling, isNot(equals(1.0)));
       expect(currentVelocity, equals(noMovement));
       expect(calledStart, equals(true));
-      expect(focalPoint, const Offset(100, 100)); // Center of Container.
+      // Focal points are given in coordinates outside of InteractiveViewer,
+      // with local being in relation to the InteractiveViewer.
+      expect(focalPoint, center);
+      expect(localFocalPoint, const Offset(100, 100));
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -625,6 +625,7 @@ void main() {
 
     testWidgets('Scale with mouse returns onInteraction properties', (WidgetTester tester) async{
       final TransformationController transformationController = TransformationController();
+      Offset focalPoint;
       double scaleChange;
       Velocity currentVelocity;
       bool calledStart;
@@ -639,6 +640,7 @@ void main() {
                 },
                 onInteractionUpdate: (ScaleUpdateDetails details){
                   scaleChange = details.scale;
+                  focalPoint = details.focalPoint;
                 },
                 onInteractionEnd: (ScaleEndDetails details){
                   currentVelocity = details.velocity;
@@ -661,6 +663,7 @@ void main() {
       expect(afterScaling, isNot(equals(1.0)));
       expect(currentVelocity, equals(noMovement));
       expect(calledStart, equals(true));
+      expect(focalPoint, const Offset(100, 100)); // Center of Container.
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

onInteractionUpdate was not passing `focalPoint` or `localFocalPoint` when using mouse scrolling. This was just an oversight when we implemented that event for mouse scrolling (https://github.com/flutter/flutter/pull/65313).

## Related Issues

Bug from https://github.com/flutter/flutter/pull/65313
Closes https://github.com/flutter/flutter/issues/66035
Closes https://github.com/flutter/flutter/issues/63606

## Tests

I added a check for focalPoint to an existing test.