### PR TITLE
Set DDS port to requested observatory port for test

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -464,7 +464,7 @@ class FlutterPlatform extends PlatformPlugin {
         enableObservatory: enableObservatory,
         startPaused: startPaused,
         disableServiceAuthCodes: disableServiceAuthCodes,
-        observatoryPort: explicitObservatoryPort,
+        observatoryPort: disableDds ? explicitObservatoryPort : 0,
         serverPort: server.port,
       );
       subprocessActive = true;
@@ -502,8 +502,17 @@ class FlutterPlatform extends PlatformPlugin {
           assert(explicitObservatoryPort == null ||
               explicitObservatoryPort == detectedUri.port);
           if (!disableDds) {
+            final Uri serviceUri = Uri(
+              scheme: 'http',
+              host: (host.type == InternetAddressType.IPv6 ?
+              InternetAddress.loopbackIPv6 :
+              InternetAddress.loopbackIPv4
+              ).host,
+              port: explicitObservatoryPort ?? 0,
+            );
             final DartDevelopmentService dds = await DartDevelopmentService.startDartDevelopmentService(
               detectedUri,
+              serviceUri: serviceUri,
               enableAuthCodes: !disableServiceAuthCodes,
               ipv6: host.type == InternetAddressType.IPv6,
             );

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -913,8 +913,8 @@ class FlutterPlatform extends PlatformPlugin {
     return Uri(
       scheme: 'http',
       host: (host.type == InternetAddressType.IPv6 ?
-      InternetAddress.loopbackIPv6 :
-      InternetAddress.loopbackIPv4
+        InternetAddress.loopbackIPv6 :
+        InternetAddress.loopbackIPv4
       ).host,
       port: explicitObservatoryPort ?? 0,
     );

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -495,6 +495,7 @@ class FlutterPlatform extends PlatformPlugin {
       // Pipe stdout and stderr from the subprocess to our printStatus console.
       // We also keep track of what observatory port the engine used, if any.
       Uri processObservatoryUri;
+      final Uri ddsServiceUri = getDdsServiceUri();
       _pipeStandardStreamsToConsole(
         process,
         reportObservatoryUri: (Uri detectedUri) async {
@@ -502,17 +503,9 @@ class FlutterPlatform extends PlatformPlugin {
           assert(explicitObservatoryPort == null ||
               explicitObservatoryPort == detectedUri.port);
           if (!disableDds) {
-            final Uri serviceUri = Uri(
-              scheme: 'http',
-              host: (host.type == InternetAddressType.IPv6 ?
-              InternetAddress.loopbackIPv6 :
-              InternetAddress.loopbackIPv4
-              ).host,
-              port: explicitObservatoryPort ?? 0,
-            );
             final DartDevelopmentService dds = await DartDevelopmentService.startDartDevelopmentService(
               detectedUri,
-              serviceUri: serviceUri,
+              serviceUri: ddsServiceUri,
               enableAuthCodes: !disableServiceAuthCodes,
               ipv6: host.type == InternetAddressType.IPv6,
             );
@@ -912,6 +905,19 @@ class FlutterPlatform extends PlatformPlugin {
       default:
         return 'Shell subprocess crashed with unexpected exit code $exitCode $when.';
     }
+  }
+
+  @visibleForTesting
+  @protected
+  Uri getDdsServiceUri() {
+    return Uri(
+      scheme: 'http',
+      host: (host.type == InternetAddressType.IPv6 ?
+      InternetAddress.loopbackIPv6 :
+      InternetAddress.loopbackIPv4
+      ).host,
+      port: explicitObservatoryPort ?? 0,
+    );
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -70,7 +70,7 @@ void main() {
       };
 
       setUp(() {
-        fakePlatform = FakePlatform(operatingSystem: 'linux', environment: {});
+        fakePlatform = FakePlatform(operatingSystem: 'linux', environment: <String, String>{});
         mockProcessManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>[

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -98,7 +98,7 @@ void main() {
       testUsingContext('skips setting observatory port and uses the input port for for DDS instead', () async {
         flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
         final TestObservatoryFlutterPlatform testPlatform = flutterPlatform as TestObservatoryFlutterPlatform;
-        await testPlatform.ddsServiceUriCompleter.future.then((Uri uri) => expect(uri.port, 1234));
+        await testPlatform.ddsServiceUriFuture().then((Uri uri) => expect(uri.port, 1234));
       }, overrides: contextOverrides);
     });
 
@@ -282,7 +282,11 @@ class TestObservatoryFlutterPlatform extends FlutterPlatform {
     disableDds: false,
   );
 
-  Completer<Uri> ddsServiceUriCompleter = Completer<Uri>();
+  final Completer<Uri> _ddsServiceUriCompleter = Completer<Uri>();
+
+  Future<Uri> ddsServiceUriFuture() {
+    return _ddsServiceUriCompleter.future;
+  }
 
   @override
   @protected
@@ -291,7 +295,7 @@ class TestObservatoryFlutterPlatform extends FlutterPlatform {
   @override
   Uri getDdsServiceUri() {
     final Uri result = super.getDdsServiceUri();
-    ddsServiceUriCompleter.complete(result);
+    _ddsServiceUriCompleter.complete(result);
     return result;
   }
 }

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -60,18 +60,17 @@ void main() {
     });
 
     group('Observatory and DDS setup', () {
-      MockPlatform mockPlatform;
+      Platform fakePlatform;
       MockProcessManager mockProcessManager;
       FlutterPlatform flutterPlatform;
       final Map<Type, Generator> contextOverrides = <Type, Generator>{
-        Platform: () => mockPlatform,
+        Platform: () => fakePlatform,
         ProcessManager: () => mockProcessManager,
         FileSystem: () => fileSystem,
       };
 
       setUp(() {
-        mockPlatform = MockPlatform();
-        when(mockPlatform.isWindows).thenReturn(false);
+        fakePlatform = FakePlatform(operatingSystem: 'linux', environment: {});
         mockProcessManager = MockProcessManager();
         flutterPlatform = TestObservatoryFlutterPlatform();
       });
@@ -95,7 +94,6 @@ void main() {
       }
 
       testUsingContext('skips setting observatory port and uses the input port for for DDS instead', () async {
-        when(mockPlatform.environment).thenReturn(<String, String>{});
         final List<String> capturedEnvironment = await captureCommand();
         expect(capturedEnvironment.contains('--observatory-port=0'), true);
         final TestObservatoryFlutterPlatform testPlatform = flutterPlatform as TestObservatoryFlutterPlatform;


### PR DESCRIPTION
## Description

When an observatory port is passed during testing with DDS enabled, we want to let DDS use that port instead. This is so that a remote machine can connect to DDS on a predictable port.

## Related Issues

https://github.com/flutter/flutter/issues/66480

## Tests

I added the following tests:
- Verified that when observatory port is passed with DDS enabled, the observatory port is set to 0 and instead the specified port is used by DDS.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
