### PR TITLE
[flutter_tools] dont crash if attach is given a bad debug uri

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -141,7 +141,10 @@ class AttachCommand extends FlutterCommand {
     if (argResults['debug-uri'] == null) {
       return null;
     }
-    final Uri uri = Uri.parse(stringArg('debug-uri'));
+    final Uri uri = Uri.tryParse(stringArg('debug-uri'));
+    if (uri == null) {
+      throwToolExit('Invalid `--debug-uri`: ${stringArg('debug-uri')}');
+    }
     if (!uri.hasPort) {
       throwToolExit('Port not specified for `--debug-uri`: $uri');
     }

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -153,4 +153,21 @@ void main() {
 
     expect(versionInfo, containsPair('flutterRoot', isNotNull));
   });
+
+  testWithoutContext('A tool exit is thrown for an invalid debug-uri in flutter attach', () async {
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      '--show-test-device',
+      'attach',
+      '-d',
+      'flutter-tester',
+      '--debug-uri=http://127.0.0.1:3333*/',
+    ], workingDirectory: helloWorld);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('Invalid `--debug-uri`: http://127.0.0.1:3333*/'));
+  });
 }

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -58,13 +58,13 @@ String getFlutterRoot() {
   Error invalidScript() => StateError('Could not determine flutter_tools/ path from script URL (${globals.platform.script}); consider setting FLUTTER_ROOT explicitly.');
 
   Uri scriptUri;
-  switch (globals.platform.script.scheme) {
+  switch (platform.script.scheme) {
     case 'file':
-      scriptUri = globals.platform.script;
+      scriptUri = platform.script;
       break;
     case 'data':
       final RegExp flutterTools = RegExp(r'(file://[^"]*[/\\]flutter_tools[/\\][^"]+\.dart)', multiLine: true);
-      final Match match = flutterTools.firstMatch(Uri.decodeFull(globals.platform.script.path));
+      final Match match = flutterTools.firstMatch(Uri.decodeFull(platform.script.path));
       if (match == null) {
         throw invalidScript();
       }


### PR DESCRIPTION
## Description

Uri.parse throws a FormatException if the formatting is bad. Catch and handle this, seen in crash logging