### PR TITLE
[flutter_tools] bypass pubspec yaml content check when running pubdependencies

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -647,7 +647,7 @@ class PubDependencies extends ArtifactSet {
       logger: _logger,
       throwOnError: false,
     );
-    if (packageConfig == null || packageConfig == PackageConfig.empty ) {
+    if (packageConfig == null || packageConfig == PackageConfig.empty) {
       return false;
     }
     for (final Package package in packageConfig.packages) {
@@ -667,6 +667,8 @@ class PubDependencies extends ArtifactSet {
       context: PubContext.pubGet,
       directory: _fileSystem.path.join(_flutterRoot(), 'packages', 'flutter_tools'),
       generateSyntheticPackage: false,
+      skipPubspecYamlCheck: true,
+      checkLastModified: false,
     );
   }
 }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -744,6 +744,8 @@ void main() {
       context: PubContext.pubGet,
       directory: 'packages/flutter_tools',
       generateSyntheticPackage: false,
+      skipPubspecYamlCheck: true,
+      checkLastModified: false,
     )).called(1);
   });
 }


### PR DESCRIPTION
## Description

Otherwise the heuristics we have may decide to skip running pub. We should consider reducing the number of dimensions of caching here to a single check optimized for the run/test case.