### PR TITLE
[flutter_tools] pass existsSync through error handling io

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -331,6 +331,16 @@ class ErrorHandlingDirectory
   }
 
   @override
+  bool existsSync() {
+    return _runSync<bool>(
+      () => delegate.existsSync(),
+      platform: _platform,
+      failureMessage:
+        'Flutter failed to check for directory existence at "${delegate.path}"',
+    );
+  }
+
+  @override
   String toString() => delegate.toString();
 }
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -93,6 +93,8 @@ void setupDirectoryMocks({
     .thenThrow(FileSystemException('', '', OSError('', errorCode)));
   when(mockDirectory.deleteSync())
     .thenThrow(FileSystemException('', '', OSError('', errorCode)));
+  when(mockDirectory.existsSync())
+    .thenThrow(FileSystemException('', '', OSError('', errorCode)));
 }
 
 void main() {
@@ -203,6 +205,20 @@ void main() {
       expect(() => directory.createSync(recursive: true),
              throwsToolExit(message: expectedMessage));
     });
+
+    testWithoutContext('when checking for directory existence with permission issues', () async {
+      setupDirectoryMocks(
+        mockFileSystem: mockFileSystem,
+        fs: fs,
+        errorCode: kUserPermissionDenied,
+      );
+
+      final Directory directory = fs.directory('directory');
+
+      const String expectedMessage = 'Flutter failed to check for directory existence at';
+      expect(() => directory.existsSync(),
+             throwsToolExit(message: expectedMessage));
+    });
   });
 
   group('throws ToolExit on Linux', () {
@@ -298,6 +314,20 @@ void main() {
       expect(() => directory.createTempSync('prefix'),
              throwsToolExit(message: expectedMessage));
     });
+
+    testWithoutContext('when checking for directory existence with permission issues', () async {
+      setupDirectoryMocks(
+        mockFileSystem: mockFileSystem,
+        fs: fs,
+        errorCode: eacces,
+      );
+
+      final Directory directory = fs.directory('directory');
+
+      const String expectedMessage = 'Flutter failed to check for directory existence at';
+      expect(() => directory.existsSync(),
+             throwsToolExit(message: expectedMessage));
+    });
   });
 
   group('throws ToolExit on macOS', () {
@@ -391,6 +421,20 @@ void main() {
       expect(() async => await directory.createTemp('prefix'),
              throwsToolExit(message: expectedMessage));
       expect(() => directory.createTempSync('prefix'),
+             throwsToolExit(message: expectedMessage));
+    });
+
+    testWithoutContext('when checking for directory existence with permission issues', () async {
+      setupDirectoryMocks(
+        mockFileSystem: mockFileSystem,
+        fs: fs,
+        errorCode: eacces,
+      );
+
+      final Directory directory = fs.directory('directory');
+
+      const String expectedMessage = 'Flutter failed to check for directory existence at';
+      expect(() => directory.existsSync(),
              throwsToolExit(message: expectedMessage));
     });
   });


### PR DESCRIPTION
## Description

Crash reporting shows at least one instance of EACCES during an existsSync cache call. Add this to the list of error handling io methods. Did not add the async exists method since we lint against its usage.