### PR TITLE
move resampler to handlePointerEvent and fix complex_layout_android__scroll_smoothness with PointerEvent

### DIFF
--- a/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
+++ b/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
@@ -6,8 +6,6 @@
 // the test should be run as:
 // flutter drive -t test/using_array.dart --driver test_driver/scrolling_test_e2e_test.dart
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,68 +26,44 @@ class PointerDataTestBinding extends E2EWidgetsFlutterBinding {
   }
 }
 
-/// A union of [ui.PointerDataPacket] and the time it should be sent.
-class PointerDataRecord {
-  PointerDataRecord(this.timeStamp, List<ui.PointerData> data)
-    : data = ui.PointerDataPacket(data: data);
-  final ui.PointerDataPacket data;
-  final Duration timeStamp;
-}
-
-/// Generates the [PointerDataRecord] to simulate a drag operation from
+/// Generates the [PointerEvent] to simulate a drag operation from
 /// `center - totalMove/2` to `center + totalMove/2`.
-Iterable<PointerDataRecord> dragInputDatas(
+Iterable<PointerEvent> dragInputEvents(
   final Duration epoch,
   final Offset center, {
   final Offset totalMove = const Offset(0, -400),
   final Duration totalTime = const Duration(milliseconds: 2000),
   final double frequency = 90,
 }) sync* {
-  final Offset startLocation = (center - totalMove / 2) * ui.window.devicePixelRatio;
+  final Offset startLocation = center - totalMove / 2;
   // The issue is about 120Hz input on 90Hz refresh rate device.
   // We test 90Hz input on 60Hz device here, which shows similar pattern.
   final int moveEventCount = totalTime.inMicroseconds * frequency ~/ const Duration(seconds: 1).inMicroseconds;
-  final Offset movePerEvent = totalMove / moveEventCount.toDouble() * ui.window.devicePixelRatio;
-  yield PointerDataRecord(epoch, <ui.PointerData>[
-    ui.PointerData(
-      timeStamp: epoch,
-      change: ui.PointerChange.add,
-      physicalX: startLocation.dx,
-      physicalY: startLocation.dy,
-    ),
-    ui.PointerData(
-      timeStamp: epoch,
-      change: ui.PointerChange.down,
-      physicalX: startLocation.dx,
-      physicalY: startLocation.dy,
-      pointerIdentifier: 1,
-    ),
-  ]);
+  final Offset movePerEvent = totalMove / moveEventCount.toDouble();
+  yield PointerAddedEvent(
+    timeStamp: epoch,
+    position: startLocation,
+  );
+  yield PointerDownEvent(
+    timeStamp: epoch,
+    position: startLocation,
+    pointer: 1,
+  );
   for (int t = 0; t < moveEventCount + 1; t++) {
     final Offset position = startLocation + movePerEvent * t.toDouble();
-    yield PointerDataRecord(
-      epoch + totalTime * t ~/ moveEventCount,
-      <ui.PointerData>[ui.PointerData(
-        timeStamp: epoch + totalTime * t ~/ moveEventCount,
-        change: ui.PointerChange.move,
-        physicalX: position.dx,
-        physicalY: position.dy,
-        // Scrolling behavior depends on this delta rather
-        // than the position difference.
-        physicalDeltaX: movePerEvent.dx,
-        physicalDeltaY: movePerEvent.dy,
-        pointerIdentifier: 1,
-      )],
+    yield PointerMoveEvent(
+      timeStamp: epoch + totalTime * t ~/ moveEventCount,
+      position: position,
+      delta: movePerEvent,
+      pointer: 1,
     );
   }
   final Offset position = startLocation + totalMove;
-  yield PointerDataRecord(epoch + totalTime, <ui.PointerData>[ui.PointerData(
+  yield PointerUpEvent(
     timeStamp: epoch + totalTime,
-    change: ui.PointerChange.up,
-    physicalX: position.dx,
-    physicalY: position.dy,
-    pointerIdentifier: 1,
-  )]);
+    position: position,
+    pointer: 1,
+  );
 }
 
 enum TestScenario {
@@ -190,14 +164,14 @@ Future<void> main() async {
     Future<void> scroll() async {
       // Extra 50ms to avoid timeouts.
       final Duration startTime = const Duration(milliseconds: 500) + now();
-      for (final PointerDataRecord record in dragInputDatas(
+      for (final PointerEvent event in dragInputEvents(
         startTime,
         tester.getCenter(scrollerFinder),
         frequency: variant.frequency,
       )) {
-        await tester.binding.delayed(record.timeStamp - now());
+        await tester.binding.delayed(event.timeStamp - now());
         // This now measures how accurate the above delayed is.
-        final Duration delay = now() - record.timeStamp;
+        final Duration delay = now() - event.timeStamp;
         if (delays.length < frameTimestamp.length) {
           while (delays.length < frameTimestamp.length - 1) {
             delays.add(Duration.zero);
@@ -206,7 +180,7 @@ Future<void> main() async {
         } else if (delays.last < delay) {
           delays.last = delay;
         }
-        ui.window.onPointerDataPacket(record.data);
+        tester.binding.handlePointerEvent(event, source: TestBindingEventSource.test);
       }
     }
 

--- a/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
+++ b/dev/benchmarks/complex_layout/test/measure_scroll_smoothness.dart
@@ -13,19 +13,6 @@ import 'package:e2e/e2e.dart';
 
 import 'package:complex_layout/main.dart' as app;
 
-class PointerDataTestBinding extends E2EWidgetsFlutterBinding {
-  // PointerData injection would usually be considered device input and therefore
-  // blocked by [TestWidgetsFlutterBinding]. Override this behavior
-  // to help events go into widget tree.
-  @override
-  void handlePointerEvent(
-    PointerEvent event, {
-    TestBindingEventSource source = TestBindingEventSource.device,
-  }) {
-    super.handlePointerEvent(event, source: TestBindingEventSource.test);
-  }
-}
-
 /// Generates the [PointerEvent] to simulate a drag operation from
 /// `center - totalMove/2` to `center + totalMove/2`.
 Iterable<PointerEvent> dragInputEvents(
@@ -137,8 +124,9 @@ class ResampleFlagVariant extends TestVariant<TestScenario> {
 }
 
 Future<void> main() async {
-  final PointerDataTestBinding binding = PointerDataTestBinding();
-  assert(WidgetsBinding.instance == binding);
+  final WidgetsBinding _binding = E2EWidgetsFlutterBinding.ensureInitialized();
+  assert(_binding is E2EWidgetsFlutterBinding);
+  final E2EWidgetsFlutterBinding binding = _binding as E2EWidgetsFlutterBinding;
   binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive;
   binding.reportData ??= <String, dynamic>{};
   final ResampleFlagVariant variant = ResampleFlagVariant(binding);

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -388,7 +388,12 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
   void _handleSampleTimeChanged() {
     if (!locked) {
-      _resampler.sample(samplingOffset);
+      if (resamplingEnabled) {
+        _resampler.sample(samplingOffset);
+      }
+      else {
+        _resampler.stop();
+      }
     }
   }
 

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -223,18 +223,6 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
     while (_pendingPointerEvents.isNotEmpty)
       handlePointerEvent(_pendingPointerEvents.removeFirst());
-
-    if (resamplingEnabled) {
-      triggerResample();
-    }
-  }
-
-  /// to force resampler for triggering a resample operation.
-  ///
-  /// This should only be called when resampling is enabled.
-  void triggerResample() {
-    assert(resamplingEnabled);
-    _resampler.sample(samplingOffset);
   }
 
   /// A router that routes all pointer events received from the engine.
@@ -269,6 +257,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
     if (resamplingEnabled) {
       _resampler.addOrDispatch(event);
+      _resampler.sample(samplingOffset);
       return;
     }
 
@@ -399,7 +388,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
   void _handleSampleTimeChanged() {
     if (!locked) {
-      _flushPointerEventQueue();
+      _resampler.sample(samplingOffset);
     }
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -508,9 +508,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _pointerEventSource = source;
     try {
       super.handlePointerEvent(event);
-      if (source == TestBindingEventSource.test && resamplingEnabled) {
-        triggerResample();
-      }
     } finally {
       _pointerEventSource = previousSource;
     }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -508,6 +508,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _pointerEventSource = source;
     try {
       super.handlePointerEvent(event);
+      if (source == TestBindingEventSource.test && resamplingEnabled) {
+        triggerResample();
+      }
     } finally {
       _pointerEventSource = previousSource;
     }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -524,7 +524,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   @override
-  Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records) {
+  Future<List<Duration>> handlePointerEventRecord(Iterable<PointerEventRecord> records) {
     assert(records != null);
     assert(records.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {


### PR DESCRIPTION
## Description

This is to move the resampling logic to `handlePointerEvent`, so that it's accessible to `WidgetTester`, as enabled by #64846. This also fixes #66608 and closes #66612 . 

In terms of fixing #66608, this is an alternative to #66611.  #66611 is more close to the solution before  #64846, so I suggest to land #66611 and observe for a couple of runs before merge this PR to see if the change makes some difference to the test result. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
