### PR TITLE
[flutter_tools] dont mention git clone of flutter in run message

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -264,8 +264,7 @@ class UserMessages {
   String get flutterNoConnectedDevices => 'No connected devices.';
   String get flutterNoPubspec =>
       'Error: No pubspec.yaml file found.\n'
-      'This command should be run from the root of your Flutter project.\n'
-      'Do not run this command from the root of your git clone of Flutter.';
+      'This command should be run from the root of your Flutter project.';
   String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
   String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
   String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';


### PR DESCRIPTION
## Description

This message is displayed if we do not find a pubspec.yaml

99% of the time this additional advice is going to have nothing to do with the actual error. Just remove it because it will cause more confusion than it could clear up

Fixes flutter/flutter#48116