### PR TITLE
[flutter_tools] fix calling debugToggleBrightness on release mode

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -197,55 +197,74 @@ abstract class ResidentWebRunner extends ResidentRunner {
   }
 
   @override
-  Future<void> debugDumpApp() async {
+  Future<bool> debugDumpApp() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterDebugDumpApp(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugDumpRenderTree() async {
+  Future<bool> debugDumpRenderTree() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterDebugDumpRenderTree(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugDumpLayerTree() async {
+  Future<bool> debugDumpLayerTree() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterDebugDumpLayerTree(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugDumpSemanticsTreeInTraversalOrder() async {
+  Future<bool> debugDumpSemanticsTreeInTraversalOrder() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterDebugDumpSemanticsTreeInTraversalOrder(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugTogglePlatform() async {
+  Future<bool> debugTogglePlatform() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       final String currentPlatform = await _vmService
         ?.flutterPlatformOverride(
@@ -259,12 +278,16 @@ abstract class ResidentWebRunner extends ResidentRunner {
           );
       globals.printStatus('Switched operating system to $platform');
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleBrightness() async {
+  Future<bool> debugToggleBrightness() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       final Brightness currentBrightness = await _vmService
         ?.flutterBrightnessOverride(
@@ -283,8 +306,9 @@ abstract class ResidentWebRunner extends ResidentRunner {
           );
       globals.logger.printStatus('Changed brightness to $next.');
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
@@ -294,87 +318,115 @@ abstract class ResidentWebRunner extends ResidentRunner {
   }
 
   @override
-  Future<void> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+  Future<bool> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleDebugPaintSizeEnabled() async {
+  Future<bool> debugToggleDebugPaintSizeEnabled() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterToggleDebugPaintSizeEnabled(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleDebugCheckElevationsEnabled() async {
+  Future<bool> debugToggleDebugCheckElevationsEnabled() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterToggleDebugCheckElevationsEnabled(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugTogglePerformanceOverlayOverride() async {
+  Future<bool> debugTogglePerformanceOverlayOverride() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterTogglePerformanceOverlayOverride(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleWidgetInspector() async {
+  Future<bool> debugToggleWidgetInspector() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterToggleWidgetInspector(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleInvertOversizedImages() async {
+  Future<bool> debugToggleInvertOversizedImages() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterToggleInvertOversizedImages(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 
   @override
-  Future<void> debugToggleProfileWidgetBuilds() async {
+  Future<bool> debugToggleProfileWidgetBuilds() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     try {
       await _vmService
         ?.flutterToggleProfileWidgetBuilds(
           isolateId: null,
         );
     } on vmservice.RPCError {
-      return;
+      // do nothing.
     }
+    return true;
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -340,7 +340,12 @@ class AttachCommand extends FlutterCommand {
         final Completer<void> onAppStart = Completer<void>.sync();
         TerminalHandler terminalHandler;
         unawaited(onAppStart.future.whenComplete(() {
-          terminalHandler = TerminalHandler(runner)
+          terminalHandler = TerminalHandler(
+            runner,
+            logger: globals.logger,
+            terminal: globals.terminal,
+            signals: globals.signals,
+          )
             ..setupTerminal()
             ..registerSignalHandlers();
         }));

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -592,7 +592,12 @@ class RunCommand extends RunCommandBase {
       (_) {
         appStartedTime = globals.systemClock.now();
         if (stayResident) {
-          TerminalHandler(runner)
+          TerminalHandler(
+            runner,
+            logger: globals.logger,
+            terminal: globals.terminal,
+            signals: globals.signals,
+          )
             ..setupTerminal()
             ..registerSignalHandlers();
         }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -979,73 +979,120 @@ abstract class ResidentRunner {
     appFinished();
   }
 
-  Future<void> debugDumpApp() async {
+  Future<bool> debugDumpApp() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpApp();
     }
+    return true;
   }
 
-  Future<void> debugDumpRenderTree() async {
+  Future<bool> debugDumpRenderTree() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpRenderTree();
     }
+    return true;
   }
 
-  Future<void> debugDumpLayerTree() async {
+  Future<bool> debugDumpLayerTree() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpLayerTree();
     }
+    return true;
   }
 
-  Future<void> debugDumpSemanticsTreeInTraversalOrder() async {
+  Future<bool> debugDumpSemanticsTreeInTraversalOrder() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpSemanticsTreeInTraversalOrder();
     }
+    return true;
   }
 
-  Future<void> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+  Future<bool> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpSemanticsTreeInInverseHitTestOrder();
     }
+    return true;
   }
 
-  Future<void> debugToggleDebugPaintSizeEnabled() async {
+  Future<bool> debugToggleDebugPaintSizeEnabled() async {
+    if (!supportsServiceProtocol || !isRunningDebug) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleDebugPaintSizeEnabled();
     }
+    return true;
   }
 
-  Future<void> debugToggleDebugCheckElevationsEnabled() async {
+  Future<bool> debugToggleDebugCheckElevationsEnabled() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleDebugCheckElevationsEnabled();
     }
+    return true;
   }
 
-  Future<void> debugTogglePerformanceOverlayOverride() async {
+  Future<bool> debugTogglePerformanceOverlayOverride() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.debugTogglePerformanceOverlayOverride();
     }
+    return true;
   }
 
-  Future<void> debugToggleWidgetInspector() async {
+  Future<bool> debugToggleWidgetInspector() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleWidgetInspector();
     }
+    return true;
   }
 
-  Future<void> debugToggleInvertOversizedImages() async {
+  Future<bool> debugToggleInvertOversizedImages() async {
+    if (!supportsServiceProtocol || !isRunningDebug) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleInvertOversizedImages();
     }
+    return true;
   }
 
-  Future<void> debugToggleProfileWidgetBuilds() async {
+  Future<bool> debugToggleProfileWidgetBuilds() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleProfileWidgetBuilds();
     }
+    return true;
   }
 
-  Future<void> debugToggleBrightness() async {
+  Future<bool> debugToggleBrightness() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     final Brightness brightness = await flutterDevices.first.toggleBrightness();
     Brightness next;
     for (final FlutterDevice device in flutterDevices) {
@@ -1054,6 +1101,7 @@ abstract class ResidentRunner {
       );
       globals.logger.printStatus('Changed brightness to $next.');
     }
+    return true;
   }
 
   /// Take a screenshot on the provided [device].
@@ -1118,7 +1166,10 @@ abstract class ResidentRunner {
     }
   }
 
-  Future<void> debugTogglePlatform() async {
+  Future<bool> debugTogglePlatform() async {
+    if (!supportsServiceProtocol || !isRunningDebug) {
+      return false;
+    }
     final List<FlutterView> views = await flutterDevices
       .first
       .vmService.getFlutterViews();
@@ -1132,6 +1183,7 @@ abstract class ResidentRunner {
       to = await device.togglePlatform(from: from);
     }
     globals.printStatus('Switched operating system to $to');
+    return true;
   }
 
   Future<void> stopEchoingDeviceLog() async {
@@ -1230,10 +1282,14 @@ abstract class ResidentRunner {
     }
   }
 
-  Future<void> launchDevTools() async {
+  Future<bool> launchDevTools() async {
+    if (!supportsServiceProtocol) {
+      return false;
+    }
     assert(supportsServiceProtocol);
     _devtoolsLauncher ??= DevtoolsLauncher.instance;
-    return _devtoolsLauncher.launch(flutterDevices.first.vmService.httpAddress);
+    await _devtoolsLauncher.launch(flutterDevices.first.vmService.httpAddress);
+    return true;
   }
 
   Future<void> shutdownDevtools() async {
@@ -1453,17 +1509,9 @@ class TerminalHandler {
     _logger.printStatus(''); // the key the user tapped might be on this line
     switch (character) {
       case 'a':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugToggleProfileWidgetBuilds();
-          return true;
-        }
-        return false;
+        return residentRunner.debugToggleProfileWidgetBuilds();
       case 'b':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugToggleBrightness();
-          return true;
-        }
-        return false;
+        return residentRunner.debugToggleBrightness();
       case 'c':
         residentRunner.clearScreen();
         return true;
@@ -1481,30 +1529,14 @@ class TerminalHandler {
         residentRunner.printHelp(details: true);
         return true;
       case 'i':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugToggleWidgetInspector();
-          return true;
-        }
-        return false;
+        return residentRunner.debugToggleWidgetInspector();
       case 'I':
-        if (residentRunner.supportsServiceProtocol && residentRunner.isRunningDebug) {
-          await residentRunner.debugToggleInvertOversizedImages();
-          return true;
-        }
-        return false;
+        return residentRunner.debugToggleInvertOversizedImages();
       case 'L':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugDumpLayerTree();
-          return true;
-        }
-        return false;
+        return residentRunner.debugDumpLayerTree();
       case 'o':
       case 'O':
-        if (residentRunner.supportsServiceProtocol && residentRunner.isRunningDebug) {
-          await residentRunner.debugTogglePlatform();
-          return true;
-        }
-        return false;
+        return residentRunner.debugTogglePlatform();
       case 'M':
         if (residentRunner.supportsWriteSkSL) {
           await residentRunner.writeSkSL();
@@ -1512,17 +1544,9 @@ class TerminalHandler {
         }
         return false;
       case 'p':
-        if (residentRunner.supportsServiceProtocol && residentRunner.isRunningDebug) {
-          await residentRunner.debugToggleDebugPaintSizeEnabled();
-          return true;
-        }
-        return false;
+        return residentRunner.debugToggleDebugPaintSizeEnabled();
       case 'P':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugTogglePerformanceOverlayOverride();
-          return true;
-        }
-        return false;
+        return residentRunner.debugTogglePerformanceOverlayOverride();
       case 'q':
       case 'Q':
         // exit
@@ -1561,41 +1585,20 @@ class TerminalHandler {
         }
         return true;
       case 'S':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugDumpSemanticsTreeInTraversalOrder();
-          return true;
-        }
-        return false;
+        return residentRunner.debugDumpSemanticsTreeInTraversalOrder();
       case 't':
       case 'T':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugDumpRenderTree();
-          return true;
-        }
-        return false;
+        return residentRunner.debugDumpRenderTree();
       case 'U':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
-          return true;
-        }
-        return false;
+        return residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
       case 'v':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.launchDevTools();
-          return true;
-        }
-        return false;
+        return residentRunner.launchDevTools();
       case 'w':
       case 'W':
-        if (residentRunner.supportsServiceProtocol) {
-          await residentRunner.debugDumpApp();
-          return true;
-        }
-        return false;
+        return residentRunner.debugDumpApp();
       case 'z':
       case 'Z':
-        await residentRunner.debugToggleDebugCheckElevationsEnabled();
-        return true;
+        return residentRunner.debugToggleDebugCheckElevationsEnabled();
     }
     return false;
   }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:devtools_server/devtools_server.dart' as devtools_server;
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -21,6 +20,7 @@ import 'base/io.dart' as io;
 import 'base/logger.dart';
 import 'base/platform.dart';
 import 'base/signals.dart';
+import 'base/terminal.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'build_system/build_system.dart';

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1652,51 +1652,149 @@ void main() {
 
   testUsingContext('ResidentRunner debugDumpApp calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugDumpApp();
 
+    expect(await residentRunner.debugDumpApp(), true);
     verify(mockFlutterDevice.debugDumpApp()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugDumpApp does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugDumpApp(), false);
+    verifyNever(mockFlutterDevice.debugDumpApp());
   }));
 
   testUsingContext('ResidentRunner debugDumpRenderTree calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugDumpRenderTree();
 
+    expect(await residentRunner.debugDumpRenderTree(), true);
     verify(mockFlutterDevice.debugDumpRenderTree()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugDumpRenderTree does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugDumpRenderTree(), false);
+    verifyNever(mockFlutterDevice.debugDumpRenderTree());
   }));
 
   testUsingContext('ResidentRunner debugDumpLayerTree calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugDumpLayerTree();
 
+    expect(await residentRunner.debugDumpLayerTree(), true);
     verify(mockFlutterDevice.debugDumpLayerTree()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugDumpLayerTree does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugDumpLayerTree(), false);
+    verifyNever(mockFlutterDevice.debugDumpLayerTree());
   }));
 
   testUsingContext('ResidentRunner debugDumpSemanticsTreeInTraversalOrder calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugDumpSemanticsTreeInTraversalOrder();
 
+    expect(await residentRunner.debugDumpSemanticsTreeInTraversalOrder(), true);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInTraversalOrder()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugDumpSemanticsTreeInTraversalOrder does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugDumpSemanticsTreeInTraversalOrder(), false);
+    verifyNever(mockFlutterDevice.debugDumpSemanticsTreeInTraversalOrder());
   }));
 
   testUsingContext('ResidentRunner debugDumpSemanticsTreeInInverseHitTestOrder calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
 
+    expect(await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder(), true);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInInverseHitTestOrder()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugDumpSemanticsTreeInInverseHitTestOrder does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder(), false);
+    verifyNever(mockFlutterDevice.debugDumpSemanticsTreeInInverseHitTestOrder());
   }));
 
   testUsingContext('ResidentRunner debugToggleDebugPaintSizeEnabled calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugToggleDebugPaintSizeEnabled();
 
+    expect(await residentRunner.debugToggleDebugPaintSizeEnabled(), true);
     verify(mockFlutterDevice.toggleDebugPaintSizeEnabled()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleDebugPaintSizeEnabled does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleDebugPaintSizeEnabled(), false);
+    verifyNever(mockFlutterDevice.toggleDebugPaintSizeEnabled());
   }));
 
   testUsingContext('ResidentRunner debugToggleBrightness calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugToggleBrightness();
 
+    expect(await residentRunner.debugToggleBrightness(), true);
     verify(mockFlutterDevice.toggleBrightness()).called(2);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleBrightness does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleBrightness(), false);
+    verifyNever(mockFlutterDevice.toggleBrightness());
   }));
 
   testUsingContext('FlutterDevice.toggleBrightness invokes correct VM service request', () => testbed.run(() async {
@@ -1724,9 +1822,37 @@ void main() {
 
   testUsingContext('ResidentRunner debugToggleInvertOversizedImages calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugToggleInvertOversizedImages();
 
+    expect(await residentRunner.debugToggleInvertOversizedImages(), true);
     verify(mockFlutterDevice.toggleInvertOversizedImages()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleInvertOversizedImages does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleInvertOversizedImages(), false);
+    verifyNever(mockFlutterDevice.toggleInvertOversizedImages());
+  }));
+
+  testUsingContext('ResidentRunner debugToggleInvertOversizedImages does not call flutter device if in profile mode', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile),
+    );
+
+    expect(await residentRunner.debugToggleInvertOversizedImages(), false);
+    verifyNever(mockFlutterDevice.toggleInvertOversizedImages());
   }));
 
   testUsingContext('FlutterDevice.toggleInvertOversizedImages invokes correct VM service request', () => testbed.run(() async {
@@ -1754,23 +1880,66 @@ void main() {
 
   testUsingContext('ResidentRunner debugToggleDebugCheckElevationsEnabled calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugToggleDebugCheckElevationsEnabled();
 
+    expect(await residentRunner.debugToggleDebugCheckElevationsEnabled(), true);
     verify(mockFlutterDevice.toggleDebugCheckElevationsEnabled()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleDebugCheckElevationsEnabled does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleDebugCheckElevationsEnabled(), false);
+    verifyNever(mockFlutterDevice.toggleDebugCheckElevationsEnabled());
   }));
 
   testUsingContext('ResidentRunner debugTogglePerformanceOverlayOverride calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugTogglePerformanceOverlayOverride();
 
+    expect(await residentRunner.debugTogglePerformanceOverlayOverride(), true);
     verify(mockFlutterDevice.debugTogglePerformanceOverlayOverride()).called(1);
   }));
 
+  testUsingContext('ResidentRunner debugTogglePerformanceOverlayOverride does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugTogglePerformanceOverlayOverride(), false);
+    verifyNever(mockFlutterDevice.debugTogglePerformanceOverlayOverride());
+  }));
+
+
   testUsingContext('ResidentRunner debugToggleWidgetInspector calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.debugToggleWidgetInspector();
 
+    expect(await residentRunner.debugToggleWidgetInspector(), true);
     verify(mockFlutterDevice.toggleWidgetInspector()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleWidgetInspector does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleWidgetInspector(), false);
+    verifyNever(mockFlutterDevice.toggleWidgetInspector());
   }));
 
   testUsingContext('ResidentRunner debugToggleProfileWidgetBuilds calls flutter device', () => testbed.run(() async {
@@ -1778,6 +1947,20 @@ void main() {
     await residentRunner.debugToggleProfileWidgetBuilds();
 
     verify(mockFlutterDevice.toggleProfileWidgetBuilds()).called(1);
+  }));
+
+  testUsingContext('ResidentRunner debugToggleProfileWidgetBuilds does not call flutter device if service protocol is unsupported', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+    );
+
+    expect(await residentRunner.debugToggleProfileWidgetBuilds(), false);
+    verifyNever(mockFlutterDevice.toggleProfileWidgetBuilds());
   }));
 
   testUsingContext('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -86,14 +86,6 @@ void main() {
       verify(mockResidentRunner.debugToggleProfileWidgetBuilds()).called(1);
     });
 
-    testWithoutContext('a - debugToggleProfileWidgetBuilds without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('a');
-
-      verifyNever(mockResidentRunner.debugToggleProfileWidgetBuilds());
-    });
-
-
     testWithoutContext('a - debugToggleProfileWidgetBuilds', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
       await terminalHandler.processTerminalInput('a');
@@ -107,14 +99,6 @@ void main() {
 
       verify(mockResidentRunner.debugToggleBrightness()).called(1);
     });
-
-    testWithoutContext('b - debugToggleBrightness not called if service protocol is unsupported', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('b');
-
-      verifyNever(mockResidentRunner.debugToggleBrightness());
-    });
-
 
     testWithoutContext('d,D - detach', () async {
       await terminalHandler.processTerminalInput('d');
@@ -137,13 +121,6 @@ void main() {
       verify(mockResidentRunner.debugToggleWidgetInspector()).called(1);
     });
 
-    testWithoutContext('i - debugToggleWidgetInspector without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('i');
-
-      verifyNever(mockResidentRunner.debugToggleWidgetInspector());
-    });
-
     testWithoutContext('I - debugToggleInvertOversizedImages with service protocol/debug', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('I');
@@ -151,30 +128,10 @@ void main() {
       verify(mockResidentRunner.debugToggleInvertOversizedImages()).called(1);
     });
 
-    testWithoutContext('I - debugToggleInvertOversizedImages with service protocol/ndebug', () async {
-      when(mockResidentRunner.isRunningDebug).thenReturn(false);
-      await terminalHandler.processTerminalInput('I');
-
-      verifyNever(mockResidentRunner.debugToggleInvertOversizedImages());
-    });
-
-    testWithoutContext('I - debugToggleInvertOversizedImages without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('I');
-
-    });
-
     testWithoutContext('L - debugDumpLayerTree with service protocol', () async {
       await terminalHandler.processTerminalInput('L');
 
       verify(mockResidentRunner.debugDumpLayerTree()).called(1);
-    });
-
-    testWithoutContext('L - debugDumpLayerTree without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('L');
-
-      verifyNever(mockResidentRunner.debugDumpLayerTree());
     });
 
     testWithoutContext('o,O - debugTogglePlatform with service protocol and debug mode', () async {
@@ -185,15 +142,6 @@ void main() {
       verify(mockResidentRunner.debugTogglePlatform()).called(2);
     });
 
-    testWithoutContext('o,O - debugTogglePlatform without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      when(mockResidentRunner.isRunningDebug).thenReturn(true);
-      await terminalHandler.processTerminalInput('o');
-      await terminalHandler.processTerminalInput('O');
-
-      verifyNever(mockResidentRunner.debugTogglePlatform());
-    });
-
     testWithoutContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
@@ -201,40 +149,17 @@ void main() {
       verify(mockResidentRunner.debugToggleDebugPaintSizeEnabled()).called(1);
     });
 
-    testWithoutContext('p - debugTogglePlatform without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      when(mockResidentRunner.isRunningDebug).thenReturn(true);
-      await terminalHandler.processTerminalInput('p');
-
-      verifyNever(mockResidentRunner.debugToggleDebugPaintSizeEnabled());
-    });
-
     testWithoutContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
 
       verify(mockResidentRunner.debugToggleDebugPaintSizeEnabled()).called(1);
-    });
-
-    testWithoutContext('p - debugTogglePlatform without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      when(mockResidentRunner.isRunningDebug).thenReturn(true);
-      await terminalHandler.processTerminalInput('p');
-
-      verifyNever(mockResidentRunner.debugToggleDebugPaintSizeEnabled());
     });
 
     testWithoutContext('P - debugTogglePerformanceOverlayOverride with service protocol', () async {
       await terminalHandler.processTerminalInput('P');
 
       verify(mockResidentRunner.debugTogglePerformanceOverlayOverride()).called(1);
-    });
-
-    testWithoutContext('P - debugTogglePerformanceOverlayOverride without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('P');
-
-      verifyNever(mockResidentRunner.debugTogglePerformanceOverlayOverride());
     });
 
     testWithoutContext('q,Q - exit', () async {
@@ -347,13 +272,6 @@ void main() {
       verify(mockResidentRunner.debugDumpSemanticsTreeInTraversalOrder()).called(1);
     });
 
-    testWithoutContext('S - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('S');
-
-      verifyNever(mockResidentRunner.debugDumpSemanticsTreeInTraversalOrder());
-    });
-
     testWithoutContext('t,T - debugDumpRenderTree with service protocol', () async {
       await terminalHandler.processTerminalInput('t');
       await terminalHandler.processTerminalInput('T');
@@ -361,25 +279,10 @@ void main() {
       verify(mockResidentRunner.debugDumpRenderTree()).called(2);
     });
 
-    testWithoutContext('t,T - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('t');
-      await terminalHandler.processTerminalInput('T');
-
-      verifyNever(mockResidentRunner.debugDumpRenderTree());
-    });
-
     testWithoutContext('U - debugDumpRenderTree with service protocol', () async {
       await terminalHandler.processTerminalInput('U');
 
       verify(mockResidentRunner.debugDumpSemanticsTreeInInverseHitTestOrder()).called(1);
-    });
-
-    testWithoutContext('U - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('U');
-
-      verifyNever(mockResidentRunner.debugDumpSemanticsTreeInInverseHitTestOrder());
     });
 
     testWithoutContext('v - launchDevTools', () async {
@@ -394,14 +297,6 @@ void main() {
       await terminalHandler.processTerminalInput('W');
 
       verify(mockResidentRunner.debugDumpApp()).called(2);
-    });
-
-    testWithoutContext('w,W - debugDumpApp without service protocol', () async {
-      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
-      await terminalHandler.processTerminalInput('w');
-      await terminalHandler.processTerminalInput('W');
-
-      verifyNever(mockResidentRunner.debugDumpApp());
     });
 
     testWithoutContext('z,Z - debugToggleDebugCheckElevationsEnabled with service protocol', () async {

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -4,82 +4,89 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/signals.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 
 void main() {
-  TestRunner createTestRunner() {
-    // TODO(jacobr): make these tests run with `trackWidgetCreation: true` as
-    // well as the default flags.
-    return TestRunner(
-      <FlutterDevice>[
-        FlutterDevice(
-          MockDevice(),
-          buildInfo: const BuildInfo(
-            BuildMode.debug,
-            null,
-            trackWidgetCreation: false,
-            treeShakeIcons: false,
-          ),
-          generator: MockResidentCompiler(),
-        ),
-      ],
+  testWithoutContext('keyboard input handling single help character', () async {
+    final TestRunner testRunner = TestRunner();
+    final Logger logger = BufferLogger.test();
+    final Signals signals = Signals.test();
+    final Terminal terminal = Terminal.test();
+    final TerminalHandler terminalHandler = TerminalHandler(
+      testRunner,
+      logger: logger,
+      signals: signals,
+      terminal: terminal,
     );
-  }
 
-  group('keyboard input handling', () {
-    testUsingContext('single help character', () async {
-      final TestRunner testRunner = createTestRunner();
-      final TerminalHandler terminalHandler = TerminalHandler(testRunner);
-      expect(testRunner.hasHelpBeenPrinted, false);
-      await terminalHandler.processTerminalInput('h');
-      expect(testRunner.hasHelpBeenPrinted, true);
-    });
+    expect(testRunner.hasHelpBeenPrinted, false);
+    await terminalHandler.processTerminalInput('h');
+    expect(testRunner.hasHelpBeenPrinted, true);
+  });
 
-    testUsingContext('help character surrounded with newlines', () async {
-      final TestRunner testRunner = createTestRunner();
-      final TerminalHandler terminalHandler = TerminalHandler(testRunner);
-      expect(testRunner.hasHelpBeenPrinted, false);
-      await terminalHandler.processTerminalInput('\nh\n');
-      expect(testRunner.hasHelpBeenPrinted, true);
-    });
+  testWithoutContext('keyboard input handling help character surrounded with newlines', () async {
+    final TestRunner testRunner = TestRunner();
+    final Logger logger = BufferLogger.test();
+    final Signals signals = Signals.test();
+    final Terminal terminal = Terminal.test();
+    final TerminalHandler terminalHandler = TerminalHandler(
+      testRunner,
+      logger: logger,
+      signals: signals,
+      terminal: terminal,
+    );
+
+    expect(testRunner.hasHelpBeenPrinted, false);
+    await terminalHandler.processTerminalInput('\nh\n');
+    expect(testRunner.hasHelpBeenPrinted, true);
   });
 
   group('keycode verification, brought to you by the letter', () {
     MockResidentRunner mockResidentRunner;
     TerminalHandler terminalHandler;
+    BufferLogger testLogger;
 
     setUp(() {
+      testLogger = BufferLogger.test();
+      final Signals signals = Signals.test();
+      final Terminal terminal = Terminal.test();
       mockResidentRunner = MockResidentRunner();
-      terminalHandler = TerminalHandler(mockResidentRunner);
+      terminalHandler = TerminalHandler(
+        mockResidentRunner,
+        logger: testLogger,
+        signals: signals,
+        terminal: terminal,
+      );
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
     });
 
-    testUsingContext('a, can handle trailing newlines', () async {
+    testWithoutContext('a, can handle trailing newlines', () async {
       await terminalHandler.processTerminalInput('a\n');
 
       expect(terminalHandler.lastReceivedCommand, 'a');
     });
 
-    testUsingContext('n, can handle trailing only newlines', () async {
+    testWithoutContext('n, can handle trailing only newlines', () async {
       await terminalHandler.processTerminalInput('\n\n');
 
       expect(terminalHandler.lastReceivedCommand, '');
     });
 
-    testUsingContext('a - debugToggleProfileWidgetBuilds with service protocol', () async {
+    testWithoutContext('a - debugToggleProfileWidgetBuilds with service protocol', () async {
       await terminalHandler.processTerminalInput('a');
 
       verify(mockResidentRunner.debugToggleProfileWidgetBuilds()).called(1);
     });
 
-    testUsingContext('a - debugToggleProfileWidgetBuilds without service protocol', () async {
+    testWithoutContext('a - debugToggleProfileWidgetBuilds without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('a');
 
@@ -87,21 +94,36 @@ void main() {
     });
 
 
-    testUsingContext('a - debugToggleProfileWidgetBuilds', () async {
+    testWithoutContext('a - debugToggleProfileWidgetBuilds', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
       await terminalHandler.processTerminalInput('a');
 
       verify(mockResidentRunner.debugToggleProfileWidgetBuilds()).called(1);
     });
 
-    testUsingContext('d,D - detach', () async {
+    testWithoutContext('b - debugToggleBrightness', () async {
+      when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
+      await terminalHandler.processTerminalInput('b');
+
+      verify(mockResidentRunner.debugToggleBrightness()).called(1);
+    });
+
+    testWithoutContext('b - debugToggleBrightness not called if service protocol is unsupported', () async {
+      when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
+      await terminalHandler.processTerminalInput('b');
+
+      verifyNever(mockResidentRunner.debugToggleBrightness());
+    });
+
+
+    testWithoutContext('d,D - detach', () async {
       await terminalHandler.processTerminalInput('d');
       await terminalHandler.processTerminalInput('D');
 
       verify(mockResidentRunner.detach()).called(2);
     });
 
-    testUsingContext('h,H,? - printHelp', () async {
+    testWithoutContext('h,H,? - printHelp', () async {
       await terminalHandler.processTerminalInput('h');
       await terminalHandler.processTerminalInput('H');
       await terminalHandler.processTerminalInput('?');
@@ -109,53 +131,53 @@ void main() {
       verify(mockResidentRunner.printHelp(details: true)).called(3);
     });
 
-    testUsingContext('i - debugToggleWidgetInspector with service protocol', () async {
+    testWithoutContext('i - debugToggleWidgetInspector with service protocol', () async {
       await terminalHandler.processTerminalInput('i');
 
       verify(mockResidentRunner.debugToggleWidgetInspector()).called(1);
     });
 
-    testUsingContext('i - debugToggleWidgetInspector without service protocol', () async {
+    testWithoutContext('i - debugToggleWidgetInspector without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('i');
 
       verifyNever(mockResidentRunner.debugToggleWidgetInspector());
     });
 
-    testUsingContext('I - debugToggleInvertOversizedImages with service protocol/debug', () async {
+    testWithoutContext('I - debugToggleInvertOversizedImages with service protocol/debug', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('I');
 
       verify(mockResidentRunner.debugToggleInvertOversizedImages()).called(1);
     });
 
-    testUsingContext('I - debugToggleInvertOversizedImages with service protocol/ndebug', () async {
+    testWithoutContext('I - debugToggleInvertOversizedImages with service protocol/ndebug', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(false);
       await terminalHandler.processTerminalInput('I');
 
       verifyNever(mockResidentRunner.debugToggleInvertOversizedImages());
     });
 
-    testUsingContext('I - debugToggleInvertOversizedImages without service protocol', () async {
+    testWithoutContext('I - debugToggleInvertOversizedImages without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('I');
 
     });
 
-    testUsingContext('L - debugDumpLayerTree with service protocol', () async {
+    testWithoutContext('L - debugDumpLayerTree with service protocol', () async {
       await terminalHandler.processTerminalInput('L');
 
       verify(mockResidentRunner.debugDumpLayerTree()).called(1);
     });
 
-    testUsingContext('L - debugDumpLayerTree without service protocol', () async {
+    testWithoutContext('L - debugDumpLayerTree without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('L');
 
       verifyNever(mockResidentRunner.debugDumpLayerTree());
     });
 
-    testUsingContext('o,O - debugTogglePlatform with service protocol and debug mode', () async {
+    testWithoutContext('o,O - debugTogglePlatform with service protocol and debug mode', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('o');
       await terminalHandler.processTerminalInput('O');
@@ -163,7 +185,7 @@ void main() {
       verify(mockResidentRunner.debugTogglePlatform()).called(2);
     });
 
-    testUsingContext('o,O - debugTogglePlatform without service protocol', () async {
+    testWithoutContext('o,O - debugTogglePlatform without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('o');
@@ -172,14 +194,14 @@ void main() {
       verifyNever(mockResidentRunner.debugTogglePlatform());
     });
 
-    testUsingContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
+    testWithoutContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
 
       verify(mockResidentRunner.debugToggleDebugPaintSizeEnabled()).called(1);
     });
 
-    testUsingContext('p - debugTogglePlatform without service protocol', () async {
+    testWithoutContext('p - debugTogglePlatform without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
@@ -187,14 +209,14 @@ void main() {
       verifyNever(mockResidentRunner.debugToggleDebugPaintSizeEnabled());
     });
 
-    testUsingContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
+    testWithoutContext('p - debugToggleDebugPaintSizeEnabled with service protocol and debug mode', () async {
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
 
       verify(mockResidentRunner.debugToggleDebugPaintSizeEnabled()).called(1);
     });
 
-    testUsingContext('p - debugTogglePlatform without service protocol', () async {
+    testWithoutContext('p - debugTogglePlatform without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       await terminalHandler.processTerminalInput('p');
@@ -202,27 +224,27 @@ void main() {
       verifyNever(mockResidentRunner.debugToggleDebugPaintSizeEnabled());
     });
 
-    testUsingContext('P - debugTogglePerformanceOverlayOverride with service protocol', () async {
+    testWithoutContext('P - debugTogglePerformanceOverlayOverride with service protocol', () async {
       await terminalHandler.processTerminalInput('P');
 
       verify(mockResidentRunner.debugTogglePerformanceOverlayOverride()).called(1);
     });
 
-    testUsingContext('P - debugTogglePerformanceOverlayOverride without service protocol', () async {
+    testWithoutContext('P - debugTogglePerformanceOverlayOverride without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('P');
 
       verifyNever(mockResidentRunner.debugTogglePerformanceOverlayOverride());
     });
 
-    testUsingContext('q,Q - exit', () async {
+    testWithoutContext('q,Q - exit', () async {
       await terminalHandler.processTerminalInput('q');
       await terminalHandler.processTerminalInput('Q');
 
       verify(mockResidentRunner.exit()).called(2);
     });
 
-    testUsingContext('s - screenshot', () async {
+    testWithoutContext('s - screenshot', () async {
       final MockDevice mockDevice = MockDevice();
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
@@ -235,7 +257,7 @@ void main() {
       verify(mockResidentRunner.screenshot(mockFlutterDevice)).called(1);
     });
 
-    testUsingContext('r - hotReload supported and succeeds', () async {
+    testWithoutContext('r - hotReload supported and succeeds', () async {
       when(mockResidentRunner.canHotReload).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: false))
           .thenAnswer((Invocation invocation) async {
@@ -246,7 +268,7 @@ void main() {
       verify(mockResidentRunner.restart(fullRestart: false)).called(1);
     });
 
-    testUsingContext('r - hotReload supported and fails', () async {
+    testWithoutContext('r - hotReload supported and fails', () async {
       when(mockResidentRunner.canHotReload).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: false))
           .thenAnswer((Invocation invocation) async {
@@ -259,7 +281,7 @@ void main() {
       expect(testLogger.statusText, contains('Try again after fixing the above error(s).'));
     });
 
-    testUsingContext('r - hotReload supported and fails fatally', () async {
+    testWithoutContext('r - hotReload supported and fails fatally', () async {
       when(mockResidentRunner.canHotReload).thenReturn(true);
       when(mockResidentRunner.hotMode).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: false))
@@ -269,14 +291,14 @@ void main() {
       expect(terminalHandler.processTerminalInput('r'), throwsToolExit());
     });
 
-    testUsingContext('r - hotReload unsupported', () async {
+    testWithoutContext('r - hotReload unsupported', () async {
       when(mockResidentRunner.canHotReload).thenReturn(false);
       await terminalHandler.processTerminalInput('r');
 
       verifyNever(mockResidentRunner.restart(fullRestart: false));
     });
 
-    testUsingContext('R - hotRestart supported and succeeds', () async {
+    testWithoutContext('R - hotRestart supported and succeeds', () async {
       when(mockResidentRunner.canHotRestart).thenReturn(true);
       when(mockResidentRunner.hotMode).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: true))
@@ -288,7 +310,7 @@ void main() {
       verify(mockResidentRunner.restart(fullRestart: true)).called(1);
     });
 
-    testUsingContext('R - hotRestart supported and fails', () async {
+    testWithoutContext('R - hotRestart supported and fails', () async {
       when(mockResidentRunner.canHotRestart).thenReturn(true);
       when(mockResidentRunner.hotMode).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: true))
@@ -302,7 +324,7 @@ void main() {
       expect(testLogger.statusText, contains('Try again after fixing the above error(s).'));
     });
 
-    testUsingContext('R - hotRestart supported and fails fatally', () async {
+    testWithoutContext('R - hotRestart supported and fails fatally', () async {
       when(mockResidentRunner.canHotRestart).thenReturn(true);
       when(mockResidentRunner.hotMode).thenReturn(true);
       when(mockResidentRunner.restart(fullRestart: true))
@@ -312,34 +334,34 @@ void main() {
       expect(() => terminalHandler.processTerminalInput('R'), throwsToolExit());
     });
 
-    testUsingContext('R - hot restart unsupported', () async {
+    testWithoutContext('R - hot restart unsupported', () async {
       when(mockResidentRunner.canHotRestart).thenReturn(false);
       await terminalHandler.processTerminalInput('R');
 
       verifyNever(mockResidentRunner.restart(fullRestart: true));
     });
 
-    testUsingContext('S - debugDumpSemanticsTreeInTraversalOrder with service protocol', () async {
+    testWithoutContext('S - debugDumpSemanticsTreeInTraversalOrder with service protocol', () async {
       await terminalHandler.processTerminalInput('S');
 
       verify(mockResidentRunner.debugDumpSemanticsTreeInTraversalOrder()).called(1);
     });
 
-    testUsingContext('S - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
+    testWithoutContext('S - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('S');
 
       verifyNever(mockResidentRunner.debugDumpSemanticsTreeInTraversalOrder());
     });
 
-    testUsingContext('t,T - debugDumpRenderTree with service protocol', () async {
+    testWithoutContext('t,T - debugDumpRenderTree with service protocol', () async {
       await terminalHandler.processTerminalInput('t');
       await terminalHandler.processTerminalInput('T');
 
       verify(mockResidentRunner.debugDumpRenderTree()).called(2);
     });
 
-    testUsingContext('t,T - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
+    testWithoutContext('t,T - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('t');
       await terminalHandler.processTerminalInput('T');
@@ -347,34 +369,34 @@ void main() {
       verifyNever(mockResidentRunner.debugDumpRenderTree());
     });
 
-    testUsingContext('U - debugDumpRenderTree with service protocol', () async {
+    testWithoutContext('U - debugDumpRenderTree with service protocol', () async {
       await terminalHandler.processTerminalInput('U');
 
       verify(mockResidentRunner.debugDumpSemanticsTreeInInverseHitTestOrder()).called(1);
     });
 
-    testUsingContext('U - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
+    testWithoutContext('U - debugDumpSemanticsTreeInTraversalOrder without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('U');
 
       verifyNever(mockResidentRunner.debugDumpSemanticsTreeInInverseHitTestOrder());
     });
 
-    testUsingContext('v - launchDevTools', () async {
+    testWithoutContext('v - launchDevTools', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
       await terminalHandler.processTerminalInput('v');
 
       verify(mockResidentRunner.launchDevTools()).called(1);
     });
 
-    testUsingContext('w,W - debugDumpApp with service protocol', () async {
+    testWithoutContext('w,W - debugDumpApp with service protocol', () async {
       await terminalHandler.processTerminalInput('w');
       await terminalHandler.processTerminalInput('W');
 
       verify(mockResidentRunner.debugDumpApp()).called(2);
     });
 
-    testUsingContext('w,W - debugDumpApp without service protocol', () async {
+    testWithoutContext('w,W - debugDumpApp without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('w');
       await terminalHandler.processTerminalInput('W');
@@ -382,14 +404,14 @@ void main() {
       verifyNever(mockResidentRunner.debugDumpApp());
     });
 
-    testUsingContext('z,Z - debugToggleDebugCheckElevationsEnabled with service protocol', () async {
+    testWithoutContext('z,Z - debugToggleDebugCheckElevationsEnabled with service protocol', () async {
       await terminalHandler.processTerminalInput('z');
       await terminalHandler.processTerminalInput('Z');
 
       verify(mockResidentRunner.debugToggleDebugCheckElevationsEnabled()).called(2);
     });
 
-    testUsingContext('z,Z - debugToggleDebugCheckElevationsEnabled without service protocol', () async {
+    testWithoutContext('z,Z - debugToggleDebugCheckElevationsEnabled without service protocol', () async {
       when(mockResidentRunner.supportsServiceProtocol).thenReturn(false);
       await terminalHandler.processTerminalInput('z');
       await terminalHandler.processTerminalInput('Z');
@@ -410,10 +432,7 @@ class MockResidentRunner extends Mock implements ResidentRunner {}
 class MockFlutterDevice extends Mock implements FlutterDevice {}
 class MockResidentCompiler extends Mock implements ResidentCompiler {}
 
-class TestRunner extends ResidentRunner {
-  TestRunner(List<FlutterDevice> devices)
-    : super(devices, debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug));
-
+class TestRunner extends Mock implements ResidentRunner {
   bool hasHelpBeenPrinted = false;
   String receivedCommand;
 


### PR DESCRIPTION
## Description

ensure that the terminal handler checks if the service protocol is enabled before calling debug toggle brightness. Also removes globals from TerminalHander and test cases.

Fixes https://github.com/flutter/flutter/issues/65477