### PR TITLE
Make FlutterErrorDetails.exception non-nullable as documented

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -390,7 +390,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// their default values. (`throw null` results in a
   /// [NullThrownError] exception.)
   const FlutterErrorDetails({
-    this.exception,
+    required this.exception,
     this.stack,
     this.library = 'Flutter framework',
     this.context,
@@ -403,7 +403,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// with new values.
   FlutterErrorDetails copyWith({
     DiagnosticsNode? context,
-    dynamic exception,
+    Object? exception,
     InformationCollector? informationCollector,
     String? library,
     bool? silent,
@@ -437,7 +437,7 @@ class FlutterErrorDetails with Diagnosticable {
 
   /// The exception. Often this will be an [AssertionError], maybe specifically
   /// a [FlutterError]. However, this could be any value at all.
-  final dynamic exception;
+  final Object exception;
 
   /// The stack trace from where the [exception] was thrown (as opposed to where
   /// it was caught).
@@ -552,7 +552,7 @@ class FlutterErrorDetails with Diagnosticable {
       // some code snippets. This leads to ugly messages. To avoid this, we move
       // the assertion message up to before the code snippets, separated by a
       // newline, if we recognize that format is being used.
-      final Object? message = exception.message;
+      final Object? message = (exception as AssertionError).message;
       final String fullMessage = exception.toString();
       if (message is String && message != fullMessage) {
         if (fullMessage.length > message.length) {
@@ -589,8 +589,11 @@ class FlutterErrorDetails with Diagnosticable {
     if (exception is FlutterError) {
       return exception as FlutterError;
     }
-    if (exception is AssertionError && exception.message is FlutterError) {
-      return exception.message as FlutterError;
+    if (exception is AssertionError) {
+      final AssertionError assertion = exception as AssertionError;
+      if (assertion.message is FlutterError) {
+        return assertion.message as FlutterError;
+      }
     }
     return null;
   }

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -591,7 +591,7 @@ class FlutterErrorDetails with Diagnosticable {
       return exception;
     }
     if (exception is AssertionError && exception.message is FlutterError) {
-        return exception.message as FlutterError;
+      return exception.message as FlutterError;
     }
     return null;
   }

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -397,7 +397,7 @@ class FlutterErrorDetails with Diagnosticable {
     this.stackFilter,
     this.informationCollector,
     this.silent = false,
-  });
+  }) : assert(exception != null);
 
   /// Creates a copy of the error details but with the given fields replaced
   /// with new values.
@@ -586,14 +586,12 @@ class FlutterErrorDetails with Diagnosticable {
   }
 
   Diagnosticable? _exceptionToDiagnosticable() {
+    final Object exception = this.exception;
     if (exception is FlutterError) {
-      return exception as FlutterError;
+      return exception;
     }
-    if (exception is AssertionError) {
-      final AssertionError assertion = exception as AssertionError;
-      if (assertion.message is FlutterError) {
-        return assertion.message as FlutterError;
-      }
+    if (exception is AssertionError && exception.message is FlutterError) {
+        return exception.message as FlutterError;
     }
     return null;
   }

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -539,7 +539,7 @@ abstract class BindingBase {
         return Future<void>.delayed(Duration.zero);
       });
 
-      dynamic caughtException;
+      Object? caughtException;
       StackTrace? caughtStack;
       late Map<String, dynamic> result;
       try {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -428,7 +428,7 @@ class FlutterErrorDetailsForPointerEventDispatcher extends FlutterErrorDetails {
   /// The gesture library calls this constructor when catching an exception
   /// that will subsequently be reported using [FlutterError.onError].
   const FlutterErrorDetailsForPointerEventDispatcher({
-    dynamic exception,
+    required Object exception,
     StackTrace? stack,
     String? library,
     DiagnosticsNode? context,

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -22,7 +22,7 @@ import 'image_stream.dart';
 typedef _KeyAndErrorHandlerCallback<T> = void Function(T key, ImageErrorListener handleError);
 
 /// Signature used for error handling by [_createErrorHandlerAndKey].
-typedef _AsyncKeyErrorHandler<T> = Future<void> Function(T key, dynamic exception, StackTrace? stack);
+typedef _AsyncKeyErrorHandler<T> = Future<void> Function(T key, Object exception, StackTrace? stack);
 
 /// Configuration information passed to the [ImageProvider.resolve] method to
 /// select a specific image.
@@ -335,7 +335,7 @@ abstract class ImageProvider<T extends Object> {
       (T key, ImageErrorListener errorHandler) {
         resolveStreamForKey(configuration, stream, key, errorHandler);
       },
-      (T? key, dynamic exception, StackTrace? stack) async {
+      (T? key, Object exception, StackTrace? stack) async {
         await null; // wait an event turn in case a listener has been added to the image stream.
         final _ErrorImageCompleter imageCompleter = _ErrorImageCompleter();
         stream.setCompleter(imageCompleter);
@@ -391,7 +391,7 @@ abstract class ImageProvider<T extends Object> {
       (T key, ImageErrorListener innerHandleError) {
         completer.complete(PaintingBinding.instance!.imageCache!.statusForKey(key));
       },
-      (T? key, dynamic exception, StackTrace? stack) async {
+      (T? key, Object exception, StackTrace? stack) async {
         if (handleError != null) {
           handleError(exception, stack);
         } else {
@@ -427,7 +427,7 @@ abstract class ImageProvider<T extends Object> {
   ) {
     T? obtainedKey;
     bool didError = false;
-    Future<void> handleError(dynamic exception, StackTrace? stack) async {
+    Future<void> handleError(Object exception, StackTrace? stack) async {
       if (didError) {
         return;
       }
@@ -1118,7 +1118,7 @@ class _ErrorImageCompleter extends ImageStreamCompleter {
 
   void setError({
     DiagnosticsNode? context,
-    dynamic exception,
+    required Object exception,
     StackTrace? stack,
     InformationCollector? informationCollector,
     bool silent = false,

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -233,7 +233,7 @@ typedef ImageChunkListener = void Function(ImageChunkEvent event);
 ///
 /// Used in [ImageStreamListener], as well as by [ImageCache.putIfAbsent] and
 /// [precacheImage], to report errors.
-typedef ImageErrorListener = void Function(dynamic exception, StackTrace? stackTrace);
+typedef ImageErrorListener = void Function(Object exception, StackTrace? stackTrace);
 
 /// An immutable notification of image bytes that have been incrementally loaded.
 ///
@@ -655,7 +655,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
   @protected
   void reportError({
     DiagnosticsNode? context,
-    dynamic exception,
+    required Object exception,
     StackTrace? stack,
     InformationCollector? informationCollector,
     bool silent = false,
@@ -747,7 +747,7 @@ class OneFrameImageStreamCompleter extends ImageStreamCompleter {
   /// FlutterErrorDetails]).
   OneFrameImageStreamCompleter(Future<ImageInfo> image, { InformationCollector? informationCollector })
       : assert(image != null) {
-    image.then<void>(setImage, onError: (dynamic error, StackTrace stack) {
+    image.then<void>(setImage, onError: (Object error, StackTrace stack) {
       reportError(
         context: ErrorDescription('resolving a single-frame image stream'),
         exception: error,
@@ -819,7 +819,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
        _informationCollector = informationCollector,
        _scale = scale {
     this.debugLabel = debugLabel;
-    codec.then<void>(_handleCodecReady, onError: (dynamic error, StackTrace stack) {
+    codec.then<void>(_handleCodecReady, onError: (Object error, StackTrace stack) {
       reportError(
         context: ErrorDescription('resolving an image codec'),
         exception: error,
@@ -830,7 +830,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
     });
     if (chunkEvents != null) {
       chunkEvents.listen(reportImageChunkEvent,
-        onError: (dynamic error, StackTrace stack) {
+        onError: (Object error, StackTrace stack) {
           reportError(
             context: ErrorDescription('loading an image'),
             exception: error,

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1307,7 +1307,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// Used in debug messages.
   Object? debugCreator;
 
-  void _debugReportException(String method, dynamic exception, StackTrace stack) {
+  void _debugReportException(String method, Object exception, StackTrace stack) {
     FlutterError.reportError(FlutterErrorDetails(
       exception: exception,
       stack: stack,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4507,7 +4507,7 @@ class ErrorWidget extends LeafRenderObjectWidget {
       message = _stringify(details.exception) + '\nSee also: https://flutter.dev/docs/testing/errors';
       return true;
     }());
-    final dynamic exception = details.exception;
+    final Object exception = details.exception;
     return ErrorWidget.withDetails(message: message, error: exception is FlutterError ? exception : null);
   }
 
@@ -6293,7 +6293,7 @@ class DebugCreator {
 
 FlutterErrorDetails _debugReportException(
   DiagnosticsNode context,
-  dynamic exception,
+  Object exception,
   StackTrace? stack, {
   InformationCollector? informationCollector,
 }) {

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -123,7 +123,7 @@ Future<void> precacheImage(
         stream.removeListener(listener!);
       });
     },
-    onError: (dynamic exception, StackTrace? stackTrace) {
+    onError: (Object exception, StackTrace? stackTrace) {
       if (!completer.isCompleted) {
         completer.complete();
       }

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -393,7 +393,7 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
 
 FlutterErrorDetails _debugReportException(
   DiagnosticsNode context,
-  dynamic exception,
+  Object exception,
   StackTrace stack, {
   InformationCollector? informationCollector,
 }) {

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1670,7 +1670,7 @@ class KeepAlive extends ParentDataWidget<KeepAliveParentDataMixin> {
 }
 
 // Return a Widget for the given Exception
-Widget _createErrorWidget(dynamic exception, StackTrace stackTrace) {
+Widget _createErrorWidget(Object exception, StackTrace stackTrace) {
   final FlutterErrorDetails details = FlutterErrorDetails(
     exception: exception,
     stack: stackTrace,

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -57,7 +57,21 @@ void main() {
         '\n'
         'INFO\n'
         '═════════════════════════════════════════════════════════════════\n',
-
+    );
+    expect(
+      FlutterErrorDetails(
+        exception: NullThrownError(),
+        library: 'LIBRARY',
+        context: ErrorDescription('CONTEXTING'),
+        informationCollector: () sync* {
+          yield ErrorDescription('INFO');
+        },
+      ).toString(),
+        '══╡ EXCEPTION CAUGHT BY LIBRARY ╞════════════════════════════════\n'
+        'The null value was thrown CONTEXTING.\n'
+        '\n'
+        'INFO\n'
+        '═════════════════════════════════════════════════════════════════\n'
     );
     expect(
       FlutterErrorDetails(
@@ -97,6 +111,12 @@ void main() {
       'The following message was thrown:\n'
       'MESSAGE\n'
       '═════════════════════════════════════════════════════════════════\n',
+    );
+    expect(
+      FlutterErrorDetails(exception: NullThrownError()).toString(),
+      '══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞══════════════════════\n'
+      'The null value was thrown.\n'
+      '═════════════════════════════════════════════════════════════════\n'
     );
   });
 

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -61,21 +61,6 @@ void main() {
     );
     expect(
       FlutterErrorDetails(
-        library: 'LIBRARY',
-        context: ErrorDescription('CONTEXTING'),
-        informationCollector: () sync* {
-          yield ErrorDescription('INFO');
-        },
-      ).toString(),
-      '══╡ EXCEPTION CAUGHT BY LIBRARY ╞════════════════════════════════\n'
-      'The following Null object was thrown CONTEXTING:\n'
-      '  null\n'
-      '\n'
-      'INFO\n'
-      '═════════════════════════════════════════════════════════════════\n',
-    );
-    expect(
-      FlutterErrorDetails(
         exception: 'MESSAGE',
         context: ErrorDescription('CONTEXTING'),
         informationCollector: () sync* {
@@ -111,13 +96,6 @@ void main() {
       '══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞══════════════════════\n'
       'The following message was thrown:\n'
       'MESSAGE\n'
-      '═════════════════════════════════════════════════════════════════\n',
-    );
-    expect(
-      const FlutterErrorDetails().toString(),
-      '══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞══════════════════════\n'
-      'The following Null object was thrown:\n'
-      '  null\n'
       '═════════════════════════════════════════════════════════════════\n',
     );
   });

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -67,11 +67,11 @@ void main() {
           yield ErrorDescription('INFO');
         },
       ).toString(),
-        '══╡ EXCEPTION CAUGHT BY LIBRARY ╞════════════════════════════════\n'
-        'The null value was thrown CONTEXTING.\n'
-        '\n'
-        'INFO\n'
-        '═════════════════════════════════════════════════════════════════\n'
+      '══╡ EXCEPTION CAUGHT BY LIBRARY ╞════════════════════════════════\n'
+      'The null value was thrown CONTEXTING.\n'
+      '\n'
+      'INFO\n'
+      '═════════════════════════════════════════════════════════════════\n'
     );
     expect(
       FlutterErrorDetails(

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/foundation.dart';
 import '../flutter_test_alternative.dart';
 
-dynamic getAssertionErrorWithMessage() {
+Object getAssertionErrorWithMessage() {
   try {
     assert(false, 'Message goes here.');
   } catch (e) {
@@ -16,7 +16,7 @@ dynamic getAssertionErrorWithMessage() {
   throw 'assert failed';
 }
 
-dynamic getAssertionErrorWithoutMessage() {
+Object getAssertionErrorWithoutMessage() {
   try {
     assert(false);
   } catch (e) {
@@ -25,7 +25,7 @@ dynamic getAssertionErrorWithoutMessage() {
   throw 'assert failed';
 }
 
-dynamic getAssertionErrorWithLongMessage() {
+Object getAssertionErrorWithLongMessage() {
   try {
     assert(false, 'word ' * 100);
   } catch (e) {

--- a/packages/flutter/test/rendering/aspect_ratio_test.dart
+++ b/packages/flutter/test/rendering/aspect_ratio_test.dart
@@ -117,7 +117,7 @@ void main() {
     });
     expect(errors, hasLength(2));
     expect(errors.first.exception, isFlutterError);
-    expect(errors.first.exception.toStringDeep(),
+    expect((errors.first.exception as FlutterError).toStringDeep(),
       'FlutterError\n'
       '   RenderAspectRatio has unbounded constraints.\n'
       '   This RenderAspectRatio was given an aspect ratio of 0.5 but was\n'

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -27,7 +27,7 @@ class TestRenderingFlutterBinding extends BindingBase with SchedulerBinding, Ser
   TestRenderingFlutterBinding({ this.onErrors }) {
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.dumpErrorToConsole(details);
-      Zone.current.parent!.handleUncaughtError(details.exception as Object, details.stack!);
+      Zone.current.parent!.handleUncaughtError(details.exception, details.stack!);
     };
   }
 

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1627,7 +1627,7 @@ void main() {
       }
       expect(errors, isNotEmpty);
       expect(errors.first.exception, isFlutterError);
-      expect(errors.first.exception.toStringDeep(), message);
+      expect((errors.first.exception as FlutterError).toStringDeep(), message);
     }
 
     testWidgets('Horizontal viewport was given unbounded height', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -301,7 +301,7 @@ void main() {
       expect(errors.length, isNonZero);
       expect(errors.first, isNotNull);
       expect(errors.first.exception, isFlutterError);
-      expect(errors.first.exception.toStringDeep(), equalsIgnoringHashCodes(message));
+      expect((errors.first.exception as FlutterError).toStringDeep(), equalsIgnoringHashCodes(message));
     }
 
     testWidgets('layoutChild on non existent child', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/list_body_test.dart
+++ b/packages/flutter/test/widgets/list_body_test.dart
@@ -134,7 +134,7 @@ void main() {
     }
     expect(errors, isNotEmpty);
     expect(errors.first.exception, isFlutterError);
-    expect(errors.first.exception.toStringDeep(), equalsIgnoringHashCodes(
+    expect((errors.first.exception as FlutterError).toStringDeep(), equalsIgnoringHashCodes(
       'FlutterError\n'
       '   RenderListBody must have unlimited space along its main axis.\n'
       '   RenderListBody does not clip or resize its children, so it must\n'
@@ -183,7 +183,7 @@ void main() {
     }
     expect(errors, isNotEmpty);
     expect(errors.first.exception, isFlutterError);
-    expect(errors.first.exception.toStringDeep(), equalsIgnoringHashCodes(
+    expect((errors.first.exception as FlutterError).toStringDeep(), equalsIgnoringHashCodes(
       'FlutterError\n'
       '   RenderListBody must have a bounded constraint for its cross axis.\n'
       '   RenderListBody forces its children to expand to fit the\n'

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -686,7 +686,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     };
     final Completer<void> testCompleter = Completer<void>();
     final VoidCallback testCompletionHandler = _createTestCompletionHandler(description, testCompleter);
-    void handleUncaughtError(dynamic exception, StackTrace stack) {
+    void handleUncaughtError(Object exception, StackTrace stack) {
       if (testCompleter.isCompleted) {
         // Well this is not a good sign.
         // Ideally, once the test has failed we would stop getting errors from the test.
@@ -765,7 +765,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _parentZone!.run<void>(testCompletionHandler);
     }
     final ZoneSpecification errorHandlingZoneSpecification = ZoneSpecification(
-      handleUncaughtError: (Zone self, ZoneDelegate parent, Zone zone, dynamic exception, StackTrace stack) {
+      handleUncaughtError: (Zone self, ZoneDelegate parent, Zone zone, Object exception, StackTrace stack) {
         handleUncaughtError(exception, stack);
       }
     );
@@ -1013,7 +1013,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
     return realAsyncZone.run<Future<T>>(() {
       _pendingAsyncTasks = Completer<void>();
-      return callback().catchError((dynamic exception, StackTrace stack) {
+      return callback().catchError((Object exception, StackTrace stack) {
         FlutterError.reportError(FlutterErrorDetails(
           exception: exception,
           stack: stack,

--- a/packages/flutter_test/test/bindings_async_gap_test.dart
+++ b/packages/flutter_test/test/bindings_async_gap_test.dart
@@ -28,7 +28,7 @@ Future<void> main() async {
 
       completer.future.then(
         (String value) {},
-        onError: (dynamic error, StackTrace stack) {
+        onError: (Object error, StackTrace stack) {
           assert(stack is stack_trace.Chain);
           FlutterError.reportError(FlutterErrorDetails(
             exception: error,

--- a/packages/flutter_test/test/custom_exception_reporter/flutter_test_config.dart
+++ b/packages/flutter_test/test/custom_exception_reporter/flutter_test_config.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 Future<void> main(FutureOr<void> testMain()) async {
   reportTestException = (FlutterErrorDetails details, String testDescription) {
     expect(details.exception, isA<StateError>());
-    expect(details.exception.message, 'foo');
+    expect((details.exception as StateError).message, 'foo');
     expect(testDescription, 'custom exception reporter');
   };
 

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -737,7 +737,7 @@ void main() {
       }, () {});
 
       expect(flutterErrorDetails.exception, isA<AssertionError>());
-      expect(flutterErrorDetails.exception!.message, 'A Timer is still pending even after the widget tree was disposed.');
+      expect((flutterErrorDetails.exception as AssertionError).message, 'A Timer is still pending even after the widget tree was disposed.');
     });
   });
 }


### PR DESCRIPTION
## Description

The `FlutterErrorDetails` constructor documents that `exception` must not be null, but that wasn't enforced. That led to some ugly code when the `exception` had to be passed to an error handle that enforced non-nullability. This code makes `exception` non-nullable by changing its type from `dynamic` to `Object`.

## Related Issues

n/a

## Tests

I added the following tests:

* updated affected tests

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
