### PR TITLE
[flutter_tools] disable source maps by default for release builds, enable for run and with command line arg

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -37,6 +37,13 @@ class BuildWebCommand extends BuildSubCommand {
       help: 'Disable dynamic generation of code in the generated output. '
         'This is necessary to satisfy CSP restrictions (see http://www.w3.org/TR/CSP/).'
     );
+    argParser.addFlag(
+      'source-maps',
+      defaultsTo: false,
+      help: 'Whether to generate a sourcemap file. These can be used by browsers '
+      'To view the original source code of a compiled and minified Dart application. '
+      'Defaults to false.'
+    );
     argParser.addOption('pwa-strategy',
       defaultsTo: kOfflineFirst,
       help:
@@ -88,6 +95,7 @@ class BuildWebCommand extends BuildSubCommand {
       boolArg('web-initialize-platform'),
       boolArg('csp'),
       stringArg('pwa-strategy'),
+      boolArg('source-maps')
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -41,8 +41,8 @@ class BuildWebCommand extends BuildSubCommand {
       'source-maps',
       defaultsTo: false,
       help: 'Whether to generate a sourcemap file. These can be used by browsers '
-      'To view the original source code of a compiled and minified Dart application. '
-      'Defaults to false.'
+      'To view and debug the original source code of a compiled and minified Dart '
+      'application. Defaults to false (no sourcemaps produced).'
     );
     argParser.addOption('pwa-strategy',
       defaultsTo: kOfflineFirst,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -531,6 +531,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
             debuggingOptions.initializePlatform,
             false,
             kNoneWorker,
+            true,
           );
         }
         await device.device.startApp(
@@ -601,6 +602,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           debuggingOptions.initializePlatform,
           false,
           kNoneWorker,
+          true,
         );
       } on ToolExit {
         return OperationResult(1, 'Failed to recompile application.');

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -57,6 +57,7 @@ void main() {
       false,
       false,
       null,
+      true,
     ), throwsToolExit());
   }, overrides: <Type, Generator>{
     Platform: () => fakePlatform,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -305,6 +305,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -316,6 +317,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-O4',
         '--no-minify',
         '--csp',
@@ -339,6 +341,7 @@ void main() {
         ...kDart2jsLinuxArgs,
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -351,6 +354,7 @@ void main() {
         ...kDart2jsLinuxArgs,
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-O4',
         '--no-minify',
         '-o',
@@ -370,6 +374,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -381,6 +386,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.profile=true',
+        '--no-source-maps',
         '-O4',
         '--no-minify',
         '-o',
@@ -400,6 +406,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.product=true',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -411,6 +418,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.product=true',
+        '--no-source-maps',
         '-O4',
         '-o',
         environment.buildDir.childFile('main.dart.js').absolute.path,
@@ -430,6 +438,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.product=true',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -441,6 +450,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '-Ddart.vm.product=true',
+        '--no-source-maps',
         '-O3',
         '-o',
         environment.buildDir.childFile('main.dart.js').absolute.path,
@@ -481,6 +491,7 @@ void main() {
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -494,6 +505,7 @@ void main() {
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
+        '--no-source-maps',
         '-O4',
         '-o',
         environment.buildDir.childFile('main.dart.js').absolute.path,
@@ -506,6 +518,37 @@ void main() {
     ProcessManager: () => processManager,
   }));
 
+  test('Dart2JSTarget can enable source maps', () => testbed.run(() async {
+    environment.defines[kBuildMode] = 'release';
+    environment.defines[kSourceMapsEnabled] = 'true';
+    processManager.addCommand(FakeCommand(
+      command: <String>[
+        ...kDart2jsLinuxArgs,
+        '-Ddart.vm.product=true',
+        '-o',
+        environment.buildDir.childFile('app.dill').absolute.path,
+        '--packages=.packages',
+       '--cfe-only',
+        environment.buildDir.childFile('main.dart').absolute.path,
+      ]
+    ));
+    processManager.addCommand(FakeCommand(
+      command: <String>[
+        ...kDart2jsLinuxArgs,
+        '-Ddart.vm.product=true',
+        '-O4',
+        '-o',
+        environment.buildDir.childFile('main.dart.js').absolute.path,
+        environment.buildDir.childFile('app.dill').absolute.path,
+      ]
+    ));
+
+    await const Dart2JSTarget().build(environment);
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => processManager,
+  }));
+
+
   test('Dart2JSTarget calls dart2js with Dart defines in profile mode', () => testbed.run(() async {
     environment.defines[kBuildMode] = 'profile';
     environment.defines[kDartDefines] = 'FOO=bar,BAZ=qux';
@@ -515,6 +558,7 @@ void main() {
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
+        '--no-source-maps',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
         '--packages=.packages',
@@ -528,6 +572,7 @@ void main() {
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
+        '--no-source-maps',
         '-O4',
         '--no-minify',
         '-o',


### PR DESCRIPTION
## Description

Disables source map production by default for `build web`. For web builds performed as a part of `flutter run --release`, enable the source maps, or allow force enabling with `--source-maps` command line flag.

fixes https://github.com/flutter/flutter/issues/67328