### PR TITLE
Improve consistency of top-level help text

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -114,7 +114,7 @@ class AssembleCommand extends FlutterCommand {
   }
 
   @override
-  String get description => 'Assemble and build flutter resources.';
+  String get description => 'Assemble and build Flutter resources.';
 
   @override
   String get name => 'assemble';

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -77,7 +77,7 @@ class AttachCommand extends FlutterCommand {
         help: 'The URI at which the observatory is listening.',
       )..addOption(
         'app-id',
-        help: 'The package name (Android) or bundle identifier (iOS) for the application. '
+        help: 'The package name (Android) or bundle identifier (iOS) for the app. '
               'This can be specified to avoid being prompted if multiple observatory ports '
               'are advertised.\n'
               'If you have multiple devices or emulators running, you should include the '
@@ -110,7 +110,7 @@ class AttachCommand extends FlutterCommand {
   final String name = 'attach';
 
   @override
-  final String description = '''Attach to a running application.
+  final String description = '''Attach to a running app.
 
   For attaching to Android or iOS devices, simply using `flutter attach` is
   usually sufficient. The tool will search for a running Flutter app or module,

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -40,7 +40,7 @@ class BuildCommand extends FlutterCommand {
   final String name = 'build';
 
   @override
-  final String description = 'Flutter build commands.';
+  final String description = 'Build an executable app or install bundle.';
 
   @override
   Future<FlutterCommandResult> runCommand() async => null;

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -24,7 +24,7 @@ class ChannelCommand extends FlutterCommand {
   final String name = 'channel';
 
   @override
-  final String description = 'List or switch flutter channels.';
+  final String description = 'List or switch Flutter channels.';
 
   @override
   String get invocation => '${runner.executableName} $name [<channel-name>]';

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -130,7 +130,7 @@ class DriveCommand extends RunCommandBase {
   final String name = 'drive';
 
   @override
-  final String description = 'Runs Flutter Driver tests for the current project.';
+  final String description = 'Run integration tests for the project on an attached device or emulator.';
 
   @override
   final List<String> aliases = <String>['driver'];

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -41,7 +41,7 @@ class FormatCommand extends FlutterCommand {
   List<String> get aliases => const <String>['dartfmt'];
 
   @override
-  final String description = 'Format one or more dart files.';
+  final String description = 'Format one or more Dart files.';
 
   @override
   String get invocation => '${runner.executableName} $name <one or more paths>';

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -155,7 +155,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
   final FileSystem _fileSystem;
 
   @override
-  String get description => 'Generate localizations for the Flutter project.';
+  String get description => 'Generate localizations for the current project.';
 
   @override
   String get name => 'gen-l10n';

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -69,7 +69,7 @@ class PrecacheCommand extends FlutterCommand {
   final String name = 'precache';
 
   @override
-  final String description = "Populates the Flutter tool's cache of binary artifacts.";
+  final String description = "Populate the Flutter tool's cache of binary artifacts.";
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -52,7 +52,7 @@ class SymbolizeCommand extends FlutterCommand {
   final DwarfSymbolizationService _dwarfSymbolizationService;
 
   @override
-  String get description => 'Symbolize a stack trace from an AOT compiled flutter application.';
+  String get description => 'Symbolize a stack trace from an AOT-compiled Flutter application.';
 
   @override
   String get name => 'symbolize';

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -52,7 +52,7 @@ class SymbolizeCommand extends FlutterCommand {
   final DwarfSymbolizationService _dwarfSymbolizationService;
 
   @override
-  String get description => 'Symbolize a stack trace from an AOT-compiled Flutter application.';
+  String get description => 'Symbolize a stack trace from an AOT-compiled Flutter app.';
 
   @override
   String get name => 'symbolize';


### PR DESCRIPTION
## Description

Looking at `flutter help`, there's some inconsistency in how commands are described:

 - Some have active verbs ('Run', 'Compile') and others have passive verbs ('Populates', 'Symbolizes').
 - Some are non-specific (e.g. `flutter build` -> 'Flutter build commands')
 - Varying capitalization for 'Dart' and 'Flutter' (lower or title case).
 - Inconsistent use of 'simulator' vs. 'emulator' to describe the same entity.
 - Inconsistency of 'application' vs. 'app'

This PR attempts to rationalize top-level command descriptions for consistency, since this is a highly-trafficked experience for new-to-Flutter users.

## Related Issues

- None

## Tests

I added the following tests:

- None

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X]  I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X]  I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
