### PR TITLE
Added default TextStyle() to TextSpan constructor

### DIFF
--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -69,7 +69,7 @@ class TextSpan extends InlineSpan {
   const TextSpan({
     this.text,
     this.children,
-    TextStyle? style,
+    TextStyle? style = const TextStyle(),
     this.recognizer,
     this.semanticsLabel,
   }) : super(style: style);

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -245,16 +245,6 @@ void main() {
     expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
   });
 
-  test('TextSpan with a null child should throw FlutterError', () {
-    const TextSpan text = TextSpan(
-      text: 'foo bar',
-      children: <InlineSpan>[
-        null,
-      ],
-    );
-    expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
-  });
-
   test('TextSpan should have non-null default TextStyle()', () {
     const TextSpan textSpan = TextSpan();
     expect(textSpan.style, const TextStyle());

--- a/packages/flutter/test/painting/text_span_test.dart
+++ b/packages/flutter/test/painting/text_span_test.dart
@@ -245,4 +245,37 @@ void main() {
     expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
   });
 
+  test('TextSpan with a null child should throw FlutterError', () {
+    const TextSpan text = TextSpan(
+      text: 'foo bar',
+      children: <InlineSpan>[
+        null,
+      ],
+    );
+    expect(() => text.computeToPlainText(StringBuffer()), anyOf(throwsFlutterError, throwsAssertionError));
+  });
+
+  test('TextSpan should have non-null default TextStyle()', () {
+    const TextSpan textSpan = TextSpan();
+    expect(textSpan.style, const TextStyle());
+  });
+
+  test('TextSpan in TextPainter should scale according to textScaleFactor', () {
+    const TextSpan textSpan = TextSpan(text: ' ');
+    final TextPainter painterScaleOne = TextPainter(
+      text: textSpan,
+      textScaleFactor: 1,
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+    final TextPainter painterScaleDouble = TextPainter(
+      text: textSpan,
+      textScaleFactor: 2,
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+    painterScaleOne.layout();
+    painterScaleDouble.layout();
+    expect(painterScaleOne.size.width < painterScaleDouble.size.width, true);
+  });
 }


### PR DESCRIPTION
## Description

Added default TextStyle() to TextSpan constructor ([here](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/painting/text_span.dart#L72)) 
<details>
<summary>before</summary>

```dart
  const TextSpan({
    this.text,
    this.children,
    TextStyle? style,
    this.recognizer,
    this.semanticsLabel,
  }) : super(style: style);
```

</details>
<details>
<summary>after</summary>

```dart
  const TextSpan({
    this.text,
    this.children,
    TextStyle? style = const TextStyle(),
    this.recognizer,
    this.semanticsLabel,
  }) : super(style: style);
```

</details>

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66196

## Tests

[edit] please see this [comment](https://github.com/flutter/flutter/pull/66197#issuecomment-695840761)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
