### PR TITLE
Added timeout for closing devfs sync http connections.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -239,7 +239,11 @@ class _DevFSHttpWriter implements DevFSWriter {
   final String fsName;
   final Uri httpAddress;
 
-  static const int kMaxInFlight = 6;
+  // 3 was chosen to try to limit the varience in the time it takes to execute
+  // `await request.close()` since there is a known bug in Dart where it doesn't
+  // always return a status code in response to a PUT request:
+  // https://github.com/dart-lang/sdk/issues/43525.
+  static const int kMaxInFlight = 3;
 
   int _inFlight = 0;
   Map<Uri, DevFSContent> _outstanding;
@@ -291,9 +295,14 @@ class _DevFSHttpWriter implements DevFSWriter {
         await request.addStream(contents);
         // The contents has already been streamed, closing the request should
         // not take long but we are experiencing hangs with it, see #63869.
+        //
+        // Once the bug in Dart is solved we can remove the timeout
+        // (https://github.com/dart-lang/sdk/issues/43525).  The timeout was
+        // chosen to be inflated based on the max observed time when running the
+        // tests in "Google Tests".
         try {
           final HttpClientResponse response = await request.close().timeout(
-            const Duration(milliseconds: 500));
+            const Duration(milliseconds: 10000));
           response.listen((_) {},
             onError: (dynamic error) {
               _logger.printTrace('error: $error');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -289,7 +289,10 @@ class _DevFSHttpWriter implements DevFSWriter {
           _osUtils,
         );
         await request.addStream(contents);
-        final HttpClientResponse response = await request.close();
+        // The contents has already been streamed, closing the request should
+        // not take long but we are experiencing hangs with it, see #63869.
+        final HttpClientResponse response =
+            await request.close().timeout(const Duration(milliseconds: 500));
         response.listen((_) {},
           onError: (dynamic error) {
             _logger.printTrace('error: $error');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -292,8 +292,8 @@ class _DevFSHttpWriter implements DevFSWriter {
         // The contents has already been streamed, closing the request should
         // not take long but we are experiencing hangs with it, see #63869.
         try {
-          final HttpClientResponse response =
-              await request.close().timeout(const Duration(milliseconds: 500));
+          final HttpClientResponse response = await request.close().timeout(
+            const Duration(milliseconds: 500));
           response.listen((_) {},
             onError: (dynamic error) {
               _logger.printTrace('error: $error');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -302,6 +302,9 @@ class _DevFSHttpWriter implements DevFSWriter {
           );
         } on TimeoutException {
           request.abort();
+          // This should throw "HttpException: Request has been aborted".
+          await request.done;
+          // Just to be safe we rethrow the TimeoutException.
           rethrow;
         }
         break;

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -372,12 +372,13 @@ void main() {
       }
     });
 
+    final BufferLogger logger = BufferLogger.test();
     final DevFS devFS = DevFS(
       fakeVmServiceHost.vmService,
       'test',
       fileSystem.currentDirectory,
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
+      logger: logger,
       osUtils: FakeOperatingSystemUtils(),
       httpClient: httpClient,
     );
@@ -409,6 +410,7 @@ void main() {
     expect(report.success, true);
     expect(devFS.lastCompiled, isNot(previousCompile));
     expect(closeCount, 2);
+    expect(logger.errorText, '');
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -352,10 +352,10 @@ void main() {
       <Completer<MockHttpClientResponse>>[hanger, succeeder];
     succeeder.complete(MockHttpClientResponse());
 
-    when(httpRequest.close()).thenAnswer((Invocation invocation) async {
+    when(httpRequest.close()).thenAnswer((Invocation invocation) {
       final Completer<MockHttpClientResponse> completer = closeCompleters[closeCount];
       closeCount += 1;
-      return await completer.future;
+      return completer.future;
     });
     when(httpRequest.abort()).thenAnswer((_) {
       hanger.completeError(const HttpException('aborted'));
@@ -367,7 +367,7 @@ void main() {
         return succeeder.future;
       } else {
         // This branch shouldn't happen.
-        assert(false);
+        fail('This branch should not happen');
         return null;
       }
     });

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -350,9 +350,9 @@ void main() {
     when(httpRequest.close()).thenAnswer((Invocation invocation) async {
       if (!didAbort) {
         while (!didAbort) {
-          await new Future.delayed(const Duration(milliseconds : 10));
+          await Future<dynamic>.delayed(const Duration(milliseconds : 10));
         }
-        throw HttpException('aborted');
+        throw const HttpException('aborted');
       }
       didRetry = true;
       return httpClientResponse;

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -368,7 +368,6 @@ void main() {
       } else {
         // This branch shouldn't happen.
         fail('This branch should not happen');
-        return null;
       }
     });
 


### PR DESCRIPTION
## Description

HttpClientRequest.close is randomly hanging then throwing a generic exception after 4 minutes.  I've filed a bug against dart and introduced a timeout in flutter since the request that would fail to converge on close would succeed on the second attempt in my testing.

I was able to validate with local testing that this addresses the issue and the 500ms timeout is well above my observed time for close to succeed which was more like 10ms in my observations.

cc @jmagman @xster

## Related Issues

https://github.com/flutter/flutter/issues/63869
Fixes https://github.com/flutter/flutter/issues/65402

## Tests

I added the following tests:

none

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
