### PR TITLE
[flutter_tools] Use XDG_CONFIG_HOME dir by default for config files

### DIFF
--- a/packages/flutter_tools/lib/src/persistent_tool_state.dart
+++ b/packages/flutter_tools/lib/src/persistent_tool_state.dart
@@ -73,7 +73,7 @@ class _DefaultPersistentToolState implements PersistentToolState {
       logger: logger,
     );
 
-  static const String _kFileName = '.flutter_tool_state';
+  static const String _kFileName = 'tool_state';
   static const String _kRedisplayWelcomeMessage = 'redisplay-welcome-message';
   static const Map<Channel, String> _lastActiveVersionKeys = <Channel,String>{
     Channel.master: 'last-active-master-version',

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -65,7 +65,7 @@ void main() {
 
   testWithoutContext('Config parse error', () {
     final BufferLogger bufferLogger = BufferLogger.test();
-    final File file = memoryFileSystem.file('example')
+    final File file = memoryFileSystem.file('.flutter_example')
       ..writeAsStringSync('{"hello":"bar');
     config = Config(
       'example',
@@ -105,6 +105,30 @@ void main() {
     expect(bufferLogger.errorText, contains('Could not read preferences in testfile'));
     // Also contains original error message:
     expect(bufferLogger.errorText, contains('The flutter tool cannot access the file or directory'));
+  });
+
+  testWithoutContext('Config in home dir is used if it exists', () {
+    memoryFileSystem.file('.flutter_example').writeAsStringSync('{"hello":"bar"}');
+    config = Config(
+      'example',
+      fileSystem: memoryFileSystem,
+      logger: BufferLogger.test(),
+      platform: fakePlatform,
+    );
+    expect(config.getValue('hello'), 'bar');
+    expect(memoryFileSystem.file('.config/flutter/example').existsSync(), false);
+  });
+
+  testWithoutContext('Config is created in config dir if it does not already exist in home dir', () {
+    config = Config(
+      'example',
+      fileSystem: memoryFileSystem,
+      logger: BufferLogger.test(),
+      platform: fakePlatform,
+    );
+
+    config.setValue('foo', 'bar');
+    expect(memoryFileSystem.file('.config/flutter/example').existsSync(), true);
   });
 }
 


### PR DESCRIPTION
## Description

This PR changes the `Config` class in `flutter_tools` to use the XDG Base directory [specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) instead of putting files directly in the user's home directory. If those files are already present in the home directory, they are used instead.

## Related Issues

fixes #59430

## Tests

I added the following tests:

config_test.dart: `Config in home dir`, `Config in config dir`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
