### PR TITLE
Updated .gitignore.tmpl for Android

### DIFF
--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -38,6 +38,9 @@ build/
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/app/debug
+**/android/app/profile
+**/android/app/release
 
 # iOS/XCode related
 **/ios/**/*.mode1v3


### PR DESCRIPTION


## Description

When building with Android Studio, .apk, .aab and .json files are added to this directory, which causes it to be uploaded to git. I created a new project with "flutter create". Then I opened the project's android directory with Android Studio. I created the app bundle with the Genarate signed bundle option from the Build menu. The app-release.aab file occurred in the /android/app/release/ directory.