### PR TITLE
Condense package:test_core imports

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -8,11 +8,7 @@ import 'package:dds/dds.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
+import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/common.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -19,14 +19,7 @@ import 'package:shelf_packages_handler/shelf_packages_handler.dart';
 import 'package:shelf_static/shelf_static.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:test_api/src/backend/runtime.dart';
-import 'package:test_api/src/backend/suite_platform.dart';
-import 'package:test_core/src/runner/configuration.dart';
-import 'package:test_core/src/runner/environment.dart';
-import 'package:test_core/src/runner/platform.dart';
-import 'package:test_core/src/runner/plugin/platform_helpers.dart';
-import 'package:test_core/src/runner/runner_suite.dart';
-import 'package:test_core/src/runner/suite.dart';
+import 'package:test_core/src/platform.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart' hide StackTrace;
 

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -4,13 +4,12 @@
 
 import 'dart:async';
 
-import 'package:test_api/backend.dart'; // ignore: deprecated_member_use
-import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
-import 'package:test_core/src/runner/hack_register_platform.dart' as hack; // ignore: implementation_imports
+import 'package:test_core/src/platform.dart' as hack show registerPlatformPlugin; // ignore: implementation_imports
+import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 
 export 'package:test_api/backend.dart' show Runtime; // ignore: deprecated_member_use
-export 'package:test_core/src/runner/platform.dart' show PlatformPlugin; // ignore: implementation_imports
+export 'package:test_core/src/platform.dart' show PlatformPlugin; // ignore: implementation_imports
 
 abstract class TestWrapper {
   const factory TestWrapper() = _DefaultTestWrapper;


### PR DESCRIPTION
Use the new single `src/platform.dart` import to pick up what is needed
to implement a test platform from both `test_api` and `test_core`.

## Tests

No tests should be impacted.

This should make it easier to divide `test_core` into individual targets in bazel build config.