### PR TITLE
TextSelectionTheme support (step 3 of 3)

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -82,7 +82,6 @@ ThemeData _buildShrineTheme() {
     buttonColor: kShrinePink100,
     scaffoldBackgroundColor: kShrineBackgroundWhite,
     cardColor: kShrineBackgroundWhite,
-    textSelectionColor: kShrinePink100,
     errorColor: kShrineErrorRed,
     buttonTheme: const ButtonThemeData(
       colorScheme: kShrineColorScheme,

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -578,17 +578,13 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
     switch (theme.platform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
+        final CupertinoThemeData cupertinoTheme = CupertinoTheme.of(context);
         forcePressEnabled = true;
         textSelectionControls = cupertinoTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = true;
-        if (theme.useTextSelectionTheme) {
-          cursorColor ??= selectionTheme.cursorColor ?? CupertinoTheme.of(context).primaryColor;
-          selectionColor = selectionTheme.selectionColor ?? CupertinoTheme.of(context).primaryColor;
-        } else {
-          cursorColor ??= CupertinoTheme.of(context).primaryColor;
-          selectionColor = theme.textSelectionColor;
-        }
+        cursorColor ??= selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
+        selectionColor = selectionTheme.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
         break;
@@ -601,13 +597,8 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
         textSelectionControls = materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
-        if (theme.useTextSelectionTheme) {
-          cursorColor ??= selectionTheme.cursorColor ?? theme.colorScheme.primary;
-          selectionColor = selectionTheme.selectionColor ?? theme.colorScheme.primary;
-        } else {
-          cursorColor ??= theme.cursorColor;
-          selectionColor = theme.textSelectionColor;
-        }
+        cursorColor ??= selectionTheme.cursorColor ?? theme.colorScheme.primary;
+        selectionColor = selectionTheme.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
         break;
     }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -663,17 +663,11 @@ class TextField extends StatefulWidget {
   /// The cursor indicates the current location of text insertion point in
   /// the field.
   ///
-  /// If this is null it will default to a value based on the following:
-  ///
-  /// * If the ambient [ThemeData.useTextSelectionTheme] is true then it
-  ///   will use the value of the ambient [TextSelectionThemeData.cursorColor].
-  ///   If that is null then if the [ThemeData.platform] is [TargetPlatform.iOS]
-  ///   or [TargetPlatform.macOS] then it will use [CupertinoThemeData.primaryColor].
-  ///   Otherwise it will use the value of [ColorScheme.primary] of [ThemeData.colorScheme].
-  ///
-  /// * If the ambient [ThemeData.useTextSelectionTheme] is false then it
-  ///   will use either [ThemeData.cursorColor] or [CupertinoThemeData.primaryColor]
-  ///   depending on [ThemeData.platform].
+  /// If this is null it will default to the ambient
+  /// [TextSelectionThemeData.cursorColor]. If that is null, and the
+  /// [ThemeData.platform] is [TargetPlatform.iOS] or [TargetPlatform.macOS]
+  /// it will use [CupertinoThemeData.primaryColor]. Otherwise it will use
+  /// the value of [ColorScheme.primary] of [ThemeData.colorScheme].
   final Color cursorColor;
 
   /// Controls how tall the selection highlight boxes are computed to be.
@@ -1136,13 +1130,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         textSelectionControls = cupertinoTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = true;
-        if (theme.useTextSelectionTheme) {
-          cursorColor ??= selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
-          selectionColor = selectionTheme.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
-        } else {
-          cursorColor ??= CupertinoTheme.of(context).primaryColor;
-          selectionColor = theme.textSelectionColor;
-        }
+        cursorColor ??= selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
+        selectionColor = selectionTheme.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
         autocorrectionTextRectColor = selectionColor;
@@ -1156,13 +1145,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         textSelectionControls = materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
-        if (theme.useTextSelectionTheme) {
-          cursorColor ??= selectionTheme.cursorColor ?? theme.colorScheme.primary;
-          selectionColor = selectionTheme.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
-        } else {
-          cursorColor ??= theme.cursorColor;
-          selectionColor = theme.textSelectionColor;
-        }
+        cursorColor ??= selectionTheme.cursorColor ?? theme.colorScheme.primary;
+        selectionColor = selectionTheme.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
         break;
     }
 

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -797,9 +797,7 @@ class _MaterialTextSelectionControls extends TextSelectionControls {
   @override
   Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight) {
     final ThemeData theme = Theme.of(context);
-    final Color handleColor = theme.useTextSelectionTheme ?
-      TextSelectionTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary :
-      theme.textSelectionHandleColor;
+    final Color handleColor = TextSelectionTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary;
     final Widget handle = SizedBox(
       width: _kHandleSize,
       height: _kHandleSize,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -238,8 +238,20 @@ class ThemeData with Diagnosticable {
     ButtonThemeData buttonTheme,
     ToggleButtonsThemeData toggleButtonsTheme,
     Color secondaryHeaderColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color textSelectionColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.cursorColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color cursorColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionHandleColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color textSelectionHandleColor,
     Color backgroundColor,
     Color dialogBackgroundColor,
@@ -286,6 +298,10 @@ class ThemeData with Diagnosticable {
     TextSelectionThemeData textSelectionTheme,
     DataTableThemeData dataTableTheme,
     bool fixTextFieldOutlineLabel,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     bool useTextSelectionTheme,
   }) {
     assert(colorScheme?.brightness == null || brightness == null || colorScheme.brightness == brightness);
@@ -883,21 +899,24 @@ class ThemeData with Diagnosticable {
   final Color secondaryHeaderColor;
 
   /// The color of text selections in text fields, such as [TextField].
-  ///
-  /// By default this property is no longer used. It has been replaced with
-  /// [TextSelectionThemeData.selectionColor] and will soon be deprecated.
+  @Deprecated(
+    'Use TextSelectionThemeData.selectionColor instead. '
+    'This feature was deprecated after v1.23.0-4.0.pre.'
+  )
   final Color textSelectionColor;
 
   /// The color of cursors in Material-style text fields, such as [TextField].
-  ///
-  /// By default this property is no longer used. It has been replaced with
-  /// [TextSelectionThemeData.cursorColor] and will soon be deprecated.
+  @Deprecated(
+    'Use TextSelectionThemeData.cursorColor instead. '
+    'This feature was deprecated after v1.23.0-4.0.pre.'
+  )
   final Color cursorColor;
 
   /// The color of the handles used to adjust what part of the text is currently selected.
-  ///
-  /// By default this property is no longer used. It has been replaced with
-  /// [TextSelectionThemeData.selectionHandleColor] and will soon be deprecated.
+  @Deprecated(
+    'Use TextSelectionThemeData.selectionHandleColor instead. '
+    'This feature was deprecated after v1.23.0-4.0.pre.'
+  )
   final Color textSelectionHandleColor;
 
   /// A color that contrasts with the [primaryColor], e.g. used as the
@@ -1137,16 +1156,14 @@ class ThemeData with Diagnosticable {
   /// stable release (1.19).
   final bool fixTextFieldOutlineLabel;
 
-  /// A temporary flag to allow apps to opt-in to the new [TextSelectionTheme], with
-  /// its new defaults for the [cursorColor] and [textSelectionHandleColor].
-  ///
-  /// Setting this flag to true will cause the [textSelectionTheme] to be used
-  /// instead of the [cursorColor] and [textSelectionHandleColor] by [TextField]
-  /// and [SelectableText] widgets. In addition, the default values of these
-  /// colors have changed to [ColorScheme.primary].
-  ///
-  /// The flag is currently false by default. It will be removed after migration
-  /// to the [TextSelectionTheme] has been completed.
+  /// A temporary flag that was used to opt-in to the new [TextSelectionTheme]
+  /// during the migration to this new theme. That migration is now complete
+  /// and this flag is not longer used by the framework. Please remove any
+  /// reference to this property, as it will be removed in future releases.
+  @Deprecated(
+    'No longer used by the framework, please remove any reference to it. '
+    'This feature was deprecated after v1.23.0-4.0.pre.'
+  )
   final bool useTextSelectionTheme;
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
@@ -1179,8 +1196,20 @@ class ThemeData with Diagnosticable {
     ToggleButtonsThemeData toggleButtonsTheme,
     Color buttonColor,
     Color secondaryHeaderColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color textSelectionColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.cursorColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color cursorColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionHandleColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     Color textSelectionHandleColor,
     Color backgroundColor,
     Color dialogBackgroundColor,
@@ -1226,6 +1255,10 @@ class ThemeData with Diagnosticable {
     TextSelectionThemeData textSelectionTheme,
     DataTableThemeData dataTableTheme,
     bool fixTextFieldOutlineLabel,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     bool useTextSelectionTheme,
   }) {
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();


### PR DESCRIPTION
## Description

This PR completes the migration to the new `TextSelectionTheme` started in #62014 and is described in the [design doc](https://flutter.dev/go/text-selection-theme). 

This step changes makes the `TextSelectionTheme` always used for defaults by the `TextField` and `SelectableText` widgets. As such, the following parameters of the `ThemeData` are now deprecated and will eventually removed:

- `cursorColor`
- `textSelectionColor`
- `textSelectionHandleColor`
- `useTextSelectionTheme`


## Related Issues

#17635
#56082
#61227

## Tests

The tests were updated in the previous PR: #65044 this just removes and deprecates parameters already covered by these test updates.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

This step is not a breaking, but is part of a soft landing breaking change (see #62014 for more details).

- [x] No, no existing tests failed, so this is *not* a breaking change.
