### PR TITLE
[desktop] default to shrink wrap on desktop platforms

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -368,7 +368,18 @@ class ThemeData with Diagnosticable {
     textTheme = defaultTextTheme.merge(textTheme);
     primaryTextTheme = defaultPrimaryTextTheme.merge(primaryTextTheme);
     accentTextTheme = defaultAccentTextTheme.merge(accentTextTheme);
-    materialTapTargetSize ??= MaterialTapTargetSize.padded;
+    switch (platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        materialTapTargetSize ??= MaterialTapTargetSize.padded;
+        break;
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+         materialTapTargetSize ??= MaterialTapTargetSize.shrinkWrap;
+        break;
+    }
     applyElevationOverlayColor ??= false;
 
     // Used as the default color (fill color) for RaisedButtons. Computing the

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -96,25 +96,21 @@ void main() {
     expect(darkTheme.accentTextTheme.headline6.color, typography.white.headline6.color);
   });
 
-  test('Defaults to MaterialTapTargetBehavior.padded on mobile platforms and MaterialTapTargetBehavior.shrinkWrap on desktop', () {
-    for (final TargetPlatform platform in <TargetPlatform>[
-      TargetPlatform.android,
-      TargetPlatform.iOS,
-      TargetPlatform.fuchsia,
-    ]) {
-      final ThemeData themeData = ThemeData(platform: platform);
-      expect(themeData.materialTapTargetSize, MaterialTapTargetSize.padded);
+  testWidgets('Defaults to MaterialTapTargetBehavior.padded on mobile platforms and MaterialTapTargetBehavior.shrinkWrap on desktop', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData(platform: defaultTargetPlatform);
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        expect(themeData.materialTapTargetSize, MaterialTapTargetSize.padded);
+        break;
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        expect(themeData.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
+        break;
     }
-
-    for (final TargetPlatform platform in <TargetPlatform>[
-      TargetPlatform.windows,
-      TargetPlatform.linux,
-      TargetPlatform.macOS,
-    ]) {
-      final ThemeData themeData = ThemeData(platform: platform);
-      expect(themeData.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
-    }
-  });
+  }, variant: TargetPlatformVariant.all());
 
   test('Can control fontFamily default', () {
     final ThemeData themeData = ThemeData(

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -96,10 +96,24 @@ void main() {
     expect(darkTheme.accentTextTheme.headline6.color, typography.white.headline6.color);
   });
 
-  test('Defaults to MaterialTapTargetBehavior.expanded', () {
-    final ThemeData themeData = ThemeData();
+  test('Defaults to MaterialTapTargetBehavior.padded on mobile platforms and MaterialTapTargetBehavior.shrinkWrap on desktop', () {
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+      TargetPlatform.fuchsia,
+    ]) {
+      final ThemeData themeData = ThemeData(platform: platform);
+      expect(themeData.materialTapTargetSize, MaterialTapTargetSize.padded);
+    }
 
-    expect(themeData.materialTapTargetSize, MaterialTapTargetSize.padded);
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+    ]) {
+      final ThemeData themeData = ThemeData(platform: platform);
+      expect(themeData.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
+    }
   });
 
   test('Can control fontFamily default', () {

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -25,6 +25,9 @@ void main() {
       Axis scrollDirection = Axis.vertical,
     }) {
     return MaterialApp(
+      theme:  ThemeData(
+        materialTapTargetSize: MaterialTapTargetSize.padded,
+      ),
       home: Scaffold(
         body: CustomScrollView(
           scrollDirection: scrollDirection,


### PR DESCRIPTION
## Description

MaterialTapTargetSize adds some additional padding to bring the hit test size to 48x48 for Android's mobile accessibility guidelines. This isn't necessary for desktop devices, so default to the shrinkwrap mode that compresses slightly