### PR TITLE
[flutter_tools] prevent running analyze-size with split-debug-info

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -471,7 +471,8 @@ abstract class FlutterCommand extends Command<void> {
         'symbol files can be stored for later use. These symbol files contain '
         'the information needed to symbolize Dart stack traces. For an app built '
         "with this flag, the 'flutter symbolize' command with the right program "
-        'symbol file is required to obtain a human readable stack trace.',
+        'symbol file is required to obtain a human readable stack trace.\n'
+        'This flag cannot be combined with --analyze-size',
       valueHelp: 'v1.2.3/',
     );
   }
@@ -667,7 +668,8 @@ abstract class FlutterCommand extends Command<void> {
       help: 'Whether to produce additional profile information for artifact output size. '
         'This flag is only supported on release builds. When building for Android, a single '
         'ABI must be specified at a time with the --target-platform flag. When building for iOS, '
-        'only the symbols from the arm64 architecture are used to analyze code size.'
+        'only the symbols from the arm64 architecture are used to analyze code size.\n'
+        'This flag cannot be combined with --split-debug-info.'
     );
   }
 
@@ -749,6 +751,9 @@ abstract class FlutterCommand extends Command<void> {
     final BuildMode buildMode = forcedBuildMode ?? getBuildMode();
     if (buildMode != BuildMode.release && codeSizeDirectory != null) {
       throwToolExit('--analyze-size can only be used on release builds.');
+    }
+    if (codeSizeDirectory != null && splitDebugInfoPath != null) {
+      throwToolExit('--analyze-size cannot be combined with --split-debug-info.');
     }
 
     final bool treeShakeIcons = argParser.options.containsKey('tree-shake-icons')

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -81,4 +81,21 @@ void main() {
 
     expect(result.exitCode, 1);
   });
+
+  testWithoutContext('--analyze-size is not supported in combination with --split-debug-info', () async {
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+       ...getLocalEngineArguments(),
+      'build',
+      'apk',
+      '--analyze-size',
+      '--target-platform=android-arm64',
+      '--split-debug-info=infos'
+    ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
+
+    expect(result.stderr.toString(), contains('--analyze-size cannot be combined with --split-debug-info'));
+
+    expect(result.exitCode, 1);
+  });
 }


### PR DESCRIPTION
## Description

Running a build command with split debug info and analyze size causes a crash in the snapshot analysis library. Disable the combination of these two flags.

Fixes https://github.com/flutter/flutter/issues/66962