### PR TITLE
Update dartdoc to 0.35.0

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -28,6 +28,7 @@ dartdoc:
     - ignored-canonical-for
     - missing-from-search-index
     - no-canonical-found
+    - no-documentable-libraries
     - no-library-level-docs
     - not-implemented
     - orphaned-file

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -39,7 +39,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.34.0
+    "$PUB" global activate dartdoc 0.35.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/docs/dartdoc_options.yaml
+++ b/dev/docs/dartdoc_options.yaml
@@ -1,0 +1,3 @@
+dartdoc:
+  ignore:
+    - no-documentable-libraries

--- a/dev/docs/dartdoc_options.yaml
+++ b/dev/docs/dartdoc_options.yaml
@@ -1,3 +1,5 @@
 dartdoc:
   ignore:
+    # The stub `Flutter` package is expected to have no
+    # documentable libraries.
     - no-documentable-libraries


### PR DESCRIPTION
## Description

This PR updates the version of dartdoc used by Flutter to 0.35.0.  See the release notes, below, for the complete list of changes implied by this PR.  Due to dart-lang/dartdoc#2360, the stub `Flutter` package emits a warning by default because it has no libraries.  A `dartdoc_options.yaml` file has been added to ignore that warning.

## Related Issues

Dartdoc Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.35.0

## Tests

Tested by running `dev/bots/docs.sh` and spot checking the output for any additional warnings (none), and browsing the resulting documentation.  Dartdoc is slightly faster with this release than the prior version (30% faster on initialization, roughly equivalent on documentation generation speed).
