### PR TITLE
[flutter_tools] flutter devices add header

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -685,6 +685,13 @@ abstract class Device {
 
     // Extract device information
     final List<List<String>> table = <List<String>>[];
+    table.add(<String>[
+      '[A]: device.name',
+      '[B]: device.id',
+      '[C]: targetPlatform',
+      '[D]: device.sdkNameAndVersion',
+    ]);
+
     for (final Device device in devices) {
       String supportIndicator = device.isSupported() ? '' : ' (unsupported)';
       final TargetPlatform targetPlatform = await device.targetPlatform;
@@ -693,10 +700,10 @@ abstract class Device {
         supportIndicator += ' ($type)';
       }
       table.add(<String>[
-        '${device.name} (${device.category})',
-        device.id,
-        getNameForTargetPlatform(targetPlatform),
-        '${await device.sdkNameAndVersion}$supportIndicator',
+        '[A]: ${device.name} (${device.category})',
+        '[B]: ${device.id}',
+        '[C]: ${getNameForTargetPlatform(targetPlatform)}',
+        '[D]: ${await device.sdkNameAndVersion}$supportIndicator',
       ]);
     }
 
@@ -709,7 +716,10 @@ abstract class Device {
 
     // Join columns into lines of text
     for (final List<String> row in table) {
-      yield indices.map<String>((int i) => row[i].padRight(widths[i])).join(' • ') + ' • ${row.last}';
+      yield indices
+              .map<String>((int i) => row[i].padRight(widths[i]))
+              .join(' ') +
+          ' ${row.last}';
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -120,8 +120,9 @@ void main() {
         '''
 2 connected devices:
 
-ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
-webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
+[A]: device.name        [B]: device.id [C]: targetPlatform [D]: device.sdkNameAndVersion
+[A]: ephemeral (mobile) [B]: ephemeral [C]: android-arm    [D]: Test SDK (1.2.3) (emulator)
+[A]: webby (mobile)     [B]: webby     [C]: web-javascript [D]: Web SDK (1.2.4) (emulator)
 
 • Cannot connect to device ABC
 '''

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -253,7 +253,8 @@ void main() {
         final ValidationResult result = await deviceValidator.validate();
         expect(result.type, ValidationType.installed);
         expect(result.messages, const <ValidationMessage>[
-          ValidationMessage('null (null) • device-id • android • null'),
+          ValidationMessage('[A]: device.name [B]: device.id [C]: targetPlatform [D]: device.sdkNameAndVersion'),
+          ValidationMessage('[A]: null (null) [B]: device-id [C]: android        [D]: null'),
           ValidationMessage.hint('Device locked'),
         ]);
         expect(result.statusInfo, '1 available');


### PR DESCRIPTION
## Description

**Use case**

Multiple connected devices found while `flutter run`, Target device id used to add after `-d, --device-id` option.   

**Current situation**

* `flutter devices` shows device information includes `device.name`, `device.id`, `targetPlatform`, `device.sdkNameAndVersion`.
* Device information is a table data structure `List<List<String>>`, each device is a row, has column.  

**Fix issue**

* Which one of them are in this column? It's friendly to add header before devices information.  
* Even though each column has padding, if column width is very long, user still not easy to find `device.id`. Replace '•' with more helpful characters(Column number).

Especially in uncertain terminal window size.

**Before**

``` bash

3 connected devices:

iPhone SE (2nd generation) (mobile) • 93917077-668A-493D-B9E5-D52FAAD5BB76 • ios            •
com.apple.CoreSimulator.SimRuntime.iOS-14-0 (simulator)
Web Server (web)                    • web-server                           • web-javascript • Flutter Tools
Chrome (web)                        • chrome                               • web-javascript • Google Chrome 85.0.4183.121
```

**After**

``` bash
3 connected devices:

[A]: device.name                         [B]: device.id                            [C]: targetPlatform [D]: device.sdkNameAndVersion
[A]: iPhone SE (2nd generation) (mobile) [B]: 93917077-668A-493D-B9E5-D52FAAD5BB76 [C]: ios            [D]: com.apple.CoreSimulator.SimRuntime.iOS-14-0 (simulator)
[A]: Web Server (web)                    [B]: web-server                           [C]: web-javascript [D]: Flutter Tools
[A]: Chrome (web)                        [B]: chrome                               [C]: web-javascript [D]: Google Chrome 85.0.4183.121
```

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

1. Modify devices_test.dart
2. Modify doctor_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
