### PR TITLE
Update SearchDelegate's Textfield theme

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -520,6 +520,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           textTheme: theme.primaryTextTheme,
           brightness: theme.primaryColorBrightness,
           leading: widget.delegate.buildLeading(context),
+          // [TextField] uses the theme provided by SearchDelegate.appBarTheme(context)
           title: TextField(
             controller: widget.delegate._queryTextController,
             focusNode: focusNode,
@@ -529,7 +530,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             onSubmitted: (String _) {
               widget.delegate.showResults(context);
             },
-            decoration: InputDecoration(
+            decoration: const InputDecoration().applyDefaults(theme.inputDecorationTheme).copyWith(
               border: InputBorder.none,
               hintText: searchFieldLabel,
               hintStyle: searchFieldStyle,


### PR DESCRIPTION
## Description

Let `_SearchPage`'s TextField use the theme provided by `SearchDelegate.appBarTheme(_)` to allow greater customization.

## Related Issues

Closes #66726 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I added relevant comments.
- [x] All existing tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.