### PR TITLE
Increase device discovery timeout in devicelab health check

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -636,7 +636,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   Future<List<String>> discoverDevices() async {
     final List<dynamic> results = json.decode(await eval(
       path.join(flutterDirectory.path, 'bin', 'flutter'),
-      <String>['devices', '--machine', '--suppress-analytics'],
+      <String>['devices', '--machine', '--suppress-analytics', '--timeout', '10'],
     )) as List<dynamic>;
 
     // [


### PR DESCRIPTION
## Description

Match cocoon health timeout https://github.com/flutter/cocoon/pull/929 to find the slower iOS devices.

## Related Issues

https://github.com/flutter/flutter/issues/64753
https://github.com/flutter/flutter/issues/67321
