### PR TITLE
[null-safety] allow web shard to compile null-safe tests.

### DIFF
--- a/packages/_flutter_web_build_script/lib/build_script.dart
+++ b/packages/_flutter_web_build_script/lib/build_script.dart
@@ -261,6 +261,7 @@ class FlutterWebTestBootstrapBuilder implements Builder {
 
     if (metadata.testOn.evaluate(SuitePlatform(Runtime.chrome))) {
       await buildStep.writeAsString(id.addExtension('.browser_test.dart'), '''
+// @dart = 2.8
 import 'dart:ui' as ui;
 import 'dart:html';
 import 'dart:js';

--- a/packages/flutter_tools/lib/src/isolated/web_compilation_delegate.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_compilation_delegate.dart
@@ -223,6 +223,7 @@ class BuildDaemonCreator {
       '--packages=$buildScriptPackages',
       buildScript,
       'daemon',
+      '--enable-experiment=non-nullable',
       '--skip-build-script-check',
       '--define', 'flutter_tools:ddc=flutterWebSdk=$flutterWebSdk',
       '--define', 'flutter_tools:entrypoint=flutterWebSdk=$flutterWebSdk',


### PR DESCRIPTION
## Description

To enable null-safe migration of framework shard.