### PR TITLE
GlobalKey docs improvement

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -120,11 +120,12 @@ class ObjectKey extends LocalKey {
 /// GlobalKeys should not be re-created on every build. They should usually be
 /// long-lived objects owned by a [State] object, for example.
 ///
-/// Creating a new GlobalKey on every build will indicate to the framework that
-/// the corresponding widget subtree has changed on every build. Besides harming
-/// performance, this can also cause unexpected behavior in widgets in the
-/// subtree. For example, a GestureDetector in the subtree will be unable to
-/// track ongoing gestures since it will be recreated on each build.
+/// Creating a new GlobalKey on every build will throw away the state of the
+/// subtree associated with the old key and create a new fresh subtree for the
+/// new key. Besides harming performance, this can also cause unexpected
+/// behavior in widgets in the subtree. For example, a [GestureDetector] in the
+/// subtree will be unable to track ongoing gestures since it will be recreated
+/// on each build.
 ///
 /// Instead, a good practice is to let a State object own the GlobalKey, and
 /// instantiate it outside the build method, such as in [State.initState].

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -117,17 +117,17 @@ class ObjectKey extends LocalKey {
 /// global key. Attempting to do so will assert at runtime.
 ///
 /// ## Pitfalls
-/// It is not advised to instantiate a GlobalKey inside of a build method. Doing
-/// so will create a new GlobalKey on every build, which will indicate that the
-/// corresponding widget subtree has changed on every build.
+/// GlobalKeys should not be re-created on every build. They should usually be
+/// long-lived objects owned by a [State] object, for example.
 ///
-/// Besides harming performance, this can also cause unexpected behavior in
-/// widgets in the subtree. For example, a GestureDetector in the subtree will
-/// be unable to track ongoing gestures since it will be recreated on each
-/// build.
+/// Creating a new GlobalKey on every build will indicate to the framework that
+/// the corresponding widget subtree has changed on every build. Besides harming
+/// performance, this can also cause unexpected behavior in widgets in the
+/// subtree. For example, a GestureDetector in the subtree will be unable to
+/// track ongoing gestures since it will be recreated on each build.
 ///
-/// Instead, instantiate the GlobalKey outside of the build method, such as when
-/// the class instance is created.
+/// Instead, a good practice is to let a State object own the GlobalKey, and
+/// instantiate it outside the build method, such as in [State.initState].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -116,6 +116,19 @@ class ObjectKey extends LocalKey {
 /// You cannot simultaneously include two widgets in the tree with the same
 /// global key. Attempting to do so will assert at runtime.
 ///
+/// ## Pitfalls
+/// It is not advised to instantiate a GlobalKey inside of a build method. Doing
+/// so will create a new GlobalKey on every build, which will indicate that the
+/// corresponding widget subtree has changed on every build.
+///
+/// Besides harming performance, this can also cause unexpected behavior in
+/// widgets in the subtree. For example, a GestureDetector in the subtree will
+/// be unable to track ongoing gestures since it will be recreated on each
+/// build.
+///
+/// Instead, instantiate the GlobalKey outside of the build method, such as when
+/// the class instance is created.
+///
 /// See also:
 ///
 ///  * The discussion at [Widget.key] for more information about how widgets use


### PR DESCRIPTION
## Description

An [issue](https://github.com/flutter/flutter/issues/66427) was filed as an InteractiveViewer bug that ended up being just a misuse of GlobalKey.  It was noted in that issue that the docs should warn against instantiating GlobalKeys inside of build methods to avoid this in the future.  This PR adds this warning to GlobalKey's docs.

## Related Issues

https://github.com/flutter/flutter/issues/66427
Closes https://github.com/flutter/flutter/issues/66625

## Tests

None, docs change only.