### PR TITLE
enable lint unnecessary_nullable_for_final_variable_declarations

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -192,6 +192,7 @@ linter:
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -453,13 +453,13 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         return buffer.getFloat64List(length);
       case _valueList:
         final int length = readSize(buffer);
-        final dynamic result = List<dynamic>.filled(length, null, growable: false);
+        final List<dynamic> result = List<dynamic>.filled(length, null, growable: false);
         for (int i = 0; i < length; i++)
           result[i] = readValue(buffer);
         return result;
       case _valueMap:
         final int length = readSize(buffer);
-        final dynamic result = <dynamic, dynamic>{};
+        final Map<dynamic, dynamic> result = <dynamic, dynamic>{};
         for (int i = 0; i < length; i++)
           result[readValue(buffer)] = readValue(buffer);
         return result;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -321,7 +321,7 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
     final Element? element = _currentElement;
     if (element is StatefulElement) {
       final StatefulElement statefulElement = element;
-      final State? state = statefulElement.state;
+      final State state = statefulElement.state;
       if (state is T)
         return state;
     }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -181,7 +181,11 @@ class ListWheelChildBuilderDelegate extends ListWheelChildDelegate {
   @override
   Widget? build(BuildContext context, int index) {
     if (childCount == null) {
-      final Widget? child = builder(context, index);
+      final Widget child = builder(context, index);
+      // `child` has a non-nullable return type, but might be null when
+      // running with weak checking, so we need to null check it anyway (and
+      // ignore the warning that the null-handling logic is dead code).
+      // ignore: dead_code
       return child == null ? null : IndexedSemantics(child: child, index: index);
     }
     if (index < 0 || index >= childCount!)

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1048,10 +1048,8 @@ mixin WidgetInspectorService {
               renderObject.markNeedsPaint();
               renderObject.visitChildren(markTreeNeedsPaint);
             }
-            final RenderObject? root = RendererBinding.instance!.renderView;
-            if (root != null) {
-              markTreeNeedsPaint(root);
-            }
+            final RenderObject root = RendererBinding.instance!.renderView;
+            markTreeNeedsPaint(root);
           } else {
             debugOnProfilePaint = null;
           }


### PR DESCRIPTION
## Description

Enable [unnecessary_nullable_for_final_variable_declarations](https://dart-lang.github.io/linter/lints/unnecessary_nullable_for_final_variable_declarations.html)

## Related Issues

None
