### PR TITLE
Provide defaulting for textScaleFactor when passing to dart:ui

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -16,6 +16,11 @@ import 'text_span.dart';
 
 export 'package:flutter/services.dart' show TextRange, TextSelection;
 
+// The default font size if none is specified. This should be kept in
+// sync with the default values in text_style.dart, as well as the
+// defaults set in the engine (eg, LibTxt's text_style.h, paragraph_style.h).
+const double _kDefaultFontSize = 14.0;
+
 /// Holds the [Size] and baseline required to represent the dimensions of
 /// a placeholder in text.
 ///
@@ -420,7 +425,9 @@ class TextPainter {
     ) ?? ui.ParagraphStyle(
       textAlign: textAlign,
       textDirection: textDirection ?? defaultTextDirection,
-      textHeightBehavior: _textHeightBehavior,
+      // Use the default font size to multiply by as RichText does not
+      // perform inheriting [TextStyle]s
+      fontSize: _kDefaultFontSize * textScaleFactor,
       maxLines: maxLines,
       textHeightBehavior: _textHeightBehavior,
       ellipsis: ellipsis,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -420,6 +420,7 @@ class TextPainter {
     ) ?? ui.ParagraphStyle(
       textAlign: textAlign,
       textDirection: textDirection ?? defaultTextDirection,
+      textHeightBehavior: _textHeightBehavior,
       maxLines: maxLines,
       textHeightBehavior: _textHeightBehavior,
       ellipsis: ellipsis,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -426,7 +426,8 @@ class TextPainter {
       textAlign: textAlign,
       textDirection: textDirection ?? defaultTextDirection,
       // Use the default font size to multiply by as RichText does not
-      // perform inheriting [TextStyle]s
+      // perform inheriting [TextStyle]s and would otherwise
+      // fail to apply textScaleFactor.
       fontSize: _kDefaultFontSize * textScaleFactor,
       maxLines: maxLines,
       textHeightBehavior: _textHeightBehavior,

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -21,7 +21,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 
 // The default font size if none is specified. This should be kept in
 // sync with the default values in text_painter.dart, as well as the
-// defaults set in the engine.
+// defaults set in the engine (eg, LibTxt's text_style.h, paragraph_style.h).
 const double _kDefaultFontSize = 14.0;
 
 // Examples can assume:

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -19,6 +19,11 @@ const String _kColorForegroundWarning = 'Cannot provide both a color and a foreg
 const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor and a background\n'
     'The backgroundColor argument is just a shorthand for "background: new Paint()..color = color".';
 
+// The default font size if none is specified. This should be kept in
+// sync with the default values in text_painter.dart, as well as the
+// defaults set in the engine.
+const double _kDefaultFontSize = 14.0;
+
 // Examples can assume:
 // BuildContext context;
 
@@ -511,9 +516,6 @@ class TextStyle with Diagnosticable {
   /// [getParagraphStyle] will default to 14 logical pixels if the font size
   /// isn't specified here.
   final double? fontSize;
-
-  // The default font size if none is specified.
-  static const double _defaultFontSize = 14.0;
 
   /// The typeface thickness to use when painting the text (e.g., bold).
   final FontWeight? fontWeight;
@@ -1092,7 +1094,7 @@ class TextStyle with Diagnosticable {
       fontWeight: fontWeight ?? this.fontWeight,
       fontStyle: fontStyle ?? this.fontStyle,
       fontFamily: fontFamily ?? this.fontFamily,
-      fontSize: (fontSize ?? this.fontSize ?? _defaultFontSize) * textScaleFactor,
+      fontSize: (fontSize ?? this.fontSize ?? _kDefaultFontSize) * textScaleFactor,
       height: height ?? this.height,
       textHeightBehavior: textHeightBehavior,
       strutStyle: strutStyle == null ? null : ui.StrutStyle(

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -192,6 +192,18 @@ void main() {
     expect(painter.size, const Size(20.0, 20.0));
   });
 
+  test('TextPainter textScaleFactor null style test', () {
+    final TextPainter painter = TextPainter(
+      text: const TextSpan(
+        text: 'X',
+      ),
+      textDirection: TextDirection.ltr,
+      textScaleFactor: 2.0,
+    );
+    painter.layout();
+    expect(painter.size, const Size(20.0, 20.0));
+  });
+
   test('TextPainter default text height is 14 pixels', () {
     final TextPainter painter = TextPainter(
       text: const TextSpan(text: 'x'),

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -201,7 +201,7 @@ void main() {
       textScaleFactor: 2.0,
     );
     painter.layout();
-    expect(painter.size, const Size(20.0, 20.0));
+    expect(painter.size, const Size(28.0, 28.0));
   });
 
   test('TextPainter default text height is 14 pixels', () {


### PR DESCRIPTION
## Description

`textScaleFactor` depends on an existing fontSize to be multiplied with in order to be passed into dart:ui. TextSpans using RichText do not inherit styles from parents, and thus, fail to pass `textScaleFactor` when style is null.

Here, we provide the default font size as a base font to be multiplied by. This does not change behavior other than fix the bug, since the default font size would have been applied at the engine level anyways.

## Related Issues

Fixes #66196

and https://github.com/flutter/flutter/pull/66197
