### PR TITLE
Prevent a potential infinite loop in setMessageHandler

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -309,13 +309,14 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
 
   @override
   void setMessageHandler(String channel, MessageHandler? handler) {
-    if (handler == null)
+    if (handler == null) {
       _handlers.remove(channel);
-    else
+    } else {
       _handlers[channel] = handler;
-    ui.channelBuffers.drain(channel, (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
-      await handlePlatformMessage(channel, data, callback);
-    });
+      ui.channelBuffers.drain(channel, (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
+        await handlePlatformMessage(channel, data, callback);
+      });
+    }
   }
 
   @override

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -25,6 +25,7 @@ void main() {
       final String reply = await channel.send('hello');
       expect(reply, equals('hello world'));
     });
+
     test('can receive string message and send reply', () async {
       channel.setMessageHandler((String message) async => message + ' world');
       String reply;
@@ -170,13 +171,25 @@ void main() {
       expect(result, isNull);
     });
 
-    test('can handle method call with no registered plugin', () async {
+    test('can handle method call with no registered plugin (setting before)', () async {
       channel.setMethodCallHandler(null);
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
       ByteData envelope;
       await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
         envelope = result;
       });
+      await null; // just in case there's something async happening
+      expect(envelope, isNull);
+    });
+
+    test('can handle method call with no registered plugin (setting after)', () async {
+      final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
+      ByteData envelope;
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('ch7', call, (ByteData result) {
+        envelope = result;
+      });
+      channel.setMethodCallHandler(null);
+      await null; // just in case there's something async happening
       expect(envelope, isNull);
     });
 
@@ -262,6 +275,7 @@ void main() {
       expect(channel.checkMockMethodCallHandler(handler), true);
     });
   });
+
   group('EventChannel', () {
     const MessageCodec<dynamic> jsonMessage = JSONMessageCodec();
     const MethodCodec jsonMethod = JSONMethodCodec();
@@ -298,6 +312,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect(canceled, isTrue);
     });
+
     test('can receive error event', () async {
       ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'ch',


### PR DESCRIPTION
The new test added in this PR would hang, because when you remove a message handler (by setting it to null) we tried to drain the messages, but since no handler was registered, we'd immediately add them back to the queue, which would then be drained, ad infinitum.