### PR TITLE
fix complex_layout_android__scroll_smoothness's lost of input event

### DIFF
--- a/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
+++ b/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
@@ -16,6 +16,16 @@ import 'package:e2e/e2e.dart';
 import 'package:complex_layout/main.dart' as app;
 
 class PointerDataTestBinding extends E2EWidgetsFlutterBinding {
+  // PointerData injection would usually be considered device input and therefore
+  // blocked by [TestWidgetsFlutterBinding]. Override this behavior
+  // to help events go into widget tree.
+  @override
+  void handlePointerEvent(
+    PointerEvent event, {
+    TestBindingEventSource source = TestBindingEventSource.device,
+  }) {
+    super.handlePointerEvent(event, source: TestBindingEventSource.test);
+  }
 }
 
 /// A union of [ui.PointerDataPacket] and the time it should be sent.


### PR DESCRIPTION
## Description

This is to revert #64846 's change to the `complex_layout_android__scroll_smoothness` test to fix #66608


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
