### PR TITLE
Warn tapping of non-visible area when test

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -761,6 +761,12 @@ abstract class WidgetController {
       kind: kind,
       buttons: buttons,
     );
+
+    final size = binding.window.physicalSize / binding.window.devicePixelRatio;
+    if (!size.contains(downLocation)) {
+      print('Trying to tap non-visible area.');
+    }
+
     await result.down(downLocation);
     return result;
   }


### PR DESCRIPTION
## Description

Hi,

In unit tests, finding widget (`find.text('foo')`) works even if it's invisible but tapping it (`tester.tap`) does nothing. This behavior makes it harder to write tests. It would be nice if `flutter test` warns tapping of non-visible area.

NOTE: I honestly don't think the change is well-written but mainly wanted to get attention from the maintainers.

Thank you.

## Related Issues

https://github.com/flutter/flutter/issues/48463.

## Tests

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*