### PR TITLE
Add Overflow back with deprecation

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -268,6 +268,24 @@ enum StackFit {
   passthrough,
 }
 
+@Deprecated(
+  'Use clipBehavior instead. See the migration guide in '
+  'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+)
+/// Whether overflowing children should be clipped, or their overflow be
+/// visible.
+///
+/// Deprecated. Use clipBehavior instead.
+enum Overflow {
+  /// Overflowing children will be visible.
+  ///
+  /// The visible overflow area will not accept hit testing.
+  visible,
+
+  /// Overflowing children will be clipped to the bounds of their parent.
+  clip,
+}
+
 /// Implements the stack layout algorithm.
 ///
 /// In a stack layout, the children are positioned on top of each other in the

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -273,8 +273,8 @@ enum StackFit {
 ///
 /// Deprecated. Use [Stack.clipBehavior] instead.
 @Deprecated(
-    'Use clipBehavior instead. See the migration guide in '
-    'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+  'Use clipBehavior instead. See the migration guide in flutter.dev/go/clip-behavior. '
+  'This feature was deprecated after v1.22.0-12.0.pre.'
 )
 enum Overflow {
   /// Overflowing children will be visible.

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -275,7 +275,7 @@ enum StackFit {
 /// Whether overflowing children should be clipped, or their overflow be
 /// visible.
 ///
-/// Deprecated. Use clipBehavior instead.
+/// Deprecated. Use [Stack.clipBehavior] instead.
 enum Overflow {
   /// Overflowing children will be visible.
   ///

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -268,14 +268,14 @@ enum StackFit {
   passthrough,
 }
 
-@Deprecated(
-  'Use clipBehavior instead. See the migration guide in '
-  'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
-)
 /// Whether overflowing children should be clipped, or their overflow be
 /// visible.
 ///
 /// Deprecated. Use [Stack.clipBehavior] instead.
+@Deprecated(
+    'Use clipBehavior instead. See the migration guide in '
+    'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+)
 enum Overflow {
   /// Overflowing children will be visible.
   ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3276,6 +3276,10 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
+    @Deprecated(
+      'Use clipBehavior instead. See the migration guide in '
+      'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+    )
     this.overflow = Overflow.clip,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
@@ -3317,10 +3321,6 @@ class Stack extends MultiChildRenderObjectWidget {
   /// ([StackFit.expand]).
   final StackFit fit;
 
-  @Deprecated(
-    'Use clipBehavior instead. See the migration guide in '
-    'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
-  )
   /// Whether overflowing children should be clipped. See [Overflow].
   ///
   /// Some children in a stack might overflow its box. When this flag is set to
@@ -3329,10 +3329,14 @@ class Stack extends MultiChildRenderObjectWidget {
   /// When set to [Overflow.visible], the visible overflow area will not accept
   /// hit testing.
   ///
-  /// This overrides [clipBehavior] for now due to a staged roll out without
-  /// breaking Google. We will remove it and only use [clipBehavior] soon.
+  /// This overrides [clipBehavior] for now due to a staged roll out.
+  /// We will remove it and only use [clipBehavior] soon.
   ///
   /// Deprecated. Use [clipBehavior] instead.
+  @Deprecated(
+      'Use clipBehavior instead. See the migration guide in '
+          'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+  )
   final Overflow overflow;
 
   /// {@macro flutter.widgets.Clip}

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3277,8 +3277,8 @@ class Stack extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.fit = StackFit.loose,
     @Deprecated(
-      'Use clipBehavior instead. See the migration guide in '
-      'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+      'Use clipBehavior instead. See the migration guide in flutter.dev/go/clip-behavior. '
+      'This feature was deprecated after v1.22.0-12.0.pre.'
     )
     this.overflow = Overflow.clip,
     this.clipBehavior = Clip.hardEdge,
@@ -3334,8 +3334,8 @@ class Stack extends MultiChildRenderObjectWidget {
   ///
   /// Deprecated. Use [clipBehavior] instead.
   @Deprecated(
-      'Use clipBehavior instead. See the migration guide in '
-      'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+    'Use clipBehavior instead. See the migration guide in flutter.dev/go/clip-behavior. '
+    'This feature was deprecated after v1.22.0-12.0.pre.'
   )
   final Overflow overflow;
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3335,7 +3335,7 @@ class Stack extends MultiChildRenderObjectWidget {
   /// Deprecated. Use [clipBehavior] instead.
   @Deprecated(
       'Use clipBehavior instead. See the migration guide in '
-          'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+      'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
   )
   final Overflow overflow;
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -42,6 +42,7 @@ export 'package:flutter/rendering.dart' show
   MainAxisAlignment,
   MainAxisSize,
   MultiChildLayoutDelegate,
+  Overflow,
   PaintingContext,
   PointerCancelEvent,
   PointerCancelEventListener,
@@ -3275,6 +3276,7 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
+    this.overflow = Overflow.clip,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) : assert(clipBehavior != null),
@@ -3315,6 +3317,24 @@ class Stack extends MultiChildRenderObjectWidget {
   /// ([StackFit.expand]).
   final StackFit fit;
 
+  @Deprecated(
+    'Use clipBehavior instead. See the migration guide in '
+    'flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.'
+  )
+  /// Whether overflowing children should be clipped. See [Overflow].
+  ///
+  /// Some children in a stack might overflow its box. When this flag is set to
+  /// [Overflow.clip], children cannot paint outside of the stack's box.
+  ///
+  /// When set to [Overflow.visible], the visible overflow area will not accept
+  /// hit testing.
+  ///
+  /// This overrides [clipBehavior] for now due to a staged roll out without
+  /// breaking Google. We will remove it and only use [clipBehavior] soon.
+  ///
+  /// Deprecated. Use [clipBehavior] instead.
+  final Overflow overflow;
+
   /// {@macro flutter.widgets.Clip}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -3339,7 +3359,7 @@ class Stack extends MultiChildRenderObjectWidget {
       alignment: alignment,
       textDirection: textDirection ?? Directionality.of(context),
       fit: fit,
-      clipBehavior: clipBehavior,
+      clipBehavior: overflow == Overflow.visible ? Clip.none : clipBehavior,
     );
   }
 
@@ -3350,7 +3370,7 @@ class Stack extends MultiChildRenderObjectWidget {
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.of(context)
       ..fit = fit
-      ..clipBehavior = clipBehavior;
+      ..clipBehavior = overflow == Overflow.visible ? Clip.none : clipBehavior;
   }
 
   @override

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -453,6 +453,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
+            overflow: Overflow.visible,
             clipBehavior: Clip.none,
             children: const <Widget>[
               SizedBox(


### PR DESCRIPTION
As the overflow option in the Stack is so popular, let's put it in deprecation for a while before completely removing it.

Fixes https://github.com/flutter/flutter/issues/66030