### PR TITLE
Change emoji in About dialog to be a divider

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -18,6 +18,7 @@ import 'card.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'dialog.dart';
+import 'divider.dart';
 import 'floating_action_button.dart';
 import 'floating_action_button_location.dart';
 import 'ink_decoration.dart';
@@ -856,11 +857,8 @@ class _PackageLicensePageState extends State<_PackageLicensePage> {
       }
       setState(() {
         _licenses.add(const Padding(
-          padding: EdgeInsets.symmetric(vertical: 18.0),
-          child: Text(
-            '🍀‬', // That's U+1F340. Could also use U+2766 (❦) if U+1F340 doesn't work everywhere.
-            textAlign: TextAlign.center,
-          ),
+          padding: EdgeInsets.all(18.0),
+          child: Divider(),
         ));
         for (final LicenseParagraph paragraph in paragraphs) {
           if (paragraph.indent == LicenseParagraph.centeredIndent) {


### PR DESCRIPTION
## Description

Changes the four-leaf-clover emoji (🍀‬) in the license pages to be a divider widget instead.  Not all platforms had that emoji in their default font, and a divider is more appropriate anyhow.

It changes it from this (on Linux, where the emoji is missing):
![image](https://user-images.githubusercontent.com/8867023/93956271-9c2c4700-fd06-11ea-99ef-cfc609b3a150.png)


To this:
![image](https://user-images.githubusercontent.com/8867023/93956203-73a44d00-fd06-11ea-96b4-f243f1763593.png)

## Tests

- I didn't test this, because I'd just be testing that it includes a widget, which seems like a very fragile test, and if I did that, why wouldn't I test that the widget tree included all the widgets?

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.