### PR TITLE
Move assert(s) that reference 'this' to the constructor bodies.

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -349,8 +349,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
   }) : assert(builder != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
-       assert(opaque),
-       super(settings: settings, fullscreenDialog: fullscreenDialog);
+       super(settings: settings, fullscreenDialog: fullscreenDialog) {
+    assert(opaque);
+  }
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
@@ -376,8 +377,9 @@ class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTr
   _PageBasedCupertinoPageRoute({
     required CupertinoPage<T> page,
   }) : assert(page != null),
-       assert(opaque),
-       super(settings: page);
+       super(settings: page) {
+    assert(opaque);
+  }
 
   CupertinoPage<T> get _page => settings as CupertinoPage<T>;
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -45,8 +45,9 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
   }) : assert(builder != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
-       assert(opaque),
-       super(settings: settings, fullscreenDialog: fullscreenDialog);
+       super(settings: settings, fullscreenDialog: fullscreenDialog) {
+    assert(opaque);
+  }
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
@@ -186,8 +187,9 @@ class _PageBasedMaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTran
   _PageBasedMaterialPageRoute({
     @required MaterialPage<T> page,
   }) : assert(page != null),
-       assert(opaque),
-       super(settings: page);
+       super(settings: page) {
+    assert(opaque);
+  }
 
   MaterialPage<T> get _page => settings as MaterialPage<T>;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1904,19 +1904,20 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// objects.
   MultiChildRenderObjectWidget({ Key? key, this.children = const <Widget>[] })
     : assert(children != null),
-      assert(() {
-        for (int index = 0; index < children.length; index++) {
-          // TODO(a14n): remove this check to have a lot more const widget
-          if (children[index] == null) { // ignore: dead_code
-            throw FlutterError(
+      super(key: key) {
+    assert(() {
+      for (int index = 0; index < children.length; index++) {
+        // TODO(a14n): remove this check to have a lot more const widget
+        if (children[index] == null) { // ignore: dead_code
+          throw FlutterError(
               "$runtimeType's children must not contain any null values, "
-              'but a null value was found at index $index'
-            );
-          }
+                  'but a null value was found at index $index'
+          );
         }
-        return true;
-      }()), // https://github.com/dart-lang/sdk/issues/29276
-      super(key: key);
+      }
+      return true;
+    }()); // https://github.com/dart-lang/sdk/issues/29276
+  }
 
   /// The widgets below this widget in the tree.
   ///


### PR DESCRIPTION
We found a bug in both the Dart analyzer and CFE.
See https://github.com/dart-lang/sdk/issues/43175 for the full context.
To fix the implementation we need to fix the clients.