### PR TITLE
[flutter_tools] do not crash if chrome preference save fails

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -106,13 +106,14 @@ class ChromiumLauncher {
     @required OperatingSystemUtils operatingSystemUtils,
     @required BrowserFinder browserFinder,
     @required Logger logger,
+    @visibleForTesting FileSystemUtils fileSystemUtils,
   }) : _fileSystem = fileSystem,
        _platform = platform,
        _processManager = processManager,
        _operatingSystemUtils = operatingSystemUtils,
        _browserFinder = browserFinder,
        _logger = logger,
-       _fileSystemUtils = FileSystemUtils(
+       _fileSystemUtils = fileSystemUtils ?? FileSystemUtils(
          fileSystem: fileSystem,
          platform: platform,
        );
@@ -227,6 +228,7 @@ class ChromiumLauncher {
 
     // When the process exits, copy the user settings back to the provided data-dir.
     if (cacheDir != null) {
+      print('gonna save');
       unawaited(process.exitCode.whenComplete(() {
         _cacheUserSessionInformation(userDataDir, cacheDir);
       }));
@@ -268,7 +270,13 @@ class ChromiumLauncher {
 
     if (sourceLocalStorageDir.existsSync()) {
       targetLocalStorageDir.createSync(recursive: true);
-      _fileSystemUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+      try {
+        _fileSystemUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+      } on FileSystemException catch (err) {
+        // This is a best-effort update. Display the message in case the failure is relevant.
+        // one possible example is a file lock due to multiple running chrome instances.
+        _logger.printError('Failed to save Chrome preferences: $err');
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -228,7 +228,6 @@ class ChromiumLauncher {
 
     // When the process exits, copy the user settings back to the provided data-dir.
     if (cacheDir != null) {
-      print('gonna save');
       unawaited(process.exitCode.whenComplete(() {
         _cacheUserSessionInformation(userDataDir, cacheDir);
       }));


### PR DESCRIPTION
## Description

Crash reporting shows at least one occurrence of this due to a windows file lock. That could happen if there is another running chrome instance, or perhaps a virus scanner is running.

Print out the error and do not crash.