### PR TITLE
Improve pageStorage behavior

### DIFF
--- a/packages/flutter/test/widgets/page_storage_test.dart
+++ b/packages/flutter/test/widgets/page_storage_test.dart
@@ -81,4 +81,53 @@ void main() {
     expect(PageStorage.of(builderElement).readState(builderElement, identifier: 123), equals(storedValue));
   });
 
+  testWidgets('Data can be stored without overwriting each other When multiple widgets share one [PageStorageKey]', (WidgetTester tester) async {
+    // regression test for https://github.com/flutter/flutter/issues/62332
+    const Key key0 = Key('key0');
+    const Key key1 = Key('key1');
+    StateSetter setState;
+    int storedValue0 = 0;
+    int storedValue1 = 1;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          key: const PageStorageKey<String>('storageKey'),
+          child: StatefulBuilder(
+            key: key0,
+            builder: (BuildContext context, StateSetter setter) {
+              PageStorage.of(context).writeState(context, storedValue0);
+              setState = setter;
+              return StatefulBuilder(
+                key: key1,
+                builder: (BuildContext context, StateSetter setter) {
+                  PageStorage.of(context).writeState(context, storedValue1);
+                  return Center(
+                    child: Text('storedValues: $storedValue0 $storedValue1'),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final Element builderElement0 = tester.element(find.byKey(key0));
+    final Element builderElement1 = tester.element(find.byKey(key1));
+
+    // Store data normally
+    expect(PageStorage.of(builderElement0).readState(builderElement0), storedValue0);
+    expect(PageStorage.of(builderElement1).readState(builderElement1), storedValue1);
+
+    setState(() {
+      storedValue0 = 10;
+      storedValue1 = 11;
+    });
+
+    await tester.pump();
+    // The stored data is updated normally
+    expect(PageStorage.of(builderElement0).readState(builderElement0), storedValue0);
+    expect(PageStorage.of(builderElement1).readState(builderElement1), storedValue1);
+  });
 }


### PR DESCRIPTION
## Description

Currently, `PageStroage` behavior weird and not developer-friendly when multiple scrollable widgets share only one [PageStorageKey]. See also #62332 

### A Solution
They are distinguished by adding depth information to the page storage identifier, and their data can be stored separately without interfering with each other

## Related Issues

Fixes #62332 
#63656 

## Tests

See files.