### PR TITLE
Make CupertinoTabView restorable

### DIFF
--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -9,9 +9,9 @@ import 'route.dart';
 
 /// A single tab view with its own [Navigator] state and history.
 ///
-/// A typical tab view used as the content of each tab in a [CupertinoTabScaffold]
-/// where multiple tabs with parallel navigation states and history can
-/// co-exist.
+/// A typical tab view is used as the content of each tab in a
+/// [CupertinoTabScaffold] where multiple tabs with parallel navigation states
+/// and history can co-exist.
 ///
 /// [CupertinoTabView] configures the top-level [Navigator] to search for routes
 /// in the following order:
@@ -49,6 +49,7 @@ class CupertinoTabView extends StatefulWidget {
     this.onGenerateRoute,
     this.onUnknownRoute,
     this.navigatorObservers = const <NavigatorObserver>[],
+    this.restorationScopeId,
   }) : assert(navigatorObservers != null),
        super(key: key);
 
@@ -125,6 +126,12 @@ class CupertinoTabView extends StatefulWidget {
   /// This list of observers is not shared with ancestor or descendant [Navigator]s.
   final List<NavigatorObserver> navigatorObservers;
 
+  /// Restoration ID to save and restore the state of the [Navigator] built by
+  /// this [CupertinoTabView].
+  ///
+  /// {@macro flutter.widgets.navigator.restorationScopeId}
+  final String? restorationScopeId;
+
   @override
   _CupertinoTabViewState createState() {
     return _CupertinoTabViewState();
@@ -164,6 +171,7 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
       onGenerateRoute: _onGenerateRoute,
       onUnknownRoute: _onUnknownRoute,
       observers: _navigatorObservers,
+      restorationScopeId: widget.restorationScopeId,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1544,6 +1544,12 @@ class Navigator extends StatefulWidget {
   ///
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
+  ///  * [RestorationMixin], which contains a runnable code sample showcasing
+  ///    state restoration in Flutter.
+  ///  * [Navigator], which explains under the heading "state restoration"
+  ///    how and under what conditions the navigator restores its state.
+  ///  * [Navigator.restorablePush], which includes an example showcasing how
+  ///    to push a restorable route unto the navigator.
   /// {@endtemplate}
   final String? restorationScopeId;
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1528,6 +1528,7 @@ class Navigator extends StatefulWidget {
   /// Restoration ID to save and restore the state of the navigator, including
   /// its history.
   ///
+  /// {@template flutter.widgets.navigator.restorationScopeId}
   /// If a restoration ID is provided, the navigator will persist its internal
   /// state (including the route history as well as the restorable state of the
   /// routes) and restore it during state restoration.
@@ -1543,6 +1544,7 @@ class Navigator extends StatefulWidget {
   ///
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
+  /// {@endtemplate}
   final String? restorationScopeId;
 
   /// The name for the default route of the application.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1539,6 +1539,8 @@ class Navigator extends StatefulWidget {
   ///
   /// The state is persisted in a [RestorationBucket] claimed from
   /// the surrounding [RestorationScope] using the provided restoration ID.
+  /// Within that bucket, the [Navigator] also creates a new [RestorationScope]
+  /// for its children (the [Route]s).
   ///
   /// See also:
   ///

--- a/packages/flutter/test/cupertino/tab_test.dart
+++ b/packages/flutter/test/cupertino/tab_test.dart
@@ -237,4 +237,91 @@ void main() {
       '   callback returned null. Such callbacks must never return null.\n'
     ));
   });
+
+  testWidgets('Navigator of CupertinoTabView restores state', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        restorationScopeId: 'app',
+        home: CupertinoTabView(
+          restorationScopeId: 'tab',
+          builder: (BuildContext context) => CupertinoButton(
+            child: const Text('home'),
+            onPressed: () {
+              Navigator.of(context).restorablePushNamed('/2');
+            },
+          ),
+          routes: <String, WidgetBuilder>{
+            '/2' : (BuildContext context) => CupertinoButton(
+              child: const Text('second route'),
+              onPressed: () {
+                Navigator.of(context).restorablePush(_routeBuilder, arguments: 'yay');
+              },
+            ),
+          }
+        ),
+      ),
+    );
+
+    expect(find.text('home'), findsOneWidget);
+    await tester.tap(find.text('home'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsOneWidget);
+
+    await tester.tap(find.text('second route'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsNothing);
+    expect(find.text('third route: yay'), findsOneWidget);
+
+    final TestRestorationData data = await tester.getRestorationData();
+
+    await tester.restartAndRestore();
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsNothing);
+    expect(find.text('third route: yay'), findsOneWidget);
+
+    Navigator.of(tester.element(find.text('third route: yay'))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsOneWidget);
+    expect(find.text('third route: yay'), findsNothing);
+
+    Navigator.of(tester.element(find.text('second route'))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsOneWidget);
+    expect(find.text('second route'), findsNothing);
+    expect(find.text('third route: yay'), findsNothing);
+
+    await tester.restoreFrom(data);
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsNothing);
+    expect(find.text('third route: yay'), findsOneWidget);
+
+    Navigator.of(tester.element(find.text('third route: yay'))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsNothing);
+    expect(find.text('second route'), findsOneWidget);
+    expect(find.text('third route: yay'), findsNothing);
+
+    Navigator.of(tester.element(find.text('second route'))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsOneWidget);
+    expect(find.text('second route'), findsNothing);
+    expect(find.text('third route: yay'), findsNothing);
+  });
+}
+
+Route<void> _routeBuilder(BuildContext context, Object arguments) {
+  return CupertinoPageRoute<void>(
+    builder: (BuildContext context) => Text('third route: $arguments'),
+  );
 }

--- a/packages/flutter/test/cupertino/tab_test.dart
+++ b/packages/flutter/test/cupertino/tab_test.dart
@@ -251,12 +251,7 @@ void main() {
             },
           ),
           routes: <String, WidgetBuilder>{
-            '/2' : (BuildContext context) => CupertinoButton(
-              child: const Text('second route'),
-              onPressed: () {
-                Navigator.of(context).restorablePush(_routeBuilder, arguments: 'yay');
-              },
-            ),
+            '/2' : (BuildContext context) => const Text('second route'),
           }
         ),
       ),
@@ -269,59 +264,28 @@ void main() {
     expect(find.text('home'), findsNothing);
     expect(find.text('second route'), findsOneWidget);
 
-    await tester.tap(find.text('second route'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('home'), findsNothing);
-    expect(find.text('second route'), findsNothing);
-    expect(find.text('third route: yay'), findsOneWidget);
-
     final TestRestorationData data = await tester.getRestorationData();
 
     await tester.restartAndRestore();
 
     expect(find.text('home'), findsNothing);
-    expect(find.text('second route'), findsNothing);
-    expect(find.text('third route: yay'), findsOneWidget);
-
-    Navigator.of(tester.element(find.text('third route: yay'))).pop();
-    await tester.pumpAndSettle();
-
-    expect(find.text('home'), findsNothing);
     expect(find.text('second route'), findsOneWidget);
-    expect(find.text('third route: yay'), findsNothing);
 
     Navigator.of(tester.element(find.text('second route'))).pop();
     await tester.pumpAndSettle();
 
     expect(find.text('home'), findsOneWidget);
     expect(find.text('second route'), findsNothing);
-    expect(find.text('third route: yay'), findsNothing);
 
     await tester.restoreFrom(data);
 
     expect(find.text('home'), findsNothing);
-    expect(find.text('second route'), findsNothing);
-    expect(find.text('third route: yay'), findsOneWidget);
-
-    Navigator.of(tester.element(find.text('third route: yay'))).pop();
-    await tester.pumpAndSettle();
-
-    expect(find.text('home'), findsNothing);
     expect(find.text('second route'), findsOneWidget);
-    expect(find.text('third route: yay'), findsNothing);
 
     Navigator.of(tester.element(find.text('second route'))).pop();
     await tester.pumpAndSettle();
 
     expect(find.text('home'), findsOneWidget);
     expect(find.text('second route'), findsNothing);
-    expect(find.text('third route: yay'), findsNothing);
   });
-}
-
-Route<void> _routeBuilder(BuildContext context, Object arguments) {
-  return CupertinoPageRoute<void>(
-    builder: (BuildContext context) => Text('third route: $arguments'),
-  );
 }


### PR DESCRIPTION
## Description

`CupertinoTabView` can now restore the state of its internal Navigator if provided with e restoration ID.

## Related Issues

https://github.com/flutter/flutter/issues/62916

## Tests

I added the following tests:

* Navigator of CupertinoTabView restores state

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
