### PR TITLE
Add a compressionState value to HttpResponse mocks

### DIFF
--- a/dev/manual_tests/test/mock_image_http.dart
+++ b/dev/manual_tests/test/mock_image_http.dart
@@ -19,6 +19,7 @@ MockHttpClient createMockImageHttpClient(SecurityContext _) {
   when(request.close()).thenAnswer((_) => Future<HttpClientResponse>.value(response));
   when(response.contentLength).thenReturn(kTransparentImage.length);
   when(response.statusCode).thenReturn(HttpStatus.ok);
+  when(response.compressionState).thenReturn(HttpClientResponseCompressionState.notCompressed);
   when(response.listen(any)).thenAnswer((Invocation invocation) {
     final void Function(List<int>) onData = invocation.positionalArguments[0] as void Function(List<int>);
     final void Function() onDone = invocation.namedArguments[#onDone] as void Function();


### PR DESCRIPTION
The Dart SDK now requires non-null enum values if the enum is used in an
exhaustive switch statement on a non-nullable type.

See https://github.com/flutter/flutter/issues/66674
