### PR TITLE
Force plugins to inherit minimum iOS version from Flutter app

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -274,13 +274,20 @@ public class DummyPluginAClass {
         section('Build plugin A example iOS app');
 
         await inDirectory(exampleApp, () async {
-          await evalFlutter(
+          final String output = await evalFlutter(
             'build',
             options: <String>[
               'ios',
               '--no-codesign',
+              '-v',
             ],
           );
+          // This warning is confusing and shouldn't be emitted. Plugins often support lower versions than the
+          // Flutter app, but as long as they support the minimum it will work.
+          // warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99. (in target 'plugin_a' from project 'Pods')
+           if (output.contains('but the range of supported deployment target versions')) {
+            throw TaskResult.failure('Minimum plugin version warning present');
+          }
         });
 
         final Directory appBundle = Directory(path.join(

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -274,20 +274,13 @@ public class DummyPluginAClass {
         section('Build plugin A example iOS app');
 
         await inDirectory(exampleApp, () async {
-          final String output = await evalFlutter(
+          await evalFlutter(
             'build',
             options: <String>[
               'ios',
               '--no-codesign',
-              '-v',
             ],
           );
-          // This warning is confusing and shouldn't be emitted. Plugins often support lower versions than the
-          // Flutter app, but as long as they support the minimum it will work.
-          // warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99. (in target 'plugin_a' from project 'Pods')
-           if (output.contains('but the range of supported deployment target versions')) {
-            throw TaskResult.failure('Minimum plugin version warning present');
-          }
         });
 
         final Directory appBundle = Directory(path.join(

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -27,8 +27,16 @@ end
 # end
 # @param [PBXAggregateTarget] target Pod target.
 def flutter_additional_ios_build_settings(target)
+  return unless target.platform_name == :ios
+
+  inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
   target.build_configurations.each do |build_configuration|
-     build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
+    build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
+    # Suppress warning when pod supports a version lower than the minimum supported by Xcode (Xcode 12 - iOS 9).
+    # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
+    # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
+    # If the pod only supports a higher version, do not delete to correctly produce an error.
+    build_configuration.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET' if inherit_deployment_target
   end
 end
 

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -29,6 +29,7 @@ end
 def flutter_additional_ios_build_settings(target)
   return unless target.platform_name == :ios
 
+  # [target.deployment_target] is a [String] formatted as "8.0".
   inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
   target.build_configurations.each do |build_configuration|
     build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -240,6 +240,12 @@ class AOTSnapshotter {
     final List<String> commonBuildOptions = <String>[
       '-arch', targetArch,
       if (isIOS)
+        // When the minimum version is updated, remember to update
+        // template IPHONEOS_DEPLOYMENT_TARGET and MinimumOSVersion.
+        // https://github.com/flutter/flutter/pull/62902
+        // Also update the podhelper.rb "deployment version too low"
+        // warning suppression version.
+        // https://github.com/flutter/flutter/pull/66590
         '-miphoneos-version-min=9.0',
     ];
 


### PR DESCRIPTION
## Background

Xcode supports specific SDK ranges, and every release they drop the lowest.  For example, Xcode 11 dropped support for iOS 7, and Xcode 12 dropped support for iOS 8.
Xcode emits a warning when build targets support a minimum version lower than the range to indicate it can't validate compilation against the older SDK.
```
warning: The iOS deployment target is set to 6.0, but the range of supported deployment target versions for this platform is 8.0 to 12.0. (in target 'firebase_analytics')
warning: The iOS deployment target is set to 6.0, but the range of supported deployment target versions for this platform is 8.0 to 12.0. (in target 'firebase_remote_config')
warning: The iOS deployment target is set to 4.3, but the range of supported deployment target versions for this platform is 8.0 to 12.0. (in target 'image_picker')
```
This warning is benign: if the app supports a minimum of iOS 9.0, it doesn't cause any problems that a plugin framework embedded in the app supports iOS 7.0.  These warnings concern users who think there's something wrong with their app, and there's no way for users to fix it (the plugin author would have to up their minimum supported version).

Flutter's plugin template defaults to a minimum of iOS 8, so when Xcode 12 dropped that version, every plugin started emitting this warning, so this problem became much more visible.

## Description
If the plugin's minimum version is less than iOS 9, remove the version build setting.  This will cause it to inherit from the minimum version set in the Flutter app (currently 9.0).

If the plugin minimum is higher than iOS 9, leave the build setting so if there is a versioning range issue (the plugin supports a minimum iOS 12 but the app needs iOS 9) the correct error (not warning) will be emitted.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40109
Fixes https://github.com/flutter/flutter/issues/63253

See also
https://github.com/CocoaPods/CocoaPods/issues/7314
https://github.com/flutter/flutter/pull/36117

## Tests

Updated plugin_dependencies_test to make sure this warning isn't emitted.  Confirmed it fails on master.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*