### PR TITLE
Fix BottomNavigationBar can not apply some theme property

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -189,7 +189,7 @@ class BottomNavigationBar extends StatefulWidget {
     this.unselectedFontSize = 12.0,
     this.selectedLabelStyle,
     this.unselectedLabelStyle,
-    this.showSelectedLabels = true,
+    this.showSelectedLabels,
     this.showUnselectedLabels,
     this.mouseCursor,
   }) : assert(items != null),
@@ -208,7 +208,6 @@ class BottomNavigationBar extends StatefulWidget {
        ),
        assert(selectedFontSize != null && selectedFontSize >= 0.0),
        assert(unselectedFontSize != null && unselectedFontSize >= 0.0),
-       assert(showSelectedLabels != null),
        selectedItemColor = selectedItemColor ?? fixedColor,
        super(key: key);
 
@@ -316,10 +315,10 @@ class BottomNavigationBar extends StatefulWidget {
   /// Defaults to `12.0`.
   final double unselectedFontSize;
 
-  /// Whether the labels are shown for the selected [BottomNavigationBarItem].
+  /// Whether the labels are shown for the unselected [BottomNavigationBarItem].
   final bool showUnselectedLabels;
 
-  /// Whether the labels are shown for the unselected [BottomNavigationBarItem]s.
+  /// Whether the labels are shown for the selected [BottomNavigationBarItem]s.
   final bool showSelectedLabels;
 
   /// The cursor for a mouse pointer when it enters or is hovering over the
@@ -358,6 +357,8 @@ class _BottomNavigationTile extends StatelessWidget {
          assert(selected != null),
          assert(selectedLabelStyle != null),
          assert(unselectedLabelStyle != null),
+         assert(showSelectedLabels != null),
+         assert(showUnselectedLabels != null),
          assert(mouseCursor != null);
 
   final BottomNavigationBarType type;
@@ -483,10 +484,10 @@ class _BottomNavigationTile extends StatelessWidget {
               colorTween: colorTween,
               animation: animation,
               item: item,
-              selectedLabelStyle: selectedLabelStyle ?? bottomTheme.selectedLabelStyle,
-              unselectedLabelStyle: unselectedLabelStyle ?? bottomTheme.unselectedLabelStyle,
-              showSelectedLabels: showSelectedLabels ?? bottomTheme.showUnselectedLabels,
-              showUnselectedLabels: showUnselectedLabels ?? bottomTheme.showUnselectedLabels,
+              selectedLabelStyle: selectedLabelStyle,
+              unselectedLabelStyle: unselectedLabelStyle,
+              showSelectedLabels: showSelectedLabels,
+              showUnselectedLabels: showUnselectedLabels,
             ),
           ],
         ),
@@ -739,6 +740,8 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     return false;
   }
 
+  bool get _defaultShowSelected => true;
+
   @override
   void initState() {
     super.initState();
@@ -898,7 +901,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         colorTween: colorTween,
         flex: _evaluateFlex(_animations[i]),
         selected: i == widget.currentIndex,
-        showSelectedLabels: widget.showSelectedLabels ?? bottomTheme.showSelectedLabels,
+        showSelectedLabels: widget.showSelectedLabels ?? bottomTheme.showSelectedLabels ?? _defaultShowSelected,
         showUnselectedLabels: widget.showUnselectedLabels ?? bottomTheme.showUnselectedLabels ?? _defaultShowUnselected,
         indexLabel: localizations.tabLabel(tabIndex: i + 1, tabCount: widget.items.length),
         mouseCursor: effectiveMouseCursor,

--- a/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
@@ -93,12 +93,12 @@ class BottomNavigationBarThemeData with Diagnosticable {
   /// See [BottomNavigationBar.unselectedLabelStyle].
   final TextStyle unselectedLabelStyle;
 
-  /// Whether the labels are shown for the unselected [BottomNavigationBarItem]s.
+  /// Whether the labels are shown for the selected [BottomNavigationBarItem]s.
   ///
   /// See [BottomNavigationBar.showSelectedLabels].
   final bool showSelectedLabels;
 
-  /// Whether the labels are shown for the selected [BottomNavigationBarItem].
+  /// Whether the labels are shown for the unselected [BottomNavigationBarItem].
   ///
   /// See [BottomNavigationBar.showUnselectedLabels].
   final bool showUnselectedLabels;

--- a/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
@@ -260,6 +260,44 @@ void main() {
     expect(_material(tester).elevation, equals(elevation));
     expect(_material(tester).color, equals(backgroundColor));
   });
+
+  testWidgets('BottomNavigationBar can apply [showSelectedLabels] value from the theme', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/66738
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+            showUnselectedLabels: false,
+            showSelectedLabels: false,
+            type: BottomNavigationBarType.fixed,
+          ),
+        ),
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder findOpacity = find.descendant(
+      of: find.byType(BottomNavigationBar),
+      matching: find.byType(Opacity),
+    );
+
+    // There should be two [Opacity]s widgets
+    // since showUnselectedLabels and showSelectedLabels are false.
+    expect(findOpacity, findsNWidgets(2));
+  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
## Description

Removed the default value in the constructor so that the value in the theme can take effect. At the same time, some documentation errors were corrected and some redundant codes were removed.

## Related Issues

Fixes  #66738

## Tests

See files.