### PR TITLE
Changed TickerProviderStateMixin to SingleTickerProviderStateMixin in…

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -83,7 +83,7 @@ class Scrollbar extends StatefulWidget {
   _ScrollbarState createState() => _ScrollbarState();
 }
 
-class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
+class _ScrollbarState extends State<Scrollbar> with SingleTickerProviderStateMixin {
   ScrollbarPainter _materialPainter;
   TextDirection _textDirection;
   Color _themeColor;


### PR DESCRIPTION
## Description

The `_ScrollbarState` implements the `TickerProviderStateMixin`, however it uses only 1 `AnimationController` , that is, `_fadeoutAnimationController`. In cases where there is only one AnimationController, a `SingleTickerProviderStateMixin` is more efficient.

## Related Issues

Fixes #66492 

## Tests

N/A

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.