### PR TITLE
[desktop] prefer higher dpr images on desktop

### DIFF
--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -230,7 +230,7 @@ class AssetImage extends AssetBundleImageProvider {
     return SynchronousFuture<Map<String, List<String>>?>(parsedManifest);
   }
 
-  String? _chooseVariant(String main, ImageConfiguration config, List<String>? candidates){
+  String? _chooseVariant(String main, ImageConfiguration config, List<String>? candidates) {
     if (config.devicePixelRatio == null || candidates == null || candidates.isEmpty)
       return main;
     // TODO(ianh): Consider moving this parsing logic into _manifestParser.

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -227,10 +226,6 @@ class PlatformAssetBundle extends CachingAssetBundle {
   }
 }
 
-AssetBundle _initRootBundle() {
-  return PlatformAssetBundle();
-}
-
 /// The [AssetBundle] from which this application was loaded.
 ///
 /// The [rootBundle] contains the resources that were packaged with the
@@ -260,4 +255,4 @@ AssetBundle _initRootBundle() {
 ///
 ///  * [DefaultAssetBundle]
 ///  * [NetworkAssetBundle]
-final AssetBundle rootBundle = _initRootBundle();
+final AssetBundle rootBundle =  PlatformAssetBundle();

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -273,7 +273,7 @@ void main() {
   ]) {
     testWidgets('Image for device pixel ratio 1.01 on $platform rounds up', (WidgetTester tester) async {
       debugDefaultTargetPlatformOverride = platform;
-      const double ratio = 1.0;
+      const double ratio = 1.01;
       Key key = GlobalKey();
       await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
@@ -294,15 +294,15 @@ void main() {
   ]) {
     testWidgets('Image for device pixel ratio 1.01 on $platform rounds down', (WidgetTester tester) async {
       debugDefaultTargetPlatformOverride = platform;
-      const double ratio = 1.0;
+      const double ratio = 1.01;
       Key key = GlobalKey();
       await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
       expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
-      expect(getRenderImage(tester, key).scale, 1.5);
+      expect(getRenderImage(tester, key).scale, 1.0);
       key = GlobalKey();
       await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
       expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
-      expect(getRenderImage(tester, key).scale, 1.5);
+      expect(getRenderImage(tester, key).scale, 1.0);
       debugDefaultTargetPlatformOverride = null;
     });
   }

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -266,6 +266,47 @@ void main() {
     expect(getRenderImage(tester, key).scale, 4.0);
   });
 
+  for (final TargetPlatform platform in <TargetPlatform>[
+    TargetPlatform.windows,
+    TargetPlatform.linux,
+    TargetPlatform.macOS,
+  ]) {
+    testWidgets('Image for device pixel ratio 1.01 on $platform rounds up', (WidgetTester tester) async {
+      debugDefaultTargetPlatformOverride = platform;
+      const double ratio = 1.0;
+      Key key = GlobalKey();
+      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
+      expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+      expect(getRenderImage(tester, key).scale, 1.5);
+      key = GlobalKey();
+      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
+      expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+      expect(getRenderImage(tester, key).scale, 1.5);
+      debugDefaultTargetPlatformOverride = null;
+    });
+  }
+
+  for (final TargetPlatform platform in <TargetPlatform>[
+    TargetPlatform.android,
+    TargetPlatform.iOS,
+    TargetPlatform.fuchsia,
+    null,
+  ]) {
+    testWidgets('Image for device pixel ratio 1.01 on $platform rounds down', (WidgetTester tester) async {
+      debugDefaultTargetPlatformOverride = platform;
+      const double ratio = 1.0;
+      Key key = GlobalKey();
+      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
+      expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+      expect(getRenderImage(tester, key).scale, 1.5);
+      key = GlobalKey();
+      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
+      expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+      expect(getRenderImage(tester, key).scale, 1.5);
+      debugDefaultTargetPlatformOverride = null;
+    });
+  }
+
   testWidgets('Image for device pixel ratio 1.0, with no main asset', (WidgetTester tester) async {
     const String manifest = '''
     {

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -266,46 +266,29 @@ void main() {
     expect(getRenderImage(tester, key).scale, 4.0);
   });
 
-  for (final TargetPlatform platform in <TargetPlatform>[
-    TargetPlatform.windows,
-    TargetPlatform.linux,
-    TargetPlatform.macOS,
-  ]) {
-    testWidgets('Image for device pixel ratio 1.01 on $platform rounds up', (WidgetTester tester) async {
-      debugDefaultTargetPlatformOverride = platform;
-      const double ratio = 1.01;
-      Key key = GlobalKey();
-      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-      expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
-      expect(getRenderImage(tester, key).scale, 1.5);
-      key = GlobalKey();
-      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-      expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
-      expect(getRenderImage(tester, key).scale, 1.5);
-      debugDefaultTargetPlatformOverride = null;
-    });
-  }
+  testWidgets('Image for device pixel ratio 1.01 rounds up on desktop', (WidgetTester tester) async {
+    const double ratio = 1.01;
+    Key key = GlobalKey();
+    await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
+    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).scale, 1.5);
+    key = GlobalKey();
+    await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
+    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).scale, 1.5);
+  }, variant: TargetPlatformVariant.desktop());
 
-  for (final TargetPlatform platform in <TargetPlatform>[
-    TargetPlatform.android,
-    TargetPlatform.iOS,
-    TargetPlatform.fuchsia,
-    null,
-  ]) {
-    testWidgets('Image for device pixel ratio 1.01 on $platform rounds down', (WidgetTester tester) async {
-      debugDefaultTargetPlatformOverride = platform;
-      const double ratio = 1.01;
-      Key key = GlobalKey();
-      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-      expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
-      expect(getRenderImage(tester, key).scale, 1.0);
-      key = GlobalKey();
-      await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-      expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
-      expect(getRenderImage(tester, key).scale, 1.0);
-      debugDefaultTargetPlatformOverride = null;
-    });
-  }
+  testWidgets('Image for device pixel ratio 1.01 on mobile rounds down', (WidgetTester tester) async {
+    const double ratio = 1.01;
+    Key key = GlobalKey();
+    await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
+    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).scale, 1.0);
+    key = GlobalKey();
+    await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
+    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).scale, 1.0);
+  }, variant: TargetPlatformVariant.mobile());
 
   testWidgets('Image for device pixel ratio 1.0, with no main asset', (WidgetTester tester) async {
     const String manifest = '''


### PR DESCRIPTION
## Description

Discussed in https://github.com/flutter/flutter/issues/63122, desktop devices frequently have high resolution screens but low DPR. For example, I have a 1920 something monitor with a DPR of 1.25, so the gallery app looks incredibly pixelated by default.

This can be mitigated somewhat by preferring the higher DPR asset variant on desktop, though it isn't a complete solution.