### PR TITLE
5x startup test repitition to reduce noise

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -454,7 +454,7 @@ class StartupTest {
       final String deviceId = (await devices.workingDevice).deviceId;
       await flutter('packages', options: <String>['get']);
 
-      const int iterations = 3;
+      const int iterations = 15;
       final List<Map<String, dynamic>> results = <Map<String, dynamic>>[];
       for (int i = 0; i < iterations; ++i) {
         await flutter('run', options: <String>[


### PR DESCRIPTION
The current test is still too noisy for Skia perf's step-function-based
alert algorithm to detect performance regressions. See
https://flutter-flutter-perf.skia.org/e/?begin=1596666370&end=1601603433&queries=test%3Dcomplex_layout__start_up&requestType=0
for an example where we fail to detect a regression for commit 1510865fb.

Currently, a startup test runs for about 1 minute. After the change, the
test should run for about 5 minutes or less because some setup steps
don't need to be repeated 5 times.
