### PR TITLE
Fix windows hostonly_devicelab tests.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,11 +4,6 @@
 # YAML anchors used to share fields between tasks.
 # See https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html
 
-windows_shard_template: &WINDOWS_SHARD_TEMPLATE
-  only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
-  script:
-    - dart --enable-asserts ./dev/bots/test.dart
-
 firebase_shard_template: &FIREBASE_SHARD_TEMPLATE
   environment:
     # Empirically, this shard runs in 20-25 minutes with just one CPU and 4G of RAM, as of
@@ -269,59 +264,6 @@ task:
         ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0f2aca35f05b26add5d9edea2a7449341269a2b7e22d5c667f876996e2e8bc44ff1369431ebf73b7c5581fd95d0e5902]
       script:
         - ./dev/bots/deploy_gallery.sh
-
-# WINDOWS SHARDS
-task:
-  windows_container:
-    image: cirrusci/android-sdk:30-windowsservercore-2019
-    os_version: 2019
-    cpu: $CPU
-    memory: $MEMORY
-  environment:
-    CPU: 1 # 1-8 without compute credits, 1-30 with
-    MEMORY: 2G # 256M-24G without compute credits, 256M-90G with
-    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\$FLUTTER_SDK_PATH_WITH_SPACE"
-    PATH: "$CIRRUS_WORKING_DIR/bin;$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin;$PATH"
-    SHOULD_UPDATE_PACKAGES: "TRUE"
-  pub_cache:
-    folder: $APPDATA\Pub\Cache
-    fingerprint_script:
-      - ps: $Environment:OS; Get-ChildItem -Path "$Environment:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-    reupload_on_changes: false
-  flutter_pkg_cache:
-    folder: bin\cache\pkg
-    fingerprint_script: echo %OS% & type bin\internal\*.version
-    reupload_on_changes: false
-  artifacts_cache:
-    folder: bin\cache\artifacts
-    fingerprint_script: echo %OS% & type bin\internal\*.version
-    reupload_on_changes: false
-  setup_script:
-    - git clean -xffd --exclude=bin/cache/ # git wants forward slash path separators, even on Windows.
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-    - flutter config --no-analytics
-    - flutter doctor -v
-    - CMD /C IF "%SHOULD_UPDATE_PACKAGES%" EQU "TRUE" flutter update-packages
-    - git fetch origin master
-  matrix:
-    - name: hostonly_devicelab_tests-0-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-0-windows shard needs at least 6G RAM to
-        # succeed. The shard got faster with more CPUs up to 6 CPUs and more RAM up to 8 GB
-        # (running in about 30 minutes).
-        CPU: 6
-        MEMORY: 8G
-
-    - name: hostonly_devicelab_tests-1_last-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-1-windows shard requires 4 GB RAM to
-        # succeed. The optimal configuration was 4 CPUs and 6 GB RAM, running in ~26 minutes.
-        # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
-        CPU: 4
-        MEMORY: 6G
 
 # MACOS SHARDS
 # Mac doesn't use caches because they apparently take longer to populate and save

--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -9,6 +9,9 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
+final String platformLineSep = Platform.isWindows ? '\r\n': '\n';
+
+
 final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
 final String gradlewExecutable = Platform.isWindows ? '.\\$gradlew' : './$gradlew';
 
@@ -58,12 +61,12 @@ Future<void> main() async {
       final File modulePubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
       String content = modulePubspec.readAsStringSync();
       content = content.replaceFirst(
-        '\ndependencies:\n',
-        '\ndependencies:\n'
-          '  plugin_with_android:\n'
-          '    path: ../plugin_with_android\n'
-          '  plugin_without_android:\n'
-          '    path: ../plugin_without_android\n',
+        '${platformLineSep}dependencies:$platformLineSep',
+        '${platformLineSep}dependencies:$platformLineSep'
+          '  plugin_with_android:$platformLineSep'
+          '    path: ../plugin_with_android$platformLineSep'
+          '  plugin_without_android:$platformLineSep'
+          '    path: ../plugin_without_android$platformLineSep',
       );
       modulePubspec.writeAsStringSync(content, flush: true);
 

--- a/dev/devicelab/bin/tasks/gradle_jetifier_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_jetifier_test.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as path;
 
 final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
 final String gradlewExecutable = Platform.isWindows ? '.\\$gradlew' : './$gradlew';
+final String platformLineSep = Platform.isWindows ? '\r\n': '\n';
 
 /// Tests that Jetifier can translate plugins that use support libraries.
 Future<void> main() async {
@@ -43,8 +44,8 @@ Future<void> main() async {
       final File pubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
       String content = pubspec.readAsStringSync();
       content = content.replaceFirst(
-        '\ndependencies:\n',
-        '\ndependencies:\n  firebase_auth: 0.7.0\n',
+        '${platformLineSep}dependencies:$platformLineSep',
+        '${platformLineSep}dependencies:$platformLineSep  firebase_auth: 0.7.0$platformLineSep',
       );
       pubspec.writeAsStringSync(content, flush: true);
       await inDirectory(projectDir, () async {

--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
 final String gradlewExecutable = Platform.isWindows ? '.\\$gradlew' : './$gradlew';
 final String fileReadWriteMode = Platform.isWindows ? 'rw-rw-rw-' : 'rw-r--r--';
+final String platformLineSep = Platform.isWindows ? '\r\n': '\n';
 
 /// Tests that the Flutter module project template works and supports
 /// adding Flutter to an existing Android app.
@@ -60,8 +61,8 @@ Future<void> main() async {
       final File pubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
       String content = await pubspec.readAsString();
       content = content.replaceFirst(
-        '\n  # assets:\n',
-        '\n  assets:\n    - assets/read-only.txt\n',
+        '$platformLineSep  # assets:$platformLineSep',
+        '$platformLineSep  assets:$platformLineSep    - assets/read-only.txt$platformLineSep',
       );
       await pubspec.writeAsString(content, flush: true);
 
@@ -69,8 +70,8 @@ Future<void> main() async {
 
       content = await pubspec.readAsString();
       content = content.replaceFirst(
-        '\ndependencies:\n',
-        '\ndependencies:\n  device_info: 0.4.1\n  package_info: 0.4.0+9\n',
+        '${platformLineSep}dependencies:$platformLineSep',
+        '${platformLineSep}dependencies:$platformLineSep  device_info: 0.4.1$platformLineSep  package_info: 0.4.0+9$platformLineSep',
       );
       await pubspec.writeAsString(content, flush: true);
       await inDirectory(projectDir, () async {

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
 final String gradlewExecutable = Platform.isWindows ? '.\\$gradlew' : './$gradlew';
 final String fileReadWriteMode = Platform.isWindows ? 'rw-rw-rw-' : 'rw-r--r--';
+final String platformLineSep = Platform.isWindows ? '\r\n': '\n';
 
 /// Tests that the Flutter module project template works and supports
 /// adding Flutter to an existing Android app.
@@ -60,8 +61,8 @@ Future<void> main() async {
       final File pubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
       String content = await pubspec.readAsString();
       content = content.replaceFirst(
-        '\n  # assets:\n',
-        '\n  assets:\n    - assets/read-only.txt\n',
+        '$platformLineSep  # assets:$platformLineSep',
+        '$platformLineSep  assets:$platformLineSep    - assets/read-only.txt$platformLineSep',
       );
       await pubspec.writeAsString(content, flush: true);
 
@@ -69,8 +70,8 @@ Future<void> main() async {
 
       content = await pubspec.readAsString();
       content = content.replaceFirst(
-        '\ndependencies:\n',
-        '\ndependencies:\n  device_info: 0.4.1\n  package_info: 0.4.0+9\n',
+        '${platformLineSep}dependencies:$platformLineSep',
+        '${platformLineSep}dependencies:$platformLineSep  device_info: 0.4.1$platformLineSep  package_info: 0.4.0+9$platformLineSep',
       );
       await pubspec.writeAsString(content, flush: true);
       await inDirectory(projectDir, () async {

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
+final String platformLineSep = Platform.isWindows ? '\r\n': '\n';
+
 /// Tests that a plugin A can depend on platform code from a plugin B
 /// as long as plugin B is defined as a pub dependency of plugin A.
 ///
@@ -150,14 +152,14 @@ public class DummyPluginBClass {
       final File pluginApubspec = File(path.join(pluginADirectory.path, 'pubspec.yaml'));
       String pluginApubspecContent = await pluginApubspec.readAsString();
       pluginApubspecContent = pluginApubspecContent.replaceFirst(
-        '\ndependencies:\n',
-        '\ndependencies:\n'
-        '  plugin_b:\n'
-        '    path: ${pluginBDirectory.path}\n'
-        '  plugin_c:\n'
-        '    path: ${pluginCDirectory.path}\n'
-        '  plugin_d:\n'
-        '    path: ${pluginDDirectory.path}\n',
+        '${platformLineSep}dependencies:$platformLineSep',
+        '${platformLineSep}dependencies:$platformLineSep'
+        '  plugin_b:$platformLineSep'
+        '    path: ${pluginBDirectory.path}$platformLineSep'
+        '  plugin_c:$platformLineSep'
+        '    path: ${pluginCDirectory.path}$platformLineSep'
+        '  plugin_d:$platformLineSep'
+        '    path: ${pluginDDirectory.path}$platformLineSep',
       );
       await pluginApubspec.writeAsString(pluginApubspecContent, flush: true);
 

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -73,12 +73,6 @@
          "flaky": false
       },
       {
-         "name": "Linux gradle_plugin_light_apk_test",
-         "repo": "flutter",
-         "task_name": "linux_gradle_plugin_light_apk_test",
-         "flaky": false
-      },
-      {
          "name": "Linux gradle_r8_test",
          "repo": "flutter",
          "task_name": "linux_gradle_r8_test",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -265,6 +265,12 @@
          "flaky": false
       },
       {
+         "name": "Windows build_aar_module_test",
+         "repo": "flutter",
+         "task_name": "win_build_aar_module_test",
+         "flaky": false
+      },
+      {
          "name": "Windows build_tests",
          "repo": "flutter",
          "task_name": "win_build_tests",
@@ -286,6 +292,18 @@
          "name": "Windows gradle_fast_start_test",
          "repo": "flutter",
          "task_name": "win_gradle_fast_start_test",
+         "flaky": false
+      },
+      {
+         "name": "Windows gradle_jetifier_test",
+         "repo": "flutter",
+         "task_name": "win_gradle_jetifier_test",
+         "flaky": false
+      },
+      {
+         "name": "Windows gradle_plugin_light_apk_test",
+         "repo": "flutter",
+         "task_name": "win_gradle_plugin_light_apk_test",
          "flaky": false
       },
       {
@@ -313,9 +331,27 @@
          "flaky": false
       },
       {
+         "name": "Windows module_custom_host_app_name_test",
+         "repo": "flutter",
+         "task_name": "win_module_custom_host_app_name_test",
+         "flaky": false
+      },
+      {
          "name": "Windows module_host_with_custom_build_test",
          "repo": "flutter",
          "task_name": "win_module_host_with_custom_build_test",
+         "flaky": false
+      },
+      {
+         "name": "Windows module_test",
+         "repo": "flutter",
+         "task_name": "win_module_test",
+         "flaky": false
+      },
+      {
+         "name": "Windows plugin_dependencies_test",
+         "repo": "flutter",
+         "task_name": "win_plugin_dependencies_test",
          "flaky": false
       },
       {

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -358,13 +358,6 @@
          "run_if":["dev/**", "bin/**"]
       },
       {
-         "name": "Windows gradle_plugin_light_apk_test",
-         "repo": "flutter",
-         "task_name": "win_gradle_plugin_light_apk_test",
-         "enabled":true,
-         "run_if":["dev/**", "bin/**"]
-      },
-      {
          "name": "Windows gradle_r8_test",
          "repo": "flutter",
          "task_name": "win_gradle_r8_test",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -303,6 +303,13 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
+         "name": "Windows build_aar_module_test",
+         "repo": "flutter",
+         "task_name": "win_build_aar_module_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
          "name": "Windows build_tests",
          "repo": "flutter",
          "task_name": "win_build_tests",
@@ -330,6 +337,13 @@
          "run_if":["dev/**", "bin/**"]
       },
       {
+         "name": "Windows gradle_jetifier_test",
+         "repo": "flutter",
+         "task_name": "win_gradle_jetifier_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
          "name": "Windows gradle_non_android_plugin_test",
          "repo": "flutter",
          "task_name": "win_gradle_non_android_plugin_test",
@@ -344,6 +358,13 @@
          "run_if":["dev/**", "bin/**"]
       },
       {
+         "name": "Windows gradle_plugin_light_apk_test",
+         "repo": "flutter",
+         "task_name": "win_gradle_plugin_light_apk_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
          "name": "Windows gradle_r8_test",
          "repo": "flutter",
          "task_name": "win_gradle_r8_test",
@@ -351,9 +372,30 @@
          "run_if":["dev/**", "bin/**"]
       },
       {
+         "name": "Windows module_custom_host_app_name_test",
+         "repo": "flutter",
+         "task_name": "win_module_custom_host_app_name_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
+         "name": "Windows module_test",
+         "repo": "flutter",
+         "task_name": "win_module_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
          "name": "Windows module_host_with_custom_build_test",
          "repo": "flutter",
          "task_name": "win_module_host_with_custom_build_test",
+         "enabled":true,
+         "run_if":["dev/**", "bin/**"]
+      },
+      {
+         "name": "Windows plugin_dependencies_test",
+         "repo": "flutter",
+         "task_name": "win_plugin_dependencies_test",
          "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },


### PR DESCRIPTION
## Description

Tests have been failing because windows 10 files use \r\n instead of just \n for file separators. Because of this the test was not replacing the assets/modules in pusbspec files.

## Related Issues

Bug:
  https://github.com/flutter/flutter/issues/64466

## Tests

I added the following tests:

N/A

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
