### PR TITLE
[flutter_tools] optimize fetch requests and remove main.dart.js bypass

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -334,9 +334,9 @@ class WebReleaseBundle extends Target {
         outputFile.parent.createSync(recursive: true);
       }
       outputResourcesFiles.add(outputFile);
-      // insert a random hash into the requests for main.dart.js and service_worker.js. This is
-      // not a content hash, because it would need to be the hash for the entire bundle and not
-      // just the resource in question.
+      // insert a random hash into the requests for service_worker.js. This is not a content hash,
+      // because it would need to be the hash for the entire bundle and not just the resource
+      // in question.
       if (environment.fileSystem.path.basename(inputFile.path) == 'index.html') {
         final String randomHash = Random().nextInt(4294967296).toString();
         final String resultString = inputFile.readAsStringSync()

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -472,7 +472,7 @@ const CORE = [
   ${coreBundle.map((String file) => '"$file"').join(',\n')}];
 // During install, the TEMP cache is populated with the application shell files.
 self.addEventListener("install", (event) => {
-  skipWaiting();
+  self.skipWaiting();
   return event.waitUntil(
     caches.open(TEMP).then((cache) => {
       return cache.addAll(
@@ -580,7 +580,7 @@ self.addEventListener('message', (event) => {
   // SkipWaiting can be used to immediately activate a waiting service worker.
   // This will also require a page refresh triggered by the main worker.
   if (event.data === 'skipWaiting') {
-    skipWaiting();
+    self.skipWaiting();
     return;
   }
   if (event.data === 'downloadOffline') {
@@ -630,12 +630,6 @@ function onlineFirst(event) {
       });
     })
   );
-}
-
-function skipWaiting() {
-  if (self.skipWaiting != undefined) {
-    self.skipWaiting();
-  }
 }
 ''';
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -136,9 +136,9 @@ void main() {
 
     expect(environment.outputDir.childFile('foo.txt')
       .readAsStringSync(), 'B');
-    // Appends number to requests for service worker and main.dart.js
+    // Appends number to requests for service worker only
     expect(environment.outputDir.childFile('index.html').readAsStringSync(), allOf(
-      contains('<script src="main.dart.js?v='),
+      contains('<script src="main.dart.js" type="application/javascript">'),
       contains('flutter_service_worker.js?v='),
     ));
   }));


### PR DESCRIPTION
## Description

The main.dart.js bypass is not needed now that we have skipWaiting. Additionally optimize the fetch handler so that resources not in the cache skip the service worker altogether.

Fixes https://github.com/flutter/flutter/issues/66068