### PR TITLE
[web] Respond with 404 to non-found asset or package files

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -406,6 +406,11 @@ class WebAssetServer implements AssetReader {
     }
 
     if (!file.existsSync()) {
+      // Paths starting with these prefixes should've been resolved above.
+      if (requestPath.startsWith('assets/') ||
+          requestPath.startsWith('packages/')) {
+        return shelf.Response.notFound('');
+      }
       return _serveIndex();
     }
 


### PR DESCRIPTION
## Description

Requests for assets and packages should not return `index.html`. If the asset of the package file is not found, we should return 404.

May help avoid some issues similar to https://github.com/flutter/flutter/issues/67053