### PR TITLE
Listen to Debug VM stream to get Stdout logs from VMService

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -10,6 +10,7 @@ import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../application_package.dart';
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -678,6 +679,10 @@ class IOSDeviceLogReader extends DeviceLogReader {
       return;
     }
     try {
+      // The VM service will not publish logging events unless the debug stream is being listened to.
+      // Listen to this stream as a side effect.
+      unawaited(connectedVmService.streamListen('Debug'));
+
       await Future.wait(<Future<void>>[
         connectedVmService.streamListen(vm_service.EventStreams.kStdout),
         connectedVmService.streamListen(vm_service.EventStreams.kStderr),

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -189,6 +189,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
       equals('  This is a message '),
       equals('  And this is an error '),
     ]));
+    verify(vmService.streamListen('Debug'));
   });
 }
 


### PR DESCRIPTION
## Description

iOS logging broke with https://github.com/flutter/flutter/pull/54132.  The migration missed this logic:
```dart
    // The VM service will not publish logging events unless the debug stream is being listened to.
    // onDebugEvent listens to this stream as a side effect.
    unawaited(connectedVmService.onDebugEvent);
```
If the debug stream isn't listened to, the VM service won't pass along `Stdout`/`Stderr` events.

`flutter attach` now shows logs.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/65519.

## Tests

Updated ios_device_logger_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*