### PR TITLE
Theme override in search

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -328,10 +328,10 @@ class _SearchPageRoute<T> extends PageRoute<T> {
     @required this.delegate,
   }) : assert(delegate != null) {
     assert(
-      delegate._route == null,
-      'The ${delegate.runtimeType} instance is currently used by another active '
-      'search. Please close that search by calling close() on the SearchDelegate '
-      'before opening another search with the same delegate instance.',
+    delegate._route == null,
+    'The ${delegate.runtimeType} instance is currently used by another active '
+        'search. Please close that search by calling close() on the SearchDelegate '
+        'before opening another search with the same delegate instance.',
     );
     delegate._route = this;
   }
@@ -352,11 +352,11 @@ class _SearchPageRoute<T> extends PageRoute<T> {
 
   @override
   Widget buildTransitions(
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  ) {
+      BuildContext context,
+      Animation<double> animation,
+      Animation<double> secondaryAnimation,
+      Widget child,
+      ) {
     return FadeTransition(
       opacity: animation,
       child: child,
@@ -372,10 +372,10 @@ class _SearchPageRoute<T> extends PageRoute<T> {
 
   @override
   Widget buildPage(
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-  ) {
+      BuildContext context,
+      Animation<double> animation,
+      Animation<double> secondaryAnimation,
+      ) {
     return _SearchPage<T>(
       delegate: delegate,
       animation: animation,
@@ -475,9 +475,9 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = widget.delegate.appBarTheme(context);
     final String searchFieldLabel = widget.delegate.searchFieldLabel
-      ?? MaterialLocalizations.of(context).searchFieldLabel;
+        ?? MaterialLocalizations.of(context).searchFieldLabel;
     final TextStyle searchFieldStyle = widget.delegate.searchFieldStyle
-      ?? theme.inputDecorationTheme.hintStyle;
+        ?? theme.inputDecorationTheme.hintStyle;
     Widget body;
     switch(widget.delegate._currentBody) {
       case _SearchBody.suggestions:
@@ -531,6 +531,8 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
               border: InputBorder.none,
               hintText: searchFieldLabel,
               hintStyle: searchFieldStyle,
+              fillColor: theme.inputDecorationTheme.fillColor,
+              focusedBorder: theme.inputDecorationTheme.focusedBorder,
             ),
           ),
           actions: widget.delegate.buildActions(context),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -137,6 +137,38 @@ void main() {
     expect(hintColor, delegate.hintTextColor);
   });
 
+  testWidgets('InputDecoration fillColor overridden',
+          (WidgetTester tester) async {
+        final _TestSearchDelegate delegate = _TestSearchDelegate();
+
+        await tester.pumpWidget(TestHomePage(
+          delegate: delegate,
+        ));
+        await tester.tap(find.byTooltip('Search'));
+        await tester.pumpAndSettle();
+
+        final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
+        final Color fillColor = textField.decoration.fillColor;
+        expect(fillColor, delegate.fillColor);
+      });
+
+  testWidgets('InputDecoration focusedBorder overridden',
+          (WidgetTester tester) async {
+        final _TestSearchDelegate delegate = _TestSearchDelegate();
+
+        await tester.pumpWidget(TestHomePage(
+          delegate: delegate,
+        ));
+        await tester.tap(find.byTooltip('Search'));
+        await tester.pumpAndSettle();
+
+        final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
+        final InputBorder focusedBorder = textField.decoration.focusedBorder;
+        expect(focusedBorder, delegate.focusedBorder);
+      });
+
   testWidgets('Requests suggestions', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
@@ -547,9 +579,9 @@ void main() {
     final _TestSearchDelegate delegate = _TestSearchDelegate(searchFieldStyle: searchStyle);
 
     await tester.pumpWidget(
-      TestHomePage(
-      delegate: delegate,
-    ));
+        TestHomePage(
+          delegate: delegate,
+        ));
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
@@ -620,44 +652,44 @@ void main() {
                             textDirection: TextDirection.ltr,
                           ),
                           TestSemantics(
-                            id: 11,
-                            flags: <SemanticsFlag>[
+                              id: 11,
+                              flags: <SemanticsFlag>[
                               SemanticsFlag.isTextField,
                               SemanticsFlag.isFocused,
                               SemanticsFlag.isHeader,
                               if (debugDefaultTargetPlatformOverride != TargetPlatform.iOS &&
-                                debugDefaultTargetPlatformOverride != TargetPlatform.macOS) SemanticsFlag.namesRoute,
-                            ],
-                            actions: <SemanticsAction>[
-                              SemanticsAction.tap,
-                              SemanticsAction.setSelection,
-                              SemanticsAction.paste,
-                            ],
-                            label: 'Search',
-                            textDirection: TextDirection.ltr,
-                            textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
-                          ),
+                          debugDefaultTargetPlatformOverride != TargetPlatform.macOS) SemanticsFlag.namesRoute,
                         ],
-                      ),
-                      TestSemantics(
-                        id: 8,
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.hasEnabledState,
-                          SemanticsFlag.isButton,
-                          SemanticsFlag.isEnabled,
-                          SemanticsFlag.isFocusable,
+                        actions: <SemanticsAction>[
+                          SemanticsAction.tap,
+                          SemanticsAction.setSelection,
+                          SemanticsAction.paste,
                         ],
-                        actions: <SemanticsAction>[SemanticsAction.tap],
-                        label: 'Suggestions',
+                        label: 'Search',
                         textDirection: TextDirection.ltr,
+                        textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
+                  ),
+                  TestSemantics(
+                    id: 8,
+                    flags: <SemanticsFlag>[
+                      SemanticsFlag.hasEnabledState,
+                      SemanticsFlag.isButton,
+                      SemanticsFlag.isEnabled,
+                      SemanticsFlag.isFocusable,
+                    ],
+                    actions: <SemanticsAction>[SemanticsAction.tap],
+                    label: 'Suggestions',
+                    textDirection: TextDirection.ltr,
                   ),
                 ],
               ),
             ],
           ),
         ],
+      ),
+      ],
       );
     }
 
@@ -760,15 +792,20 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   final String result;
   final List<Widget> actions;
   final Color hintTextColor = Colors.green;
+  final Color fillColor = Colors.blue;
+  final InputBorder focusedBorder = InputBorder.none;
 
   @override
   ThemeData appBarTheme(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return theme.copyWith(
-      inputDecorationTheme: InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
+      inputDecorationTheme: InputDecorationTheme(
+        hintStyle: TextStyle(color: hintTextColor),
+        fillColor: fillColor,
+        focusedBorder: focusedBorder,
+      ),
     );
   }
-
   @override
   Widget buildLeading(BuildContext context) {
     return IconButton(


### PR DESCRIPTION
## Description

Internal issue: b/165582972
Internal CL: cl/327432986

The Search library wasn't overriding some required aspects of the app theme. This allows the user to override fillColor and
focusedBorder fields of InputDecoration.

## Related Issues

#19734 - SearchDelegate should respect InputDecoration theme override

## Tests

I added the following tests:

Tests added to search_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
