### PR TITLE
Invalid dates when switching back to calendar mode in the date range picker

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
@@ -303,6 +303,17 @@ class _DateRangePickerDialogState extends State<_DateRangePickerDialog> {
           break;
 
         case DatePickerEntryMode.input:
+          // Validate the range dates
+          if (_selectedStart != null &&
+              (_selectedStart!.isBefore(widget.firstDate) || _selectedStart!.isAfter(widget.lastDate))) {
+            _selectedStart = null;
+            // With no valid start date, having an end date makes no sense for the UI.
+            _selectedEnd = null;
+          }
+          if (_selectedEnd != null &&
+              (_selectedEnd!.isBefore(widget.firstDate) || _selectedEnd!.isAfter(widget.lastDate))) {
+            _selectedEnd = null;
+          }
           // If invalid range (start after end), then just use the start date
           if (_selectedStart != null && _selectedEnd != null && _selectedStart!.isAfter(_selectedEnd!)) {
             _selectedEnd = null;
@@ -313,7 +324,7 @@ class _DateRangePickerDialogState extends State<_DateRangePickerDialog> {
     });
   }
 
-  void _handleStartDateChanged(DateTime date) {
+  void _handleStartDateChanged(DateTime? date) {
     setState(() => _selectedStart = date);
   }
 

--- a/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
@@ -64,10 +64,10 @@ class InputDateRangePicker extends StatefulWidget {
   final DateTime lastDate;
 
   /// Called when the user changes the start date of the selected range.
-  final ValueChanged<DateTime>? onStartDateChanged;
+  final ValueChanged<DateTime?>? onStartDateChanged;
 
   /// Called when the user changes the end date of the selected range.
-  final ValueChanged<DateTime>? onEndDateChanged;
+  final ValueChanged<DateTime?>? onEndDateChanged;
 
   /// The text that is displayed at the top of the header.
   ///
@@ -205,7 +205,7 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
     setState(() {
       _startInputText = text;
       _startDate = _parseDate(text);
-      widget.onStartDateChanged?.call(_startDate!);
+      widget.onStartDateChanged?.call(_startDate);
     });
     if (widget.autovalidate) {
       validate();
@@ -216,7 +216,7 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
     setState(() {
       _endInputText = text;
       _endDate = _parseDate(text);
-      widget.onEndDateChanged?.call(_endDate!);
+      widget.onEndDateChanged?.call(_endDate);
     });
     if (widget.autovalidate) {
       validate();

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -256,6 +256,52 @@ void main() {
     });
   });
 
+  group('Toggle from input entry mode validates dates', () {
+    setUp(() {
+      initialEntryMode = DatePickerEntryMode.input;
+    });
+
+    testWidgets('Invalid start date', (WidgetTester tester) async {
+      // Invalid start date should have neither a start nor end date selected in
+      // calendar mode
+      await preparePicker(tester, (Future<DateTimeRange> range) async {
+        await tester.enterText(find.byType(TextField).at(0), '12/27/1918');
+        await tester.enterText(find.byType(TextField).at(1), '12/25/2016');
+        await tester.tap(find.byIcon(Icons.calendar_today));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Start Date'), findsOneWidget);
+        expect(find.text('End Date'), findsOneWidget);
+      });
+    });
+
+    testWidgets('Invalid end date', (WidgetTester tester) async {
+      // Invalid end date should only have a start date selected
+      await preparePicker(tester, (Future<DateTimeRange> range) async {
+        await tester.enterText(find.byType(TextField).at(0), '12/24/2016');
+        await tester.enterText(find.byType(TextField).at(1), '12/25/2050');
+        await tester.tap(find.byIcon(Icons.calendar_today));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Dec 24'), findsOneWidget);
+        expect(find.text('End Date'), findsOneWidget);
+      });
+    });
+
+    testWidgets('Invalid range', (WidgetTester tester) async {
+      // Start date after end date should just use the start date
+      await preparePicker(tester, (Future<DateTimeRange> range) async {
+        await tester.enterText(find.byType(TextField).at(0), '12/25/2016');
+        await tester.enterText(find.byType(TextField).at(1), '12/24/2016');
+        await tester.tap(find.byIcon(Icons.calendar_today));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Dec 25'), findsOneWidget);
+        expect(find.text('End Date'), findsOneWidget);
+      });
+    });
+  });
+
   testWidgets('OK Cancel button layout', (WidgetTester tester) async {
      Widget buildFrame(TextDirection textDirection) {
        return MaterialApp(


### PR DESCRIPTION
## Description

If the user enters invalid dates in the input date range picker and switches back to the calendar mode, it will crash (#66416). This PR validates the dates on this switch and adjusts the selection to the calendar appropriately.

## Related Issues

Fixes: #66416

## Tests

I added a group of tests that check various edge cases for invalid dates and ranges when switching back to calendar mode.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
