### PR TITLE
[flutter_tools] enable single widget reload optimization by default on master

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -242,7 +242,7 @@ const Feature singleWidgetReload = Feature(
   environmentOverride: 'FLUTTER_SINGLE_WIDGET_RELOAD',
   master: FeatureChannelSetting(
     available: true,
-    enabledByDefault: false,
+    enabledByDefault: true,
   ),
   dev: FeatureChannelSetting(
     available: true,


### PR DESCRIPTION

## Description

Just a config flip. Results should be surfaced by hot reload benchmarks