### PR TITLE
Remove the .zip method from OSUtils, as it was not used

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -192,56 +192,6 @@ void main() {
     );
   });
 
-  testWithoutContext('If zip throws an ArgumentError, display an install message', () {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    when(mockProcessManager.runSync(
-      <String>['zip', '-r', '-q', 'foo.zip', '.'],
-      workingDirectory: anyNamed('workingDirectory'),
-    )).thenThrow(ArgumentError());
-
-    final OperatingSystemUtils linuxOsUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'linux'),
-      processManager: mockProcessManager,
-    );
-
-    expect(
-      () => linuxOsUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
-      throwsToolExit(
-        message: 'Missing "zip" tool. Unable to compress /.\n'
-        'Consider running "sudo apt-get install zip".'),
-    );
-
-    final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'macos'),
-      processManager: mockProcessManager,
-    );
-
-    expect(
-      () => macOSUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
-      throwsToolExit
-      (message: 'Missing "zip" tool. Unable to compress /.\n'
-        'Consider running "brew install zip".'),
-    );
-
-    final OperatingSystemUtils unknownOsUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'fuchsia'),
-      processManager: mockProcessManager,
-    );
-
-    expect(
-      () => unknownOsUtils.zip(fileSystem.currentDirectory, fileSystem.file('foo.zip')),
-      throwsToolExit
-      (message: 'Missing "zip" tool. Unable to compress /.\n'
-        'Please install zip.'),
-    );
-  });
-
   testWithoutContext('stream compression level', () {
     expect(OperatingSystemUtils.gzipLevel1.level, equals(1));
   });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -307,9 +307,6 @@ class FakeOperatingSystemUtils implements OperatingSystemUtils {
   File makePipe(String path) => null;
 
   @override
-  void zip(Directory data, File zipFile) { }
-
-  @override
   void unzip(File file, Directory targetDirectory) { }
 
   @override


### PR DESCRIPTION
We used to use `zip` to verify the integrity of downloaded zip archives, but we now use `unzip`. This removes the `.zip` method from `OperatingSystemUtils`.