### PR TITLE
[flutter_tool] enable single widget reload optimization by default on dev

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -246,7 +246,7 @@ const Feature singleWidgetReload = Feature(
   ),
   dev: FeatureChannelSetting(
     available: true,
-    enabledByDefault: false,
+    enabledByDefault: true,
   ),
   beta: FeatureChannelSetting(
     available: true,


### PR DESCRIPTION
## Description

Continued gradual rollout of swr - dev is not that much riskier than master but will give much more data
