### PR TITLE
[flutter] Update some tests in flutter/test

### DIFF
--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3204,7 +3204,7 @@ void main() {
         controller: textController,
         decoration: null,
         inputFormatters: <TextInputFormatter> [
-          BlacklistingTextInputFormatter(
+          FilteringTextInputFormatter.deny(
             RegExp(r'[a-z]'),
             replacementString: '#',
           ),
@@ -3253,11 +3253,11 @@ void main() {
         decoration: null,
         maxLines: 2,
         inputFormatters: <TextInputFormatter> [
-          BlacklistingTextInputFormatter(
+          FilteringTextInputFormatter.deny(
             RegExp(r'[a-z]'),
             replacementString: '12\n',
           ),
-          WhitelistingTextInputFormatter(RegExp(r'\n[0-9]')),
+          FilteringTextInputFormatter.allow(RegExp(r'\n[0-9]')),
         ],
       ),
     ));
@@ -3318,7 +3318,7 @@ void main() {
           controller: textController,
           decoration: null,
           inputFormatters: <TextInputFormatter> [
-            WhitelistingTextInputFormatter.digitsOnly,
+            FilteringTextInputFormatter.digitsOnly,
           ],
         ),
       ),
@@ -3639,7 +3639,7 @@ void main() {
         controller: textController,
         maxLength: 10,
         inputFormatters: <TextInputFormatter> [
-          BlacklistingTextInputFormatter(
+          FilteringTextInputFormatter.deny(
             RegExp(r'[a-z]'),
             replacementString: '#',
           ),

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -155,7 +155,7 @@ void main() {
   });
 
   test('cursorColor', () {
-    expect(ThemeData(cursorColor: Colors.red).cursorColor, Colors.red);
+    expect(const TextSelectionThemeData(cursorColor: Colors.red).cursorColor, Colors.red);
   });
 
   testWidgets('ThemeData.from a light color scheme sets appropriate values', (WidgetTester tester) async {
@@ -432,9 +432,9 @@ void main() {
       toggleButtonsTheme: otherTheme.toggleButtonsTheme,
       buttonColor: otherTheme.buttonColor,
       secondaryHeaderColor: otherTheme.secondaryHeaderColor,
-      textSelectionColor: otherTheme.textSelectionColor,
-      cursorColor: otherTheme.cursorColor,
-      textSelectionHandleColor: otherTheme.textSelectionHandleColor,
+      textSelectionColor: otherTheme.textSelectionTheme.selectionColor,
+      cursorColor: otherTheme.textSelectionTheme.cursorColor,
+      textSelectionHandleColor: otherTheme.textSelectionTheme.selectionHandleColor,
       backgroundColor: otherTheme.backgroundColor,
       dialogBackgroundColor: otherTheme.dialogBackgroundColor,
       indicatorColor: otherTheme.indicatorColor,
@@ -478,7 +478,6 @@ void main() {
       outlinedButtonTheme: otherTheme.outlinedButtonTheme,
       textSelectionTheme: otherTheme.textSelectionTheme,
       fixTextFieldOutlineLabel: otherTheme.fixTextFieldOutlineLabel,
-      useTextSelectionTheme: otherTheme.useTextSelectionTheme,
     );
 
     expect(themeDataCopy.brightness, equals(otherTheme.brightness));
@@ -507,11 +506,11 @@ void main() {
     expect(themeDataCopy.toggleButtonsTheme, equals(otherTheme.toggleButtonsTheme));
     expect(themeDataCopy.buttonColor, equals(otherTheme.buttonColor));
     expect(themeDataCopy.secondaryHeaderColor, equals(otherTheme.secondaryHeaderColor));
-    expect(themeDataCopy.textSelectionColor, equals(otherTheme.textSelectionColor));
-    expect(themeDataCopy.cursorColor, equals(otherTheme.cursorColor));
-    expect(themeDataCopy.textSelectionColor, equals(otherTheme.textSelectionColor));
-    expect(themeDataCopy.cursorColor, equals(otherTheme.cursorColor));
-    expect(themeDataCopy.textSelectionHandleColor, equals(otherTheme.textSelectionHandleColor));
+    expect(themeDataCopy.textSelectionTheme.selectionColor, equals(otherTheme.textSelectionTheme.selectionColor));
+    expect(themeDataCopy.textSelectionTheme.cursorColor, equals(otherTheme.textSelectionTheme.cursorColor));
+    expect(themeDataCopy.textSelectionTheme.selectionColor, equals(otherTheme.textSelectionTheme.selectionColor));
+    expect(themeDataCopy.textSelectionTheme.cursorColor, equals(otherTheme.textSelectionTheme.cursorColor));
+    expect(themeDataCopy.textSelectionTheme.selectionHandleColor, equals(otherTheme.textSelectionTheme.selectionHandleColor));
     expect(themeDataCopy.backgroundColor, equals(otherTheme.backgroundColor));
     expect(themeDataCopy.dialogBackgroundColor, equals(otherTheme.dialogBackgroundColor));
     expect(themeDataCopy.indicatorColor, equals(otherTheme.indicatorColor));
@@ -551,7 +550,6 @@ void main() {
     expect(themeDataCopy.outlinedButtonTheme, equals(otherTheme.outlinedButtonTheme));
     expect(themeDataCopy.textSelectionTheme, equals(otherTheme.textSelectionTheme));
     expect(themeDataCopy.fixTextFieldOutlineLabel, equals(otherTheme.fixTextFieldOutlineLabel));
-    expect(themeDataCopy.useTextSelectionTheme, equals(otherTheme.useTextSelectionTheme));
   });
 
   testWidgets('ThemeData.toString has less than 200 characters output', (WidgetTester tester) async {

--- a/packages/flutter/test/services/text_formatter_test.dart
+++ b/packages/flutter/test/services/text_formatter_test.dart
@@ -103,7 +103,7 @@ void main() {
 
     test('test filtering formatter, deny mode (deprecated names)', () {
       final TextEditingValue actualValue =
-          BlacklistingTextInputFormatter(RegExp(r'[a-z]'))
+          FilteringTextInputFormatter.deny(RegExp(r'[a-z]'))
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
@@ -136,7 +136,7 @@ void main() {
 
     test('test single line formatter (deprecated names)', () {
       final TextEditingValue actualValue =
-          BlacklistingTextInputFormatter.singleLineFormatter
+          FilteringTextInputFormatter.singleLineFormatter
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
@@ -168,7 +168,7 @@ void main() {
 
     test('test filtering formatter, allow mode (deprecated names)', () {
       final TextEditingValue actualValue =
-          WhitelistingTextInputFormatter(RegExp(r'[a-c]'))
+          FilteringTextInputFormatter.allow(RegExp(r'[a-c]'))
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
@@ -200,7 +200,7 @@ void main() {
 
     test('test digits only formatter (deprecated names)', () {
       final TextEditingValue actualValue =
-          WhitelistingTextInputFormatter.digitsOnly
+          FilteringTextInputFormatter.digitsOnly
               .formatEditUpdate(testOldValue, testNewValue);
 
       // Expecting
@@ -530,7 +530,7 @@ void main() {
     const TextEditingValue oldValue = TextEditingValue(text: '12345');
     const TextEditingValue newValue = TextEditingValue(text: '12345@');
 
-    final WhitelistingTextInputFormatter formatter = WhitelistingTextInputFormatter.digitsOnly;
+    final TextInputFormatter formatter = FilteringTextInputFormatter.digitsOnly;
     final TextEditingValue formatted = formatter.formatEditUpdate(oldValue, newValue);
 
     // assert that we are passing digits only at the first time
@@ -585,8 +585,8 @@ void main() {
     TextEditingValue oldValue = collapsedValue('123', 0);
     TextEditingValue newValue = collapsedValue('123456', 6);
 
-    final WhitelistingTextInputFormatter formatter =
-        WhitelistingTextInputFormatter.digitsOnly;
+    final TextInputFormatter formatter =
+        FilteringTextInputFormatter.digitsOnly;
     TextEditingValue formatted = formatter.formatEditUpdate(oldValue,
         newValue);
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -453,7 +453,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
-            overflow: Overflow.visible,
             clipBehavior: Clip.none,
             children: const <Widget>[
               SizedBox(


### PR DESCRIPTION
## Description

In this PR, I have updated the tests which were using deprecated API's in `packages/flutter/test/material/text_field_test.dart`, `packages/flutter/test/material/theme_data_test.dart`, `packages/flutter/test/services/text_formatter_test.dart` and `packages/flutter/test/widgets/stack_test.dart` files.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
