### PR TITLE
[flutter_tools] flutter logs no longer requires supported device

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -66,7 +66,7 @@ class DaemonCommand extends FlutterCommand {
 
 typedef DispatchCommand = void Function(Map<String, dynamic> command);
 
-typedef CommandHandler = FutureOr<dynamic> Function(Map<String, dynamic> args);
+typedef CommandHandler = Future<dynamic> Function(Map<String, dynamic> args);
 
 class Daemon {
   Daemon(
@@ -826,14 +826,14 @@ class DeviceDomain extends Domain {
   }
 
   /// Enable device events.
-  void enable(Map<String, dynamic> args) {
+  Future<void> enable(Map<String, dynamic> args) async {
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
       discoverer.startPolling();
     }
   }
 
   /// Disable device events.
-  void disable(Map<String, dynamic> args) {
+  Future<void> disable(Map<String, dynamic> args) async {
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
       discoverer.stopPolling();
     }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -66,7 +66,7 @@ class DaemonCommand extends FlutterCommand {
 
 typedef DispatchCommand = void Function(Map<String, dynamic> command);
 
-typedef CommandHandler = Future<dynamic> Function(Map<String, dynamic> args);
+typedef CommandHandler = FutureOr<dynamic> Function(Map<String, dynamic> args);
 
 class Daemon {
   Daemon(
@@ -826,21 +826,17 @@ class DeviceDomain extends Domain {
   }
 
   /// Enable device events.
-  Future<void> enable(Map<String, dynamic> args) {
-    final List<Future<void>> calls = <Future<void>>[];
+  void enable(Map<String, dynamic> args) {
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
-      calls.add(discoverer.startPolling());
+      discoverer.startPolling();
     }
-    return Future.wait<void>(calls);
   }
 
   /// Disable device events.
-  Future<void> disable(Map<String, dynamic> args) async {
-    final List<Future<void>> calls = <Future<void>>[];
+  void disable(Map<String, dynamic> args) {
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
-      calls.add(discoverer.stopPolling());
+      discoverer.stopPolling();
     }
-    return Future.wait<void>(calls);
   }
 
   /// Forward a host port to a device port.
@@ -874,10 +870,11 @@ class DeviceDomain extends Domain {
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose() {
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
-      await discoverer.dispose();
+      discoverer.dispose();
     }
+    return Future<void>.value();
   }
 
   /// Return the device matching the deviceId field in the args.

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -34,7 +34,7 @@ class LogsCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
-    device = await findTargetDevice();
+    device = await findTargetDevice(includeUnsupportedDevices: true);
     if (device == null) {
       throwToolExit(null);
     }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -77,7 +77,7 @@ class PlatformType {
   String toString() => value;
 }
 
-/// A disover mechanism for flutter-supported development devices.
+/// A disovery mechanism for flutter-supported development devices.
 abstract class DeviceManager {
 
   /// Constructing DeviceManagers is cheap; they only do expensive work if some

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -77,7 +77,7 @@ class PlatformType {
   String toString() => value;
 }
 
-/// A class to get all available devices.
+/// A disover mechanism for flutter-supported development devices.
 abstract class DeviceManager {
 
   /// Constructing DeviceManagers is cheap; they only do expensive work if some
@@ -210,6 +210,9 @@ abstract class DeviceManager {
   /// * If the user did not specify a device id and there is more than one
   /// device connected, then filter out unsupported devices and prioritize
   /// ephemeral devices.
+  ///
+  /// * If [flutterProject] is null, then assume the project supports all
+  /// device types.
   Future<List<Device>> findTargetDevices(FlutterProject flutterProject, { Duration timeout }) async {
     if (timeout != null) {
       // Reset the cache with the specified timeout.
@@ -310,8 +313,12 @@ abstract class DeviceManager {
 
   /// Returns whether the device is supported for the project.
   ///
-  /// This exists to allow the check to be overridden for google3 clients.
+  /// This exists to allow the check to be overridden for google3 clients. If
+  /// [flutterProject] is null then return true.
   bool isDeviceSupportedForProject(Device device, FlutterProject flutterProject) {
+    if (flutterProject == null) {
+      return true;
+    }
     return device.isSupportedForProject(flutterProject);
   }
 }
@@ -428,7 +435,7 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
 
   Future<List<Device>> pollingGetDevices({ Duration timeout });
 
-  Future<void> startPolling() async {
+  void startPolling() {
     if (_timer == null) {
       deviceNotifier ??= ItemListNotifier<Device>();
       // Make initial population the default, fast polling timeout.
@@ -449,18 +456,18 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
     });
   }
 
-  Future<void> stopPolling() async {
+  void stopPolling() {
     _timer?.cancel();
     _timer = null;
   }
 
   @override
-  Future<List<Device>> get devices async {
+  Future<List<Device>> get devices {
     return _populateDevices();
   }
 
   @override
-  Future<List<Device>> discoverDevices({ Duration timeout }) async {
+  Future<List<Device>> discoverDevices({ Duration timeout }) {
     deviceNotifier = null;
     return _populateDevices(timeout: timeout);
   }
@@ -480,7 +487,7 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
     return deviceNotifier.onRemoved;
   }
 
-  Future<void> dispose() async => await stopPolling();
+  void dispose() => stopPolling();
 
   @override
   String toString() => '$name device discovery';

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1000,13 +1000,18 @@ abstract class FlutterCommand extends Command<void> {
   /// devices and criteria entered by the user on the command line.
   /// If no device can be found that meets specified criteria,
   /// then print an error message and return null.
-  Future<List<Device>> findAllTargetDevices() async {
+  Future<List<Device>> findAllTargetDevices({
+    bool includeUnsupportedDevices = false,
+  }) async {
     if (!globals.doctor.canLaunchAnything) {
       globals.printError(userMessages.flutterNoDevelopmentDevice);
       return null;
     }
     final DeviceManager deviceManager = globals.deviceManager;
-    List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current(), timeout: deviceDiscoveryTimeout);
+    List<Device> devices = await deviceManager.findTargetDevices(
+      includeUnsupportedDevices ? null : FlutterProject.current(),
+      timeout: deviceDiscoveryTimeout,
+    );
 
     if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
       globals.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId));
@@ -1052,8 +1057,13 @@ abstract class FlutterCommand extends Command<void> {
   /// devices and criteria entered by the user on the command line.
   /// If a device cannot be found that meets specified criteria,
   /// then print an error message and return null.
-  Future<Device> findTargetDevice() async {
-    List<Device> deviceList = await findAllTargetDevices();
+  ///
+  /// If [includeUnsupportedDevices] is true, the tool does not filter
+  /// the list by the current project support list.
+  Future<Device> findTargetDevice({
+    bool includeUnsupportedDevices = false,
+  }) async {
+    List<Device> deviceList = await findAllTargetDevices(includeUnsupportedDevices: includeUnsupportedDevices);
     if (deviceList == null) {
       return null;
     }

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -79,6 +79,4 @@ void main() {
   });
 }
 
-class MockDeviceManager extends Mock implements DeviceManager {
-
-}
+class MockDeviceManager extends Mock implements DeviceManager {}

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -138,26 +138,26 @@ void main() {
   });
 
   group('PollingDeviceDiscovery', () {
-    testUsingContext('startPolling', () async {
-      await FakeAsync().run((FakeAsync time) async {
+    testUsingContext('startPolling', () {
+      FakeAsync().run((FakeAsync time) {
         final FakePollingDeviceDiscovery pollingDeviceDiscovery = FakePollingDeviceDiscovery();
-        await pollingDeviceDiscovery.startPolling();
+        pollingDeviceDiscovery.startPolling();
         time.elapse(const Duration(milliseconds: 4001));
-        time.flushMicrotasks();
+
         // First check should use the default polling timeout
         // to quickly populate the list.
         expect(pollingDeviceDiscovery.lastPollingTimeout, isNull);
 
         time.elapse(const Duration(milliseconds: 4001));
-        time.flushMicrotasks();
+
         // Subsequent polling should be much longer.
         expect(pollingDeviceDiscovery.lastPollingTimeout, const Duration(seconds: 30));
-        await pollingDeviceDiscovery.stopPolling();
+        pollingDeviceDiscovery.stopPolling();
       });
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
       Cache: () => cache,
-    }, skip: true); // TODO(jonahwilliams): clean up with https://github.com/flutter/flutter/issues/60675
+    });
   });
 
   group('Filter devices', () {
@@ -370,6 +370,20 @@ void main() {
       Cache: () => cache,
     });
 
+    testUsingContext('Does not remove an unsupported device if FlutterProject is null', () async {
+      final List<Device> devices = <Device>[
+        unsupported,
+      ];
+
+      final DeviceManager deviceManager = TestDeviceManager(devices);
+      final List<Device> filtered = await deviceManager.findTargetDevices(null);
+
+      expect(filtered, <Device>[unsupported]);
+    }, overrides: <Type, Generator>{
+      Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
+    });
+
     testUsingContext('Removes web and fuchsia from --all', () async {
       final List<Device> devices = <Device>[
         webDevice,
@@ -429,9 +443,7 @@ void main() {
       ];
       final MockDeviceDiscovery mockDeviceDiscovery = MockDeviceDiscovery();
       when(mockDeviceDiscovery.supportsPlatform).thenReturn(true);
-      // when(mockDeviceDiscovery.discoverDevices(timeout: timeout)).thenAnswer((_) async => devices);
       when(mockDeviceDiscovery.devices).thenAnswer((_) async => devices);
-      // when(mockDeviceDiscovery.discoverDevices(timeout: timeout)).thenAnswer((_) async => devices);
 
       final DeviceManager deviceManager = TestDeviceManager(<Device>[], deviceDiscoveryOverrides: <DeviceDiscovery>[
         mockDeviceDiscovery
@@ -458,7 +470,6 @@ void main() {
       when(mockDeviceDiscovery.supportsPlatform).thenReturn(true);
       when(mockDeviceDiscovery.discoverDevices(timeout: timeout)).thenAnswer((_) async => devices);
       when(mockDeviceDiscovery.devices).thenAnswer((_) async => devices);
-      // when(mockDeviceDiscovery.discoverDevices(timeout: timeout)).thenAnswer((_) async => devices);
 
       final DeviceManager deviceManager = TestDeviceManager(<Device>[], deviceDiscoveryOverrides: <DeviceDiscovery>[
         mockDeviceDiscovery

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -521,7 +521,7 @@ void main() {
       expect(iosDevices.deviceNotifier.items, isEmpty);
       expect(eventStream.hasListener, isTrue);
 
-      await iosDevices.dispose();
+      iosDevices.dispose();
       expect(eventStream.hasListener, isFalse);
     });
 


### PR DESCRIPTION
## Description

Flutter logs should not attempt to filter the device list based on the current project, because it does not require a current project. Also fix disabled polling test

Fixes flutter/flutter#47996
Fixes https://github.com/flutter/flutter/issues/63550