### PR TITLE
Remove the Windows 'flutter create' warning

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -506,15 +506,6 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
             'directory in order to launch your app.');
         globals.printStatus('Your $application code is in $relativeAppMain');
       }
-
-      // Warn about unstable templates. This shuold be last so that it's not
-      // lost among the other output.
-      if (featureFlags.isWindowsEnabled && platforms.contains('windows')) {
-        globals.printStatus('');
-        globals.printStatus('WARNING: The Windows tooling and APIs are not yet stable. '
-            'You will likely need to re-create the "windows" directory after future '
-            'Flutter updates.');
-      }
     }
     return FlutterCommandResult.success();
   }


### PR DESCRIPTION
## Description

The template is now considered stable; this warning should no longer be
printed. This should have been part of
https://github.com/flutter/flutter/pull/66022
but was missed.

## Related Issues

https://github.com/flutter/flutter/issues/52748

## Tests

I added the following tests: None; this warning was never explicitly tested, so no test changes are needed.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
