### PR TITLE
[flutter_tools] handle missing zip/unzip argument errors

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -208,21 +208,49 @@ class _PosixUtils extends OperatingSystemUtils {
 
   @override
   void zip(Directory data, File zipFile) {
-    _processUtils.runSync(
-      <String>['zip', '-r', '-q', zipFile.path, '.'],
-      workingDirectory: data.path,
-      throwOnError: true,
-    );
+    try {
+      _processUtils.runSync(
+        <String>['zip', '-r', '-q', zipFile.path, '.'],
+        workingDirectory: data.path,
+        throwOnError: true,
+      );
+    } on ArgumentError {
+      // zip is not available. this error message is modeled after the download
+      // error in bin/internal/update_dart_sdk.sh
+      String message = 'Please install zip.';
+      if (_platform.isMacOS) {
+        message = 'Consider running "brew install zip".';
+      } else if (_platform.isLinux) {
+        message = 'Consider running "sudo apt-get install zip".';
+      }
+      throwToolExit(
+        'Missing "zip" tool. Unable to compress ${data.path}.\n$message'
+      );
+    }
   }
 
   // unzip -o -q zipfile -d dest
   @override
   void unzip(File file, Directory targetDirectory) {
-    _processUtils.runSync(
-      <String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path],
-      throwOnError: true,
-      verboseExceptions: true,
-    );
+    try {
+      _processUtils.runSync(
+        <String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path],
+        throwOnError: true,
+        verboseExceptions: true,
+      );
+    } on ArgumentError {
+      // unzip is not available. this error message is modeled after the download
+      // error in bin/internal/update_dart_sdk.sh
+      String message = 'Please install unzip.';
+      if (_platform.isMacOS) {
+        message = 'Consider running "brew install unzip".';
+      } else if (_platform.isLinux) {
+        message = 'Consider running "sudo apt-get install unzip".';
+      }
+      throwToolExit(
+        'Missing "unzip" tool. Unable to extract ${file.path}.\n$message'
+      );
+    }
   }
 
   // tar -xzf tarball -C dest

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -213,6 +213,7 @@ class _PosixUtils extends OperatingSystemUtils {
         <String>['zip', '-r', '-q', zipFile.path, '.'],
         workingDirectory: data.path,
         throwOnError: true,
+        verboseExceptions: true,
       );
     } on ArgumentError {
       // zip is not available. this error message is modeled after the download

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -143,6 +143,105 @@ void main() {
     );
   });
 
+  testWithoutContext('If unzip throws an ArgumentError, display an install message', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    when(mockProcessManager.runSync(
+      <String>['unzip', '-o', '-q', 'foo.zip', '-d', fileSystem.currentDirectory.path],
+    )).thenThrow(ArgumentError());
+
+    final OperatingSystemUtils linuxOsUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'linux'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => linuxOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+      throwsToolExit(
+        message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+        'Consider running "sudo apt-get install unzip".'),
+    );
+
+    final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'macos'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+      throwsToolExit
+      (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+        'Consider running "brew install unzip".'),
+    );
+
+    final OperatingSystemUtils unknownOsUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'fuchsia'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => unknownOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+      throwsToolExit
+      (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+        'Please install unzip.'),
+    );
+  });
+
+  testWithoutContext('If zip throws an ArgumentError, display an install message', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    when(mockProcessManager.runSync(
+      <String>['zip', '-r', '-q', 'foo.zip', '.'],
+      workingDirectory: anyNamed('workingDirectory'),
+    )).thenThrow(ArgumentError());
+
+    final OperatingSystemUtils linuxOsUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'linux'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => linuxOsUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
+      throwsToolExit(
+        message: 'Missing "zip" tool. Unable to compress /.\n'
+        'Consider running "sudo apt-get install zip".'),
+    );
+
+    final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'macos'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => macOSUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
+      throwsToolExit
+      (message: 'Missing "zip" tool. Unable to compress /.\n'
+        'Consider running "brew install zip".'),
+    );
+
+    final OperatingSystemUtils unknownOsUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'fuchsia'),
+      processManager: mockProcessManager,
+    );
+
+    expect(
+      () => unknownOsUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
+      throwsToolExit
+      (message: 'Missing "zip" tool. Unable to compress /.\n'
+        'Please install zip.'),
+    );
+  });
+
   testWithoutContext('stream compression level', () {
     expect(OperatingSystemUtils.gzipLevel1.level, equals(1));
   });


### PR DESCRIPTION
## Description

it is possible for users that download the prebuilt SDKs to run the tool without unzip installed. Rather than crashing with an unclear argument error, exit the tool with a message on how to install that mirrors the message in the update_dart_sdk.sh script.

Also applied to zip for completeness
