### PR TITLE
Protect against infinite sized view configuration/mediaquerydata when DPR is unknown

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -239,7 +239,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ViewConfiguration createViewConfiguration() {
     final double devicePixelRatio = window.devicePixelRatio;
     return ViewConfiguration(
-      size: window.physicalSize / devicePixelRatio,
+      size: devicePixelRatio == 0.0 ? Size.zero : window.physicalSize / devicePixelRatio,
       devicePixelRatio: devicePixelRatio,
     );
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -23,6 +23,8 @@ class ViewConfiguration {
   /// Creates a view configuration.
   ///
   /// By default, the view has zero [size] and a [devicePixelRatio] of 1.0.
+  ///
+  /// The [size] parameter must be finite and positive.
   const ViewConfiguration({
     this.size = Size.zero,
     this.devicePixelRatio = 1.0,
@@ -59,6 +61,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     required ViewConfiguration configuration,
     required ui.Window window,
   }) : assert(configuration != null),
+       assert(configuration.size.isFinite),
        _configuration = configuration,
        _window = window {
     this.child = child;
@@ -77,6 +80,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// Always call [prepareInitialFrame] before changing the configuration.
   set configuration(ViewConfiguration value) {
     assert(value != null);
+    assert(value.size.isFinite);
     if (configuration == value)
       return;
     _configuration = value;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -125,7 +125,7 @@ class MediaQueryData {
   /// window's metrics change. For example, see
   /// [WidgetsBindingObserver.didChangeMetrics] or [Window.onMetricsChanged].
   MediaQueryData.fromWindow(ui.Window window)
-    : size = window.physicalSize / window.devicePixelRatio,
+    : size = window.devicePixelRatio == 0 ? Size.zero : window.physicalSize / window.devicePixelRatio,
       devicePixelRatio = window.devicePixelRatio,
       textScaleFactor = window.textScaleFactor,
       platformBrightness = window.platformBrightness,
@@ -139,7 +139,10 @@ class MediaQueryData {
       boldText = window.accessibilityFeatures.boldText,
       highContrast = window.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat,
-      navigationMode = NavigationMode.traditional;
+      navigationMode = NavigationMode.traditional {
+    assert(size.isFinite);
+  }
+
 
   /// The size of the media in logical pixels (e.g, the size of the screen).
   ///
@@ -147,6 +150,8 @@ class MediaQueryData {
   /// pixels are the size of the actual hardware pixels on the device. The
   /// number of physical pixels per logical pixel is described by the
   /// [devicePixelRatio].
+  ///
+  /// Size is expected to be finite, even if devicePixelRatio is 0.0.
   final Size size;
 
   /// The number of device pixels for each logical pixel. This number might not

--- a/packages/flutter/test/flutter_test_alternative.dart
+++ b/packages/flutter/test/flutter_test_alternative.dart
@@ -12,7 +12,7 @@ import 'package:test_api/test_api.dart' as test_package show TypeMatcher; // ign
 
 export 'package:test_api/test_api.dart' hide TypeMatcher, isInstanceOf; // ignore: deprecated_member_use
 export 'package:test_api/fake.dart'; // ignore: deprecated_member_use
-export 'package:flutter_test/flutter_test.dart' show createTestImage;
+export 'package:flutter_test/flutter_test.dart' show createTestImage, throwsAssertionError;
 
 /// A matcher that compares the type of the actual value to the type argument T.
 test_package.TypeMatcher<T> isInstanceOf<T>() => isA<T>();

--- a/packages/flutter/test/rendering/independent_layout_test.dart
+++ b/packages/flutter/test/rendering/independent_layout_test.dart
@@ -40,6 +40,23 @@ void main() {
     devicePixelRatio: 1.0,
   );
 
+  test('RenderView asserts that the size is finite', () {
+    final ViewConfiguration badConfiguration = ViewConfiguration(
+      size: Size.zero / 0.0,
+      devicePixelRatio: 0.0,
+    );
+    expect(
+      () => RenderView(configuration: badConfiguration, window: ui.window),
+      throwsAssertionError,
+    );
+
+    final RenderView renderView = RenderView(configuration: testConfiguration, window: ui.window);
+    expect(
+      () => renderView.configuration = badConfiguration,
+      throwsAssertionError,
+    );
+  });
+
   test('onscreen layout does not affect offscreen', () {
     final TestLayout onscreen = TestLayout();
     final TestLayout offscreen = TestLayout();

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -743,4 +743,16 @@ void main() {
     fail('The assert was never called when it should have been');
   });
 
+  testWidgets('MediaQuery.size is finite', (WidgetTester tester) async {
+    tester.binding.window.devicePixelRatioTestValue = 0.0;
+    final MediaQueryData data = MediaQueryData.fromWindow(tester.binding.window);
+
+    expect(data.size, Size.zero);
+
+    await tester.pumpWidget(const SizedBox.expand());
+
+    expect(find.byType(SizedBox), findsOneWidget);
+    tester.binding.window.clearAllTestValues();
+  });
+
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -453,7 +453,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   @override
   ViewConfiguration createViewConfiguration() {
     final double devicePixelRatio = window.devicePixelRatio;
-    final Size size = _surfaceSize ?? window.physicalSize / devicePixelRatio;
+    final Size size = _surfaceSize ?? (devicePixelRatio == 0.0 ? Size.zero : window.physicalSize / devicePixelRatio);
     return ViewConfiguration(
       size: size,
       devicePixelRatio: devicePixelRatio,


### PR DESCRIPTION
## Description

In CI testing, it's been observed on Fuchsia that sometimes we get to laying out a frame before the embedder has actually reported the devicePixelRatio - which gets defaulted to 0.

When we then go to divide by zero, we end up with infinite sizes where we don't want them, and we assert pretty late in the game, making it harder to figure out what's going on.

This makes it so that we will not crash in this case, although tests that expect to find things in this state may fail. Fuchsia should still try to figure out why it's taking so long to figure out the viewport metrics (/cc @arbreng @gw280 @iskakaushik)

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=60299

## Tests

I added the following tests:

Test that MediaQueryData and RenderView do the right thing if DPR is 0.
-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
