### PR TITLE
Replace MockCache with Cache.test()

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -109,9 +109,11 @@ class GradleUtils {
       },
     );
     // Add the `gradle-wrapper.properties` file if it doesn't exist.
-    final File propertiesFile = directory.childFile(
-        globals.fs.path.join('gradle', 'wrapper', 'gradle-wrapper.properties'));
+    final Directory propertiesDirectory = directory.childDirectory(
+        globals.fs.path.join('gradle', 'wrapper'));
+    final File propertiesFile = propertiesDirectory.childFile('gradle-wrapper.properties');
     if (!propertiesFile.existsSync()) {
+      propertiesDirectory.createSync(recursive: true);
       final String gradleVersion = getGradleVersionForAndroidPlugin(directory);
       propertiesFile.writeAsStringSync('''
 distributionBase=GRADLE_USER_HOME

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -94,8 +94,8 @@ class Cache {
   /// [rootOverride] is configurable for testing.
   /// [artifacts] is configurable for testing.
   Cache({
-    @visibleForOverriding Directory rootOverride,
-    @visibleForOverriding List<ArtifactSet> artifacts,
+    @protected Directory rootOverride,
+    @protected List<ArtifactSet> artifacts,
     // TODO(jonahwilliams): make required once migrated to context-free.
     Logger logger,
     FileSystem fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -23,7 +23,6 @@ void main() {
     MemoryFileSystem memoryFileSystem;
     MockFlutterVersion mockFlutterVersion;
     MockGitTagVersion mockGitTagVersion;
-    MockCache mockCache;
     Directory outputDirectory;
     FakePlatform fakePlatform;
 
@@ -31,12 +30,17 @@ void main() {
       Cache.disableLocking();
     });
 
+    const String storageBaseUrl = 'https://fake.googleapis.com';
     setUp(() {
       memoryFileSystem = MemoryFileSystem.test();
       mockFlutterVersion = MockFlutterVersion();
       mockGitTagVersion = MockGitTagVersion();
-      mockCache = MockCache();
-      fakePlatform = FakePlatform()..operatingSystem = 'macos';
+      fakePlatform = FakePlatform(
+        operatingSystem: 'macos',
+        environment: <String, String>{
+          'FLUTTER_STORAGE_BASE_URL': storageBaseUrl,
+        },
+      );
 
       when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
       outputDirectory = globals.fs.systemTempDirectory
@@ -46,16 +50,20 @@ void main() {
     });
 
     group('podspec', () {
-      const String storageBaseUrl = 'https://fake.googleapis.com';
       const String engineRevision = '0123456789abcdef';
-      File licenseFile;
+      Cache cache;
 
       setUp(() {
+        final Directory rootOverride = memoryFileSystem.directory('cache');
+        cache = Cache.test(
+          rootOverride: rootOverride,
+          platform: fakePlatform,
+          fileSystem: memoryFileSystem,
+        );
+        rootOverride.childDirectory('bin').childDirectory('internal').childFile('engine.version')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(engineRevision);
         when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
-        when(mockCache.storageBaseUrl).thenReturn(storageBaseUrl);
-        when(mockCache.engineRevision).thenReturn(engineRevision);
-        licenseFile = memoryFileSystem.file('LICENSE');
-        when(mockCache.getLicenseFile()).thenReturn(licenseFile);
       });
 
       testUsingContext('version unknown', () async {
@@ -66,7 +74,7 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache,
+          cache: cache,
           verboseHelp: false,
         );
 
@@ -91,7 +99,7 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache,
+          cache: cache,
           verboseHelp: false,
         );
 
@@ -113,7 +121,7 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache,
+          cache: cache,
           verboseHelp: false,
         );
 
@@ -136,7 +144,7 @@ void main() {
 
           when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
 
-          licenseFile
+          cache.getLicenseFile()
             ..createSync(recursive: true)
             ..writeAsStringSync(licenseText);
         });
@@ -151,7 +159,7 @@ void main() {
               buildSystem: MockBuildSystem(),
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
-              cache: mockCache,
+              cache: cache,
               verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory, force: true);
@@ -174,7 +182,7 @@ void main() {
               buildSystem: MockBuildSystem(),
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
-              cache: mockCache,
+              cache: cache,
               verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
@@ -194,7 +202,7 @@ void main() {
               buildSystem: MockBuildSystem(),
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
-              cache: mockCache,
+              cache: cache,
               verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
@@ -212,7 +220,7 @@ void main() {
               buildSystem: MockBuildSystem(),
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
-              cache: mockCache,
+              cache: cache,
               verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
@@ -230,7 +238,7 @@ void main() {
               buildSystem: MockBuildSystem(),
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
-              cache: mockCache,
+              cache: cache,
               verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.release, outputDirectory);
@@ -250,5 +258,4 @@ void main() {
 
 class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockGitTagVersion extends Mock implements GitTagVersion {}
-class MockCache extends Mock implements Cache {}
 class MockBuildSystem extends Mock implements BuildSystem {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -24,11 +24,10 @@ void main() {
       Cache.disableLocking();
     });
 
-    MockCache cache;
+    Cache cache;
 
     setUp(() {
-      cache = MockCache();
-      when(cache.dyLdLibEntry).thenReturn(const MapEntry<String, String>('foo', 'bar'));
+      cache = Cache.test();
     });
 
     testUsingContext('returns 0 when called', () async {
@@ -192,5 +191,3 @@ class NoDevicesManager extends DeviceManager {
 @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
 }
-
-class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -29,7 +29,7 @@ void main() {
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
-      Cache: () => MockCache(),
+      Cache: () => Cache.test(),
     });
 
     testUsingContext('returns 1 when targeted device is not Android with --device-user', () async {
@@ -46,7 +46,7 @@ void main() {
       expect(() async => await createTestCommandRunner(command).run(<String>['install', '--device-user', '10']),
         throwsToolExit(message: '--device-user is only supported for Android'));
     }, overrides: <Type, Generator>{
-      Cache: () => MockCache(),
+      Cache: () => Cache.test(),
     });
 
     testUsingContext('returns 0 when iOS is connected and ready for an install', () async {
@@ -60,9 +60,7 @@ void main() {
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
-      Cache: () => MockCache(),
+      Cache: () => Cache.test(),
     });
   });
 }
-
-class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -21,13 +21,12 @@ import '../src/fake_devices.dart';
 import '../src/mocks.dart';
 
 void main() {
-  MockCache cache;
+  Cache cache;
   BufferLogger logger;
 
   setUp(() {
-    cache = MockCache();
+    cache = Cache.test();
     logger = BufferLogger.test();
-    when(cache.dyLdLibEntry).thenReturn(const MapEntry<String, String>('foo', 'bar'));
   });
 
   group('DeviceManager', () {
@@ -550,5 +549,4 @@ class TestDeviceManager extends DeviceManager {
 class MockProcess extends Mock implements Process {}
 class MockTerminal extends Mock implements AnsiTerminal {}
 class MockStdio extends Mock implements Stdio {}
-class MockCache extends Mock implements Cache {}
 class MockDeviceDiscovery extends Mock implements DeviceDiscovery {}

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -827,9 +827,10 @@ void main() {
   });
 
   testUsingContext('Correct flutter runner', () async {
-    final MockCache cache = MockCache();
+    final Cache cache = Cache.test(
+      processManager: FakeProcessManager.any(),
+    );
     final FileSystem fileSystem = MemoryFileSystem.test();
-    when(cache.getArtifactDirectory('flutter_runner')).thenReturn(fileSystem.directory('fuchsia'));
     final CachedArtifacts artifacts = CachedArtifacts(
       cache: cache,
       fileSystem: fileSystem,
@@ -1591,4 +1592,3 @@ class MockFuchsiaSdk extends Mock implements FuchsiaSdk {
 
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
 class MockFuchsiaWorkflow extends Mock implements FuchsiaWorkflow {}
-class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -37,7 +37,7 @@ void main() {
   group('IOSDevice', () {
     final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
     Artifacts mockArtifacts;
-    MockCache mockCache;
+    Cache cache;
     MockVmService mockVmService;
     Logger logger;
     IOSDeploy iosDeploy;
@@ -46,21 +46,19 @@ void main() {
 
     setUp(() {
       mockArtifacts = MockArtifacts();
-      mockCache = MockCache();
+      cache = Cache.test();
       mockVmService = MockVmService();
-      const MapEntry<String, String> dyLdLibEntry = MapEntry<String, String>('DYLD_LIBRARY_PATH', '/path/to/libs');
-      when(mockCache.dyLdLibEntry).thenReturn(dyLdLibEntry);
       logger = BufferLogger.test();
       iosDeploy = IOSDeploy(
         artifacts: mockArtifacts,
-        cache: mockCache,
+        cache: cache,
         logger: logger,
         platform: macPlatform,
         processManager: FakeProcessManager.any(),
       );
       iMobileDevice = IMobileDevice(
         artifacts: mockArtifacts,
-        cache: mockCache,
+        cache: cache,
         logger: logger,
         processManager: FakeProcessManager.any(),
       );
@@ -214,7 +212,7 @@ void main() {
       IOSDevicePortForwarder portForwarder;
       ForwardedPort forwardedPort;
       Artifacts mockArtifacts;
-      MockCache mockCache;
+      Cache cache;
       Logger logger;
       IOSDeploy iosDeploy;
       FileSystem nullFileSystem;
@@ -262,10 +260,10 @@ void main() {
         mockProcess3 = MockProcess();
         forwardedPort = ForwardedPort.withContext(123, 456, mockProcess3);
         mockArtifacts = MockArtifacts();
-        mockCache = MockCache();
+        cache = Cache.test();
         iosDeploy = IOSDeploy(
           artifacts: mockArtifacts,
-          cache: mockCache,
+          cache: cache,
           logger: logger,
           platform: macPlatform,
           processManager: FakeProcessManager.any(),
@@ -306,7 +304,7 @@ void main() {
   group('polling', () {
     MockXcdevice mockXcdevice;
     MockArtifacts mockArtifacts;
-    MockCache mockCache;
+    Cache cache;
     MockVmService mockVmService1;
     MockVmService mockVmService2;
     FakeProcessManager fakeProcessManager;
@@ -320,7 +318,7 @@ void main() {
     setUp(() {
       mockXcdevice = MockXcdevice();
       mockArtifacts = MockArtifacts();
-      mockCache = MockCache();
+      cache = Cache.test();
       mockVmService1 = MockVmService();
       mockVmService2 = MockVmService();
       logger = BufferLogger.test();
@@ -328,14 +326,14 @@ void main() {
       fakeProcessManager = FakeProcessManager.any();
       iosDeploy = IOSDeploy(
         artifacts: mockArtifacts,
-        cache: mockCache,
+        cache: cache,
         logger: logger,
         platform: macPlatform,
         processManager: fakeProcessManager,
       );
       iMobileDevice = IMobileDevice(
         artifacts: mockArtifacts,
-        cache: mockCache,
+        cache: cache,
         processManager: fakeProcessManager,
         logger: logger,
       );
@@ -605,7 +603,6 @@ void main() {
 
 class MockIOSApp extends Mock implements IOSApp {}
 class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
 class MockIOSDeploy extends Mock implements IOSDeploy {}
 class MockIOSWorkflow extends Mock implements IOSWorkflow {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -320,7 +320,6 @@ class FakeEnvironmentArtifact extends ArtifactSet {
   String get name => 'fake';
 
   @override
-  Future<void> update(ArtifactUpdater artifactUpdater) {
-    return null;
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -17,6 +17,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 void main () {
   Artifacts artifacts;
@@ -55,7 +56,7 @@ void main () {
             ].join(' '),
           ], environment: const <String, String>{
             'PATH': '/usr/bin:/usr/local/bin:/usr/bin',
-            'DYLD_LIBRARY_PATH': '/path/to/libs',
+            'DYLD_LIBRARY_PATH': '/path/to/libraries',
           },
           stdout: '(lldb)     run\nsuccess\nDid finish launching.',
         ),
@@ -293,7 +294,7 @@ IOSDeploy setUpIOSDeploy(ProcessManager processManager, {
   final Cache cache = Cache.test(
     platform: macPlatform,
     artifacts: <ArtifactSet>[
-      FakeEnvironmentArtifact(),
+      FakeDyldEnvironmentArtifact(),
     ],
   );
 
@@ -304,22 +305,4 @@ IOSDeploy setUpIOSDeploy(ProcessManager processManager, {
     artifacts: artifacts ?? Artifacts.test(),
     cache: cache,
   );
-}
-
-class FakeEnvironmentArtifact extends ArtifactSet {
-  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
-  @override
-  Map<String, String> get environment => <String, String>{
-    'DYLD_LIBRARY_PATH': '/path/to/libs'
-  };
-
-  @override
-  Future<bool> isUpToDate() => Future<bool>.value(true);
-
-  @override
-  String get name => 'fake';
-
-  @override
-  Future<void> update(ArtifactUpdater artifactUpdater) async {
-  }
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -337,7 +337,6 @@ class FakeEnvironmentArtifact extends ArtifactSet {
   String get name => 'fake';
 
   @override
-  Future<void> update(ArtifactUpdater artifactUpdater) {
-    return null;
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -35,7 +35,7 @@ void main() {
     artifacts = Artifacts.test();
     iosDeployPath = artifacts.getArtifactPath(Artifact.iosDeploy, platform: TargetPlatform.ios);
   });
-  
+
   testWithoutContext('IOSDevice.installApp calls ios-deploy correctly with USB', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final IOSApp iosApp = PrebuiltIOSApp(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -21,9 +21,10 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 const Map<String, String> kDyLdLibEntry = <String, String>{
-  'DYLD_LIBRARY_PATH': '/path/to/libs',
+  'DYLD_LIBRARY_PATH': '/path/to/libraries',
 };
 
 void main() {
@@ -291,7 +292,7 @@ IOSDevice setUpIOSDevice({
   final Cache cache = Cache.test(
     platform: platform,
     artifacts: <ArtifactSet>[
-      FakeEnvironmentArtifact(),
+      FakeDyldEnvironmentArtifact(),
     ],
   );
   return IOSDevice(
@@ -322,21 +323,3 @@ IOSDevice setUpIOSDevice({
 }
 
 class MockVmService extends Mock implements VmService {}
-
-class FakeEnvironmentArtifact extends ArtifactSet {
-  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
-  @override
-  Map<String, String> get environment => <String, String>{
-    'DYLD_LIBRARY_PATH': '/path/to/libs'
-  };
-
-  @override
-  Future<bool> isUpToDate() => Future<bool>.value(true);
-
-  @override
-  String get name => 'fake';
-
-  @override
-  Future<void> update(ArtifactUpdater artifactUpdater) async {
-  }
-}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -35,7 +35,7 @@ void main() {
     );
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'ios-deploy',
+        'Artifact.iosDeploy.TargetPlatform.ios',
         '--id',
         '1234',
         '--bundle',
@@ -65,7 +65,7 @@ void main() {
     );
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'ios-deploy',
+        'Artifact.iosDeploy.TargetPlatform.ios',
         '--id',
         '1234',
         '--bundle',
@@ -90,7 +90,7 @@ void main() {
     final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'ios-deploy',
+        'Artifact.iosDeploy.TargetPlatform.ios',
         '--id',
         '1234',
         '--uninstall_only',
@@ -113,7 +113,7 @@ void main() {
       final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: const <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '1234',
           '--exists',
@@ -125,7 +125,7 @@ void main() {
           'PATH': '/usr/bin:null',
           ...kDyLdLibEntry,
         }, onRun: () {
-          throw const ProcessException('ios-deploy', <String>[]);
+          throw const ProcessException('Artifact.iosDeploy.TargetPlatform.ios', <String>[]);
         })
       ]);
       final IOSDevice device = setUpIOSDevice(processManager: processManager);
@@ -139,7 +139,7 @@ void main() {
       final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '1234',
           '--exists',
@@ -163,7 +163,7 @@ void main() {
       final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '1234',
           '--exists',
@@ -190,7 +190,7 @@ void main() {
       const String stderr = '2020-03-26 17:48:43.484 ios-deploy[21518:5501783] [ !! ] Timed out waiting for device';
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '1234',
           '--exists',
@@ -222,7 +222,7 @@ void main() {
     );
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
-        'ios-deploy',
+        'Artifact.iosDeploy.TargetPlatform.ios',
         '--id',
         '1234',
         '--bundle',
@@ -232,7 +232,7 @@ void main() {
         'PATH': '/usr/bin:null',
         ...kDyLdLibEntry,
       }, onRun: () {
-        throw const ProcessException('ios-deploy', <String>[]);
+        throw const ProcessException('Artifact.iosDeploy.TargetPlatform.ios', <String>[]);
       })
     ]);
     final IOSDevice device = setUpIOSDevice(processManager: processManager);
@@ -245,7 +245,7 @@ void main() {
     final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
-        'ios-deploy',
+        'Artifact.iosDeploy.TargetPlatform.ios',
         '--id',
         '1234',
         '--uninstall_only',
@@ -255,7 +255,7 @@ void main() {
         'PATH': '/usr/bin:null',
         ...kDyLdLibEntry,
       }, onRun: () {
-        throw const ProcessException('ios-deploy', <String>[]);
+        throw const ProcessException('Artifact.iosDeploy.TargetPlatform.ios', <String>[]);
       })
     ]);
     final IOSDevice device = setUpIOSDevice(processManager: processManager);
@@ -276,11 +276,13 @@ IOSDevice setUpIOSDevice({
     operatingSystem: 'macos',
     environment: <String, String>{},
   );
-  final MockArtifacts artifacts = MockArtifacts();
-  final MockCache cache = MockCache();
-  when(cache.dyLdLibEntry).thenReturn(kDyLdLibEntry.entries.first);
-  when(artifacts.getArtifactPath(Artifact.iosDeploy, platform: anyNamed('platform')))
-    .thenReturn('ios-deploy');
+  final Artifacts artifacts = Artifacts.test();
+  final Cache cache = Cache.test(
+    platform: platform,
+    artifacts: <ArtifactSet>[
+      FakeEnvironmentArtifact(),
+    ],
+  );
   return IOSDevice(
     '1234',
     name: 'iPhone 1',
@@ -308,6 +310,23 @@ IOSDevice setUpIOSDevice({
   );
 }
 
-class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}
 class MockVmService extends Mock implements VmService {}
+
+class FakeEnvironmentArtifact extends ArtifactSet {
+  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
+  @override
+  Map<String, String> get environment => <String, String>{
+    'DYLD_LIBRARY_PATH': '/path/to/libs'
+  };
+
+  @override
+  Future<bool> isUpToDate() => Future<bool>.value(true);
+
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<void> update(ArtifactUpdater artifactUpdater) {
+    return null;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -114,7 +114,7 @@ void main() {
       processManager.addCommand(const FakeCommand(command: <String>[...kRunReleaseArgs, '-showBuildSettings']));
       processManager.addCommand(FakeCommand(
         command: <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '123',
           '--bundle',
@@ -176,7 +176,7 @@ void main() {
           ));
         processManager.addCommand(FakeCommand(
           command: <String>[
-            'ios-deploy',
+            'Artifact.iosDeploy.TargetPlatform.ios',
             '--id',
             '123',
             '--bundle',
@@ -250,7 +250,7 @@ void main() {
         ));
       processManager.addCommand(FakeCommand(
         command: <String>[
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '123',
           '--bundle',
@@ -307,16 +307,14 @@ IOSDevice setUpIOSDevice({
   Logger logger,
   ProcessManager processManager,
 }) {
-  const MapEntry<String, String> dyldLibraryEntry = MapEntry<String, String>(
-    'DYLD_LIBRARY_PATH',
-    '/path/to/libraries',
+  final Artifacts artifacts = Artifacts.test();
+  final Cache cache = Cache.test(
+    artifacts: <ArtifactSet>[
+      FakeEnvironmentArtifact(),
+    ],
   );
-  final MockCache cache = MockCache();
-  final MockArtifacts artifacts = MockArtifacts();
+
   logger ??= BufferLogger.test();
-  when(cache.dyLdLibEntry).thenReturn(dyldLibraryEntry);
-  when(artifacts.getArtifactPath(Artifact.iosDeploy, platform: anyNamed('platform')))
-    .thenReturn('ios-deploy');
   return IOSDevice('123',
     name: 'iPhone 1',
     sdkVersion: sdkVersion,
@@ -343,8 +341,25 @@ IOSDevice setUpIOSDevice({
   );
 }
 
-class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}
 class MockXcode extends Mock implements Xcode {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 class MockVmService extends Mock implements VmService {}
+
+class FakeEnvironmentArtifact extends ArtifactSet {
+  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
+  @override
+  Map<String, String> get environment => <String, String>{
+    'DYLD_LIBRARY_PATH': '/path/to/libraries'
+  };
+
+  @override
+  Future<bool> isUpToDate() => Future<bool>.value(true);
+
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<void> update(ArtifactUpdater artifactUpdater) {
+    return null;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -25,6 +25,7 @@ import 'package:vm_service/vm_service.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
 
 List<String> _xattrArgs(FlutterProject flutterProject) {
   return <String>[
@@ -322,7 +323,7 @@ IOSDevice setUpIOSDevice({
   artifacts ??= Artifacts.test();
   final Cache cache = Cache.test(
     artifacts: <ArtifactSet>[
-      FakeEnvironmentArtifact(),
+      FakeDyldEnvironmentArtifact(),
     ],
   );
 
@@ -356,21 +357,3 @@ IOSDevice setUpIOSDevice({
 class MockXcode extends Mock implements Xcode {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 class MockVmService extends Mock implements VmService {}
-
-class FakeEnvironmentArtifact extends ArtifactSet {
-  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
-  @override
-  Map<String, String> get environment => <String, String>{
-    'DYLD_LIBRARY_PATH': '/path/to/libraries'
-  };
-
-  @override
-  Future<bool> isUpToDate() => Future<bool>.value(true);
-
-  @override
-  String get name => 'fake';
-
-  @override
-  Future<void> update(ArtifactUpdater artifactUpdater) async {
-  }
-}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -371,7 +371,6 @@ class FakeEnvironmentArtifact extends ArtifactSet {
   String get name => 'fake';
 
   @override
-  Future<void> update(ArtifactUpdater artifactUpdater) {
-    return null;
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -68,6 +68,14 @@ final FakePlatform macPlatform = FakePlatform(
 );
 
 void main() {
+  Artifacts artifacts;
+  String iosDeployPath;
+
+  setUp(() {
+    artifacts = Artifacts.test();
+    iosDeployPath = artifacts.getArtifactPath(Artifact.iosDeploy, platform: TargetPlatform.ios);
+  });
+
   group('IOSDevice.startApp succeeds in release mode', () {
     FileSystem fileSystem;
     FakeProcessManager processManager;
@@ -104,6 +112,7 @@ void main() {
         fileSystem: fileSystem,
         processManager: processManager,
         logger: logger,
+        artifacts: artifacts,
       );
       setUpIOSProject(fileSystem);
       final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
@@ -114,7 +123,7 @@ void main() {
       processManager.addCommand(const FakeCommand(command: <String>[...kRunReleaseArgs, '-showBuildSettings']));
       processManager.addCommand(FakeCommand(
         command: <String>[
-          'Artifact.iosDeploy.TargetPlatform.ios',
+          iosDeployPath,
           '--id',
           '123',
           '--bundle',
@@ -155,6 +164,7 @@ void main() {
           fileSystem: fileSystem,
           processManager: processManager,
           logger: logger,
+          artifacts: artifacts,
         );
         setUpIOSProject(fileSystem);
         final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
@@ -176,7 +186,7 @@ void main() {
           ));
         processManager.addCommand(FakeCommand(
           command: <String>[
-            'Artifact.iosDeploy.TargetPlatform.ios',
+            iosDeployPath,
             '--id',
             '123',
             '--bundle',
@@ -228,6 +238,7 @@ void main() {
         fileSystem: fileSystem,
         processManager: processManager,
         logger: logger,
+        artifacts: artifacts,
       );
       setUpIOSProject(fileSystem);
       final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
@@ -250,7 +261,7 @@ void main() {
         ));
       processManager.addCommand(FakeCommand(
         command: <String>[
-          'Artifact.iosDeploy.TargetPlatform.ios',
+          iosDeployPath,
           '--id',
           '123',
           '--bundle',
@@ -306,8 +317,9 @@ IOSDevice setUpIOSDevice({
   FileSystem fileSystem,
   Logger logger,
   ProcessManager processManager,
+  Artifacts artifacts,
 }) {
-  final Artifacts artifacts = Artifacts.test();
+  artifacts ??= Artifacts.test();
   final Cache cache = Cache.test(
     artifacts: <ArtifactSet>[
       FakeEnvironmentArtifact(),

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -32,7 +32,7 @@ import '../../src/fakes.dart';
 
 const FakeCommand kDeployCommand = FakeCommand(
   command: <String>[
-    'ios-deploy',
+    'Artifact.iosDeploy.TargetPlatform.ios',
     '--id',
     '123',
     '--bundle',
@@ -48,7 +48,7 @@ const FakeCommand kDeployCommand = FakeCommand(
 // The command used to actually launch the app with args in release/profile.
 const FakeCommand kLaunchReleaseCommand = FakeCommand(
   command: <String>[
-    'ios-deploy',
+    'Artifact.iosDeploy.TargetPlatform.ios',
     '--id',
     '123',
     '--bundle',
@@ -67,7 +67,7 @@ const FakeCommand kLaunchReleaseCommand = FakeCommand(
 
 // The command used to just launch the app with args in debug.
 const FakeCommand kLaunchDebugCommand = FakeCommand(command: <String>[
-  'ios-deploy',
+  'Artifact.iosDeploy.TargetPlatform.ios',
   '--id',
   '123',
   '--bundle',
@@ -87,7 +87,7 @@ const FakeCommand kAttachDebuggerCommand = FakeCommand(command: <String>[
   '-t',
   '0',
   '/dev/null',
-  'ios-deploy',
+  'Artifact.iosDeploy.TargetPlatform.ios',
   '--id',
   '123',
   '--bundle',
@@ -382,7 +382,7 @@ void main() {
           '-t',
           '0',
           '/dev/null',
-          'ios-deploy',
+          'Artifact.iosDeploy.TargetPlatform.ios',
           '--id',
           '123',
           '--bundle',
@@ -482,20 +482,20 @@ IOSDevice setUpIOSDevice({
   ProcessManager processManager,
   VmServiceConnector vmServiceConnector,
 }) {
-  const MapEntry<String, String> dyldLibraryEntry = MapEntry<String, String>(
-    'DYLD_LIBRARY_PATH',
-    '/path/to/libraries',
-  );
-  final MockCache cache = MockCache();
-  final MockArtifacts artifacts = MockArtifacts();
+  final Artifacts artifacts = Artifacts.test();
   final FakePlatform macPlatform = FakePlatform(
     operatingSystem: 'macos',
     environment: <String, String>{},
   );
+
+  final Cache cache = Cache.test(
+    platform: macPlatform,
+    artifacts: <ArtifactSet>[
+      FakeEnvironmentArtifact(),
+    ],
+  );
+
   vmServiceConnector ??= (String uri, {Log log}) async => MockVmService();
-  when(cache.dyLdLibEntry).thenReturn(dyldLibraryEntry);
-  when(artifacts.getArtifactPath(Artifact.iosDeploy, platform: anyNamed('platform')))
-    .thenReturn('ios-deploy');
   return IOSDevice('123',
     name: 'iPhone 1',
     sdkVersion: sdkVersion,
@@ -526,7 +526,24 @@ class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
 class MockDeviceLogReader extends Mock implements DeviceLogReader  {}
 class MockUsage extends Mock implements Usage {}
 class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}
-class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}
 class MockVmService extends Mock implements VmService {}
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
+
+class FakeEnvironmentArtifact extends ArtifactSet {
+  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
+  @override
+  Map<String, String> get environment => <String, String>{
+    'DYLD_LIBRARY_PATH': '/path/to/libraries'
+  };
+
+  @override
+  Future<bool> isUpToDate() => Future<bool>.value(true);
+
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<void> update(ArtifactUpdater artifactUpdater) {
+    return null;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -491,7 +491,7 @@ IOSDevice setUpIOSDevice({
   final Cache cache = Cache.test(
     platform: macPlatform,
     artifacts: <ArtifactSet>[
-      FakeEnvironmentArtifact(),
+      FakeDyldEnvironmentArtifact(),
     ],
   );
 
@@ -528,21 +528,3 @@ class MockUsage extends Mock implements Usage {}
 class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}
 class MockVmService extends Mock implements VmService {}
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
-
-class FakeEnvironmentArtifact extends ArtifactSet {
-  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
-  @override
-  Map<String, String> get environment => <String, String>{
-    'DYLD_LIBRARY_PATH': '/path/to/libraries'
-  };
-
-  @override
-  Future<bool> isUpToDate() => Future<bool>.value(true);
-
-  @override
-  String get name => 'fake';
-
-  @override
-  Future<void> update(ArtifactUpdater artifactUpdater) async {
-  }
-}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -543,7 +543,6 @@ class FakeEnvironmentArtifact extends ArtifactSet {
   String get name => 'fake';
 
   @override
-  Future<void> update(ArtifactUpdater artifactUpdater) {
-    return null;
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -21,8 +21,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-
-const String _libimobiledevicePath = '/bin/cache/artifacts/libimobiledevice';
+import '../../src/fakes.dart';
 
 final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false);
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
@@ -48,7 +47,7 @@ void main() {
       artifacts = Artifacts.test();
       cache = Cache.test(
         artifacts: <ArtifactSet>[
-          FakeEnvironmentArtifact(),
+          FakeDyldEnvironmentArtifact(),
         ]);
     });
 
@@ -100,7 +99,7 @@ void main() {
           IOSDeviceInterface.usb,
         );
         verify(mockProcessManager.run(<String>['Artifact.idevicescreenshot.TargetPlatform.ios', outputFile.path, '--udid', '1234'],
-            environment: <String, String>{'DYLD_LIBRARY_PATH': _libimobiledevicePath},
+            environment: <String, String>{'DYLD_LIBRARY_PATH': '/path/to/libraries'},
             workingDirectory: null,
         ));
       });
@@ -122,7 +121,7 @@ void main() {
           IOSDeviceInterface.network,
         );
         verify(mockProcessManager.run(<String>['Artifact.idevicescreenshot.TargetPlatform.ios', outputFile.path, '--udid', '1234', '--network'],
-          environment: <String, String>{'DYLD_LIBRARY_PATH': _libimobiledevicePath},
+          environment: <String, String>{'DYLD_LIBRARY_PATH': '/path/to/libraries'},
           workingDirectory: null,
         ));
       });
@@ -484,21 +483,3 @@ Exited (sigterm)''',
 }
 
 class MockUsage extends Mock implements Usage {}
-
-class FakeEnvironmentArtifact extends ArtifactSet {
-  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
-  @override
-  Map<String, String> get environment => <String, String>{
-    'DYLD_LIBRARY_PATH': _libimobiledevicePath,
-  };
-
-  @override
-  Future<bool> isUpToDate() => Future<bool>.value(true);
-
-  @override
-  String get name => 'fake';
-
-  @override
-  Future<void> update(ArtifactUpdater artifactUpdater) async {
-  }
-}

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -23,13 +22,13 @@ import 'package:process/process.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 
+const String _libimobiledevicePath = '/bin/cache/artifacts/libimobiledevice';
+
 final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false);
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };
 
-class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 class MockIosProject extends Mock implements IosProject {}
@@ -42,18 +41,15 @@ void main() {
   });
 
   group('IMobileDevice', () {
-    final String libimobiledevicePath = globals.fs.path.join('bin', 'cache', 'artifacts', 'libimobiledevice');
-    final String idevicescreenshotPath = globals.fs.path.join(libimobiledevicePath, 'idevicescreenshot');
-    MockArtifacts mockArtifacts;
-    MockCache mockCache;
+    Artifacts artifacts;
+    Cache cache;
 
     setUp(() {
-      mockCache = MockCache();
-      mockArtifacts = MockArtifacts();
-      when(mockArtifacts.getArtifactPath(Artifact.idevicescreenshot, platform: anyNamed('platform'))).thenReturn(idevicescreenshotPath);
-      when(mockCache.dyLdLibEntry).thenReturn(
-        MapEntry<String, String>('DYLD_LIBRARY_PATH', libimobiledevicePath)
-      );
+      artifacts = Artifacts.test();
+      cache = Cache.test(
+        artifacts: <ArtifactSet>[
+          FakeEnvironmentArtifact(),
+        ]);
     });
 
     group('screenshot', () {
@@ -63,19 +59,19 @@ void main() {
       setUp(() {
         mockProcessManager = MockProcessManager();
         outputFile = MemoryFileSystem.test().file('image.png');
-        when(mockArtifacts.getArtifactPath(Artifact.idevicescreenshot, platform: anyNamed('platform'))).thenReturn(idevicescreenshotPath);
+        // when(mockArtifacts.getArtifactPath(Artifact.idevicescreenshot, platform: anyNamed('platform'))).thenReturn(idevicescreenshotPath);
       });
 
       testWithoutContext('error if idevicescreenshot is not installed', () async {
         // Let `idevicescreenshot` fail with exit code 1.
-        when(mockProcessManager.run(<String>[idevicescreenshotPath, outputFile.path],
-            environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+        when(mockProcessManager.run(<String>['Artifact.idevicescreenshot.TargetPlatform.ios', outputFile.path],
+            environment: <String, String>{'DYLD_LIBRARY_PATH': 'Artifact.idevicescreenshot.TargetPlatform.ios'},
             workingDirectory: null,
         )).thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(4, 1, '', '')));
 
         final IMobileDevice iMobileDevice = IMobileDevice(
-          artifacts: mockArtifacts,
-          cache: mockCache,
+          artifacts: artifacts,
+          cache: cache,
           processManager: mockProcessManager,
           logger: logger,
         );
@@ -92,8 +88,8 @@ void main() {
             (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(4, 0, '', '')));
 
         final IMobileDevice iMobileDevice = IMobileDevice(
-          artifacts: mockArtifacts,
-          cache: mockCache,
+          artifacts: artifacts,
+          cache: cache,
           processManager: mockProcessManager,
           logger: logger,
         );
@@ -103,8 +99,8 @@ void main() {
           '1234',
           IOSDeviceInterface.usb,
         );
-        verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputFile.path, '--udid', '1234'],
-            environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+        verify(mockProcessManager.run(<String>['Artifact.idevicescreenshot.TargetPlatform.ios', outputFile.path, '--udid', '1234'],
+            environment: <String, String>{'DYLD_LIBRARY_PATH': _libimobiledevicePath},
             workingDirectory: null,
         ));
       });
@@ -114,8 +110,8 @@ void main() {
             (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(4, 0, '', '')));
 
         final IMobileDevice iMobileDevice = IMobileDevice(
-          artifacts: mockArtifacts,
-          cache: mockCache,
+          artifacts: artifacts,
+          cache: cache,
           processManager: mockProcessManager,
           logger: logger,
         );
@@ -125,8 +121,8 @@ void main() {
           '1234',
           IOSDeviceInterface.network,
         );
-        verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputFile.path, '--udid', '1234', '--network'],
-          environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+        verify(mockProcessManager.run(<String>['Artifact.idevicescreenshot.TargetPlatform.ios', outputFile.path, '--udid', '1234', '--network'],
+          environment: <String, String>{'DYLD_LIBRARY_PATH': _libimobiledevicePath},
           workingDirectory: null,
         ));
       });
@@ -488,3 +484,22 @@ Exited (sigterm)''',
 }
 
 class MockUsage extends Mock implements Usage {}
+
+class FakeEnvironmentArtifact extends ArtifactSet {
+  FakeEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
+  @override
+  Map<String, String> get environment => <String, String>{
+    'DYLD_LIBRARY_PATH': _libimobiledevicePath,
+  };
+
+  @override
+  Future<bool> isUpToDate() => Future<bool>.value(true);
+
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<void> update(ArtifactUpdater artifactUpdater) {
+    return null;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -499,7 +499,6 @@ class FakeEnvironmentArtifact extends ArtifactSet {
   String get name => 'fake';
 
   @override
-  Future<void> update(ArtifactUpdater artifactUpdater) {
-    return null;
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -43,7 +43,7 @@ void main() {
       setUp(() {
         xcode = Xcode(
           logger: logger,
-          platform: FakePlatform(),
+          platform: MockPlatform(),
           fileSystem: MemoryFileSystem.test(),
           processManager: processManager,
           xcodeProjectInterpreter: MockXcodeProjectInterpreter(),
@@ -137,7 +137,7 @@ void main() {
         platform = MockPlatform();
         xcode = Xcode(
           logger: logger,
-          platform: FakePlatform(),
+          platform: platform,
           fileSystem: MemoryFileSystem.test(),
           processManager: fakeProcessManager,
           xcodeProjectInterpreter: mockXcodeProjectInterpreter,

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -43,7 +43,7 @@ void main() {
       setUp(() {
         xcode = Xcode(
           logger: logger,
-          platform: MockPlatform(),
+          platform: FakePlatform(),
           fileSystem: MemoryFileSystem.test(),
           processManager: processManager,
           xcodeProjectInterpreter: MockXcodeProjectInterpreter(),
@@ -79,8 +79,8 @@ void main() {
           logger: logger,
           xcode: mockXcode,
           platform: null,
-          artifacts: MockArtifacts(),
-          cache: MockCache(),
+          artifacts: Artifacts.test(),
+          cache: Cache.test(),
           iproxy: IProxy.test(logger: logger, processManager: processManager),
         );
       });
@@ -137,7 +137,7 @@ void main() {
         platform = MockPlatform();
         xcode = Xcode(
           logger: logger,
-          platform: platform,
+          platform: FakePlatform(),
           fileSystem: MemoryFileSystem.test(),
           processManager: fakeProcessManager,
           xcodeProjectInterpreter: mockXcodeProjectInterpreter,
@@ -338,20 +338,16 @@ void main() {
     group('xcdevice', () {
       XCDevice xcdevice;
       MockXcode mockXcode;
-      MockArtifacts mockArtifacts;
-      MockCache mockCache;
 
       setUp(() {
         mockXcode = MockXcode();
-        mockArtifacts = MockArtifacts();
-        mockCache = MockCache();
         xcdevice = XCDevice(
           processManager: fakeProcessManager,
           logger: logger,
           xcode: mockXcode,
           platform: null,
-          artifacts: mockArtifacts,
-          cache: mockCache,
+          artifacts: Artifacts.test(),
+          cache: Cache.test(),
           iproxy: IProxy.test(logger: logger, processManager: fakeProcessManager),
         );
       });
@@ -843,5 +839,3 @@ class MockXcode extends Mock implements Xcode {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 class MockPlatform extends Mock implements Platform {}
-class MockArtifacts extends Mock implements Artifacts {}
-class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 
 /// A fake implementation of the [DeviceLogReader].
@@ -38,5 +39,24 @@ class FakeDeviceLogReader extends DeviceLogReader {
   Future<void> dispose() async {
     _lineQueue.clear();
     await _linesController.close();
+  }
+}
+
+/// Environment with DYLD_LIBRARY_PATH=/path/to/libraries
+class FakeDyldEnvironmentArtifact extends ArtifactSet {
+  FakeDyldEnvironmentArtifact() : super(DevelopmentArtifact.iOS);
+  @override
+  Map<String, String> get environment => <String, String>{
+    'DYLD_LIBRARY_PATH': '/path/to/libraries'
+  };
+
+  @override
+  Future<bool> isUpToDate() => Future<bool>.value(true);
+
+  @override
+  String get name => 'fake';
+
+  @override
+  Future<void> update(ArtifactUpdater artifactUpdater) async {
   }
 }


### PR DESCRIPTION
## Description

1. Create a `Cache.test()` factory, set it to memory file system, fake platform, etc.
2. Replace MockCache with the new `Cache.test()` where possible.
3. Replace MockArtifacts with `Artifacts.test()` in a few related places.
3. Fix an exposed `injectGradleWrapperIfNeeded` bug where the `gradle-wrapper.properties` directory isn't recursively created before the child file.