### PR TITLE
Roll gallery to the newest version

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'a208eac6e6e8336ae9820e54c572c099231f1da2';
+const String galleryVersion = '53462151bf753dc70284be9274a798fa485265f2';


### PR DESCRIPTION
The previously broken test should be fixed by
https://github.com/flutter/gallery/pull/331