### PR TITLE
Remove goldens request timeout

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -888,7 +888,7 @@ class TestGoldenComparator {
     final TestGoldenComparatorProcess process = await _processForTestFile(testUri);
     process.sendCommand(imageFile, goldenKey, updateGoldens);
 
-    final Map<String, dynamic> result = await process.getResponse().timeout(const Duration(seconds: 20));
+    final Map<String, dynamic> result = await process.getResponse();
 
     if (result == null) {
       return 'unknown error';


### PR DESCRIPTION
Caused a flake seen here: 

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8867265324557441584/+/steps/run_test.dart_for_web_tests_shard_and_subshard_6/0/stdout#L5678_0