### PR TITLE
[flutter_tools] work around hostonly test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -26,6 +26,13 @@ class DoctorCommand extends FlutterCommand {
   final String name = 'doctor';
 
   @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
+    // This is required because the gradle hostonly tests do not correctly specify
+    // their dependencies.
+    DevelopmentArtifact.androidGenSnapshot,
+  };
+
+  @override
   final String description = 'Show information about the installed tooling.';
 
   @override


### PR DESCRIPTION
## Description

Many of the host only devicelab tests were relying on doctor to download android dependencies.

TBR @christopherfujino 