### PR TITLE
Turn off flutter_gallery__transition_perf_e2e_ios32 in devicelab

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -775,12 +775,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  flutter_gallery__transition_perf_e2e_ios32:
-    description: >
-      Measures the performance of screen transitions in Flutter Gallery on
-      Android with e2e.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios32"]
+#  TODO(jmagman): https://github.com/flutter/flutter/issues/66166
+#  flutter_gallery__transition_perf_e2e_ios32:
+#    description: >
+#      Measures the performance of screen transitions in Flutter Gallery on
+#      Android with e2e.
+#    stage: devicelab_ios
+#    required_agent_capabilities: ["mac/ios32"]
 
   flutter_gallery__transition_perf_e2e_ios:
     description: >


### PR DESCRIPTION
## Description

Test started failing on a particular commit, revert didn't fix it.  Infra investigation at https://github.com/flutter/flutter/issues/66166.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66162