### PR TITLE
Do not cleanup Gradle in non-Android integration tests

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:vm_service_client/vm_service_client.dart';
 
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/framework/adb.dart' show DeviceIdEnvName;
+import 'package:flutter_devicelab/framework/adb.dart';
 
 /// Runs a task in a separate Dart VM and collects the result using the VM
 /// service protocol.
@@ -123,43 +123,45 @@ Future<VMIsolateRef> _connectToRunnerIsolate(Uri vmServiceUri) async {
 }
 
 Future<void> cleanupSystem() async {
-  print('\n\nCleaning up system after task...');
-  final String javaHome = await findJavaHome();
-  if (javaHome != null) {
-    // To shut gradle down, we have to call "gradlew --stop".
-    // To call gradlew, we need to have a gradle-wrapper.properties file along
-    // with a shell script, a .jar file, etc. We get these from various places
-    // as you see in the code below, and we save them all into a temporary dir
-    // which we can then delete after.
-    // All the steps below are somewhat tolerant of errors, because it doesn't
-    // really matter if this succeeds every time or not.
-    print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
-    final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
-    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
-    recursiveCopy(Directory(path.join(flutterDirectory.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper')), tempDir);
-    copy(File(path.join(path.join(flutterDirectory.path, 'packages', 'flutter_tools'), 'templates', 'app', 'android.tmpl', 'gradle', 'wrapper', 'gradle-wrapper.properties')), Directory(path.join(tempDir.path, 'gradle', 'wrapper')));
-    if (!Platform.isWindows) {
+  if (deviceOperatingSystem == null || deviceOperatingSystem == DeviceOperatingSystem.android) {
+    print('\n\nCleaning up system after task...');
+    final String javaHome = await findJavaHome();
+    if (javaHome != null) {
+      // To shut gradle down, we have to call "gradlew --stop".
+      // To call gradlew, we need to have a gradle-wrapper.properties file along
+      // with a shell script, a .jar file, etc. We get these from various places
+      // as you see in the code below, and we save them all into a temporary dir
+      // which we can then delete after.
+      // All the steps below are somewhat tolerant of errors, because it doesn't
+      // really matter if this succeeds every time or not.
+      print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
+      final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
+      final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
+      recursiveCopy(Directory(path.join(flutterDirectory.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper')), tempDir);
+      copy(File(path.join(path.join(flutterDirectory.path, 'packages', 'flutter_tools'), 'templates', 'app', 'android.tmpl', 'gradle', 'wrapper', 'gradle-wrapper.properties')), Directory(path.join(tempDir.path, 'gradle', 'wrapper')));
+      if (!Platform.isWindows) {
+        await exec(
+          'chmod',
+          <String>['a+x', path.join(tempDir.path, gradlewBinaryName)],
+          canFail: true,
+        );
+      }
       await exec(
-        'chmod',
-        <String>['a+x', path.join(tempDir.path, gradlewBinaryName)],
+        path.join(tempDir.path, gradlewBinaryName),
+        <String>['--stop'],
+        environment: <String, String>{ 'JAVA_HOME': javaHome},
+        workingDirectory: tempDir.path,
         canFail: true,
       );
+      rmTree(tempDir);
+      print('\n');
+    } else {
+      print('Could not determine JAVA_HOME; not shutting down Gradle.');
     }
-    await exec(
-      path.join(tempDir.path, gradlewBinaryName),
-      <String>['--stop'],
-      environment: <String, String>{ 'JAVA_HOME': javaHome },
-      workingDirectory: tempDir.path,
-      canFail: true,
-    );
-    rmTree(tempDir);
-    print('\n');
-  } else {
-    print('Could not determine JAVA_HOME; not shutting down Gradle.');
+    // Removes the .gradle directory because sometimes gradle fails in downloading
+    // a new version and leaves a corrupted zip archive, which could cause the
+    // next devicelab task to fail.
+    // https://github.com/flutter/flutter/issues/65277
+    rmTree(dir('${Platform.environment['HOME']}/.gradle'));
   }
-  // Removes the .gradle directory because sometimes gradle fails in downloading
-  // a new version and leaves a corrupted zip archive, which could cause the
-  // next devicelab task to fail.
-  // https://github.com/flutter/flutter/issues/65277
-  rmTree(dir('${Platform.environment['HOME']}/.gradle'));
 }


### PR DESCRIPTION
## Description

When I run iOS tests locally, I always see Gradle get downloaded when the test is over:
```
stdout: • No issues found!
"/Users/m/Projects/flutter/bin/flutter" exit code: 0

Telling Gradle to shut down (JAVA_HOME=/Applications/Android Studio.app/Contents/jre/jdk/Contents/Home)

Executing: chmod a+x /var/folders/bx/pyplw7v92lj58gm3_lztz5sc00mfq2/T/flutter_devicelab_shutdown_gradle.whHIvX/gradlew in /Users/m/Projects/flutter/dev/devicelab
"chmod" exit code: 0

Executing: /var/folders/bx/pyplw7v92lj58gm3_lztz5sc00mfq2/T/flutter_devicelab_shutdown_gradle.whHIvX/gradlew --stop in /var/folders/bx/pyplw7v92lj58gm3_lztz5sc00mfq2/T/flutter_devicelab_shutdown_gradle.whHIvX with environment {JAVA_HOME: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home}
stdout: Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
stdout: ...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
```

Instead, let's only do that cleanup if the test is for Android.  I don't think this is actually happening in the devicelab because JAVA_HOME isn't set up on the iOS host agents.