### PR TITLE
Length formatter minor fix

### DIFF
--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -319,8 +319,8 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
   /// The limit on the number of characters (i.e. Unicode scalar values) this formatter
   /// will allow.
   ///
-  /// The value must be null or greater than zero. If it is null, then no limit
-  /// is enforced.
+  /// The value must be null or greater than zero. If it is null or -1, then no
+  /// limit is enforced.
   ///
   /// This formatter does not currently count Unicode grapheme clusters (i.e.
   /// characters visible to the user), it counts Unicode scalar values, which leaves

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -379,25 +379,22 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    // Return the new value when the old value has not reached the max
-    // limit or the old value is composing too.
-    if (newValue.composing.isValid) {
-      if (maxLength != null && maxLength! > 0 &&
-          oldValue.text.characters.length == maxLength! &&
-          !oldValue.composing.isValid) {
-        return oldValue;
-      }
+    final int? maxLength = this.maxLength;
+
+    if (maxLength == null || maxLength == -1 || newValue.text.characters.length <= maxLength)
       return newValue;
+
+    assert(maxLength > 0);
+
+    // If already at the maximum and tried to enter even more, keep the old
+    // value.
+    if (oldValue.text.characters.length == maxLength && !oldValue.composing.isValid) {
+      return oldValue;
     }
-    if (maxLength != null && maxLength! > 0 && newValue.text.characters.length > maxLength!) {
-      // If already at the maximum and tried to enter even more, keep the old
-      // value.
-      if (oldValue.text.characters.length == maxLength) {
-        return oldValue;
-      }
-      return truncate(newValue, maxLength!);
-    }
-    return newValue;
+
+    // Temporarily exempt `newValue` from the maxLength limit if it has a
+    // composing text going, until the composing is finished.
+    return newValue.composing.isValid ? newValue : truncate(newValue, maxLength);
   }
 }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5756,6 +5756,8 @@ void main() {
     controller.text = '12345' ;
     assert(state.currentTextEditingValue == const TextEditingValue(text: '12345'));
 
+    // Should be able to change the editing value if the new value is still shorter
+    // than maxLength.
     state.updateEditingValue(const TextEditingValue(text: '12345', composing: TextRange(start: 2, end: 4)));
     expect(state.currentTextEditingValue.composing, const TextRange(start: 2, end: 4));
 
@@ -5765,7 +5767,7 @@ void main() {
 
     // The text should not change when trying to insert when the text is already
     // at maxLength.
-    state.updateEditingValue(const TextEditingValue(text: '123456', composing: TextRange(start: 5, end: 6)));
+    state.updateEditingValue(const TextEditingValue(text: 'abcdef', composing: TextRange(start: 5, end: 6)));
     expect(state.currentTextEditingValue.text, '12345');
     expect(state.currentTextEditingValue.composing, TextRange.empty);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5734,6 +5734,41 @@ void main() {
     expect(state.currentTextEditingValue.text, '12345');
     expect(state.currentTextEditingValue.composing, TextRange.empty);
   });
+
+  testWidgets('Length formatter handles composing text correctly, continued', (WidgetTester tester) async {
+    final TextInputFormatter formatter = LengthLimitingTextInputFormatter(5);
+    final Widget widget = MaterialApp(
+      home: EditableText(
+        backgroundCursorColor: Colors.grey,
+        controller: controller,
+        focusNode: focusNode,
+        inputFormatters: <TextInputFormatter>[formatter],
+        style: textStyle,
+        cursorColor: cursorColor,
+        selectionControls: materialTextSelectionControls,
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+
+    // Initially we're at maxLength with no composing text.
+    controller.text = '12345' ;
+    assert(state.currentTextEditingValue == const TextEditingValue(text: '12345'));
+
+    state.updateEditingValue(const TextEditingValue(text: '12345', composing: TextRange(start: 2, end: 4)));
+    expect(state.currentTextEditingValue.composing, const TextRange(start: 2, end: 4));
+
+    // Reset.
+    controller.text = '12345' ;
+    assert(state.currentTextEditingValue == const TextEditingValue(text: '12345'));
+
+    // The text should not change when trying to insert when the text is already
+    // at maxLength.
+    state.updateEditingValue(const TextEditingValue(text: '123456', composing: TextRange(start: 5, end: 6)));
+    expect(state.currentTextEditingValue.text, '12345');
+    expect(state.currentTextEditingValue.composing, TextRange.empty);
+  });
 }
 
 class MockTextFormatter extends TextInputFormatter {


### PR DESCRIPTION
## Description

Came across this while changing the logic in `EditableText._formatAndSave`, the "Length formatter will not cause crash while the TextEditingValue is composing" test fails with those changes. Making this a separate PR. 

## Tests

I added the following tests:

- Length formatter handles composing text correctly, continued

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
