### PR TITLE
Make CupertinoThemeData properties non-nullable

### DIFF
--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -143,7 +143,7 @@ class _InheritedCupertinoTheme extends InheritedWidget {
 ///  * [ThemeData], a Material equivalent that also configures Cupertino
 ///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData].
 @immutable
-class CupertinoThemeData with Diagnosticable {
+class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable  {
   /// Creates a [CupertinoTheme] styling specification.
   ///
   /// Unspecified parameters default to a reasonable iOS default style.
@@ -186,34 +186,24 @@ class CupertinoThemeData with Diagnosticable {
   );
 
   const CupertinoThemeData._rawWithDefaults(
-    this.brightness,
-    this._primaryColor,
-    this._primaryContrastingColor,
-    this._textTheme,
-    this._barBackgroundColor,
-    this._scaffoldBackgroundColor,
+    Brightness? brightness,
+    Color? primaryColor,
+    Color? primaryContrastingColor,
+    CupertinoTextThemeData? textTheme,
+    Color? barBackgroundColor,
+    Color? scaffoldBackgroundColor,
     this._defaults,
+  ) : super(
+    brightness: brightness,
+    primaryColor: primaryColor,
+    primaryContrastingColor: primaryContrastingColor,
+    textTheme: textTheme,
+    barBackgroundColor: barBackgroundColor,
+    scaffoldBackgroundColor: scaffoldBackgroundColor,
   );
 
-  final _CupertinoThemeDefaults? _defaults;
+  final _CupertinoThemeDefaults _defaults;
 
-  /// The brightness override for Cupertino descendants.
-  ///
-  /// Defaults to null. If a non-null [Brightness] is specified, the value will
-  /// take precedence over the ambient [MediaQueryData.platformBrightness], when
-  /// determining the brightness of descendant Cupertino widgets.
-  ///
-  /// If coming from a Material [Theme] and unspecified, [brightness] will be
-  /// derived from the Material [ThemeData]'s `brightness`.
-  ///
-  /// See also:
-  ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [brightness] to its Material [Theme] parent if it's unspecified.
-  ///
-  ///  * [CupertinoTheme.brightnessOf], a method used to retrieve the overall
-  ///    [Brightness] from a [BuildContext], for Cupertino widgets.
-  final Brightness? brightness;
 
   /// A color used on interactive elements of the theme.
   ///
@@ -230,8 +220,8 @@ class CupertinoThemeData with Diagnosticable {
   ///
   ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
   ///    [primaryColor] to its Material [Theme] parent if it's unspecified.
-  Color? get primaryColor => _primaryColor ?? _defaults!.primaryColor;
-  final Color? _primaryColor;
+  @override
+  Color get primaryColor => super.primaryColor ?? _defaults.primaryColor;
 
   /// A color that must be easy to see when rendered on a [primaryColor] background.
   ///
@@ -245,43 +235,44 @@ class CupertinoThemeData with Diagnosticable {
   ///
   ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
   ///    [primaryContrastingColor] to its Material [Theme] parent if it's unspecified.
-  Color? get primaryContrastingColor => _primaryContrastingColor ?? _defaults!.primaryContrastingColor;
-  final Color? _primaryContrastingColor;
+  @override
+  Color get primaryContrastingColor => super.primaryContrastingColor ?? _defaults.primaryContrastingColor;
 
   /// Text styles used by Cupertino widgets.
   ///
   /// Derived from [primaryColor] if unspecified.
-  CupertinoTextThemeData? get textTheme {
-    return _textTheme ?? _defaults!.textThemeDefaults.createDefaults(primaryColor: primaryColor!);
+  @override
+  CupertinoTextThemeData get textTheme {
+    return super.textTheme ?? _defaults.textThemeDefaults.createDefaults(primaryColor: primaryColor);
   }
-  final CupertinoTextThemeData? _textTheme;
 
   /// Background color of the top nav bar and bottom tab bar.
   ///
   /// Defaults to a light gray in light mode, or a dark translucent gray color in
   /// dark mode.
-  Color? get barBackgroundColor => _barBackgroundColor ?? _defaults!.barBackgroundColor;
-  final Color? _barBackgroundColor;
+  @override
+  Color get barBackgroundColor => super.barBackgroundColor ?? _defaults.barBackgroundColor;
 
   /// Background color of the scaffold.
   ///
   /// Defaults to [CupertinoColors.systemBackground].
-  Color? get scaffoldBackgroundColor => _scaffoldBackgroundColor ?? _defaults!.scaffoldBackgroundColor;
-  final Color? _scaffoldBackgroundColor;
+  @override
+  Color get scaffoldBackgroundColor => super.scaffoldBackgroundColor ?? _defaults.scaffoldBackgroundColor;
 
   /// Returns an instance of the [CupertinoThemeData] whose property getters
   /// only return the construction time specifications with no derived values.
   ///
   /// Used in Material themes to let unspecified properties fallback to Material
   /// theme properties instead of iOS defaults.
-  CupertinoThemeData noDefault() {
-    return _NoDefaultCupertinoThemeData(
-      brightness,
-      _primaryColor,
-      _primaryContrastingColor,
-      _textTheme,
-      _barBackgroundColor,
-      _scaffoldBackgroundColor,
+  @override
+  NoDefaultCupertinoThemeData noDefault() {
+    return NoDefaultCupertinoThemeData(
+      brightness: super.brightness,
+      primaryColor: super.primaryColor,
+      primaryContrastingColor: super.primaryContrastingColor,
+      textTheme: super.textTheme,
+      barBackgroundColor: super.barBackgroundColor,
+      scaffoldBackgroundColor: super.scaffoldBackgroundColor,
     );
   }
 
@@ -291,17 +282,18 @@ class CupertinoThemeData with Diagnosticable {
   /// Called by [CupertinoTheme.of] to resolve colors defined in the retrieved
   /// [CupertinoThemeData].
   @protected
+  @override
   CupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
     Color? convertColor(Color? color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
     return CupertinoThemeData._rawWithDefaults(
       brightness,
-      convertColor(_primaryColor),
-      convertColor(_primaryContrastingColor),
-      _textTheme?.resolveFrom(context, nullOk: nullOk),
-      convertColor(_barBackgroundColor),
-      convertColor(_scaffoldBackgroundColor),
-      _defaults!.resolveFrom(context, _textTheme == null, nullOk: nullOk),
+      convertColor(super.primaryColor),
+      convertColor(super.primaryContrastingColor),
+      super.textTheme?.resolveFrom(context, nullOk: nullOk),
+      convertColor(super.barBackgroundColor),
+      convertColor(super.scaffoldBackgroundColor),
+      _defaults.resolveFrom(context, super.textTheme == null, nullOk: nullOk),
     );
   }
 
@@ -312,6 +304,7 @@ class CupertinoThemeData with Diagnosticable {
   /// is implied from the current [primaryColor] because it was not specified,
   /// copying with a different [primaryColor] will also change the copy's implied
   /// [textTheme].
+  @override
   CupertinoThemeData copyWith({
     Brightness? brightness,
     Color? primaryColor,
@@ -321,12 +314,12 @@ class CupertinoThemeData with Diagnosticable {
     Color? scaffoldBackgroundColor,
   }) {
     return CupertinoThemeData._rawWithDefaults(
-      brightness ?? this.brightness,
-      primaryColor ?? _primaryColor,
-      primaryContrastingColor ?? _primaryContrastingColor,
-      textTheme ?? _textTheme,
-      barBackgroundColor ?? _barBackgroundColor,
-      scaffoldBackgroundColor ?? _scaffoldBackgroundColor,
+      brightness ?? super.brightness,
+      primaryColor ?? super.primaryColor,
+      primaryContrastingColor ?? super.primaryContrastingColor,
+      textTheme ?? super.textTheme,
+      barBackgroundColor ?? super.barBackgroundColor,
+      scaffoldBackgroundColor ?? super.scaffoldBackgroundColor,
       _defaults,
     );
   }
@@ -340,55 +333,41 @@ class CupertinoThemeData with Diagnosticable {
     properties.add(createCupertinoColorProperty('primaryContrastingColor', primaryContrastingColor, defaultValue: defaultData.primaryContrastingColor));
     properties.add(createCupertinoColorProperty('barBackgroundColor', barBackgroundColor, defaultValue: defaultData.barBackgroundColor));
     properties.add(createCupertinoColorProperty('scaffoldBackgroundColor', scaffoldBackgroundColor, defaultValue: defaultData.scaffoldBackgroundColor));
-    textTheme!.debugFillProperties(properties);
+    textTheme.debugFillProperties(properties);
   }
 }
 
-class _NoDefaultCupertinoThemeData extends CupertinoThemeData {
-  const _NoDefaultCupertinoThemeData(
-    Brightness? brightness,
+class NoDefaultCupertinoThemeData {
+  const NoDefaultCupertinoThemeData({
+    this.brightness,
     this.primaryColor,
     this.primaryContrastingColor,
     this.textTheme,
     this.barBackgroundColor,
     this.scaffoldBackgroundColor,
-  ) : super._rawWithDefaults(
-        brightness,
-        primaryColor,
-        primaryContrastingColor,
-        textTheme,
-        barBackgroundColor,
-        scaffoldBackgroundColor,
-        null,
-      );
+  });
 
-  @override
+  final Brightness? brightness;
   final Color? primaryColor;
-  @override
   final Color? primaryContrastingColor;
-  @override
   final CupertinoTextThemeData? textTheme;
-  @override
   final Color? barBackgroundColor;
-  @override
   final Color? scaffoldBackgroundColor;
 
-  @override
-  _NoDefaultCupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
+  NoDefaultCupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
     Color? convertColor(Color? color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
-    return _NoDefaultCupertinoThemeData(
-      brightness,
-      convertColor(primaryColor),
-      convertColor(primaryContrastingColor),
-      textTheme?.resolveFrom(context, nullOk: nullOk),
-      convertColor(barBackgroundColor),
-      convertColor(scaffoldBackgroundColor),
+    return NoDefaultCupertinoThemeData(
+      brightness: brightness,
+      primaryColor: convertColor(primaryColor),
+      primaryContrastingColor: convertColor(primaryContrastingColor),
+      textTheme: textTheme?.resolveFrom(context, nullOk: nullOk),
+      barBackgroundColor: convertColor(barBackgroundColor),
+      scaffoldBackgroundColor: convertColor(scaffoldBackgroundColor),
     );
   }
 
-  @override
-  CupertinoThemeData copyWith({
+  NoDefaultCupertinoThemeData copyWith({
     Brightness? brightness,
     Color? primaryColor,
     Color? primaryContrastingColor,
@@ -396,15 +375,17 @@ class _NoDefaultCupertinoThemeData extends CupertinoThemeData {
     Color? barBackgroundColor ,
     Color? scaffoldBackgroundColor,
   }) {
-    return _NoDefaultCupertinoThemeData(
-      brightness ?? this.brightness,
-      primaryColor ?? this.primaryColor,
-      primaryContrastingColor ?? this.primaryContrastingColor,
-      textTheme ?? this.textTheme,
-      barBackgroundColor ?? this.barBackgroundColor,
-      scaffoldBackgroundColor ?? this.scaffoldBackgroundColor,
+    return NoDefaultCupertinoThemeData(
+      brightness: brightness ?? this.brightness,
+      primaryColor: primaryColor ?? this.primaryColor,
+      primaryContrastingColor: primaryContrastingColor ?? this.primaryContrastingColor,
+      textTheme: textTheme ?? this.textTheme,
+      barBackgroundColor: barBackgroundColor ?? this.barBackgroundColor,
+      scaffoldBackgroundColor: scaffoldBackgroundColor ?? this.scaffoldBackgroundColor,
     );
   }
+
+  NoDefaultCupertinoThemeData noDefault() => this;
 }
 
 @immutable

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -233,7 +233,6 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
     );
   }
 
-  @protected
   @override
   CupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
     Color? convertColor(Color? color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
@@ -384,6 +383,7 @@ class NoDefaultCupertinoThemeData {
   ///
   /// Called by [CupertinoTheme.of] to resolve colors defined in the retrieved
   /// [CupertinoThemeData].
+  @protected
   NoDefaultCupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
     Color? convertColor(Color? color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -285,15 +285,15 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 /// Styling specifications for a cupertino theme without default values for
 /// unspecified properties.
 ///
-/// Unlike [CupetinoThemeData] instances of this class do not return default
+/// Unlike [CupertinoThemeData] instances of this class do not return default
 /// values for properties that have been left unspecified in the constructor.
 /// Instead, unspecified properties will return null. This is used by
 /// Material's [ThemeData.cupertinoOverrideTheme].
 ///
 /// See also:
 ///
-///  * [CupetinoThemeData], which uses reasonable default values for unspecified
-///    theme properties.
+///  * [CupertinoThemeData], which uses reasonable default values for
+///    unspecified theme properties.
 class NoDefaultCupertinoThemeData {
   /// Creates a [NoDefaultCupertinoThemeData] styling specification.
   ///

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -204,66 +204,23 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 
   final _CupertinoThemeDefaults _defaults;
 
-
-  /// A color used on interactive elements of the theme.
-  ///
-  /// This color is generally used on text and icons in buttons and tappable
-  /// elements. Defaults to [CupertinoColors.activeBlue].
-  ///
-  /// If coming from a Material [Theme] and unspecified, [primaryColor] will be
-  /// derived from the Material [ThemeData]'s `colorScheme.primary`. However, in
-  /// iOS styling, the [primaryColor] is more sparsely used than in Material
-  /// Design where the [primaryColor] can appear on non-interactive surfaces like
-  /// the [AppBar] background, [TextField] borders etc.
-  ///
-  /// See also:
-  ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [primaryColor] to its Material [Theme] parent if it's unspecified.
   @override
   Color get primaryColor => super.primaryColor ?? _defaults.primaryColor;
 
-  /// A color that must be easy to see when rendered on a [primaryColor] background.
-  ///
-  /// For example, this color is used for a [CupertinoButton]'s text and icons
-  /// when the button's background is [primaryColor].
-  ///
-  /// If coming from a Material [Theme] and unspecified, [primaryContrastingColor]
-  /// will be derived from the Material [ThemeData]'s `colorScheme.onPrimary`.
-  ///
-  /// See also:
-  ///
-  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
-  ///    [primaryContrastingColor] to its Material [Theme] parent if it's unspecified.
   @override
   Color get primaryContrastingColor => super.primaryContrastingColor ?? _defaults.primaryContrastingColor;
 
-  /// Text styles used by Cupertino widgets.
-  ///
-  /// Derived from [primaryColor] if unspecified.
   @override
   CupertinoTextThemeData get textTheme {
     return super.textTheme ?? _defaults.textThemeDefaults.createDefaults(primaryColor: primaryColor);
   }
 
-  /// Background color of the top nav bar and bottom tab bar.
-  ///
-  /// Defaults to a light gray in light mode, or a dark translucent gray color in
-  /// dark mode.
   @override
   Color get barBackgroundColor => super.barBackgroundColor ?? _defaults.barBackgroundColor;
 
-  /// Background color of the scaffold.
-  ///
-  /// Defaults to [CupertinoColors.systemBackground].
   @override
   Color get scaffoldBackgroundColor => super.scaffoldBackgroundColor ?? _defaults.scaffoldBackgroundColor;
 
-  /// Returns an instance of the [CupertinoThemeData] whose property getters
-  /// only return the construction time specifications with no derived values.
-  ///
-  /// Used in Material themes to let unspecified properties fallback to Material
-  /// theme properties instead of iOS defaults.
   @override
   NoDefaultCupertinoThemeData noDefault() {
     return NoDefaultCupertinoThemeData(
@@ -276,11 +233,6 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
     );
   }
 
-  /// Returns a new `CupertinoThemeData` with all its colors resolved against the
-  /// given [BuildContext].
-  ///
-  /// Called by [CupertinoTheme.of] to resolve colors defined in the retrieved
-  /// [CupertinoThemeData].
   @protected
   @override
   CupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
@@ -297,13 +249,6 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
     );
   }
 
-  /// Creates a copy of [CupertinoThemeData] with specified attributes overridden.
-  ///
-  /// Only the current instance's specified attributes are copied instead of
-  /// derived values. For instance, if the current [CupertinoThemeData.textTheme]
-  /// is implied from the current [primaryColor] because it was not specified,
-  /// copying with a different [primaryColor] will also change the copy's implied
-  /// [textTheme].
   @override
   CupertinoThemeData copyWith({
     Brightness? brightness,
@@ -337,7 +282,22 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
   }
 }
 
+/// Styling specifications for a cupertino theme without default values for
+/// unspecified properties.
+///
+/// Unlike [CupetinoThemeData] instances of this class do not return default
+/// values for properties that have been left unspecified in the constructor.
+/// Instead, unspecified properties will return null. This is used by
+/// Material's [ThemeData.cupertinoOverrideTheme].
+///
+/// See also:
+///
+///  * [CupetinoThemeData], which uses reasonable default values for unspecified
+///    theme properties.
 class NoDefaultCupertinoThemeData {
+  /// Creates a [NoDefaultCupertinoThemeData] styling specification.
+  ///
+  /// Unspecified parameters default to null.
   const NoDefaultCupertinoThemeData({
     this.brightness,
     this.primaryColor,
@@ -347,13 +307,83 @@ class NoDefaultCupertinoThemeData {
     this.scaffoldBackgroundColor,
   });
 
+  /// The brightness override for Cupertino descendants.
+  ///
+  /// Defaults to null. If a non-null [Brightness] is specified, the value will
+  /// take precedence over the ambient [MediaQueryData.platformBrightness], when
+  /// determining the brightness of descendant Cupertino widgets.
+  ///
+  /// If coming from a Material [Theme] and unspecified, [brightness] will be
+  /// derived from the Material [ThemeData]'s `brightness`.
+  ///
+  /// See also:
+  ///
+  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
+  ///    [brightness] to its Material [Theme] parent if it's unspecified.
+  ///
+  ///  * [CupertinoTheme.brightnessOf], a method used to retrieve the overall
+  ///    [Brightness] from a [BuildContext], for Cupertino widgets.
   final Brightness? brightness;
+
+  /// A color used on interactive elements of the theme.
+  ///
+  /// This color is generally used on text and icons in buttons and tappable
+  /// elements. Defaults to [CupertinoColors.activeBlue].
+  ///
+  /// If coming from a Material [Theme] and unspecified, [primaryColor] will be
+  /// derived from the Material [ThemeData]'s `colorScheme.primary`. However, in
+  /// iOS styling, the [primaryColor] is more sparsely used than in Material
+  /// Design where the [primaryColor] can appear on non-interactive surfaces like
+  /// the [AppBar] background, [TextField] borders etc.
+  ///
+  /// See also:
+  ///
+  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
+  ///    [primaryColor] to its Material [Theme] parent if it's unspecified.
   final Color? primaryColor;
+
+  /// A color that must be easy to see when rendered on a [primaryColor] background.
+  ///
+  /// For example, this color is used for a [CupertinoButton]'s text and icons
+  /// when the button's background is [primaryColor].
+  ///
+  /// If coming from a Material [Theme] and unspecified, [primaryContrastingColor]
+  /// will be derived from the Material [ThemeData]'s `colorScheme.onPrimary`.
+  ///
+  /// See also:
+  ///
+  ///  * [MaterialBasedCupertinoThemeData], a [CupertinoThemeData] that defers
+  ///    [primaryContrastingColor] to its Material [Theme] parent if it's unspecified.
   final Color? primaryContrastingColor;
+
+  /// Text styles used by Cupertino widgets.
+  ///
+  /// Derived from [primaryColor] if unspecified.
   final CupertinoTextThemeData? textTheme;
+
+  /// Background color of the top nav bar and bottom tab bar.
+  ///
+  /// Defaults to a light gray in light mode, or a dark translucent gray color in
+  /// dark mode.
   final Color? barBackgroundColor;
+
+  /// Background color of the scaffold.
+  ///
+  /// Defaults to [CupertinoColors.systemBackground].
   final Color? scaffoldBackgroundColor;
 
+  /// Returns an instance of the theme data whose property getters only return
+  /// the construction time specifications with no derived values.
+  ///
+  /// Used in Material themes to let unspecified properties fallback to Material
+  /// theme properties instead of iOS defaults.
+  NoDefaultCupertinoThemeData noDefault() => this;
+
+  /// Returns a new theme data with all its colors resolved against the
+  /// given [BuildContext].
+  ///
+  /// Called by [CupertinoTheme.of] to resolve colors defined in the retrieved
+  /// [CupertinoThemeData].
   NoDefaultCupertinoThemeData resolveFrom(BuildContext context, { bool nullOk = false }) {
     Color? convertColor(Color? color) => CupertinoDynamicColor.resolve(color, context, nullOk: nullOk);
 
@@ -367,6 +397,12 @@ class NoDefaultCupertinoThemeData {
     );
   }
 
+  /// Creates a copy of the theme data with specified attributes overridden.
+  ///
+  /// Only the current instance's specified attributes are copied instead of
+  /// derived values. For instance, if the current [textTheme] is implied from
+  /// the current [primaryColor] because it was not specified, copying with a
+  /// different [primaryColor] will also change the copy's implied [textTheme].
   NoDefaultCupertinoThemeData copyWith({
     Brightness? brightness,
     Color? primaryColor,
@@ -384,8 +420,6 @@ class NoDefaultCupertinoThemeData {
       scaffoldBackgroundColor: scaffoldBackgroundColor ?? this.scaffoldBackgroundColor,
     );
   }
-
-  NoDefaultCupertinoThemeData noDefault() => this;
 }
 
 @immutable

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -143,7 +143,7 @@ class _InheritedCupertinoTheme extends InheritedWidget {
 ///  * [ThemeData], a Material equivalent that also configures Cupertino
 ///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData].
 @immutable
-class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable  {
+class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable {
   /// Creates a [CupertinoTheme] styling specification.
   ///
   /// Unspecified parameters default to a reasonable iOS default style.
@@ -297,7 +297,7 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 class NoDefaultCupertinoThemeData {
   /// Creates a [NoDefaultCupertinoThemeData] styling specification.
   ///
-  /// Unspecified parameters default to null.
+  /// Unspecified properties default to null.
   const NoDefaultCupertinoThemeData({
     this.brightness,
     this.primaryColor,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -271,7 +271,7 @@ class ThemeData with Diagnosticable {
     FloatingActionButtonThemeData floatingActionButtonTheme,
     NavigationRailThemeData navigationRailTheme,
     Typography typography,
-    CupertinoThemeData cupertinoOverrideTheme,
+    NoDefaultCupertinoThemeData cupertinoOverrideTheme,
     SnackBarThemeData snackBarTheme,
     BottomSheetThemeData bottomSheetTheme,
     PopupMenuThemeData popupMenuTheme,
@@ -1080,7 +1080,7 @@ class ThemeData with Diagnosticable {
   ///
   /// This cascading effect for individual attributes of the [CupertinoThemeData]
   /// can be overridden using attributes of this [cupertinoOverrideTheme].
-  final CupertinoThemeData cupertinoOverrideTheme;
+  final NoDefaultCupertinoThemeData cupertinoOverrideTheme;
 
   /// A theme for customizing the color, elevation, and shape of a bottom sheet.
   final BottomSheetThemeData bottomSheetTheme;
@@ -1211,7 +1211,7 @@ class ThemeData with Diagnosticable {
     FloatingActionButtonThemeData floatingActionButtonTheme,
     NavigationRailThemeData navigationRailTheme,
     Typography typography,
-    CupertinoThemeData cupertinoOverrideTheme,
+    NoDefaultCupertinoThemeData cupertinoOverrideTheme,
     SnackBarThemeData snackBarTheme,
     BottomSheetThemeData bottomSheetTheme,
     PopupMenuThemeData popupMenuTheme,
@@ -1682,7 +1682,7 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<FloatingActionButtonThemeData>('floatingActionButtonThemeData', floatingActionButtonTheme, defaultValue: defaultData.floatingActionButtonTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<NavigationRailThemeData>('navigationRailThemeData', navigationRailTheme, defaultValue: defaultData.navigationRailTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<Typography>('typography', typography, defaultValue: defaultData.typography, level: DiagnosticLevel.debug));
-    properties.add(DiagnosticsProperty<CupertinoThemeData>('cupertinoOverrideTheme', cupertinoOverrideTheme, defaultValue: defaultData.cupertinoOverrideTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<NoDefaultCupertinoThemeData>('cupertinoOverrideTheme', cupertinoOverrideTheme, defaultValue: defaultData.cupertinoOverrideTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<SnackBarThemeData>('snackBarTheme', snackBarTheme, defaultValue: defaultData.snackBarTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<BottomSheetThemeData>('bottomSheetTheme', bottomSheetTheme, defaultValue: defaultData.bottomSheetTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<PopupMenuThemeData>('popupMenuTheme', popupMenuTheme, defaultValue: defaultData.popupMenuTheme, level: DiagnosticLevel.debug));
@@ -1759,7 +1759,7 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
       );
 
   final ThemeData _materialTheme;
-  final CupertinoThemeData _cupertinoOverrideTheme;
+  final NoDefaultCupertinoThemeData _cupertinoOverrideTheme;
 
   @override
   Brightness get brightness => _cupertinoOverrideTheme.brightness ?? _materialTheme.brightness;


### PR DESCRIPTION
## Description

In the Cupertino code we often assume that the cupertino theme properties are non-null. The code should reflect that assumption by making these properties non-nullable. Making them non-nullable is complicated by Material's `ThemeData.cupertinoOverrideTheme`, which wants to overwrite null-vales in the cupertino theme with default values from the material theme. To allow this, a new base class named `NoDefaultCupertinoThemeData` is introduced with nullable properties that is used by Material's `ThemeData.cupertinoOverrideTheme` to get around this problem.

## Related Issues

https://github.com/flutter/flutter/pull/66024

## Tests

I added the following tests:

n/a, refactoring to make our code cleaner.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
