### PR TITLE
[flutter_tools] add a mechanism to turn off immediate tool exit

### DIFF
--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -26,7 +26,7 @@ class Config {
       _userHomePath(platform),
       name,
     ));
-    return Config._(file, logger);
+    return Config.createForTesting(file, logger);
   }
 
   /// Constructs a new [Config] object from a file called [name] in
@@ -35,14 +35,16 @@ class Config {
     String name, {
     @required Directory directory,
     @required Logger logger,
-  }) => Config._(directory.childFile(name), logger);
+  }) => Config.createForTesting(directory.childFile(name), logger);
 
-  Config._(File file, Logger logger) : _file = file, _logger = logger {
+  /// Test only access to the Config constructor.
+  @visibleForTesting
+  Config.createForTesting(File file, Logger logger) : _file = file, _logger = logger {
     if (!_file.existsSync()) {
       return;
     }
     try {
-      withAllowedFailure(() {
+      ErrorHandlingFileSystem.noExitOnFailure(() {
         _values = castStringKeyedMap(json.decode(_file.readAsStringSync()));
       });
     } on FormatException {

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 
 import '../convert.dart';
+import 'error_handling_io.dart';
 import 'file_system.dart';
 import 'logger.dart';
 import 'platform.dart';
@@ -41,7 +42,9 @@ class Config {
       return;
     }
     try {
-      _values = castStringKeyedMap(json.decode(_file.readAsStringSync()));
+      withAllowedFailureSync(() {
+        _values = castStringKeyedMap(json.decode(_file.readAsStringSync()));
+      });
     } on FormatException {
       _logger
         ..printError('Failed to decode preferences in ${_file.path}.')
@@ -50,6 +53,13 @@ class Config {
             'with the "flutter config" command.',
         );
       _file.deleteSync();
+    } on Exception catch (err) {
+      _logger
+        ..printError('Could not read preferences in ${file.path}.\n$err')
+        ..printError(
+            'You may need to resolve the error above and reapply any previously '
+            'saved configuration with the "flutter config" command.',
+        );
     }
   }
 

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -42,7 +42,7 @@ class Config {
       return;
     }
     try {
-      withAllowedFailureSync(() {
+      withAllowedFailure(() {
         _values = castStringKeyedMap(json.decode(_file.readAsStringSync()));
       });
     } on FormatException {

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -39,6 +39,7 @@ Future<void> withAllowedFailure(Future<void> Function() operation) async {
 void withAllowedFailureSync(void Function() operation) {
   try {
     ErrorHandlingFileSystem._allowFailure = true;
+    operation();
   } finally {
     ErrorHandlingFileSystem._allowFailure = false;
   }

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -23,20 +23,12 @@ import 'platform.dart';
 /// Allow any file system operations executed within the closure to fail with any
 /// operating system error, rethrowing an [Exception] instead of a [ToolExit].
 ///
+/// This should not be used with async file system operation.
+///
 /// This can be used to bypass the [ErrorHandlingFileSystem] permission exit
 /// checks for situations where failure is acceptable, such as the flutter
 /// persistent settings cache.
-Future<void> withAllowedFailure(Future<void> Function() operation) async {
-  try {
-    ErrorHandlingFileSystem._allowFailure = true;
-    await operation();
-  } finally {
-    ErrorHandlingFileSystem._allowFailure = false;
-  }
-}
-
-/// The same as [withAllowedFailure] but can be run sync.
-void withAllowedFailureSync(void Function() operation) {
+void withAllowedFailure(void Function() operation) {
   try {
     ErrorHandlingFileSystem._allowFailure = true;
     operation();

--- a/packages/flutter_tools/lib/src/convert.dart
+++ b/packages/flutter_tools/lib/src/convert.dart
@@ -7,8 +7,18 @@
 import 'dart:convert' hide utf8;
 import 'dart:convert' as cnv show utf8, Utf8Decoder;
 
+import 'package:meta/meta.dart';
+
 import 'base/common.dart';
 export 'dart:convert' hide utf8, Utf8Codec, Utf8Decoder;
+
+/// The original utf8 encoding for testing overrides only.
+///
+/// Attempting to use the flutter tool utf8 decoder will surface an analyzer
+/// warning that overrides cannot change the default value of a named
+/// parameter.
+@visibleForTesting
+const Encoding utf8ForTesting = cnv.utf8;
 
 /// A [Codec] which reports malformed bytes when decoding.
 ///

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -7,6 +7,7 @@ library reporting;
 import 'dart:async';
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -7,12 +7,12 @@ library reporting;
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:usage/usage_io.dart';
 
+import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -221,7 +221,7 @@ class _DefaultUsage implements Usage {
       _analytics = LogToFileAnalytics(logFilePath);
     } else {
       try {
-        withAllowedFailure(() {
+        ErrorHandlingFileSystem.noExitOnFailure(() {
           _analytics = analyticsIOFactory(
             _kFlutterUA,
             settingsName,

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -221,7 +221,7 @@ class _DefaultUsage implements Usage {
       _analytics = LogToFileAnalytics(logFilePath);
     } else {
       try {
-        withAllowedFailureSync(() {
+        withAllowedFailure(() {
           _analytics = analyticsIOFactory(
             _kFlutterUA,
             settingsName,

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -221,14 +221,16 @@ class _DefaultUsage implements Usage {
       _analytics = LogToFileAnalytics(logFilePath);
     } else {
       try {
-        _analytics = analyticsIOFactory(
-          _kFlutterUA,
-          settingsName,
-          version,
-          documentDirectory: configDirOverride != null
-            ? globals.fs.directory(configDirOverride)
-            : null,
-        );
+        withAllowedFailureSync(() {
+          _analytics = analyticsIOFactory(
+            _kFlutterUA,
+            settingsName,
+            version,
+            documentDirectory: configDirOverride != null
+              ? globals.fs.directory(configDirOverride)
+              : null,
+          );
+        });
       } on Exception catch (e) {
         globals.printTrace('Failed to initialize analytics reporting: $e');
         suppressAnalytics = true;

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -124,8 +124,8 @@ void main() {
 
       final File file = fs.file('file');
 
-      expect(() => withAllowedFailureSync(() => file.writeAsStringSync('')), throwsA(isA<FileSystemException>()));
-      expect(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<FileSystemException>()));
+      expect(() => withAllowedFailureSync(() => file.writeAsStringSync('')), throwsA(isA<Exception>()));
+      expect(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<Exception>()));
       // Check that state does not leak.
       expect(() => file.writeAsStringSync(''), throwsA(isA<ToolExit>()));
     });

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -112,6 +113,21 @@ void main() {
         platform: windowsPlatform,
       );
       when(mockFileSystem.path).thenReturn(MockPathContext());
+    });
+
+    testWithoutContext('bypasses error handling when withAllowedFailure is used', () {
+      setupWriteMocks(
+        mockFileSystem: mockFileSystem,
+        fs: fs,
+        errorCode: kUserPermissionDenied,
+      );
+
+      final File file = fs.file('file');
+
+      expect(() => withAllowedFailureSync(() => file.writeAsStringSync('')), throwsA(isA<FileSystemException>()));
+      expect(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<FileSystemException>()));
+      // Check that state does not leak.
+      expect(() => file.writeAsStringSync(''), throwsA(isA<ToolExit>()));
     });
 
     testWithoutContext('when access is denied', () async {

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -125,7 +125,7 @@ void main() {
       final File file = fs.file('file');
 
       expect(() => withAllowedFailureSync(() => file.writeAsStringSync('')), throwsA(isA<Exception>()));
-      expect(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<Exception>()));
+      await expectLater(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<Exception>()));
       // Check that state does not leak.
       expect(() => file.writeAsStringSync(''), throwsA(isA<ToolExit>()));
     });

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -124,8 +124,7 @@ void main() {
 
       final File file = fs.file('file');
 
-      expect(() => withAllowedFailureSync(() => file.writeAsStringSync('')), throwsA(isA<Exception>()));
-      await expectLater(() async => await withAllowedFailure(() => file.writeAsString('')), throwsA(isA<Exception>()));
+      expect(() => withAllowedFailure(() => file.writeAsStringSync('')), throwsA(isA<Exception>()));
       // Check that state does not leak.
       expect(() => file.writeAsStringSync(''), throwsA(isA<ToolExit>()));
     });

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -4,10 +4,12 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:test/fake.dart';
 
 import '../src/common.dart';
 
@@ -62,13 +64,7 @@ void main() {
   });
 
   testWithoutContext('Config parse error', () {
-    final BufferLogger bufferLogger = BufferLogger(
-      terminal: AnsiTerminal(
-        stdio: null,
-        platform: const LocalPlatform(),
-      ),
-      outputPreferences: OutputPreferences.test(),
-    );
+    final BufferLogger bufferLogger = BufferLogger.test();
     final File file = memoryFileSystem.file('example')
       ..writeAsStringSync('{"hello":"bar');
     config = Config(
@@ -81,4 +77,50 @@ void main() {
     expect(file.existsSync(), false);
     expect(bufferLogger.errorText, contains('Failed to decode preferences'));
   });
+
+  testWithoutContext('Config does not error on missing file', () {
+    final BufferLogger bufferLogger = BufferLogger.test();
+    final File file = memoryFileSystem.file('example');
+    config = Config(
+      'example',
+      fileSystem: memoryFileSystem,
+      logger: bufferLogger,
+      platform: fakePlatform,
+    );
+
+    expect(file.existsSync(), false);
+    expect(bufferLogger.errorText, isEmpty);
+  });
+
+  testWithoutContext('Config does not error on a normally fatal file system exception', () {
+    final BufferLogger bufferLogger = BufferLogger.test();
+    final File file = ErrorHandlingFile(
+      platform: FakePlatform(operatingSystem: 'linux'),
+      fileSystem: MemoryFileSystem.test(),
+      delegate: FakeFile('testfile'),
+    );
+
+    config = Config.createForTesting(file, bufferLogger);
+
+    expect(bufferLogger.errorText, contains('Could not read preferences in testfile'));
+    // Also contains original error message:
+    expect(bufferLogger.errorText, contains('The flutter tool cannot access the file or directory'));
+  });
+}
+
+class FakeFile extends Fake implements File {
+  FakeFile(this.path);
+
+  @override
+  final String path;
+
+  @override
+  bool existsSync() {
+    return true;
+  }
+
+  @override
+  String readAsStringSync({Encoding encoding = utf8ForTesting}) {
+    throw const FileSystemException('', '', OSError('', 13)); // EACCES error on linux
+  }
 }


### PR DESCRIPTION
## Description

Instead of always exiting the tool, provide a mechanism to turn off this behavior for non-critical functionality like configuration and analytics settings.

Fixes https://github.com/flutter/flutter/issues/66786
Fixes https://github.com/flutter/flutter/issues/4674