### PR TITLE
Reland fuchsia_remote_debug_protocol allows open port on remote device

### DIFF
--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -25,6 +25,9 @@ class _DummyPortForwarder implements PortForwarder {
   int get remotePort => _remotePort;
 
   @override
+  String get openPortAddress => InternetAddress.loopbackIPv4.address;
+
+  @override
   Future<void> stop() async { }
 }
 

--- a/packages/fuchsia_remote_debug_protocol/lib/src/common/network.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/common/network.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:core';
+import 'dart:io';
 
 /// Determines whether `address` is a valid IPv6 or IPv4 address.
 ///
@@ -17,7 +17,7 @@ void validateAddress(String address) {
 /// Returns true if `address` is a valid IPv6 address.
 bool isIpV6Address(String address) {
   try {
-    Uri.parseIPv6Address(address);
+    InternetAddress(address, type:InternetAddressType.IPv6);
     return true;
   } on FormatException {
     return false;
@@ -27,7 +27,7 @@ bool isIpV6Address(String address) {
 /// Returns true if `address` is a valid IPv4 address.
 bool isIpV4Address(String address) {
   try {
-    Uri.parseIPv4Address(address);
+    InternetAddress(address, type:InternetAddressType.IPv4);
     return true;
   } on FormatException {
     return false;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/common/network.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/common/network.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:core';
 
 /// Determines whether `address` is a valid IPv6 or IPv4 address.
 ///
@@ -17,7 +17,10 @@ void validateAddress(String address) {
 /// Returns true if `address` is a valid IPv6 address.
 bool isIpV6Address(String address) {
   try {
-    InternetAddress(address, type:InternetAddressType.IPv6);
+    // parseIpv6Address fails if there's a zone ID. Since this is still a valid
+    // IP, remove any zone ID before parsing.
+    final List<String> addressParts = address.split('%');
+    Uri.parseIPv6Address(addressParts[0]);
     return true;
   } on FormatException {
     return false;
@@ -27,7 +30,7 @@ bool isIpV6Address(String address) {
 /// Returns true if `address` is a valid IPv4 address.
 bool isIpV4Address(String address) {
   try {
-    InternetAddress(address, type:InternetAddressType.IPv4);
+    Uri.parseIPv4Address(address);
     return true;
   } on FormatException {
     return false;

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -409,7 +409,9 @@ class FuchsiaRemoteConnection {
     if (pf.openPortAddress == null) {
       addr = _useIpV6 ? '[$_ipv6Loopback]' : _ipv4Loopback;
     } else {
-      addr = _useIpV6 ? '[${pf.openPortAddress}]' : pf.openPortAddress;
+      addr = isIpV6Address(pf.openPortAddress)
+        ? '[${pf.openPortAddress}]'
+        : pf.openPortAddress;
     }
     final Uri uri = Uri.http('$addr:${pf.port}', '/');
     return uri;

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -29,23 +29,6 @@ void main() {
       const String interface = 'eno1';
       when(mockRunner.address).thenReturn(address);
       when(mockRunner.interface).thenReturn(interface);
-      forwardedPorts = <MockPortForwarder>[];
-      int port = 0;
-      Future<PortForwarder> mockPortForwardingFunction(
-        String address,
-        int remotePort, [
-        String interface = '',
-        String configFile,
-      ]) {
-        return Future<PortForwarder>(() {
-          final MockPortForwarder pf = MockPortForwarder();
-          forwardedPorts.add(pf);
-          when(pf.port).thenReturn(port++);
-          when(pf.remotePort).thenReturn(remotePort);
-          return pf;
-        });
-      }
-
       final List<Map<String, dynamic>> flutterViewCannedResponses =
           <Map<String, dynamic>>[
         <String, dynamic>{
@@ -88,6 +71,7 @@ void main() {
         },
       ];
 
+      forwardedPorts = <MockPortForwarder>[];
       mockPeerConnections = <MockPeer>[];
       uriConnections = <Uri>[];
       Future<json_rpc.Peer> mockVmConnectionFunction(
@@ -107,7 +91,6 @@ void main() {
         });
       }
 
-      fuchsiaPortForwardingFunction = mockPortForwardingFunction;
       fuchsiaVmServiceConnectionFunction = mockVmConnectionFunction;
     });
 
@@ -119,6 +102,24 @@ void main() {
     });
 
     test('end-to-end with three vm connections and flutter view query', () async {
+      int port = 0;
+      Future<PortForwarder> mockPortForwardingFunction(
+        String address,
+        int remotePort, [
+        String interface = '',
+        String configFile,
+      ]) {
+        return Future<PortForwarder>(() {
+          final MockPortForwarder pf = MockPortForwarder();
+          forwardedPorts.add(pf);
+          when(pf.port).thenReturn(port++);
+          when(pf.remotePort).thenReturn(remotePort);
+          return pf;
+        });
+      }
+
+      fuchsiaPortForwardingFunction = mockPortForwardingFunction;
+
       final FuchsiaRemoteConnection connection =
           await FuchsiaRemoteConnection.connectWithSshCommandRunner(mockRunner);
 
@@ -132,6 +133,77 @@ void main() {
       expect(forwardedPorts[0].port, 0);
       expect(forwardedPorts[1].port, 1);
       expect(forwardedPorts[2].port, 2);
+
+      // VMs should be accessed via localhost ports given by
+      // [mockPortForwardingFunction].
+      expect(uriConnections[0],
+        Uri(scheme:'ws', host:'[::1]', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'[::1]', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'[::1]', port:2, path:'/ws'));
+
+      final List<FlutterView> views = await connection.getFlutterViews();
+      expect(views, isNot(null));
+      expect(views.length, 3);
+      // Since name can be null, check for the ID on all of them.
+      expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
+
+      expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
+
+      // Ensure the ports are all closed after stop was called.
+      await connection.stop();
+      verify(forwardedPorts[0].stop());
+      verify(forwardedPorts[1].stop());
+      verify(forwardedPorts[2].stop());
+    });
+
+    test('end-to-end with three vms and remote open port', () async {
+      int port = 0;
+      Future<PortForwarder> mockPortForwardingFunction(
+        String address,
+        int remotePort, [
+        String interface = '',
+        String configFile,
+      ]) {
+        return Future<PortForwarder>(() {
+          final MockPortForwarder pf = MockPortForwarder();
+          forwardedPorts.add(pf);
+          when(pf.port).thenReturn(port++);
+          when(pf.remotePort).thenReturn(remotePort);
+          when(pf.openPortAddress).thenReturn('fe80::1:2%eno2');
+          return pf;
+        });
+      }
+
+      fuchsiaPortForwardingFunction = mockPortForwardingFunction;
+
+      final FuchsiaRemoteConnection connection =
+          await FuchsiaRemoteConnection.connectWithSshCommandRunner(mockRunner);
+
+      // [mockPortForwardingFunction] will have returned three different
+      // forwarded ports, incrementing the port each time by one. (Just a sanity
+      // check that the forwarding port was called).
+      expect(forwardedPorts.length, 3);
+      expect(forwardedPorts[0].remotePort, 123);
+      expect(forwardedPorts[1].remotePort, 456);
+      expect(forwardedPorts[2].remotePort, 789);
+      expect(forwardedPorts[0].port, 0);
+      expect(forwardedPorts[1].port, 1);
+      expect(forwardedPorts[2].port, 2);
+
+      // VMs should be accessed via the alternate adddress given by
+      // [mockPortForwardingFunction].
+      expect(uriConnections[0],
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:2, path:'/ws'));
 
       final List<FlutterView> views = await connection.getFlutterViews();
       expect(views, isNot(null));

--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -11,24 +11,11 @@ import 'common.dart';
 
 void main() {
   group('FuchsiaRemoteConnection.connect', () {
-    MockSshCommandRunner mockRunner;
     List<MockPortForwarder> forwardedPorts;
     List<MockPeer> mockPeerConnections;
     List<Uri> uriConnections;
 
     setUp(() {
-      mockRunner = MockSshCommandRunner();
-      // Adds some extra junk to make sure the strings will be cleaned up.
-      when(mockRunner.run(argThat(startsWith('/bin/find')))).thenAnswer(
-          (_) => Future<List<String>>.value(
-              <String>['/hub/blah/blah/blah/vmservice-port\n']));
-      when(mockRunner.run(argThat(startsWith('/bin/ls')))).thenAnswer(
-          (_) => Future<List<String>>.value(
-              <String>['123\n\n\n', '456  ', '789']));
-      const String address = 'fe80::8eae:4cff:fef4:9247';
-      const String interface = 'eno1';
-      when(mockRunner.address).thenReturn(address);
-      when(mockRunner.interface).thenReturn(interface);
       final List<Map<String, dynamic>> flutterViewCannedResponses =
           <Map<String, dynamic>>[
         <String, dynamic>{
@@ -119,6 +106,16 @@ void main() {
       }
 
       fuchsiaPortForwardingFunction = mockPortForwardingFunction;
+      final MockSshCommandRunner mockRunner = MockSshCommandRunner();
+      // Adds some extra junk to make sure the strings will be cleaned up.
+      when(mockRunner.run(argThat(startsWith('/bin/find')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['/hub/blah/blah/blah/vmservice-port\n']));
+      when(mockRunner.run(argThat(startsWith('/bin/ls')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['123\n\n\n', '456  ', '789']));
+      when(mockRunner.address).thenReturn('fe80::8eae:4cff:fef4:9247');
+      when(mockRunner.interface).thenReturn('eno1');
 
       final FuchsiaRemoteConnection connection =
           await FuchsiaRemoteConnection.connectWithSshCommandRunner(mockRunner);
@@ -181,7 +178,16 @@ void main() {
       }
 
       fuchsiaPortForwardingFunction = mockPortForwardingFunction;
-
+      final MockSshCommandRunner mockRunner = MockSshCommandRunner();
+      // Adds some extra junk to make sure the strings will be cleaned up.
+      when(mockRunner.run(argThat(startsWith('/bin/find')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['/hub/blah/blah/blah/vmservice-port\n']));
+      when(mockRunner.run(argThat(startsWith('/bin/ls')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['123\n\n\n', '456  ', '789']));
+      when(mockRunner.address).thenReturn('fe80::8eae:4cff:fef4:9247');
+      when(mockRunner.interface).thenReturn('eno1');
       final FuchsiaRemoteConnection connection =
           await FuchsiaRemoteConnection.connectWithSshCommandRunner(mockRunner);
 
@@ -204,6 +210,75 @@ void main() {
         Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:1, path:'/ws'));
       expect(uriConnections[2],
         Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:2, path:'/ws'));
+
+      final List<FlutterView> views = await connection.getFlutterViews();
+      expect(views, isNot(null));
+      expect(views.length, 3);
+      // Since name can be null, check for the ID on all of them.
+      expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
+
+      expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
+
+      // Ensure the ports are all closed after stop was called.
+      await connection.stop();
+      verify(forwardedPorts[0].stop());
+      verify(forwardedPorts[1].stop());
+      verify(forwardedPorts[2].stop());
+    });
+
+    test('end-to-end with three vms and ipv4', () async {
+      int port = 0;
+      Future<PortForwarder> mockPortForwardingFunction(
+        String address,
+        int remotePort, [
+        String interface = '',
+        String configFile,
+      ]) {
+        return Future<PortForwarder>(() {
+          final MockPortForwarder pf = MockPortForwarder();
+          forwardedPorts.add(pf);
+          when(pf.port).thenReturn(port++);
+          when(pf.remotePort).thenReturn(remotePort);
+          return pf;
+        });
+      }
+
+      fuchsiaPortForwardingFunction = mockPortForwardingFunction;
+      final MockSshCommandRunner mockRunner = MockSshCommandRunner();
+      // Adds some extra junk to make sure the strings will be cleaned up.
+      when(mockRunner.run(argThat(startsWith('/bin/find')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['/hub/blah/blah/blah/vmservice-port\n']));
+      when(mockRunner.run(argThat(startsWith('/bin/ls')))).thenAnswer(
+          (_) => Future<List<String>>.value(
+              <String>['123\n\n\n', '456  ', '789']));
+      when(mockRunner.address).thenReturn('196.168.1.4');
+
+      final FuchsiaRemoteConnection connection =
+          await FuchsiaRemoteConnection.connectWithSshCommandRunner(mockRunner);
+
+      // [mockPortForwardingFunction] will have returned three different
+      // forwarded ports, incrementing the port each time by one. (Just a sanity
+      // check that the forwarding port was called).
+      expect(forwardedPorts.length, 3);
+      expect(forwardedPorts[0].remotePort, 123);
+      expect(forwardedPorts[1].remotePort, 456);
+      expect(forwardedPorts[2].remotePort, 789);
+      expect(forwardedPorts[0].port, 0);
+      expect(forwardedPorts[1].port, 1);
+      expect(forwardedPorts[2].port, 2);
+
+      // VMs should be accessed via the ipv4 loopback.
+      expect(uriConnections[0],
+        Uri(scheme:'ws', host:'127.0.0.1', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'127.0.0.1', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'127.0.0.1', port:2, path:'/ws'));
 
       final List<FlutterView> views = await connection.getFlutterViews();
       expect(views, isNot(null));

--- a/packages/fuchsia_remote_debug_protocol/test/src/common/network_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/common/network_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/fuchsia_remote_debug_protocol/test/src/common/network_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/common/network_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fuchsia_remote_debug_protocol/src/common/network.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final List<String> ipv4Addresses = <String>['127.0.0.1', '8.8.8.8'];
+  final List<String> ipv6Addresses = <String>['::1',
+    'fe80::8eae:4cff:fef4:9247', 'fe80::8eae:4cff:fef4:9247%e0'];
+
+  group('test validation', () {
+    test('isIpV4Address', () {
+      expect(ipv4Addresses.map(isIpV4Address), everyElement(isTrue));
+      expect(ipv6Addresses.map(isIpV4Address), everyElement(isFalse));
+    });
+
+    test('isIpV6Address', () {
+      expect(ipv4Addresses.map(isIpV6Address), everyElement(isFalse));
+      expect(ipv6Addresses.map(isIpV6Address), everyElement(isTrue));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Relands #63996 and fixes an issue where ipv4 addresses are incorrectly identified as ipv6 addresses and wrapped in brackets.

The original set of changes is the first commit, the second commit contains the fixes.

Original description:
This change extends the functionality of the fuchsia_remote_debug_protocol package. Currently, the package allows forwarding ports from a host device to some other target device running a Flutter instance, which enables the host device to access the debug port exposed by the Flutter instance.
This updates the definition of a port forwarding function to allow for cases where the host device accesses the debug port by calling a port on the target device rather than the local loopback of the host device.

## Related Issues

63968

## Tests

The change is largely tested against internal tests.

I added the following tests:

* End to end test from the original change.
* Unit tests to verify ipv4/ipv6 address detection.


## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
