### PR TITLE
Add contentPadding property for RadioListTile

### DIFF
--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -320,7 +320,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.controlAffinity = ListTileControlAffinity.platform,
     this.autofocus = false,
     this.contentPadding,
-    
+
   }) : assert(toggleable != null),
        assert(isThreeLine != null),
        assert(!isThreeLine || subtitle != null),
@@ -471,10 +471,10 @@ class RadioListTile<T> extends StatelessWidget {
   final bool autofocus;
 
   /// Defines the insets surrounding the contents of the tile.
-  /// 
+  ///
   /// Insets the [Radio], [title], [subtitle], and [secondary] widgets
   /// in [RadioListTile].
-  /// 
+  ///
   /// When null, `EdgeInsets.symmetric(horizontal: 16.0)` is used.
   final EdgeInsetsGeometry? contentPadding;
 

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -319,7 +319,8 @@ class RadioListTile<T> extends StatelessWidget {
     this.selected = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.autofocus = false,
-
+    this.contentPadding,
+    
   }) : assert(toggleable != null),
        assert(isThreeLine != null),
        assert(!isThreeLine || subtitle != null),
@@ -469,6 +470,14 @@ class RadioListTile<T> extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  /// Defines the insets surrounding the contents of the tile.
+  /// 
+  /// Insets the [Radio], [title], [subtitle], and [secondary] widgets
+  /// in [RadioListTile].
+  /// 
+  /// When null, `EdgeInsets.symmetric(horizontal: 16.0)` is used.
+  final EdgeInsetsGeometry? contentPadding;
+
   /// Whether this radio button is checked.
   ///
   /// To control this value, set [value] and [groupValue] appropriately.
@@ -519,6 +528,7 @@ class RadioListTile<T> extends StatelessWidget {
           } : null,
           selected: selected,
           autofocus: autofocus,
+          contentPadding: contentPadding,
         ),
       ),
     );

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -608,4 +608,44 @@ void main() {
     await tester.pump();
     expect(Focus.of(childKey.currentContext, nullOk: true).hasPrimaryFocus, isFalse);
   });
+
+  testWidgets('RadioListTile contentPadding test', (WidgetTester tester) async {
+    final Type radioType = const Radio<bool>(
+      groupValue: true,
+      value: true,
+      onChanged: null,
+    ).runtimeType;
+
+    await tester.pumpWidget(
+      wrap(
+        child: Center(
+          child: RadioListTile<bool>(
+            groupValue: true,
+            value: true,
+            title: const Text('Title'),
+            onChanged: (_){},
+            contentPadding: const EdgeInsets.fromLTRB(8, 10, 15, 20),
+          )
+        )
+      )
+    );
+    
+    final Rect paddingRect = tester.getRect(find.byType(Padding));
+    final Rect radioRect = tester.getRect(find.byType(radioType));
+    final Rect titleRect = tester.getRect(find.text('Title'));
+
+    // Get the taller Rect of the Radio and Text widgets
+    final Rect tallerRect = radioRect.height > titleRect.height ? radioRect : titleRect;
+
+    // Get the extra height between the tallerRect and ListTile height
+    final double extraHeight = 56 - tallerRect.height;
+
+    // Check for correct top and bottom padding
+    expect(paddingRect.top, tallerRect.top - extraHeight / 2 - 10); //top padding
+    expect(paddingRect.bottom, tallerRect.bottom + extraHeight / 2 + 20); //bottom padding
+
+    // Check for correct left and right padding
+    expect(paddingRect.left, radioRect.left - 8); //left padding
+    expect(paddingRect.right, titleRect.right + 15); //right padding
+  });
 }

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -629,7 +629,7 @@ void main() {
         )
       )
     );
-    
+
     final Rect paddingRect = tester.getRect(find.byType(Padding));
     final Rect radioRect = tester.getRect(find.byType(radioType));
     final Rect titleRect = tester.getRect(find.text('Title'));


### PR DESCRIPTION
## Description

Exposes `contentPadding` property for **RadioListTile** from its appropriate **ListTile**.

## Related Issues

Fixes #67389.

## Tests

I added the following tests:

 - Added test for checking correct padding around the **RadioListTile**.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
