### PR TITLE
[flutter_tools] dont let crash reporter crash tool

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -188,7 +188,7 @@ class CrashReportSender {
     // Catch all exceptions to print the message that makes clear that the
     // crash logger crashed.
     } catch (sendError, sendStackTrace) { // ignore: avoid_catches_without_on_clauses
-      if (sendError is SocketException || sendError is HttpException) {
+      if (sendError is SocketException || sendError is HttpException || sendError is http.ClientException) {
         _logger.printError('Failed to send crash report due to a network error: $sendError');
       } else {
         // If the sender itself crashes, just print. We did our best.

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -183,6 +183,25 @@ void main() {
       expect(logger.errorText, contains('Failed to send crash report due to a network error'));
     });
 
+    testWithoutContext('should print an explanatory message when there is a ClientException', () async {
+      final CrashReportSender crashReportSender = CrashReportSender(
+        client: CrashingCrashReportSender(const HttpException('no internets')),
+        usage: mockUsage,
+        platform: platform,
+        logger: logger,
+        operatingSystemUtils: operatingSystemUtils,
+      );
+
+      await crashReportSender.sendReport(
+        error: ClientException('Test bad state error'),
+        stackTrace: null,
+        getFlutterVersion: () => 'test-version',
+        command: 'crash',
+      );
+
+      expect(logger.errorText, contains('Failed to send crash report due to a network error'));
+    });
+
     testWithoutContext('should send only one crash report when sent many times', () async {
       final RequestInfo requestInfo = RequestInfo();
 


### PR DESCRIPTION
## Description

package:http can throw a ClientException, which the crash reporter must catch or the tool will crash in the crash reporter. 3/4 crash on dev.