### PR TITLE
Fix complex_layout_android__scroll_smoothness by switching to using PointerEvent

### DIFF
--- a/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
+++ b/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
@@ -6,8 +6,6 @@
 // the test should be run as:
 // flutter drive -t test/using_array.dart --driver test_driver/scrolling_test_e2e_test.dart
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -40,7 +38,7 @@ Iterable<PointerEvent> dragInputDatas(
     timeStamp: epoch,
     position: startLocation,
     pointer: 1,
-  )
+  );
   for (int t = 0; t < moveEventCount + 1; t++) {
     final Offset position = startLocation + movePerEvent * t.toDouble();
     yield PointerMoveEvent(
@@ -48,14 +46,14 @@ Iterable<PointerEvent> dragInputDatas(
       position: position,
       delta: movePerEvent,
       pointer: 1,
-    )
+    );
   }
   final Offset position = startLocation + totalMove;
   yield PointerUpEvent(
     timeStamp: epoch + totalTime,
     position: position,
     pointer: 1,
-  )
+  );
 }
 
 enum TestScenario {
@@ -161,9 +159,9 @@ Future<void> main() async {
         tester.getCenter(scrollerFinder),
         frequency: variant.frequency,
       )) {
-        await tester.binding.delayed(record.timeStamp - now());
+        await tester.binding.delayed(event.timeStamp - now());
         // This now measures how accurate the above delayed is.
-        final Duration delay = now() - record.timeStamp;
+        final Duration delay = now() - event.timeStamp;
         if (delays.length < frameTimestamp.length) {
           while (delays.length < frameTimestamp.length - 1) {
             delays.add(Duration.zero);
@@ -172,7 +170,7 @@ Future<void> main() async {
         } else if (delays.last < delay) {
           delays.last = delay;
         }
-        tester.binding.handlePointerEvent(event);
+        tester.binding.handlePointerEvent(event, source: TestBindingEventSource.test);
       }
     }
 

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -226,16 +226,6 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void _flushPointerEventQueue() {
     assert(!locked);
 
-    if (resamplingEnabled) {
-      _resampler.addOrDispatchAll(_pendingPointerEvents);
-      _resampler.sample(samplingOffset);
-      return;
-    }
-
-    // Stop resampler if resampling is not enabled. This is a no-op if
-    // resampling was never enabled.
-    _resampler.stop();
-
     while (_pendingPointerEvents.isNotEmpty)
       handlePointerEvent(_pendingPointerEvents.removeFirst());
   }
@@ -269,6 +259,17 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   ///    are dispatched without a hit test result.
   void handlePointerEvent(PointerEvent event) {
     assert(!locked);
+
+    if (resamplingEnabled) {
+      _resampler.addOrDispatchAll(_pendingPointerEvents);
+      _resampler.sample(samplingOffset);
+      return;
+    }
+
+    // Stop resampler if resampling is not enabled. This is a no-op if
+    // resampling was never enabled.
+    _resampler.stop();
+
     HitTestResult? hitTestResult;
     if (event is PointerDownEvent || event is PointerSignalEvent) {
       assert(!_hitTests.containsKey(event.pointer));


### PR DESCRIPTION
## Description

> This PR is a draft since I can not run the test locally due to lack of test devices.

This PR fixes the issue that causes complex_layout_android__scroll_smoothness to not scroll at all by making it dispatch  `PointerEvent` with `GestureBinding.handlePointerEvent`, and moves the resampling in `GestureBinding` to `handlePointerEvent`.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/66608

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
