### PR TITLE
[flutter_tools] remove k toggle for canvaskit from web runner

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -810,9 +810,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
   }
 
   @override
-  bool get supportsCanvasKit => supportsServiceProtocol;
-
-  @override
   Future<bool> toggleCanvaskit() async {
     final WebDevFS webDevFS = device.devFS as WebDevFS;
     webDevFS.webAssetServer.canvasKitRendering = !webDevFS.webAssetServer.canvasKitRendering;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -837,7 +837,6 @@ abstract class ResidentRunner {
   bool get isRunningProfile => debuggingOptions.buildInfo.isProfile;
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;
   bool get supportsServiceProtocol => isRunningDebug || isRunningProfile;
-  bool get supportsCanvasKit => false;
   bool get supportsWriteSkSL => supportsServiceProtocol;
   bool get trackWidgetCreation => debuggingOptions.buildInfo.trackWidgetCreation;
 
@@ -1358,9 +1357,6 @@ abstract class ResidentRunner {
         commandHelp.S.print();
         commandHelp.U.print();
       }
-      if (supportsCanvasKit){
-        commandHelp.k.print();
-      }
       if (supportsWriteSkSL) {
         commandHelp.M.print();
       }
@@ -1512,13 +1508,6 @@ class TerminalHandler {
       case 'I':
         if (residentRunner.supportsServiceProtocol && residentRunner.isRunningDebug) {
           await residentRunner.debugToggleInvertOversizedImages();
-          return true;
-        }
-        return false;
-      case 'k':
-        if (residentRunner.supportsCanvasKit) {
-          final bool result = await residentRunner.toggleCanvaskit();
-          globals.printStatus('${result ? 'Enabled' : 'Disabled'} CanvasKit');
           return true;
         }
         return false;

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1360,8 +1360,6 @@ void main() {
     expect(residentRunner.supportsServiceProtocol, true);
     // isRunningDebug
     expect(residentRunner.isRunningDebug, true);
-    // does not support CanvasKit
-    expect(residentRunner.supportsCanvasKit, false);
     // does support SkSL
     expect(residentRunner.supportsWriteSkSL, true);
     // commands
@@ -1415,8 +1413,6 @@ void main() {
     expect(residentRunner.supportsServiceProtocol, false);
     // isRunningDebug
     expect(residentRunner.isRunningDebug, false);
-    // does not support CanvasKit
-    expect(residentRunner.supportsCanvasKit, false);
     // does support SkSL
     expect(residentRunner.supportsWriteSkSL, false);
     // commands

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -765,7 +765,6 @@ void main() {
     final WebAssetServer webAssetServer = WebAssetServer(null, null, null, null, null, null);
     when(mockWebDevFS.webAssetServer).thenReturn(webAssetServer);
 
-    expect(residentWebRunner.supportsCanvasKit, true);
     expect(webAssetServer.canvasKitRendering, false);
 
     final bool toggleResult = await residentWebRunner.toggleCanvaskit();

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -109,17 +109,6 @@ void main() {
       verify(mockResidentRunner.printHelp(details: true)).called(3);
     });
 
-    testUsingContext('k - toggles CanvasKit rendering and prints results', () async {
-      when(mockResidentRunner.toggleCanvaskit())
-        .thenAnswer((Invocation invocation) async {
-          return true;
-        });
-
-      await terminalHandler.processTerminalInput('k');
-
-      verify(mockResidentRunner.toggleCanvaskit()).called(1);
-    });
-
     testUsingContext('i - debugToggleWidgetInspector with service protocol', () async {
       await terminalHandler.processTerminalInput('i');
 

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -110,7 +110,6 @@ void main() {
     });
 
     testUsingContext('k - toggles CanvasKit rendering and prints results', () async {
-      when(mockResidentRunner.supportsCanvasKit).thenReturn(true);
       when(mockResidentRunner.toggleCanvaskit())
         .thenAnswer((Invocation invocation) async {
           return true;


### PR DESCRIPTION
## Description

The k toggle allows switching between canvaskit and html backend at runtime. unfortunately this causes hot restart to break, since the dart_sdk modules stores state at runtime.

The recommendation will be to use cavaskit via dart-defines.