### PR TITLE
Fix last month not being displayed if last date is selected in DateRangePicker

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
@@ -110,7 +110,8 @@ class _CalendarDateRangePickerState extends State<CalendarDateRangePicker> {
     // divide the list of months into two `SliverList`s.
     final DateTime initialDate = widget.initialStartDate ?? widget.currentDate;
     if (widget.firstDate.isBefore(initialDate) &&
-        widget.lastDate.isAfter(initialDate)) {
+        widget.lastDate.isAfter(initialDate) ||
+        widget.lastDate.isAtSameMomentAs(initialDate)) {
       _initialMonthIndex = utils.monthDelta(widget.firstDate, initialDate);
     }
 

--- a/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
@@ -109,9 +109,8 @@ class _CalendarDateRangePickerState extends State<CalendarDateRangePicker> {
     // Calculate the index for the initially displayed month. This is needed to
     // divide the list of months into two `SliverList`s.
     final DateTime initialDate = widget.initialStartDate ?? widget.currentDate;
-    if (widget.firstDate.isBefore(initialDate) &&
-        widget.lastDate.isAfter(initialDate) ||
-        widget.lastDate.isAtSameMomentAs(initialDate)) {
+    if (!initialDate.isBefore(widget.firstDate) &&
+        !initialDate.isAfter(widget.lastDate)) {
       _initialMonthIndex = utils.monthDelta(widget.firstDate, initialDate);
     }
 

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -122,6 +122,82 @@ void main() {
     });
   });
 
+  testWidgets('Last month should be visible if last date is selected',
+      (WidgetTester tester) async {
+    initialDateRange = DateTimeRange(
+      start: DateTime(2016, DateTime.december, 31),
+      end: DateTime(2016, DateTime.december, 31),
+    );
+    await preparePicker(tester, (Future<DateTimeRange> range) async {
+      expect(find.text('December 2016'), findsOneWidget);
+      expect(find.text('November 2016'), findsNothing);
+    });
+  });
+
+  testWidgets('First month should be visible if first date is selected',
+      (WidgetTester tester) async {
+    initialDateRange = DateTimeRange(
+      start: DateTime(2015, DateTime.january, 01),
+      end: DateTime(2015, DateTime.january, 01),
+    );
+    await preparePicker(tester, (Future<DateTimeRange> range) async {
+      expect(find.text('January 2015'), findsOneWidget);
+      expect(find.text('February 2015'), findsOneWidget);
+      expect(find.text('March 2015'), findsNothing);
+    });
+  });
+
+  testWidgets('Current month should be visible if no date is selected',
+      (WidgetTester tester) async {
+    firstDate = DateTime(DateTime.now().year - 1);
+    lastDate = DateTime(DateTime.now().year + 1);
+    initialDateRange = null;
+
+    String _getMonthName(int month) {
+      switch (month) {
+        case DateTime.january:
+          return 'January';
+        case DateTime.february:
+          return 'February';
+        case DateTime.march:
+          return 'March';
+        case DateTime.april:
+          return 'April';
+        case DateTime.may:
+          return 'May';
+        case DateTime.june:
+          return 'June';
+        case DateTime.july:
+          return 'July';
+        case DateTime.august:
+          return 'August';
+        case DateTime.september:
+          return 'September';
+        case DateTime.october:
+          return 'October';
+        case DateTime.november:
+          return 'November';
+        case DateTime.december:
+          return 'December';
+      }
+      return '';
+    }
+
+    await preparePicker(tester, (Future<DateTimeRange> range) async {
+      final DateTime currentMonth = DateTime.now();
+      final DateTime lastMonth =
+          DateTime(currentMonth.year, currentMonth.month - 1);
+
+      final String currentMonthText =
+          '${_getMonthName(currentMonth.month)} ${currentMonth.year}';
+      final String lastMonthText =
+          '${_getMonthName(lastMonth.month)} ${lastMonth.year}';
+
+      expect(find.text(currentMonthText), findsOneWidget);
+      expect(find.text(lastMonthText), findsNothing);
+    });
+  });
+
   testWidgets('Can cancel', (WidgetTester tester) async {
     await preparePicker(tester, (Future<DateTimeRange> range) async {
       await tester.tap(find.byIcon(Icons.close));

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -122,32 +122,38 @@ void main() {
     });
   });
 
-  testWidgets('Last month should be visible if last date is selected',
+  testWidgets('Last month header should be visible if last date is selected',
       (WidgetTester tester) async {
+    firstDate = DateTime(2015, DateTime.january, 1);
+    lastDate = DateTime(2016, DateTime.december, 31);
     initialDateRange = DateTimeRange(
-      start: DateTime(2016, DateTime.december, 31),
-      end: DateTime(2016, DateTime.december, 31),
+      start: lastDate,
+      end: lastDate,
     );
     await preparePicker(tester, (Future<DateTimeRange> range) async {
+      // December header should be showing, but no November
       expect(find.text('December 2016'), findsOneWidget);
       expect(find.text('November 2016'), findsNothing);
     });
   });
 
-  testWidgets('First month should be visible if first date is selected',
+  testWidgets('First month header should be visible if first date is selected',
       (WidgetTester tester) async {
+    firstDate = DateTime(2015, DateTime.january, 1);
+    lastDate = DateTime(2016, DateTime.december, 31);
     initialDateRange = DateTimeRange(
-      start: DateTime(2015, DateTime.january, 01),
-      end: DateTime(2015, DateTime.january, 01),
+      start: firstDate,
+      end: firstDate,
     );
     await preparePicker(tester, (Future<DateTimeRange> range) async {
+      // January and February headers should be showing, but no March
       expect(find.text('January 2015'), findsOneWidget);
       expect(find.text('February 2015'), findsOneWidget);
       expect(find.text('March 2015'), findsNothing);
     });
   });
 
-  testWidgets('Current month should be visible if no date is selected',
+  testWidgets('Current month header should be visible if no date is selected',
       (WidgetTester tester) async {
     firstDate = DateTime(DateTime.now().year - 1);
     lastDate = DateTime(DateTime.now().year + 1);
@@ -193,6 +199,8 @@ void main() {
       final String lastMonthText =
           '${_getMonthName(lastMonth.month)} ${lastMonth.year}';
 
+      // Current month header should be showing, previous month's header should
+      // not
       expect(find.text(currentMonthText), findsOneWidget);
       expect(find.text(lastMonthText), findsNothing);
     });
@@ -448,10 +456,10 @@ void main() {
 
     testWidgets('Navigating with arrow keys scrolls as needed', (WidgetTester tester) async {
       await preparePicker(tester, (Future<DateTimeRange> range) async {
-        // Jan and Feb headers should be showing, but no Mar
+        // Jan and Feb headers should be showing, but no March
         expect(find.text('January 2016'), findsOneWidget);
         expect(find.text('February 2016'), findsOneWidget);
-        expect(find.text('Mar 2016'), findsNothing);
+        expect(find.text('March 2016'), findsNothing);
 
         // Navigate to the grid
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -13,6 +13,7 @@ import 'feedback_tester.dart';
 void main() {
   DateTime firstDate;
   DateTime lastDate;
+  DateTime currentDate;
   DateTimeRange initialDateRange;
   DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar;
 
@@ -31,6 +32,7 @@ void main() {
   setUp(() {
     firstDate = DateTime(2015, DateTime.january, 1);
     lastDate = DateTime(2016, DateTime.december, 31);
+    currentDate = null;
     initialDateRange = DateTimeRange(
       start: DateTime(2016, DateTime.january, 15),
       end: DateTime(2016, DateTime.january, 25),
@@ -79,6 +81,7 @@ void main() {
       initialDateRange: initialDateRange,
       firstDate: firstDate,
       lastDate: lastDate,
+      currentDate: currentDate,
       initialEntryMode: initialEntryMode,
       cancelText: cancelText,
       confirmText: confirmText,
@@ -155,54 +158,16 @@ void main() {
 
   testWidgets('Current month header should be visible if no date is selected',
       (WidgetTester tester) async {
-    firstDate = DateTime(DateTime.now().year - 1);
-    lastDate = DateTime(DateTime.now().year + 1);
+    firstDate = DateTime(2015, DateTime.january, 1);
+    lastDate = DateTime(2016, DateTime.december, 31);
+    currentDate = DateTime(2016, DateTime.september, 1);
     initialDateRange = null;
 
-    String _getMonthName(int month) {
-      switch (month) {
-        case DateTime.january:
-          return 'January';
-        case DateTime.february:
-          return 'February';
-        case DateTime.march:
-          return 'March';
-        case DateTime.april:
-          return 'April';
-        case DateTime.may:
-          return 'May';
-        case DateTime.june:
-          return 'June';
-        case DateTime.july:
-          return 'July';
-        case DateTime.august:
-          return 'August';
-        case DateTime.september:
-          return 'September';
-        case DateTime.october:
-          return 'October';
-        case DateTime.november:
-          return 'November';
-        case DateTime.december:
-          return 'December';
-      }
-      return '';
-    }
-
     await preparePicker(tester, (Future<DateTimeRange> range) async {
-      final DateTime currentMonth = DateTime.now();
-      final DateTime lastMonth =
-          DateTime(currentMonth.year, currentMonth.month - 1);
-
-      final String currentMonthText =
-          '${_getMonthName(currentMonth.month)} ${currentMonth.year}';
-      final String lastMonthText =
-          '${_getMonthName(lastMonth.month)} ${lastMonth.year}';
-
-      // Current month header should be showing, previous month's header should
-      // not
-      expect(find.text(currentMonthText), findsOneWidget);
-      expect(find.text(lastMonthText), findsNothing);
+      // September and October headers should be showing, but no August
+      expect(find.text('September 2016'), findsOneWidget);
+      expect(find.text('October 2016'), findsOneWidget);
+      expect(find.text('August 2016'), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Description

The condition to set the `_initialMonthIndex` is missing the case if the `lastDate` is the same as `initialDate`, so if the `lastDate` is selected, then the last month will not be visible to the user at launch.

| Current | With this fix |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/8596158/94153617-30cdab00-fea7-11ea-9ceb-8b075c46d0e8.gif" width="200"> | <img src="https://user-images.githubusercontent.com/8596158/94153504-109dec00-fea7-11ea-8444-c7baf47ef256.gif" width="200"> |


## Related Issues

I've just found it.

## Tests

I added the following tests:

- A test which sets the `initialDateRange` to be the same as the `lastDate` supplied to the `DateRangePicker`. The last month should be visible in this case.
- A test which sets the `initialDateRange` to be the same as the `firstDate` supplied to the `DateRangePicker`. The first and part of the second month should be visible in this case. 
- A test which does not set the `initialDateRange`. The month from the given `currentDate` should be visible in this case.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
