### PR TITLE
[flutter_tools] fix bug where last build id parent folder is missing

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -668,6 +668,7 @@ class FlutterBuildSystem extends BuildSystem {
     final String currentBuildId = fileSystem.path.basename(environment.buildDir.path);
     final File lastBuildIdFile = environment.outputDir.childFile('.last_build_id');
     if (!lastBuildIdFile.existsSync()) {
+      lastBuildIdFile.parent.createSync(recursive: true);
       lastBuildIdFile.writeAsStringSync(currentBuildId);
       // No config file, either output was cleaned or this is the first build.
       return;
@@ -703,7 +704,6 @@ class FlutterBuildSystem extends BuildSystem {
     }
   }
 }
-
 
 /// An active instance of a build.
 class _BuildInstance {

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -475,6 +475,26 @@ void main() {
       '6666cd76f96956469e7be39d750cc7d9');
   });
 
+  testWithoutContext('trackSharedBuildDirectory handles a missing output dir', () {
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      outputDir: fileSystem.directory('a/b/c/d'),
+      artifacts: MockArtifacts(),
+      processManager: FakeProcessManager.any(),
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+    );
+    FlutterBuildSystem(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(),
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+
+    expect(environment.outputDir.childFile('.last_build_id'), exists);
+    expect(environment.outputDir.childFile('.last_build_id').readAsStringSync(),
+      '5954e2278dd01e1c4e747578776eeb94');
+  });
+
   testWithoutContext('trackSharedBuildDirectory does not modify .last_build_id when config is identical', () {
     environment.outputDir.childFile('.last_build_id')
       ..writeAsStringSync('6666cd76f96956469e7be39d750cc7d9')


### PR DESCRIPTION
## Description

```
FileSystemException: Cannot open file, path = '/.../build/.last_build_id' (OS Error: No such file or directory, errno = 2)

  | at _File.throwIfError | (file_impl.dart:635)
-- | -- | --
  | at _File.openSync | (file_impl.dart:479)
  | at _File.writeAsBytesSync | (file_impl.dart:604)
  | at _File.writeAsStringSync | (file_impl.dart:628)
  | at ForwardingFile.writeAsStringSync | (forwarding_file.dart:154)
  | at ErrorHandlingFile.writeAsStringSync.<anonymous closure> | (error_handling_io.dart:187)
  | at _runSync | (error_handling_io.dart:380)
  | at ErrorHandlingFile.writeAsStringSync | (error_handling_io.dart:186)
  | at FlutterBuildSystem.trackSharedBuildDirectory | (build_system.dart:673)
  | at FlutterBuildSystem.build | (build_system.dart:590)
  | at <asynchronous gap> | (async)
  | at AssembleCommand.runCommand | (assemble.dart:221)
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:972)
  | at _rootRunUnary | (zone.dart:1198)
  | at _CustomZone.runUnary | (zone.dart:1100)
  | at _FutureListener.handleValue | (future_impl.dart:143)
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:696)
  | at Future._propagateToListeners | (future_impl.dart:725)
  | at Future._completeWithValue | (future_impl.dart:529)
  | at Future._asyncCompleteWithValue.<anonymous closure> | (future_impl.dart:567)
  | at _rootRun | (zone.dart:1190)
  | at _CustomZone.run | (zone.dart:1093)
  | at _CustomZone.runGuarded | (zone.dart:997)
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:1037)
  | at _microtaskLoop | (schedule_microtask.dart:41)
  | at _startMicrotaskLoop | (schedule_microtask.dart:50)
  | at _runPendingImmediateCallback | (isolate_patch.dart:118)
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:169)
```