### PR TITLE
Replace MockFile with memory file system files

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       mockFlutterVersion = MockFlutterVersion();
       mockGitTagVersion = MockGitTagVersion();
       mockCache = MockCache();

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -31,7 +31,7 @@ void main() {
       FlutterProject projectUnderTest;
 
       setUp(() {
-        fs = MemoryFileSystem();
+        fs = MemoryFileSystem.test();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
 
         final Directory currentDirectory = fs.currentDirectory;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -607,7 +607,7 @@ void main() {
       expect(logger.statusText, contains('No issues found!'));
     }, overrides: <Type, Generator>{
       Artifacts: () => mockArtifacts,
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -38,7 +38,7 @@ void main() {
     setUp(() {
       command = DriveCommand();
       applyMocksToCommand(command);
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       tempDir = fs.systemTempDirectory.createTempSync('flutter_drive_test.');
       fs.currentDirectory = tempDir;
       fs.directory('test').createSync();

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -150,7 +150,7 @@ void main() {
         mockArtifacts = MockArtifacts();
         mockCache = MockCache();
         mockUsage = MockUsage();
-        fs = MemoryFileSystem();
+        fs = MemoryFileSystem.test();
         mockProcessManager = MockProcessManager();
 
         tempDir = fs.systemTempDirectory.createTempSync('flutter_run_test.');

--- a/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(globals.fs.isFileSync(outputFile), isTrue);
       expect(globals.fs.file(outputFile).readAsStringSync(), contains('__flutter_completion'));
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Stdio: () => mockStdio,
     });
@@ -73,7 +73,7 @@ void main() {
       expect(globals.fs.isFileSync(outputFile), isTrue);
       expect(globals.fs.file(outputFile).readAsStringSync(), isEmpty);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Stdio: () => mockStdio,
     });
@@ -88,7 +88,7 @@ void main() {
       expect(globals.fs.isFileSync(outputFile), isTrue);
       expect(globals.fs.file(outputFile).readAsStringSync(), contains('__flutter_completion'));
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Stdio: () => mockStdio,
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -26,7 +26,7 @@ void main() {
   MemoryFileSystem fs;
 
   setUp(() {
-    fs = MemoryFileSystem();
+    fs = MemoryFileSystem.test();
     fs.file('pubspec.yaml').createSync();
     fs.file('.packages').createSync();
     fs.directory('test').childFile('some_test.dart').createSync(recursive: true);

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -112,7 +112,7 @@ void main() {
       '--target-platform=windows-x64',
     ]), throwsToolExit());
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
   });
@@ -130,7 +130,7 @@ void main() {
       '--target-platform=linux-x64',
     ]), throwsToolExit());
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
@@ -148,7 +148,7 @@ void main() {
       '--target-platform=darwin-x64',
     ]), throwsToolExit());
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
@@ -166,7 +166,7 @@ void main() {
       '--target-platform=windows-x64',
     ]);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -184,7 +184,7 @@ void main() {
       '--target-platform=linux-x64',
     ]);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -202,7 +202,7 @@ void main() {
       '--target-platform=darwin-x64',
     ]);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -234,7 +234,7 @@ void main() {
     ]);
   }, overrides: <Type, Generator>{
     BuildSystem: () => MockBuildSystem(),
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 }

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -117,7 +117,7 @@ void main() {
       Platform: () => FakePlatform(environment: <String, String>{
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -143,7 +143,7 @@ void main() {
       Platform: () => FakePlatform(environment: <String, String>{
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -157,7 +157,7 @@ void main() {
     List<int> mockTimes;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       mockStdio = MockStdio();
       mockUsage = MockUsage();
       when(mockUsage.isFirstRun).thenReturn(false);

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   setUp(() {
     sdk = MockAndroidSdk();
-    fs = MemoryFileSystem();
+    fs = MemoryFileSystem.test();
     fs.directory('/home/me').createSync(recursive: true);
     logger = BufferLogger(
       terminal: AnsiTerminal(

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -322,7 +322,7 @@ void main() {
         ),
       ).called(1);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Usage: () => mockUsage,
     });
@@ -472,7 +472,7 @@ include ':app'
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
 
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -505,7 +505,7 @@ include ':app'
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
 
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -517,7 +517,7 @@ include ':app'
     FileSystem fs;
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       mockArtifacts = MockLocalEngineArtifacts();
       mockProcessManager = MockProcessManager();
       android = fakePlatform('android');
@@ -786,7 +786,7 @@ flutter:
     FileSystem fs;
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
     });
 
     testUsingContext('returns true when the project is using AndroidX', () async {
@@ -834,7 +834,7 @@ flutter:
     MockAndroidSdk mockAndroidSdk;
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.directory).thenReturn('irrelevant');
@@ -1013,7 +1013,7 @@ plugin1=${plugin1.path}
 
     setUp(() {
       mockUsage = MockUsage();
-      fileSystem = MemoryFileSystem();
+      fileSystem = MemoryFileSystem.test();
       fileSystemUtils = MockFileSystemUtils();
       mockAndroidSdk = MockAndroidSdk();
       mockAndroidStudio = MockAndroidStudio();

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -22,7 +22,7 @@ void main() {
     Directory gradleWrapperDirectory;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       tempDir = memoryFileSystem.systemTempDirectory.createTempSync('flutter_artifacts_test.');
       gradleWrapperDirectory = memoryFileSystem.directory(
           memoryFileSystem.path.join(tempDir.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper'));
@@ -124,7 +124,7 @@ void main() {
     MemoryFileSystem memoryFileSystem;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
     });
 
     testUsingContext("throws ToolExit if gradle.properties doesn't exist", () {
@@ -229,7 +229,7 @@ void main() {
     MockGradleUtils gradleUtils;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       operatingSystemUtils = MockOperatingSystemUtils();
       gradleUtils = MockGradleUtils();
     });

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -51,7 +51,7 @@ void main() {
     setUp(() async {
       sdk = MockitoAndroidSdk();
       mockProcessManager = MockitoProcessManager();
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       mockCache = MockCache();
       Cache.flutterRoot = '../..';
       when(sdk.licensesAvailable).thenReturn(true);
@@ -217,7 +217,7 @@ void main() {
   group('PrebuiltIOSApp', () {
     MockOperatingSystemUtils os;
     final Map<Type, Generator> overrides = <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       PlistParser: () => MockPlistUtils(),
       Platform: _kNoColorTerminalPlatform,
@@ -365,7 +365,7 @@ void main() {
 
   group('FuchsiaApp', () {
     final Map<Type, Generator> overrides = <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -23,7 +23,7 @@ void main() {
     Platform platform;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
+      fileSystem = MemoryFileSystem.test();
       final Directory cacheRoot = fileSystem.directory('root')
         ..createSync();
       platform = FakePlatform(operatingSystem: 'linux');
@@ -110,7 +110,7 @@ void main() {
     Platform platform;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
+      fileSystem = MemoryFileSystem.test();
       final Directory cacheRoot = fileSystem.directory('root')
         ..createSync();
       platform = FakePlatform(operatingSystem: 'linux');

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -21,7 +21,7 @@ void main() {
     FileSystemUtils fsUtils;
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       fsUtils = FileSystemUtils(
         fileSystem: fs,
         platform: FakePlatform(),
@@ -61,7 +61,7 @@ void main() {
     /// Test file_systems.copyDirectorySync() using MemoryFileSystem.
     /// Copies between 2 instances of file systems which is also supported by copyDirectorySync().
     testWithoutContext('test directory copy', () async {
-      final MemoryFileSystem sourceMemoryFs = MemoryFileSystem();
+      final MemoryFileSystem sourceMemoryFs = MemoryFileSystem.test();
       const String sourcePath = '/some/origin';
       final Directory sourceDirectory = await sourceMemoryFs.directory(sourcePath).create(recursive: true);
       sourceMemoryFs.currentDirectory = sourcePath;
@@ -71,7 +71,7 @@ void main() {
       sourceMemoryFs.directory('empty_directory').createSync();
 
       // Copy to another memory file system instance.
-      final MemoryFileSystem targetMemoryFs = MemoryFileSystem();
+      final MemoryFileSystem targetMemoryFs = MemoryFileSystem.test();
       const String targetPath = '/some/non-existent/target';
       final Directory targetDirectory = targetMemoryFs.directory(targetPath);
 
@@ -94,7 +94,7 @@ void main() {
     });
 
     testWithoutContext('Skip files if shouldCopyFile returns false', () {
-      final MemoryFileSystem fileSystem = MemoryFileSystem();
+      final MemoryFileSystem fileSystem = MemoryFileSystem.test();
       final FileSystemUtils fsUtils = FileSystemUtils(
         fileSystem: fileSystem,
         platform: FakePlatform(),
@@ -122,7 +122,7 @@ void main() {
 
   group('escapePath', () {
     testWithoutContext('on Windows', () {
-      final MemoryFileSystem fileSystem = MemoryFileSystem();
+      final MemoryFileSystem fileSystem = MemoryFileSystem.test();
       final FileSystemUtils fsUtils = FileSystemUtils(
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'windows'),
@@ -133,7 +133,7 @@ void main() {
     });
 
     testWithoutContext('on Linux', () {
-      final MemoryFileSystem fileSystem = MemoryFileSystem();
+      final MemoryFileSystem fileSystem = MemoryFileSystem.test();
       final FileSystemUtils fsUtils = FileSystemUtils(
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'linux'),

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -15,7 +15,7 @@ import '../../src/io.dart';
 
 void main() {
   test('IOOverrides can inject a memory file system', () async {
-    final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
+    final MemoryFileSystem memoryFileSystem = MemoryFileSystem.test();
     final FlutterIOOverrides flutterIOOverrides = FlutterIOOverrides(fileSystem: memoryFileSystem);
     await io.IOOverrides.runWithIOOverrides(() async {
       // statics delegate correctly.

--- a/packages/flutter_tools/test/general.shard/base/net_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/net_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     testWithoutContext('fetchUrl(destFile) writes the data to a file', () async {
       final Net net = createNet(FakeHttpClient(200, data: responseString));
-      final MemoryFileSystem fs = MemoryFileSystem();
+      final MemoryFileSystem fs = MemoryFileSystem.test();
       final File destFile = fs.file('dest_file')..createSync();
       final List<int> data = await net.fetchUrl(
         Uri.parse('http://example.invalid/'),

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -29,7 +29,7 @@ void main() {
 
   OperatingSystemUtils createOSUtils(Platform platform) {
     return OperatingSystemUtils(
-      fileSystem: MemoryFileSystem(),
+      fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),
       platform: platform,
       processManager: mockProcessManager,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -90,7 +90,7 @@ void main() {
     mockProcessManager = MockProcessManager();
     fontSubsetProcess = MockProcess();
     mockArtifacts = MockArtifacts();
-    fileSystem = MemoryFileSystem();
+    fileSystem = MemoryFileSystem.test();
     logger = BufferLogger(
       terminal: AnsiTerminal(
         stdio: mocks.MockStdio(),

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     setUp(() {
       mockFileSystem = MockFileSystem();
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       mockFile = MockFile();
       mockRandomAccessFile = MockRandomAccessFile();
       when(mockFileSystem.path).thenReturn(memoryFileSystem.path);
@@ -89,7 +89,7 @@ void main() {
 
     setUp(() {
       mockCache = MockCache();
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
     });
 
     testUsingContext('Continues on failed stamp file update', () async {
@@ -247,9 +247,9 @@ void main() {
   });
 
   testWithoutContext('flattenNameSubdirs', () {
-    expect(flattenNameSubdirs(Uri.parse('http://flutter.dev/foo/bar'), MemoryFileSystem()), 'flutter.dev/foo/bar');
-    expect(flattenNameSubdirs(Uri.parse('http://docs.flutter.io/foo/bar'), MemoryFileSystem()), 'docs.flutter.io/foo/bar');
-    expect(flattenNameSubdirs(Uri.parse('https://www.flutter.dev'), MemoryFileSystem()), 'www.flutter.dev');
+    expect(flattenNameSubdirs(Uri.parse('http://flutter.dev/foo/bar'), MemoryFileSystem.test()), 'flutter.dev/foo/bar');
+    expect(flattenNameSubdirs(Uri.parse('http://docs.flutter.io/foo/bar'), MemoryFileSystem.test()), 'docs.flutter.io/foo/bar');
+    expect(flattenNameSubdirs(Uri.parse('https://www.flutter.dev'), MemoryFileSystem.test()), 'www.flutter.dev');
   });
 
   group('EngineCachedArtifact', () {
@@ -303,7 +303,7 @@ void main() {
     MockCache mockCache;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       processManager = MockProcessManager();
       mockCache = MockCache();
     });
@@ -372,7 +372,7 @@ void main() {
       expect(iosUsbArtifacts.isUpToDateInner(), false);
     }, overrides: <Type, Generator>{
       Cache: () => mockCache,
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -390,7 +390,7 @@ void main() {
       expect(iosUsbArtifacts.isUpToDateInner(), false);
     }, overrides: <Type, Generator>{
       Cache: () => mockCache,
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -402,7 +402,7 @@ void main() {
       expect(iosUsbArtifacts.isUpToDateInner(), true);
     }, overrides: <Type, Generator>{
       Cache: () => mockCache,
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -254,7 +254,7 @@ void main() {
         environment: anyNamed('environment'),
       )).called(1);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => mockProcessManager,
     });
 
@@ -307,7 +307,7 @@ void main() {
       );
       expect(testLogger.errorText, hasLength(0));
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => mockProcessManager,
     });
 
@@ -368,7 +368,7 @@ void main() {
       expect(testLogger.errorText, hasLength(0));
       expect(versionCheckFile.existsSync(), isFalse);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => mockProcessManager,
     });
   });

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -94,7 +95,7 @@ void main() {
           route: anyNamed('route')
       )).thenAnswer((Invocation invocation) => Future<int>.value(1));
       final List<FlutterDevice> devices = <FlutterDevice>[mockFlutterDevice];
-      final MockFile applicationBinary = MockFile();
+      final File applicationBinary = MemoryFileSystem.test().file('binary');
       final int result = await ColdRunner(
         devices,
         applicationBinary: applicationBinary,
@@ -110,7 +111,6 @@ void main() {
   });
 }
 
-class MockFile extends Mock implements File {}
 class MockFlutterDevice extends Mock implements FlutterDevice {}
 class MockDevice extends Mock implements Device {
   MockDevice() {

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -19,7 +19,7 @@ void main() {
   FakePlatform fakePlatform;
 
   setUp(() {
-    memoryFileSystem = MemoryFileSystem();
+    memoryFileSystem = MemoryFileSystem.test();
     fakePlatform = FakePlatform(
       operatingSystem: 'linux',
       environment: <String, String>{

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -60,13 +60,11 @@ final vm_service.Isolate fakeIsolate = vm_service.Isolate(
 void main() {
   group('fuchsia device', () {
     MemoryFileSystem memoryFileSystem;
-    MockFile sshConfig;
+    File sshConfig;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
-      sshConfig = MockFile();
-      when(sshConfig.existsSync()).thenReturn(true);
-      when(sshConfig.absolute).thenReturn(sshConfig);
+      memoryFileSystem = MemoryFileSystem.test();
+      sshConfig = memoryFileSystem.file('ssh_config')..writeAsStringSync('\n');
     });
 
     testWithoutContext('stores the requested id and name', () {
@@ -293,14 +291,14 @@ void main() {
   group('displays friendly error when', () {
     MockProcessManager mockProcessManager;
     MockProcessResult mockProcessResult;
-    MockFile mockFile;
+    File artifactFile;
     MockProcessManager emptyStdoutProcessManager;
     MockProcessResult emptyStdoutProcessResult;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
       mockProcessResult = MockProcessResult();
-      mockFile = MockFile();
+      artifactFile = MemoryFileSystem.test().file('artifact');
       when(mockProcessManager.run(
         any,
         environment: anyNamed('environment'),
@@ -310,8 +308,6 @@ void main() {
       when(mockProcessResult.exitCode).thenReturn(1);
       when<String>(mockProcessResult.stdout as String).thenReturn('');
       when<String>(mockProcessResult.stderr as String).thenReturn('');
-      when(mockFile.absolute).thenReturn(mockFile);
-      when(mockFile.path).thenReturn('');
 
       emptyStdoutProcessManager = MockProcessManager();
       emptyStdoutProcessResult = MockProcessResult();
@@ -341,8 +337,8 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => emptyStdoutProcessManager,
       FuchsiaArtifacts: () => FuchsiaArtifacts(
-            sshConfig: mockFile,
-            devFinder: mockFile,
+            sshConfig: artifactFile,
+            devFinder: artifactFile,
           ),
       FuchsiaSdk: () => MockFuchsiaSdk(),
     });
@@ -362,8 +358,8 @@ void main() {
       Completer<int> exitCode;
       StreamController<List<int>> stdout;
       StreamController<List<int>> stderr;
-      MockFile devFinder;
-      MockFile sshConfig;
+      File devFinder;
+      File sshConfig;
 
       setUp(() {
         mockProcessManager = MockProcessManager();
@@ -376,12 +372,9 @@ void main() {
         when(mockProcess.exitCode).thenAnswer((Invocation _) => exitCode.future);
         when(mockProcess.stdout).thenAnswer((Invocation _) => stdout.stream);
         when(mockProcess.stderr).thenAnswer((Invocation _) => stderr.stream);
-        devFinder = MockFile();
-        sshConfig = MockFile();
-        when(devFinder.existsSync()).thenReturn(true);
-        when(sshConfig.existsSync()).thenReturn(true);
-        when(devFinder.absolute).thenReturn(devFinder);
-        when(sshConfig.absolute).thenReturn(sshConfig);
+        final FileSystem memoryFileSystem = MemoryFileSystem.test();
+        devFinder = memoryFileSystem.file('device-finder')..writeAsStringSync('\n');
+        sshConfig = memoryFileSystem.file('ssh_config')..writeAsStringSync('\n');
       });
 
       tearDown(() {
@@ -700,15 +693,11 @@ void main() {
 
   group('portForwarder', () {
     MockProcessManager mockProcessManager;
-    MockFile sshConfig;
+    File sshConfig;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
-
-      sshConfig = MockFile();
-      when(sshConfig.path).thenReturn('irrelevant');
-      when(sshConfig.existsSync()).thenReturn(true);
-      when(sshConfig.absolute).thenReturn(sshConfig);
+      sshConfig = MemoryFileSystem.test().file('irrelevant')..writeAsStringSync('\n');
     });
 
     testUsingContext('`unforward` prints stdout and stderr if ssh command failed', () async {
@@ -721,7 +710,7 @@ void main() {
       when(mockProcessManager.run(<String>[
         'ssh',
         '-F',
-        'irrelevant',
+        sshConfig.absolute.path,
         '-O',
         'cancel',
         '-vvv',
@@ -890,7 +879,7 @@ void main() {
     File runner;
 
     setUp(() {
-      memoryFileSystem = MemoryFileSystem();
+      memoryFileSystem = MemoryFileSystem.test();
       osUtils = FakeOperatingSystemUtils();
       fuchsiaDeviceTools = FakeFuchsiaDeviceTools();
       fuchsiaSdk = MockFuchsiaSdk();
@@ -1105,7 +1094,7 @@ void main() {
   });
 
   group('sdkNameAndVersion: ', () {
-    MockFile sshConfig;
+    File sshConfig;
     MockProcessManager mockSuccessProcessManager;
     MockProcessResult mockSuccessProcessResult;
     MockProcessManager mockFailureProcessManager;
@@ -1114,9 +1103,7 @@ void main() {
     MockProcessResult emptyStdoutProcessResult;
 
     setUp(() {
-      sshConfig = MockFile();
-      when(sshConfig.existsSync()).thenReturn(true);
-      when(sshConfig.absolute).thenReturn(sshConfig);
+      sshConfig = MemoryFileSystem.test().file('ssh_config')..writeAsStringSync('\n');
 
       mockSuccessProcessManager = MockProcessManager();
       mockSuccessProcessResult = MockProcessResult();
@@ -1195,8 +1182,6 @@ class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
 class MockProcessManager extends Mock implements ProcessManager {}
 
 class MockProcessResult extends Mock implements ProcessResult {}
-
-class MockFile extends Mock implements File {}
 
 class MockProcess extends Mock implements Process {}
 

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -16,13 +17,12 @@ import '../../src/mocks.dart';
 
 void main() {
   group('FuchsiaPM', () {
-    MockFile pm;
+    File pm;
     MockProcessManager mockProcessManager;
     MockFuchsiaArtifacts mockFuchsiaArtifacts;
 
     setUp(() {
-      pm = MockFile();
-      when(pm.path).thenReturn('pm');
+      pm = MemoryFileSystem.test().file('pm');
 
       mockFuchsiaArtifacts = MockFuchsiaArtifacts();
       when(mockFuchsiaArtifacts.pm).thenReturn(pm);
@@ -74,6 +74,5 @@ void main() {
 
 class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
 class MockProcessUtils extends Mock implements ProcessUtils {}
-class MockFile extends Mock implements File {}
 class MockProcess extends Mock implements Process {}
 class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -21,7 +21,7 @@ void main() {
   FileSystem fs;
   setUp(() {
     logger = BufferLogger.test();
-    fs = MemoryFileSystem();
+    fs = MemoryFileSystem.test();
   });
 
   group('GitHub template creator', () {
@@ -170,7 +170,7 @@ void main() {
             _kShortURL
         );
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
       });
 
@@ -196,7 +196,7 @@ void main() {
         );
         expect(logger.traceText, contains('Failed to shorten GitHub template URL'));
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
       });
 

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -42,7 +42,7 @@ void main() {
     Logger logger;
     IOSDeploy iosDeploy;
     IMobileDevice iMobileDevice;
-    FileSystem mockFileSystem;
+    FileSystem nullFileSystem;
 
     setUp(() {
       mockArtifacts = MockArtifacts();
@@ -70,7 +70,7 @@ void main() {
       IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -87,7 +87,7 @@ void main() {
       expect(IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -101,7 +101,7 @@ void main() {
       expect(IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -115,7 +115,7 @@ void main() {
       expect(IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -129,7 +129,7 @@ void main() {
       expect(IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -143,7 +143,7 @@ void main() {
       expect(IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -160,7 +160,7 @@ void main() {
       final IOSDevice device = IOSDevice(
         'device-123',
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-        fileSystem: mockFileSystem,
+        fileSystem: nullFileSystem,
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
@@ -185,7 +185,7 @@ void main() {
             IOSDevice(
               'device-123',
               iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-              fileSystem: mockFileSystem,
+              fileSystem: nullFileSystem,
               logger: logger,
               platform: platform,
               iosDeploy: iosDeploy,
@@ -217,7 +217,7 @@ void main() {
       MockCache mockCache;
       Logger logger;
       IOSDeploy iosDeploy;
-      FileSystem mockFileSystem;
+      FileSystem nullFileSystem;
       IProxy iproxy;
 
       IOSDevicePortForwarder createPortForwarder(
@@ -228,7 +228,7 @@ void main() {
           id: device.id,
           logger: logger,
           operatingSystemUtils: OperatingSystemUtils(
-            fileSystem: mockFileSystem,
+            fileSystem: nullFileSystem,
             logger: logger,
             platform: FakePlatform(operatingSystem: 'macos'),
             processManager: FakeProcessManager.any(),
@@ -276,7 +276,7 @@ void main() {
         device = IOSDevice(
           '123',
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
-          fileSystem: mockFileSystem,
+          fileSystem: nullFileSystem,
           logger: logger,
           platform: macPlatform,
           iosDeploy: iosDeploy,

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -46,7 +46,7 @@ void main () {
       MockXcode mockXcode;
 
       setUp(() {
-        memoryFileSystem = MemoryFileSystem();
+        memoryFileSystem = MemoryFileSystem.test();
         mockXcode = MockXcode();
         xcodeProjectInfoFile = memoryFileSystem.file('project.pbxproj');
 
@@ -265,7 +265,7 @@ keep this 2
       File xcodeWorkspaceSharedSettings;
 
       setUp(() {
-        memoryFileSystem = MemoryFileSystem();
+        memoryFileSystem = MemoryFileSystem.test();
         xcodeWorkspaceSharedSettings = memoryFileSystem.file('WorkspaceSettings.xcsettings');
 
         testLogger = BufferLogger(
@@ -345,7 +345,7 @@ keep this 2
       File xcodeProjectInfoFile;
 
       setUp(() {
-        memoryFileSystem = MemoryFileSystem();
+        memoryFileSystem = MemoryFileSystem.test();
         xcodeProjectInfoFile = memoryFileSystem.file('project.pbxproj');
 
         testLogger = BufferLogger(

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -27,7 +27,6 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 
-class MockFile extends Mock implements File {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
 class MockLogger extends Mock implements Logger {}
 class MockProcess extends Mock implements Process {}
@@ -376,8 +375,6 @@ void main() {
     MockLogger mockLogger;
     MockProcessManager mockProcessManager;
     IOSSimulator deviceUnderTest;
-    // only used for fs.path.join()
-    final FileSystem fs = globals.fs;
 
     setUp(() {
       mockXcode = MockXcode();
@@ -415,9 +412,8 @@ void main() {
         when(mockXcode.majorVersion).thenReturn(8);
         when(mockXcode.minorVersion).thenReturn(2);
         expect(deviceUnderTest.supportsScreenshot, true);
-        final MockFile mockFile = MockFile();
-        when(mockFile.path).thenReturn(fs.path.join('some', 'path', 'to', 'screenshot.png'));
-        await deviceUnderTest.takeScreenshot(mockFile);
+        final File screenshot = MemoryFileSystem.test().file('screenshot.png');
+        await deviceUnderTest.takeScreenshot(screenshot);
         verify(mockProcessManager.run(
           <String>[
             '/usr/bin/xcrun',
@@ -425,7 +421,7 @@ void main() {
             'io',
             'x',
             'screenshot',
-            fs.path.join('some', 'path', 'to', 'screenshot.png'),
+            'screenshot.png',
           ],
           environment: null,
           workingDirectory: null,
@@ -944,7 +940,7 @@ flutter:
       );
       expect(simulator.isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -962,7 +958,7 @@ flutter:
       );
       expect(simulator.isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -978,7 +974,7 @@ flutter:
       );
       expect(simulator.isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -33,7 +33,7 @@ void main() {
     setUp(() {
       processManager = mocks.MockProcessManager();
       platform = FakePlatform(operatingSystem: 'macos');
-      final FileSystem fileSystem = MemoryFileSystem();
+      final FileSystem fileSystem = MemoryFileSystem.test();
       fileSystem.file(xcodebuild).createSync(recursive: true);
       final AnsiTerminal terminal = MockAnsiTerminal();
       logger = BufferLogger.test(
@@ -85,7 +85,7 @@ void main() {
   setUp(() {
     fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
     platform = FakePlatform(operatingSystem: 'macos');
-    fileSystem = MemoryFileSystem();
+    fileSystem = MemoryFileSystem.test();
     fileSystem.file(xcodebuild).createSync(recursive: true);
     terminal = MockAnsiTerminal();
     logger = BufferLogger.test(
@@ -534,7 +534,7 @@ Information about project "Runner":
     FileSystem fs;
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       mockArtifacts = MockLocalEngineArtifacts();
       macOS = FakePlatform(operatingSystem: 'macos');
       fs.file(xcodebuild).createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -104,7 +104,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
     ).isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -119,7 +119,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
     ).isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -141,7 +141,7 @@ void main() {
     expect(device.executablePathForDevice(mockApp, BuildMode.profile), profilePath);
     expect(device.executablePathForDevice(mockApp, BuildMode.release), releasePath);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 }

--- a/packages/flutter_tools/test/general.shard/persistent_tool_state_test.dart
+++ b/packages/flutter_tools/test/general.shard/persistent_tool_state_test.dart
@@ -12,7 +12,7 @@ import '../src/common.dart';
 
 void main() {
   testWithoutContext('state can be set and persists', () {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory directory = fileSystem.directory('state_dir');
     directory.createSync();
     final File stateFile = directory.childFile('.flutter_tool_state');
@@ -35,7 +35,7 @@ void main() {
   });
 
   testWithoutContext('channel versions can be cached and stored', () {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory directory = fileSystem.directory('state_dir')..createSync();
     final PersistentToolState state1 = PersistentToolState.test(
       directory: directory,

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -106,7 +106,7 @@ void main() {
     }
 
     setUp(() async {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       fsWindows = MemoryFileSystem(style: FileSystemStyle.windows);
       mockClock = MockClock();
       mockVersion = MockFlutterVersion();
@@ -841,8 +841,7 @@ dependencies:
       testUsingContext('Does not throw when AndroidManifest.xml is not found', () async {
         when(flutterProject.isModule).thenReturn(false);
 
-        final File manifest = MockFile();
-        when(manifest.existsSync()).thenReturn(false);
+        final File manifest = fs.file('AndroidManifest.xml');
         when(androidProject.appManifestFile).thenReturn(manifest);
 
         await injectPlugins(flutterProject);
@@ -1421,8 +1420,6 @@ flutter:
 class MockAndroidProject extends Mock implements AndroidProject {}
 class MockFeatureFlags extends Mock implements FeatureFlags {}
 class MockFlutterProject extends Mock implements FlutterProject {}
-class MockFile extends Mock implements File {}
-class MockFileSystem extends Mock implements FileSystem {}
 class MockIosProject extends Mock implements IosProject {}
 class MockMacOSProject extends Mock implements MacOSProject {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -18,7 +18,7 @@ final DateTime inFuture = DateTime.now().add(const Duration(days: 100));
 void main() {
   for (final bool asyncScanning in <bool>[true, false]) {
     testWithoutContext('No last compile, asyncScanning: $asyncScanning', () async {
-      final FileSystem fileSystem = MemoryFileSystem();
+      final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
         platform: FakePlatform(),
@@ -39,7 +39,7 @@ void main() {
     });
 
     testWithoutContext('Empty project, asyncScanning: $asyncScanning', () async {
-      final FileSystem fileSystem = MemoryFileSystem();
+      final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
         platform: FakePlatform(),
@@ -60,9 +60,9 @@ void main() {
     });
 
     testWithoutContext('Non-existent files are ignored, asyncScanning: $asyncScanning', () async {
-      final FileSystem fileSystem = MemoryFileSystem();
+      final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
-        fileSystem: MemoryFileSystem(),
+        fileSystem: MemoryFileSystem.test(),
         platform: FakePlatform(),
         logger: BufferLogger.test(),
       );

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -167,7 +167,7 @@ void main() {
         await project.ensureReadyForPlatformSpecificTooling();
         expectExists(project.macos.managedDirectory.childFile('GeneratedPluginRegistrant.swift'));
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
         FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(
@@ -181,7 +181,7 @@ void main() {
         await project.ensureReadyForPlatformSpecificTooling();
         expectExists(project.macos.generatedXcodePropertiesFile);
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
         FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(
@@ -196,7 +196,7 @@ void main() {
         expectExists(project.linux.managedDirectory.childFile('generated_plugin_registrant.h'));
         expectExists(project.linux.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
         FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(
@@ -211,7 +211,7 @@ void main() {
         expectExists(project.windows.managedDirectory.childFile('generated_plugin_registrant.h'));
         expectExists(project.windows.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem(),
+        FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
         FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(
@@ -294,7 +294,7 @@ void main() {
       MemoryFileSystem fs;
       FlutterProjectFactory flutterProjectFactory;
       setUp(() {
-        fs = MemoryFileSystem();
+        fs = MemoryFileSystem.test();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
         flutterProjectFactory = FlutterProjectFactory(
           logger: logger,
@@ -332,7 +332,7 @@ apply plugin: 'kotlin-android'
       MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
       FlutterProjectFactory flutterProjectFactory;
       setUp(() {
-        fs = MemoryFileSystem();
+        fs = MemoryFileSystem.test();
         mockPlistUtils = MockPlistUtils();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
         flutterProjectFactory = FlutterProjectFactory(
@@ -496,7 +496,7 @@ apply plugin: 'kotlin-android'
       MemoryFileSystem fs;
       MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
       setUp(() {
-        fs = MemoryFileSystem();
+        fs = MemoryFileSystem.test();
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
       });
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2196,7 +2196,7 @@ void main() {
     expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
-    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem()),
+    FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
   }));
 
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -39,7 +39,7 @@ void main() {
     });
 
     setUp(() {
-      fs = MemoryFileSystem();
+      fs = MemoryFileSystem.test();
       fs.directory(_kFlutterRoot).createSync(recursive: true);
       fs.directory(_kProjectRoot).createSync(recursive: true);
       fs.currentDirectory = _kProjectRoot;

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -89,7 +89,7 @@ void main() {
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
         'FLUTTER_ROOT': '/',
       }),
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Usage: () => CrashingUsage(),
     });
@@ -130,7 +130,7 @@ void main() {
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
         'FLUTTER_ROOT': '/',
       }),
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
 
       CrashReporter: () => WaitingCrashReporter(commandCompleter.future),
@@ -190,7 +190,7 @@ void main() {
         },
         operatingSystem: 'linux'
       ),
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       UserMessages: () => CustomBugInstructions(),
     });

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
@@ -26,7 +26,7 @@ void main() {
     expect(vsCode.version, Version.unknown);
     expect(bufferLogger.traceText, contains('Error parsing VSCode'));
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 }

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -76,7 +76,7 @@ void main() {
 
       expect(WindowsDevice().isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -87,7 +87,7 @@ void main() {
 
       expect(WindowsDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -99,7 +99,7 @@ void main() {
 
       expect(WindowsDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -116,7 +116,7 @@ void main() {
       expect(WindowsDevice().executablePathForDevice(mockApp, BuildMode.profile), profilePath);
       expect(WindowsDevice().executablePathForDevice(mockApp, BuildMode.release), releasePath);
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });

--- a/packages/flutter_tools/test/general.shard/windows/windows_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_workflow_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/windows/windows_workflow.dart';
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -13,14 +12,12 @@ import '../../src/testbed.dart';
 
 void main() {
   Testbed testbed;
-  MockPlatform windows;
-  MockPlatform notWindows;
+  FakePlatform windows;
+  FakePlatform notWindows;
 
   setUp(() {
-    windows = MockPlatform();
-    notWindows = MockPlatform();
-    when(windows.isWindows).thenReturn(true);
-    when(notWindows.isWindows).thenReturn(false);
+    windows = FakePlatform(operatingSystem: 'windows');
+    notWindows = FakePlatform(operatingSystem: 'linux');
     testbed = Testbed(
       overrides: <Type, Generator>{
         Platform: () => windows,
@@ -53,9 +50,4 @@ void main() {
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
   }));
-}
-
-class MockPlatform extends Mock implements Platform {
-  @override
-  final Map<String, String> environment = <String, String>{};
 }

--- a/packages/flutter_tools/test/template_test.dart
+++ b/packages/flutter_tools/test/template_test.dart
@@ -57,7 +57,7 @@ void main() {
   });
 
   testWithoutContext('Template.render replaces .img.tmpl files with files from the image source', () {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Directory templateDir = fileSystem.directory('templates');
     final Directory imageSourceDir = fileSystem.directory('template_images');
     final Directory destination = fileSystem.directory('target');
@@ -84,7 +84,7 @@ void main() {
   });
 
   testWithoutContext('Template.fromName runs pub get if .packages is missing', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final MockPub pub = MockPub();
     when(pub.get(
       context: PubContext.pubGet,
@@ -107,7 +107,7 @@ void main() {
   });
 
   testWithoutContext('Template.fromName runs pub get if .packages is missing flutter_template_images', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final MockPub pub = MockPub();
     when(pub.get(
       context: PubContext.pubGet,
@@ -137,7 +137,7 @@ void main() {
   });
 
   testWithoutContext('Template.fromName runs pub get if flutter_template_images directory is missing', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final MockPub pub = MockPub();
     Cache.flutterRoot = '/flutter';
     final File packagesFile = fileSystem.directory(Cache.flutterRoot)


### PR DESCRIPTION
## Description

Prefer `MemoryFileSystem` files to `MockFile`s.  Use `MemoryFileSystem.test()` in tests.