### PR TITLE
Fix 'Invalid Image Data' for local Gold testing

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -648,7 +648,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     late String? testExpectation;
     testExpectation = await skiaClient.getExpectationForTest(testName);
 
-    if (testExpectation == null) {
+    if (testExpectation == null || testExpectation.isEmpty) {
       // There is no baseline for this test
       print('No expectations provided by Skia Gold for test: $golden. '
         'This may be a new test. If this is an unexpected result, check '

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -903,6 +903,8 @@ void main() {
 
         when(mockSkiaClient.getExpectationForTest('flutter.golden_test.1'))
           .thenAnswer((_) => Future<String>.value('55109a4bed52acc780530f7a9aeff6c0'));
+        when(mockSkiaClient.getExpectationForTest('flutter.new_golden_test.2'))
+          .thenAnswer((_) => Future<String>.value(''));
         when(mockSkiaClient.getImageBytes('55109a4bed52acc780530f7a9aeff6c0'))
           .thenAnswer((_) => Future<List<int>>.value(_kTestPngBytes));
         when(mockSkiaClient.cleanTestName('library.flutter.golden_test.1.png'))
@@ -919,7 +921,7 @@ void main() {
         );
       });
 
-      testWithOutput('passes non-existent baseline for new test', () async {
+      testWithOutput('passes non-existent baseline for new test, null expectation', () async {
         expect(
           await comparator.compare(
             Uint8List.fromList(_kFailPngBytes),
@@ -930,6 +932,19 @@ void main() {
       }, 'No expectations provided by Skia Gold for test: library.flutter.new_golden_test.1. '
          'This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.\n'
          'Validate image output found at flutter/test/library/'
+      );
+
+      testWithOutput('passes non-existent baseline for new test, empty expectation', () async {
+        expect(
+          await comparator.compare(
+            Uint8List.fromList(_kFailPngBytes),
+            Uri.parse('flutter.new_golden_test.2'),
+          ),
+          isTrue,
+        );
+      }, 'No expectations provided by Skia Gold for test: library.flutter.new_golden_test.2. '
+        'This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.\n'
+        'Validate image output found at flutter/test/library/'
       );
 
       test('compare properly awaits validation & output before failing.', () async {


### PR DESCRIPTION
## Description

This fixes the  local `invalid image data` error happening in local golden file testing for flutter/flutter that was specific to new tests. The new Gold endpoint `latestPositiveDigest/` introduced in https://github.com/flutter/flutter/pull/64982 can return an empty expectation, where we were relying on null as the signal for a new test.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66141

## Tests

Added a test for an empty digest returned from Gold

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
