### PR TITLE
Stop logging on iOS process exit

### DIFF
--- a/dev/automated_tests/flutter_run_test/flutter_run_test.dart
+++ b/dev/automated_tests/flutter_run_test/flutter_run_test.dart
@@ -2,11 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('example', () {
     test('passed', () {
+      print('This is print');
+      stderr.writeln('This is writeln');
       expect(true, true);
     });
     test('failed', () {

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -98,6 +98,26 @@ void main () {
           '', '']);
       });
 
+      testWithoutContext('app exit', () async {
+        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['ios-deploy'],
+            stdout: '(lldb)     run\r\nsuccess\r\nLog on attach\r\nProcess 100 exited with status = 0\r\nLog after process exit',
+          ),
+        ]);
+        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+          processManager: processManager,
+          logger: logger,
+        );
+        final List<String> receivedLogLines = <String>[];
+        final Stream<String> logLines = iosDeployDebugger.logLines
+          ..listen(receivedLogLines.add);
+
+        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
+        await logLines.toList();
+        expect(receivedLogLines, <String>['Log on attach']);
+      });
+
       testWithoutContext('attach failed', () async {
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(


### PR DESCRIPTION
## Description

Detect when an `exit()`s and don't pass on further logging to the log reader.  This pretty much never happens on iOS apps because the App Store will reject apps that exit themselves manually, but I did see it while I was writing integration tests.

## Related Issues

Follow up on https://github.com/flutter/flutter/pull/66092.  

## Tests

- Unit test for process exit log line.
- Convert flutter_run_test to an integration logging test (not just `adb` logging).  Run on iOS, let's stop regressing logging on that platform...


## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*