### PR TITLE
fix LinearGradient constructor missing '@' fixed #67444

### DIFF
--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -366,7 +366,7 @@ class LinearGradient extends Gradient {
   const LinearGradient({
     this.begin = Alignment.centerLeft,
     this.end = Alignment.centerRight,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     GradientTransform? transform,


### PR DESCRIPTION
In LinearGradient widget at package:flutter/src/painting/gradient.dart,

![Capture](https://user-images.githubusercontent.com/42943056/95254227-35964580-083d-11eb-9c8d-d1c3a22007b4.PNG)

It should be @required List colors,