### PR TITLE
[devicelab] increase timeout for cull bench

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
@@ -12,6 +12,6 @@ void main() {
     kCullOpacityRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
-    timeout: const Duration(seconds: 45),
+    timeout: const Duration(minutes: 2),
   );
 }


### PR DESCRIPTION
## Description

Currently the cull_opacity_perf__timeline_summary has a 45 second timeout. I hit this timeout once when running locally, so it seems far too short. Bump it up to 2 minutes.