### PR TITLE
SliverList perform layout start from the initial child when there is no valid layout offset

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -101,14 +101,22 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
     // offset.
     if (childScrollOffset(firstChild!) == null) {
       int leadingChildrenWithoutLayoutOffset = 0;
-      while (childScrollOffset(earliestUsefulChild!) == null) {
+      while (earliestUsefulChild != null && childScrollOffset(earliestUsefulChild) == null) {
         earliestUsefulChild = childAfter(firstChild!);
         leadingChildrenWithoutLayoutOffset += 1;
       }
       // We should be able to destroy children with null layout offset safely,
       // because they are likely outside of viewport
       collectGarbage(leadingChildrenWithoutLayoutOffset, 0);
-      assert(firstChild != null);
+      // If can not find a valid layout offset, start from the initial child.
+      if (firstChild == null) {
+        if (!addInitialChild()) {
+          // There are no children.
+          geometry = SliverGeometry.zero;
+          childManager.didFinishLayout();
+          return;
+        }
+      }
     }
 
     // Find the last child that is at or before the scrollOffset.

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -102,7 +102,7 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
     if (childScrollOffset(firstChild!) == null) {
       int leadingChildrenWithoutLayoutOffset = 0;
       while (earliestUsefulChild != null && childScrollOffset(earliestUsefulChild) == null) {
-        earliestUsefulChild = childAfter(firstChild!);
+        earliestUsefulChild = childAfter(earliestUsefulChild);
         leadingChildrenWithoutLayoutOffset += 1;
       }
       // We should be able to destroy children with null layout offset safely,

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -278,7 +278,7 @@ void main() {
     expect(find.text('Tile 3'), findsOneWidget);
   });
 
-  testWidgets('SliverList should start to perform layout from the initial child when none valid offset', (WidgetTester tester) async {
+  testWidgets('SliverList should start to perform layout from the initial child when there is no valid offset', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/66198.
     bool isShow = true;
     final ScrollController controller = ScrollController();
@@ -297,7 +297,7 @@ void main() {
                       height: 50,
                       child: Text('Tile $i'),
                     ),
-                const SizedBox(), // Use this widget to occupy the position where the offset is 0 after rebuild
+                const SizedBox(), // Use this widget to occupy the position where the offset is 0 when rebuild
                 const SizedBox(key: Key('key0'), height: 50.0),
                 const SizedBox(key: Key('key1'), height: 50.0),
               ],
@@ -310,6 +310,7 @@ void main() {
     await tester.pumpWidget(buildSliverList(controller));
     await tester.pumpAndSettle();
 
+    // Scrolling to the bottom.
     await tester.drag(find.text('Tile 2'), const Offset(0.0, -1000.0));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Description

### How did this issue #66198 happen?
1. When scrolling to the bottom, the first two children of the list do not build and layout. 
2. When rebuilding, the `SizeBox` was moved to second place due to it has a `key`.
https://github.com/flutter/flutter/blob/51fa704642774c6b6ae64c91642b62801e233e1b/packages/flutter/lib/src/widgets/sliver.dart#L1093-L1108
Finally, after `performRebuild`, the `firstChild` and `lastChild` are both this `SizeBox` without a valid layout offset and trigger the issue at below code,
https://github.com/flutter/flutter/blob/51fa704642774c6b6ae64c91642b62801e233e1b/packages/flutter/lib/src/rendering/sliver_list.dart#L102-L111

### A solution to fix it
If can not find a valid layout offset, we should start to perform layout from the initial child.


## Related Issues

Fixes #66198 

## Tests

I added the following tests:

See files.
