### PR TITLE
reverted to old getScrollPhysics from 1.17 flutter version

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -91,12 +91,12 @@ class ScrollBehavior {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        return _bouncingPhysics;
+        return const BouncingScrollPhysics();
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return _clampingPhysics;
+        return const ClampingScrollPhysics();
     }
   }
 


### PR DESCRIPTION
## Description
I reverted code to 1.19 candidate 0 to solve overscroll pagination bug, to be honest I was really upsad during last days while solving it from my app side, pls merge it, or fix the problem!

## Related Issues
https://github.com/flutter/flutter/issues/62890
