### PR TITLE
Snap the image offset to pixel grid when no scaling is applied

### DIFF
--- a/packages/flutter/test/widgets/image_rtl_test.dart
+++ b/packages/flutter/test/widgets/image_rtl_test.dart
@@ -205,7 +205,7 @@ void main() {
       ..translate(x: 50.0, y: 0.0)
       ..scale(x: -1.0, y: 1.0)
       ..translate(x: -50.0, y: 0.0)
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(0.0, 20.5, 16.0, 29.5))
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(0.0, 21.0, 16.0, 30.0))
       ..restore(),
     );
     expect(find.byType(Container), isNot(paints..scale()..scale()));
@@ -233,7 +233,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));
@@ -261,7 +261,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));
@@ -289,7 +289,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));
@@ -453,7 +453,7 @@ void main() {
       ..translate(x: 50.0, y: 0.0)
       ..scale(x: -1.0, y: 1.0)
       ..translate(x: -50.0, y: 0.0)
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(0.0, 20.5, 16.0, 29.5))
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(0.0, 21.0, 16.0, 30.0))
       ..restore(),
     );
     expect(find.byType(Container), isNot(paints..scale()..scale()));
@@ -479,7 +479,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));
@@ -505,7 +505,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));
@@ -531,7 +531,7 @@ void main() {
       EnginePhase.layout, // so that we don't try to paint the fake images
     );
     expect(find.byType(Container), paints
-      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 20.5, 100.0, 29.5)),
+      ..drawImageRect(source: const Rect.fromLTRB(0.0, 0.0, 16.0, 9.0), destination: const Rect.fromLTRB(84.0, 21.0, 100.0, 30.0)),
     );
     expect(find.byType(Container), isNot(paints..scale()));
     expect(find.byType(Container), isNot(paints..drawImageRect()..drawImageRect()));


### PR DESCRIPTION
## Description

See #66259 for an description, and an example of how it might look when the implementation is broken. Apart from fixing the broken cases, this change is intended to not result in any rendering difference.

## Related Issues

Close #66259

## Tests

It might be possible to test this behavior using snapshots (screenshots), but I don't think they are used for this repo yet.

image_rtl_test, which uses hardcoded expected values, was updated to use rounded values, adapting to the behavior of this change. Not the perfect thing to do, but I think it's OK due to the nature of snapshot-like tests.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
