### PR TITLE
Add drawer callbacks (both drawer and endDrawer) to Scaffold widget

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1031,7 +1031,9 @@ class Scaffold extends StatefulWidget {
     this.floatingActionButtonAnimator,
     this.persistentFooterButtons,
     this.drawer,
+    this.drawerCallback,
     this.endDrawer,
+    this.endDrawerCallback,
     this.bottomNavigationBar,
     this.bottomSheet,
     this.backgroundColor,
@@ -1195,6 +1197,9 @@ class Scaffold extends StatefulWidget {
   /// {@end-tool}
   final Widget? drawer;
 
+  // The callback when drawer is opened or closed
+  final DrawerCallback? drawerCallback;
+
   /// A panel displayed to the side of the [body], often hidden on mobile
   /// devices. Swipes in from right-to-left ([TextDirection.ltr]) or
   /// left-to-right ([TextDirection.rtl])
@@ -1254,6 +1259,9 @@ class Scaffold extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final Widget? endDrawer;
+  
+  // The callback when drawer is opened or closed
+  final DrawerCallback? endDrawerCallback;
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.
   ///
@@ -1621,12 +1629,14 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   bool get isEndDrawerOpen => _endDrawerOpened;
 
   void _drawerOpenedCallback(bool isOpened) {
+    widget.drawerCallback?.call(isOpened);
     setState(() {
       _drawerOpened = isOpened;
     });
   }
 
   void _endDrawerOpenedCallback(bool isOpened) {
+    widget.endDrawerCallback?.call(isOpened);
     setState(() {
       _endDrawerOpened = isOpened;
     });

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1197,7 +1197,7 @@ class Scaffold extends StatefulWidget {
   /// {@end-tool}
   final Widget? drawer;
 
-  // The callback when drawer is opened or closed
+  /// The callback when drawer is opened or closed
   final DrawerCallback? drawerCallback;
 
   /// A panel displayed to the side of the [body], often hidden on mobile
@@ -1260,7 +1260,7 @@ class Scaffold extends StatefulWidget {
   /// {@end-tool}
   final Widget? endDrawer;
   
-  // The callback when drawer is opened or closed
+  /// The callback when endDrawer is opened or closed
   final DrawerCallback? endDrawerCallback;
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.


### PR DESCRIPTION
## Description

The change contains the addition of drawer callbacks in `Scaffold` widget. These are useful for the detection of the drawer open or closed, implemented in Scaffold. This accounts for both `drawer` and `endDrawer` having their callbacks namely `drawerCallback` and `endDrawerCallback` respectively in `Scaffold` constructor properly. There might be multiple reason when we want to change the state of the widget according to the state of the drawer, open or closed. It is always better to have a simple callback in `Scaffold` rather than letting users explicitly write a bunch of code to handle this.

Implementation: **drawerCallback and endDrawerCallback are added property in the constructor which provides with the state of the drawer whether opened or closed.**
```
  return Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      drawer: NavDrawer(),
      drawerCallback: (isOpen) {
        // write your callback implementation here
        print('drawer callback isOpen=$isOpen');
      },
      endDrawer: NavDrawerEnd(),
      endDrawerCallback: (isOpen) {
        // write your callback implementation here
        print('end drawer callback isOpen=$isOpen');
      },
      body:
      ...
```

## Related Issues

[#43512](https://github.com/flutter/flutter/issues/43512)
[#14510](https://github.com/flutter/flutter/issues/14510)

## Tests

I added the following tests:

*I have used the above snippet to test the callback implementation. The following test applies for both `drawer` and `endDrawer`*

| Use case | Result |
| ------------- | ------------- |
| Hamburger menu is clicked | Drawer opens, prints "drawer callback isOpen=true" |
| Drawer is closed by clicking outside drawer | Drawer closes, prints "drawer callback isOpen=false" |
| Back button is pressed in drawer opened state | Drawer closes, prints "drawer callback isOpen=false" |

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
