### PR TITLE
Mark keys that match a shortcut, but have no action defined as "not handled".

### DIFF
--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -194,13 +194,13 @@ class UndoIntent extends Intent {
 class UndoAction extends Action<UndoIntent> {
   @override
   bool isEnabled(UndoIntent intent) {
-    final UndoableActionDispatcher manager = Actions.of(primaryFocus?.context ?? FocusDemo.appKey.currentContext, nullOk: true) as UndoableActionDispatcher;
+    final UndoableActionDispatcher manager = Actions.of(primaryFocus?.context ?? FocusDemo.appKey.currentContext) as UndoableActionDispatcher;
     return manager.canUndo;
   }
 
   @override
   void invoke(UndoIntent intent) {
-    final UndoableActionDispatcher manager = Actions.of(primaryFocus?.context ?? FocusDemo.appKey.currentContext, nullOk: true) as UndoableActionDispatcher;
+    final UndoableActionDispatcher manager = Actions.of(primaryFocus?.context ?? FocusDemo.appKey.currentContext) as UndoableActionDispatcher;
     manager?.undo();
   }
 }
@@ -212,13 +212,13 @@ class RedoIntent extends Intent {
 class RedoAction extends Action<RedoIntent> {
   @override
   bool isEnabled(RedoIntent intent) {
-    final UndoableActionDispatcher manager = Actions.of(primaryFocus.context, nullOk: true) as UndoableActionDispatcher;
+    final UndoableActionDispatcher manager = Actions.of(primaryFocus.context) as UndoableActionDispatcher;
     return manager.canRedo;
   }
 
   @override
   RedoAction invoke(RedoIntent intent) {
-    final UndoableActionDispatcher manager = Actions.of(primaryFocus.context, nullOk: true) as UndoableActionDispatcher;
+    final UndoableActionDispatcher manager = Actions.of(primaryFocus.context) as UndoableActionDispatcher;
     manager?.redo();
     return this;
   }

--- a/dev/manual_tests/lib/focus.dart
+++ b/dev/manual_tests/lib/focus.dart
@@ -97,7 +97,7 @@ class _FocusDemoState extends State<FocusDemo> {
     super.dispose();
   }
 
-  bool _handleKeyPress(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _handleKeyPress(FocusNode node, RawKeyEvent event) {
     if (event is RawKeyDownEvent) {
       print('Scope got key event: ${event.logicalKey}, $node');
       print('Keys down: ${RawKeyboard.instance.keysPressed}');
@@ -106,31 +106,31 @@ class _FocusDemoState extends State<FocusDemo> {
         if (event.isShiftPressed) {
           print('Moving to previous.');
           node.previousFocus();
-          return true;
+          return KeyEventResult.handled;
         } else {
           print('Moving to next.');
           node.nextFocus();
-          return true;
+          return KeyEventResult.handled;
         }
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
         node.focusInDirection(TraversalDirection.left);
-        return true;
+        return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
         node.focusInDirection(TraversalDirection.right);
-        return true;
+        return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
         node.focusInDirection(TraversalDirection.up);
-        return true;
+        return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
         node.focusInDirection(TraversalDirection.down);
-        return true;
+        return KeyEventResult.handled;
       }
     }
-    return false;
+    return KeyEventResult.ignored;
   }
 
   @override

--- a/dev/manual_tests/lib/raw_keyboard.dart
+++ b/dev/manual_tests/lib/raw_keyboard.dart
@@ -37,11 +37,11 @@ class _HardwareKeyDemoState extends State<RawKeyboardDemo> {
     super.dispose();
   }
 
-  bool _handleKeyEvent(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _handleKeyEvent(FocusNode node, RawKeyEvent event) {
     setState(() {
       _event = event;
     });
-    return false;
+    return KeyEventResult.ignored;
   }
 
   String _asHex(int value) => value != null ? '0x${value.toRadixString(16)}' : 'null';

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -147,7 +147,30 @@ class ChangeNotifier implements Listenable {
 
   /// Register a closure to be called when the object changes.
   ///
+  /// If the given closure is already registered, an additional instance is
+  /// added, and must be removed the same number of times it is added before it
+  /// will stop being called.
+  ///
   /// This method must not be called after [dispose] has been called.
+  ///
+  /// {@template flutter.foundation.ChangeNotifier.addListener}
+  /// If a listener is added twice, and is removed once during an iteration
+  /// (e.g. in response to a notification), it will still be called again. If,
+  /// on the other hand, it is removed as many times as it was registered, then
+  /// it will no longer be called. This odd behavior is the result of the
+  /// [ChangeNotifier] not being able to determine which listener is being
+  /// removed, since they are identical, therefore it will conservatively still
+  /// call all the listeners when it knows that any are still registered.
+  ///
+  /// This surprising behavior can be unexpectedly observed when registering a
+  /// listener on two separate objects which are both forwarding all
+  /// registrations to a common upstream object.
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///  * [removeListener], which removes a previously registered closure from
+  ///    the list of closures that are notified when the object changes.
   @override
   void addListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
@@ -161,18 +184,12 @@ class ChangeNotifier implements Listenable {
   ///
   /// This method must not be called after [dispose] has been called.
   ///
-  /// If a listener had been added twice, and is removed once during an
-  /// iteration (i.e. in response to a notification), it will still be called
-  /// again. If, on the other hand, it is removed as many times as it was
-  /// registered, then it will no longer be called. This odd behavior is the
-  /// result of the [ChangeNotifier] not being able to determine which listener
-  /// is being removed, since they are identical, and therefore conservatively
-  /// still calling all the listeners when it knows that any are still
-  /// registered.
+  /// {@macro flutter.foundation.ChangeNotifier.addListener}
   ///
-  /// This surprising behavior can be unexpectedly observed when registering a
-  /// listener on two separate objects which are both forwarding all
-  /// registrations to a common upstream object.
+  /// See also:
+  ///
+  ///  * [addListener], which registers a closure to be called when the object
+  ///    changes.
   @override
   void removeListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
@@ -208,7 +225,7 @@ class ChangeNotifier implements Listenable {
   ///
   /// This method must not be called after [dispose] has been called.
   ///
-  /// Surprising behavior can result when reentrantly removing a listener (i.e.
+  /// Surprising behavior can result when reentrantly removing a listener (e.g.
   /// in response to a notification) that has been registered multiple times.
   /// See the discussion at [removeListener].
   @protected

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -499,12 +499,73 @@ class RawKeyUpEvent extends RawKeyEvent {
   }) : super(data: data, character: character);
 }
 
+/// An enum that describes how to handle a key event.
+enum KeyEventDisposition {
+  /// The key event has been handled, and the event should not be propagated to
+  /// other key event handlers.
+  handled,
+  /// The key event has not been handled, and the event should continue to be
+  /// propagated to other key event handlers, even non-Flutter ones.
+  ignored,
+  /// The key event has not been handled, but the key event should not be
+  /// propagated to other key event handlers.
+  ///
+  /// It will be returned to the platform embedding to be propagated to text
+  /// fields and non-Flutter key event handlers on the platform.
+  skipRemainingHandlers,
+}
+
+/// A class that represents a result returned from a [RawKeyEventHandler], which
+/// is invoked when a key event is received.
+class KeyEventResult {
+  /// Const constructor for a [KeyEventResult].
+  ///
+  /// Takes a [disposition] to describe how to handle the event after the
+  /// [RawKeyEventHandler] is called.
+  const KeyEventResult(this.disposition);
+
+  /// The [KeyEventDisposition] of the result. This describes how to handle
+  /// the event after the callback has been called.
+  final KeyEventDisposition disposition;
+
+  /// A constant that may be used to return a "handled" result from a
+  /// [RawKeyEventHandler] to indicate that a key event should not be propagated
+  /// further.
+  ///
+  /// See also:
+  ///
+  ///   * [KeyEventDisposition], the enum that describes the possible key event
+  ///     dispositions.
+  static const KeyEventResult handled = KeyEventResult(KeyEventDisposition.handled);
+
+  /// A constant that may be used to return a "ignored" result from a
+  /// [RawKeyEventHandler] to indicate that a key should continue to be
+  /// propagated to other key handlers.
+  ///
+  /// See also:
+  ///
+  ///   * [KeyEventDisposition], the enum that describes the possible key event
+  ///     dispositions.
+  static const KeyEventResult ignored = KeyEventResult(KeyEventDisposition.ignored);
+
+  /// A constant that may be used to return a "skipRemainingHandlers" result from a
+  /// [RawKeyEventHandler] to indicate that the key event was not handled, but
+  /// should not be propagated to other Flutter handlers. This allows text
+  /// fields and non-Flutter components to still receive the event.
+  ///
+  /// See also:
+  ///
+  ///   * [KeyEventDisposition], the enum that describes the possible key event
+  ///     dispositions.
+  static const KeyEventResult skipRemainingHandlers = KeyEventResult(KeyEventDisposition.skipRemainingHandlers);
+}
+
 /// A callback type used by [RawKeyboard.keyEventHandler] to send key events to
 /// a handler that can determine if the key has been handled or not.
 ///
 /// The handler should return true if the key has been handled, and false if the
 /// key was not handled.  It must not return null.
-typedef RawKeyEventHandler = bool Function(RawKeyEvent event);
+typedef RawKeyEventHandler = KeyEventResult Function(RawKeyEvent event);
 
 /// An interface for listening to raw key events.
 ///
@@ -628,8 +689,18 @@ class RawKeyboard {
 
     // Send the key event to the keyEventHandler, then send the appropriate
     // response to the platform so that it can resolve the event's handling.
-    // Defaults to false if keyEventHandler is null.
-    final bool handled = keyEventHandler != null && keyEventHandler!(event);
+    // Defaults to not handling the event if keyEventHandler is null.
+    final KeyEventResult result = keyEventHandler?.call(event) ?? KeyEventResult.ignored;
+    late bool handled;
+    switch(result.disposition) {
+      case KeyEventDisposition.handled:
+        handled = true;
+        break;
+      case KeyEventDisposition.ignored:
+      case KeyEventDisposition.skipRemainingHandlers:
+        handled = false;
+        break;
+    }
     assert(handled != null, 'keyEventHandler returned null, which is not allowed');
     return <String, dynamic>{ 'handled': handled };
   }

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -566,7 +566,8 @@ class KeyEventResult {
 /// The handler should return a [KeyEventResult] with the appropriate
 /// [KeyEventDisposition] set for the intended response. See
 /// [KeyEventDisposition] for a description of the possible responses.
-typedef RawKeyEventHandler = KeyEventResult Function(RawKeyEvent event);
+// TODO(gspencergoog): Convert this from dynamic to KeyEventResult once migration is complete.
+typedef RawKeyEventHandler = dynamic Function(RawKeyEvent event);
 
 /// An interface for listening to raw key events.
 ///
@@ -691,18 +692,23 @@ class RawKeyboard {
     // Send the key event to the keyEventHandler, then send the appropriate
     // response to the platform so that it can resolve the event's handling.
     // Defaults to not handling the event if keyEventHandler is null.
-    final KeyEventResult result = keyEventHandler?.call(event) ?? KeyEventResult.ignored;
+    final dynamic result = keyEventHandler?.call(event) ?? KeyEventResult.ignored;
     late bool handled;
-    switch(result.disposition) {
-      case KeyEventDisposition.handled:
-        handled = true;
-        break;
-      case KeyEventDisposition.ignored:
-      case KeyEventDisposition.skipRemainingHandlers:
-        handled = false;
-        break;
+    if (result is KeyEventResult) {
+      switch (result.disposition) {
+        case KeyEventDisposition.handled:
+          handled = true;
+          break;
+        case KeyEventDisposition.ignored:
+        case KeyEventDisposition.skipRemainingHandlers:
+          handled = false;
+          break;
+      }
+    } else if (result is bool) {
+      handled = result;
     }
-    assert(handled != null, 'keyEventHandler returned null, which is not allowed');
+    assert(handled != null,
+        'keyEventHandler must return a non-null bool or KeyEventResult, not ${result.runtimeType}');
     return <String, dynamic>{ 'handled': handled };
   }
 

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -563,8 +563,9 @@ class KeyEventResult {
 /// A callback type used by [RawKeyboard.keyEventHandler] to send key events to
 /// a handler that can determine if the key has been handled or not.
 ///
-/// The handler should return true if the key has been handled, and false if the
-/// key was not handled.  It must not return null.
+/// The handler should return a [KeyEventResult] with the appropriate
+/// [KeyEventDisposition] set for the intended response. See
+/// [KeyEventDisposition] for a description of the possible responses.
 typedef RawKeyEventHandler = KeyEventResult Function(RawKeyEvent event);
 
 /// An interface for listening to raw key events.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1095,7 +1095,7 @@ class WidgetsApp extends StatefulWidget {
   /// The default value of [WidgetsApp.actions].
   static Map<Type, Action<Intent>> defaultActions = <Type, Action<Intent>>{
     DoNothingIntent: DoNothingAction(),
-    DoNothingAndStopPropagationIntent: DoNothingAction(shouldHandleKey: false),
+    DoNothingAndStopPropagationIntent: DoNothingAction(consumesKey: false),
     RequestFocusIntent: RequestFocusAction(),
     NextFocusIntent: NextFocusAction(),
     PreviousFocusIntent: PreviousFocusAction(),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1095,6 +1095,7 @@ class WidgetsApp extends StatefulWidget {
   /// The default value of [WidgetsApp.actions].
   static Map<Type, Action<Intent>> defaultActions = <Type, Action<Intent>>{
     DoNothingIntent: DoNothingAction(),
+    DoNothingAndStopPropagationIntent: DoNothingAction(shouldHandleKey: false),
     RequestFocusIntent: RequestFocusAction(),
     NextFocusIntent: NextFocusAction(),
     PreviousFocusIntent: PreviousFocusAction(),

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -31,8 +31,9 @@ bool _focusDebug(String message, [Iterable<String>? details]) {
   return true;
 }
 
-/// An enum that describes how to handle a key event.
-enum KeyEventDisposition {
+/// An enum that describes how to handle a key event handled by a
+/// [FocusOnKeyCallback].
+enum KeyEventResult {
   /// The key event has been handled, and the event should not be propagated to
   /// other key event handlers.
   handled,
@@ -47,58 +48,13 @@ enum KeyEventDisposition {
   skipRemainingHandlers,
 }
 
-/// A class that represents a result returned from a [RawKeyEventHandler], which
-/// is invoked when a key event is received.
-class KeyEventResult {
-  /// Const constructor for a [KeyEventResult].
-  ///
-  /// Takes a [disposition] to describe how to handle the event after the
-  /// [RawKeyEventHandler] is called.
-  const KeyEventResult(this.disposition);
-
-  /// The [KeyEventDisposition] of the result. This describes how to handle
-  /// the event after the callback has been called.
-  final KeyEventDisposition disposition;
-
-  /// A constant that may be used to return a "handled" result from a
-  /// [RawKeyEventHandler] to indicate that a key event should not be propagated
-  /// further.
-  ///
-  /// See also:
-  ///
-  ///   * [KeyEventDisposition], the enum that describes the possible key event
-  ///     dispositions.
-  static const KeyEventResult handled = KeyEventResult(KeyEventDisposition.handled);
-
-  /// A constant that may be used to return a "ignored" result from a
-  /// [RawKeyEventHandler] to indicate that a key should continue to be
-  /// propagated to other key handlers.
-  ///
-  /// See also:
-  ///
-  ///   * [KeyEventDisposition], the enum that describes the possible key event
-  ///     dispositions.
-  static const KeyEventResult ignored = KeyEventResult(KeyEventDisposition.ignored);
-
-  /// A constant that may be used to return a "skipRemainingHandlers" result from a
-  /// [RawKeyEventHandler] to indicate that the key event was not handled, but
-  /// should not be propagated to other Flutter handlers. This allows text
-  /// fields and non-Flutter components to still receive the event.
-  ///
-  /// See also:
-  ///
-  ///   * [KeyEventDisposition], the enum that describes the possible key event
-  ///     dispositions.
-  static const KeyEventResult skipRemainingHandlers = KeyEventResult(KeyEventDisposition.skipRemainingHandlers);
-}
-
 /// Signature of a callback used by [Focus.onKey] and [FocusScope.onKey]
 /// to receive key events.
 ///
 /// The [node] is the node that received the event.
 ///
-/// Returns a [KeyEventResult], containing a [KeyEventDisposition] that
-/// describes how, and whether, the key event was handled.
+/// Returns a [KeyEventResult] that describes how, and whether, the key event
+/// was handled.
 // TODO(gspencergoog): Convert this from dynamic to KeyEventResult once migration is complete.
 typedef FocusOnKeyCallback = dynamic Function(FocusNode node, RawKeyEvent event);
 
@@ -1694,16 +1650,16 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
         assert(result is bool || result is KeyEventResult,
             'Value returned from onKey handler must be a non-null bool or KeyEventResult, not ${result.runtimeType}');
         if (result is KeyEventResult) {
-          switch (result.disposition) {
-            case KeyEventDisposition.handled:
+          switch (result) {
+            case KeyEventResult.handled:
               assert(_focusDebug('Node $node handled key event $event.'));
               handled = true;
               break;
-            case KeyEventDisposition.skipRemainingHandlers:
+            case KeyEventResult.skipRemainingHandlers:
               assert(_focusDebug('Node $node stopped key event propagation: $event.'));
-              handled = true;
+              handled = false;
               break;
-            case KeyEventDisposition.ignored:
+            case KeyEventResult.ignored:
               continue;
           }
         } else if (result is bool){

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -60,7 +60,7 @@ import 'inherited_notifier.dart';
 /// ```dart
 /// Color _color = Colors.white;
 ///
-/// bool _handleKeyPress(FocusNode node, RawKeyEvent event) {
+/// KeyEventResult _handleKeyPress(FocusNode node, RawKeyEvent event) {
 ///   if (event is RawKeyDownEvent) {
 ///     print('Focus node ${node.debugLabel} got key event: ${event.logicalKey}');
 ///     if (event.logicalKey == LogicalKeyboardKey.keyR) {
@@ -68,22 +68,22 @@ import 'inherited_notifier.dart';
 ///       setState(() {
 ///         _color = Colors.red;
 ///       });
-///       return true;
+///       return KeyEventResult.handled;
 ///     } else if (event.logicalKey == LogicalKeyboardKey.keyG) {
 ///       print('Changing color to green.');
 ///       setState(() {
 ///         _color = Colors.green;
 ///       });
-///       return true;
+///       return KeyEventResult.handled;
 ///     } else if (event.logicalKey == LogicalKeyboardKey.keyB) {
 ///       print('Changing color to blue.');
 ///       setState(() {
 ///         _color = Colors.blue;
 ///       });
-///       return true;
+///       return KeyEventResult.handled;
 ///     }
 ///   }
-///   return false;
+///   return KeyEventResult.ignored;
 /// }
 ///
 /// @override

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -335,7 +335,7 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
   ///
   /// Returns a [KeyEventResult.handled] if an action was invoked, otherwise a
   /// [KeyEventResult.skipRemainingHandlers] if [modal] is true, or if it maps to a
-  /// [DoNothingAction] with [DoNothingAction.shouldHandleKey] set to false, and
+  /// [DoNothingAction] with [DoNothingAction.consumesKey] set to false, and
   /// in all other cases returns [KeyEventResult.ignored].
   ///
   /// In order for an action to be invoked (and [KeyEventResult.handled]
@@ -367,7 +367,7 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
       );
       if (action != null && action.isEnabled(matchedIntent)) {
         Actions.of(primaryContext).invokeAction(action, matchedIntent, primaryContext);
-        return action.shouldHandleKey(matchedIntent)
+        return action.consumesKey(matchedIntent)
             ? KeyEventResult.handled
             : KeyEventResult.skipRemainingHandlers;
       }

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -756,7 +756,7 @@ void main() {
         Focus(
           focusNode: focusNode,
           onKey: (FocusNode node, RawKeyEvent event) {
-            return true; // handle all events.
+            return KeyEventResult.handled; // handle all events.
           },
           child: const SizedBox(),
         ),

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -264,10 +264,7 @@ void main() {
       );
 
       await tester.pump();
-      final ActionDispatcher dispatcher = Actions.of(
-        containerKey.currentContext!,
-        nullOk: true,
-      );
+      final ActionDispatcher dispatcher = Actions.of(containerKey.currentContext!);
       expect(dispatcher, equals(testDispatcher));
     });
     testWidgets('Action can be found with find', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -852,12 +852,12 @@ void main() {
     testWidgets('Key handling bubbles up and terminates when handled.', (WidgetTester tester) async {
       final Set<FocusNode> receivedAnEvent = <FocusNode>{};
       final Set<FocusNode> shouldHandle = <FocusNode>{};
-      bool handleEvent(FocusNode node, RawKeyEvent event) {
+      KeyEventResult handleEvent(FocusNode node, RawKeyEvent event) {
         if (shouldHandle.contains(node)) {
           receivedAnEvent.add(node);
-          return true;
+          return KeyEventResult.handled;
         }
-        return false;
+        return KeyEventResult.ignored;
       }
 
       Future<void> sendEvent() async {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -404,7 +404,7 @@ void main() {
                 },
                 child: Actions(
                   actions: <Type, Action<Intent>>{
-                    TestIntent: DoNothingAction(shouldHandleKey: false),
+                    TestIntent: DoNothingAction(consumesKey: false),
                   },
                   child: TextField(key: textFieldKey, autofocus: true),
                 ),

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -28,7 +28,7 @@ class TestDispatcher extends ActionDispatcher {
   @override
   Object? invokeAction(Action<TestIntent> action, Intent intent, [BuildContext? context]) {
     final Object? result = super.invokeAction(action, intent, context);
-    postInvoke?.call(action: action, intent: intent, context: context, dispatcher: this);
+    postInvoke?.call(action: action, intent: intent, context: context!, dispatcher: this);
     return result;
   }
 }
@@ -43,8 +43,10 @@ class TestShortcutManager extends ShortcutManager {
   List<LogicalKeyboardKey> keys;
 
   @override
-  bool handleKeypress(BuildContext context, RawKeyEvent event, {LogicalKeySet? keysPressed}) {
-    keys.add(event.logicalKey);
+  KeyEventResult handleKeypress(BuildContext context, RawKeyEvent event, {LogicalKeySet? keysPressed}) {
+    if (event is RawKeyDownEvent) {
+      keys.add(event.logicalKey);
+    }
     return super.handleKeypress(context, event, keysPressed: keysPressed);
   }
 }
@@ -319,6 +321,142 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, isFalse);
       expect(pressedKeys, isEmpty);
+    });
+    testWidgets("Shortcuts that aren't bound to an action don't absorb keys meant for text fields", (WidgetTester tester) async {
+      final GlobalKey textFieldKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Shortcuts(
+              manager: testManager,
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.keyA): const TestIntent(),
+              },
+              child: TextField(key: textFieldKey, autofocus: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.of(textFieldKey.currentContext!), isNotNull);
+      final bool handled = await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      expect(handled, isFalse);
+      expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.keyA]));
+    });
+    testWidgets('Shortcuts that are bound to an action do override text fields', (WidgetTester tester) async {
+      final GlobalKey textFieldKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      bool invoked = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Shortcuts(
+              manager: testManager,
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.keyA): const TestIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  TestIntent: TestAction(
+                    onInvoke: (Intent intent) {
+                      invoked = true;
+                      return invoked;
+                    },
+                  ),
+                },
+                child: TextField(key: textFieldKey, autofocus: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.of(textFieldKey.currentContext!), isNotNull);
+      final bool result = await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      expect(result, isTrue);
+      expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.keyA]));
+      expect(invoked, isTrue);
+    });
+    testWidgets('Shortcuts can override intents that apply to text fields', (WidgetTester tester) async {
+      final GlobalKey textFieldKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      bool invoked = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Shortcuts(
+              manager: testManager,
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.keyA): const TestIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  TestIntent: TestAction(
+                    onInvoke: (Intent intent) {
+                      invoked = true;
+                      return invoked;
+                    },
+                  ),
+                },
+                child: Actions(
+                  actions: <Type, Action<Intent>>{
+                    TestIntent: DoNothingAction(shouldHandleKey: false),
+                  },
+                  child: TextField(key: textFieldKey, autofocus: true),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.of(textFieldKey.currentContext!), isNotNull);
+      final bool result = await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      expect(result, isFalse);
+      expect(invoked, isFalse);
+    });
+    testWidgets('Shortcuts can override intents that apply to text fields with DoNothingAndStopPropagationIntent', (WidgetTester tester) async {
+      final GlobalKey textFieldKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      bool invoked = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Shortcuts(
+              manager: testManager,
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.keyA): const TestIntent(),
+              },
+              child: Actions(
+                actions: <Type, Action<Intent>>{
+                  TestIntent: TestAction(
+                    onInvoke: (Intent intent) {
+                      invoked = true;
+                      return invoked;
+                    },
+                  ),
+                },
+                child: Shortcuts(
+                  shortcuts: <LogicalKeySet, Intent>{
+                    LogicalKeySet(LogicalKeyboardKey.keyA): DoNothingAndStopPropagationIntent(),
+                  },
+                  child: TextField(key: textFieldKey, autofocus: true),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.of(textFieldKey.currentContext!), isNotNull);
+      final bool result = await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      expect(result, isFalse);
+      expect(invoked, isFalse);
     });
     test('Shortcuts diagnostics work.', () {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -841,15 +841,18 @@ abstract class WidgetController {
   /// key press. To simulate individual down and/or up events, see
   /// [sendKeyDownEvent] and [sendKeyUpEvent].
   ///
+  /// Returns true if the key down event was handled by the framework.
+  ///
   /// See also:
   ///
   ///  - [sendKeyDownEvent] to simulate only a key down event.
   ///  - [sendKeyUpEvent] to simulate only a key up event.
-  Future<void> sendKeyEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
+  Future<bool> sendKeyEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
     assert(platform != null);
-    await simulateKeyDownEvent(key, platform: platform);
+    final bool handled = await simulateKeyDownEvent(key, platform: platform);
     // Internally wrapped in async guard.
-    return simulateKeyUpEvent(key, platform: platform);
+    await simulateKeyUpEvent(key, platform: platform);
+    return handled;
   }
 
   /// Simulates sending a physical key down event through the system channel.
@@ -864,11 +867,13 @@ abstract class WidgetController {
   ///
   /// Keys that are down when the test completes are cleared after each test.
   ///
+  /// Returns true if the key event was handled by the framework.
+  ///
   /// See also:
   ///
   ///  - [sendKeyUpEvent] to simulate the corresponding key up event.
   ///  - [sendKeyEvent] to simulate both the key up and key down in the same call.
-  Future<void> sendKeyDownEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
+  Future<bool> sendKeyDownEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
     assert(platform != null);
     // Internally wrapped in async guard.
     return simulateKeyDownEvent(key, platform: platform);
@@ -883,11 +888,13 @@ abstract class WidgetController {
   /// [Platform.operatingSystem] to make the event appear to be from that type
   /// of system. Defaults to "android". May not be null.
   ///
+  /// Returns true if the key event was handled by the framework.
+  ///
   /// See also:
   ///
   ///  - [sendKeyDownEvent] to simulate the corresponding key down event.
   ///  - [sendKeyEvent] to simulate both the key up and key down in the same call.
-  Future<void> sendKeyUpEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
+  Future<bool> sendKeyUpEvent(LogicalKeyboardKey key, { String platform = 'android' }) async {
     assert(platform != null);
     // Internally wrapped in async guard.
     return simulateKeyUpEvent(key, platform: platform);


### PR DESCRIPTION
## Description

When I added [notification of key events](https://github.com/flutter/engine/pull/21163) before processing them as text, it made it so that shortcut key bindings like the spacebar would prevent spaces from being inserted into text fields, which is obviously not desirable (and so that change was reverted). At the same time, we do want to make it possible to override key events so that they can do things like intercept a tab key or arrow keys that change the focus.

This PR changes the behavior of the Shortcuts widget so that if it has a shortcut defined, but no action is bound to the intent, then instead of responding that the key is "handled", it responds as if nothing handled it. This allows the engine to continue to process the key as text entry.

This PR includes:

 - Modification of the callback type for key handlers to return a `KeyEventResult` instead of a bool, so that we can return more information (i.e. the extra state of "stop propagation").
 - Modification of the `ActionDispatcher.invokeAction` contract to require that `Action.isEnabled` return true before calling it. It will now assert if the action isn't enabled when `invokeAction` is called. This is to allow optimization of the number of calls to `isEnabled`, since the shortcuts widget now wants to know if the action was enabled before deciding to either handle the key or to return `ignored`.
 - Modification to `ShortcutManager.handleKeypress` to return KeyEventResult.ignored for keys which don't have an enabled action associated with them.
 - Adds an attribute to `DoNothingAction` that allows it to mark a key as not handled, even though it does have an action associated with it. This will allow disabling of a shortcut for a subtree.

## Related Issues

 - https://github.com/flutter/flutter/issues/47156

## Tests

 - Added tests for event propagation for shortcuts.

## Breaking Change

- Yes, this will eventually be a breaking change, so I am going to have to figure out a migration plan for it. For now, the return type for the focus key events is `dynamic`, and we check the type before responding to the engine.