### PR TITLE
TextField intrinsic height layout bug

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1261,10 +1261,11 @@ class _RenderDecoration extends RenderBox {
       + (label == null ? 0.0 : decoration.floatingLabelHeight)
       + _lineHeight(width, <RenderBox>[prefix, input, suffix])
       + subtextHeight
-      + contentPadding.bottom;
+      + contentPadding.bottom
+      + densityOffset.dy;
     final double minContainerHeight = decoration.isDense || expands
       ? 0.0
-      : kMinInteractiveDimension + densityOffset.dy;
+      : kMinInteractiveDimension;
     return math.max(containerHeight, minContainerHeight);
   }
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4311,4 +4311,44 @@ void main() {
     expect(textTop, greaterThan(textFieldTop));
     expect(textTop, lessThan(textFieldBottom));
   });
+
+  testWidgets('visual density is included in the intrinsic height calculation', (WidgetTester tester) async {
+    final UniqueKey key = UniqueKey();
+    final UniqueKey intrinsicHeightKey = UniqueKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Builder(
+          builder: (BuildContext context) {
+            return Theme(
+              data: Theme.of(context).copyWith(visualDensity: VisualDensity.compact),
+              child: Center(
+                child: Row(
+                  children: <Widget>[
+                    SizedBox(
+                      width: 35.0,
+                      child: TextField(
+                        key: key,
+                      ),
+                    ),
+                    SizedBox(
+                      width: 35.0,
+                      child: IntrinsicHeight(
+                        child: TextField(
+                          key: intrinsicHeightKey,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+
+    final double height = tester.getSize(find.byKey(key)).height;
+    final double intrinsicHeight = tester.getSize(find.byKey(intrinsicHeightKey)).height;
+    expect(intrinsicHeight, equals(height));
+  });
 }


### PR DESCRIPTION
## Description

TextFields wrapped in an IntrinsicHeight widget under a low visual density were laying out incorrectly.  This was due to an inconsistency in a height calculation in _layout and computeMinIntrinsicHeight, which this PR corrects.

## Related Issues

Closes https://github.com/flutter/flutter/issues/66279
Related to https://github.com/flutter/flutter/pull/65966

## Tests

I added the following tests:

Render TextFields with and without a wrapping IntrinsicHeight, and assert that they have the same height.