### PR TITLE
Add rootOverlay flag to [Draggable], to put feedback on root [Overlay]

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -124,6 +124,7 @@ class Draggable<T extends Object> extends StatefulWidget {
     this.onDragEnd,
     this.onDragCompleted,
     this.ignoringFeedbackSemantics = true,
+    this.rootOverlay = false,
   }) : assert(child != null),
        assert(feedback != null),
        assert(ignoringFeedbackSemantics != null),
@@ -261,6 +262,15 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// the tree (i.e. [State.mounted] is true).
   final DragEndCallback? onDragEnd;
 
+  /// Whether the feedback widget will be put on the root [Overlay].
+  ///
+  /// When false, the feedback widget will be put on the closest [Overlay]. When
+  /// true, the feedback widget will be put on the farthest (aka root)
+  /// [Overlay].
+  ///
+  /// Defaults to false.
+  final bool rootOverlay;
+
   /// Creates a gesture recognizer that recognizes the start of the drag.
   ///
   /// Subclasses can override this function to customize when they start
@@ -390,7 +400,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       _activeCount += 1;
     });
     final _DragAvatar<T> avatar = _DragAvatar<T>(
-      overlayState: Overlay.of(context, debugRequiredFor: widget)!,
+      overlayState: Overlay.of(context, debugRequiredFor: widget, rootOverlay:widget.rootOverlay)!,
       data: widget.data,
       axis: widget.axis,
       initialPosition: position,
@@ -427,7 +437,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
 
   @override
   Widget build(BuildContext context) {
-    assert(Overlay.of(context, debugRequiredFor: widget) != null);
+    assert(Overlay.of(context, debugRequiredFor: widget, rootOverlay:widget.rootOverlay) != null);
     final bool canDrag = widget.maxSimultaneousDrags == null ||
                          _activeCount < widget.maxSimultaneousDrags!;
     final bool showChild = _activeCount == 0 || widget.childWhenDragging == null;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -265,7 +265,7 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// Whether the feedback widget will be put on the root [Overlay].
   ///
   /// When false, the feedback widget will be put on the closest [Overlay]. When
-  /// true, the feedback widget will be put on the farthest (aka root)
+  /// true, the [feedback] widget will be put on the farthest (aka root)
   /// [Overlay].
   ///
   /// Defaults to false.
@@ -400,7 +400,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       _activeCount += 1;
     });
     final _DragAvatar<T> avatar = _DragAvatar<T>(
-      overlayState: Overlay.of(context, debugRequiredFor: widget, rootOverlay:widget.rootOverlay)!,
+      overlayState: Overlay.of(context, debugRequiredFor: widget, rootOverlay: widget.rootOverlay)!,
       data: widget.data,
       axis: widget.axis,
       initialPosition: position,
@@ -437,7 +437,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
 
   @override
   Widget build(BuildContext context) {
-    assert(Overlay.of(context, debugRequiredFor: widget, rootOverlay:widget.rootOverlay) != null);
+    assert(Overlay.of(context, debugRequiredFor: widget, rootOverlay: widget.rootOverlay) != null);
     final bool canDrag = widget.maxSimultaneousDrags == null ||
                          _activeCount < widget.maxSimultaneousDrags!;
     final bool showChild = _activeCount == 0 || widget.childWhenDragging == null;

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2328,28 +2328,30 @@ void main() {
         home: Column(
           children: <Widget>[
             Container(
-                height: 200.0,
-                child: Navigator(
-                    key: childNavigatorKey,
-                    onGenerateRoute: (RouteSettings settings) {
-                      if (settings.name == '/') {
-                        return MaterialPageRoute<void>(
-                          settings: settings,
-                          builder: (BuildContext context) => const Draggable<int>(
-                            data: 1,
-                            child: Text('Source'),
-                            feedback: Text('Dragging'),
-                            rootOverlay: true,
-                          ),
-                        );
-                      }
-                      throw UnsupportedError('Unsupported route: $settings');
-                    })),
+              height: 200.0,
+              child: Navigator(
+                key: childNavigatorKey,
+                onGenerateRoute: (RouteSettings settings) {
+                  if (settings.name == '/') {
+                    return MaterialPageRoute<void>(
+                      settings: settings,
+                      builder: (BuildContext context) => const Draggable<int>(
+                        data: 1,
+                        child: Text('Source'),
+                        feedback: Text('Dragging'),
+                        rootOverlay: true,
+                      ),
+                    );
+                  }
+                  throw UnsupportedError('Unsupported route: $settings');
+                },
+              ),
+            ),
             DragTarget<int>(
-              builder:
-                  (BuildContext context, List<int> data, List<dynamic> rejects) {
+              builder: (BuildContext context, List<int> data, List<dynamic> rejects) {
                 return Container(
-                    height: 300.0, child: const Center(child: Text('Target 1')));
+                    height: 300.0, child: const Center(child: Text('Target 1')),
+                );
               },
             ),
           ],
@@ -2369,11 +2371,15 @@ void main() {
       // but not a descendant of the child overlay.
       expect(
           find.descendant(
-              of: find.byType(Overlay).first, matching: find.text('Dragging')),
+            of: find.byType(Overlay).first,
+            matching: find.text('Dragging'),
+          ),
           findsOneWidget);
       expect(
           find.descendant(
-              of: find.byType(Overlay).last, matching: find.text('Dragging')),
+            of: find.byType(Overlay).last,
+            matching: find.text('Dragging'),
+          ),
           findsNothing);
     });
 


### PR DESCRIPTION
## Description

Adds a 'rootOverlay' bool parameter to the [Draggable] constructor. This signifies whether the feedback widget should be
inserted into the closest [Overlay] ('false', current behavior) or the farthest 'root' [Overlay] (when 'true').

This allows a [Draggable] within a nested Navigator to be visible on the larger root Navigator's Overlay.

## Related Issues

https://github.com/flutter/flutter/issues/67338

## Tests

I added the following tests:

Added test to draggable_test.dart.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
