### PR TITLE
[NNBD] Migrates some rendering tests

### DIFF
--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -408,7 +406,7 @@ void main() {
   test('ignore key event from web platform', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -460,7 +458,7 @@ void main() {
   test('selects correct place with offsets', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -545,7 +543,7 @@ void main() {
   test('selects correct place when offsets are flipped', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -578,7 +576,7 @@ void main() {
 
   test('selection does not flicker as user is dragging', () {
     int selectionChangedCount = 0;
-    TextSelection updatedSelection;
+    TextSelection? updatedSelection;
     final TextSelectionDelegate delegate = FakeEditableTextState();
     const TextSpan text = TextSpan(
       text: 'abc def ghi',
@@ -630,8 +628,8 @@ void main() {
     editable2.selectPositionAt(from: const Offset(30, 2), to: const Offset(48, 2), cause: SelectionChangedCause.drag);
     pumpFrame();
 
-    expect(updatedSelection.baseOffset, 3);
-    expect(updatedSelection.extentOffset, 5);
+    expect(updatedSelection!.baseOffset, 3);
+    expect(updatedSelection!.extentOffset, 5);
     expect(selectionChangedCount, 1);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61028
 
@@ -742,7 +740,7 @@ void main() {
   test('arrow keys and delete handle simple text correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -791,7 +789,7 @@ void main() {
   test('arrow keys and delete handle surrogate pairs correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -841,7 +839,7 @@ void main() {
   test('arrow keys and delete handle grapheme clusters correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -891,7 +889,7 @@ void main() {
   test('arrow keys and delete handle surrogate pairs correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();
-    TextSelection currentSelection;
+    late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
       selectionColor: Colors.black,
@@ -1048,11 +1046,11 @@ void main() {
       // Give it a width that forces the editable to wrap.
       editable.layout(const BoxConstraints.tightFor(width: 200));
 
-      final Rect composingRect = editable.getRectForComposingRange(const TextRange(start: 0, end: 20 + 2));
+      final Rect composingRect = editable.getRectForComposingRange(const TextRange(start: 0, end: 20 + 2))!;
 
       // Since the range covers an entire line, the Rect should also be almost
       // as wide as the entire paragraph (give or take 1 character).
-      expect(composingRect?.width, greaterThan(200 - 10));
+      expect(composingRect.width, greaterThan(200 - 10));
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/66089
   });
 

--- a/packages/flutter/test/rendering/error_test.dart
+++ b/packages/flutter/test/rendering/error_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/rendering/first_frame_test.dart
+++ b/packages/flutter/test/rendering/first_frame_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -30,9 +28,4 @@ void main() {
   }, skip: !kIsWeb);
 }
 
-class TestRenderBinding extends BindingBase with SchedulerBinding, ServicesBinding, GestureBinding, SemanticsBinding, RendererBinding {
-  @override
-  void initInstances() {
-    super.initInstances();
-  }
-}
+class TestRenderBinding extends BindingBase with SchedulerBinding, ServicesBinding, GestureBinding, SemanticsBinding, RendererBinding {}

--- a/packages/flutter/test/rendering/flex_overflow_test.dart
+++ b/packages/flutter/test/rendering/flex_overflow_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -26,7 +26,7 @@ void main() {
     const double slightlyLarger = 438.8571428571429;
     const double slightlySmaller = 438.85714285714283;
     final List<dynamic> exceptions = <dynamic>[];
-    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,7 +26,7 @@ void main() {
     const double slightlyLarger = 438.8571428571429;
     const double slightlySmaller = 438.85714285714283;
     final List<dynamic> exceptions = <dynamic>[];
-    final FlutterExceptionHandler oldHandler = FlutterError.onError;
+    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
     FlutterError.onError = (FlutterErrorDetails details) {
       exceptions.add(details.exception);
     };

--- a/packages/flutter/test/rendering/image_test.dart
+++ b/packages/flutter/test/rendering/image_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui show Image;
 
 import 'package:flutter/foundation.dart';
@@ -179,35 +177,35 @@ Future<void> main() async {
 
   test('Render image disposes its image', () async {
     final ui.Image image = await createTestImage(width: 10, height: 10, cache: false);
-    expect(image.debugGetOpenHandleStackTraces().length, 1);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 1);
 
     final RenderImage renderImage = RenderImage(image: image.clone());
-    expect(image.debugGetOpenHandleStackTraces().length, 2);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
     renderImage.image = image.clone();
-    expect(image.debugGetOpenHandleStackTraces().length, 2);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
     renderImage.image = null;
-    expect(image.debugGetOpenHandleStackTraces().length, 1);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 1);
 
     image.dispose();
-    expect(image.debugGetOpenHandleStackTraces().length, 0);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 0);
   }, skip: kIsWeb); // Web doesn't track open image handles.
 
   test('Render image does not dispose its image if setting the same image twice', () async {
     final ui.Image image = await createTestImage(width: 10, height: 10, cache: false);
-    expect(image.debugGetOpenHandleStackTraces().length, 1);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 1);
 
     final RenderImage renderImage = RenderImage(image: image.clone());
-    expect(image.debugGetOpenHandleStackTraces().length, 2);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
     renderImage.image = renderImage.image;
-    expect(image.debugGetOpenHandleStackTraces().length, 2);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
     renderImage.image = null;
-    expect(image.debugGetOpenHandleStackTraces().length, 1);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 1);
 
     image.dispose();
-    expect(image.debugGetOpenHandleStackTraces().length, 0);
+    expect(image.debugGetOpenHandleStackTraces()!.length, 0);
   }, skip: kIsWeb); // Web doesn't track open image handles.
 }

--- a/packages/flutter/test/rendering/independent_layout_test.dart
+++ b/packages/flutter/test/rendering/independent_layout_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui show window;
 
 import 'package:flutter/material.dart';
@@ -29,8 +27,8 @@ class TestLayout {
       ),
     );
   }
-  RenderBox root;
-  RenderBox child;
+  late RenderBox root;
+  late RenderBox child;
   bool painted = false;
 }
 

--- a/packages/flutter/test/rendering/intrinsic_width_test.dart
+++ b/packages/flutter/test/rendering/intrinsic_width_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 

--- a/packages/flutter/test/rendering/layer_annotations_test.dart
+++ b/packages/flutter/test/rendering/layer_annotations_test.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -42,7 +39,7 @@ void main() {
       ]
     ).build();
 
-    final int result = root.find<int>(Offset.zero);
+    final int result = root.find<int>(Offset.zero)!;
     expect(result, 3);
   });
 
@@ -348,9 +345,9 @@ void main() {
     );
 
     void expectOneAnnotation({
-      @required Offset globalPosition,
-      @required int value,
-      @required Offset localPosition,
+      required Offset globalPosition,
+      required int value,
+      required Offset localPosition,
     }) {
       expect(
         root.findAllAnnotations<int>(globalPosition).entries.toList(),
@@ -747,7 +744,7 @@ class _Layers {
 
   final ContainerLayer root;
   // Each element must be instance of Layer or _Layers.
-  final List<Object> children;
+  final List<Object>? children;
   bool _assigned = false;
 
   // Build the layer tree by calling each child's `build`, then append children
@@ -756,8 +753,8 @@ class _Layers {
     assert(!_assigned);
     _assigned = true;
     if (children != null) {
-      for (final Object child in children) {
-        Layer layer;
+      for (final Object child in children!) {
+        late Layer layer;
         if (child is Layer) {
           layer = child;
         } else if (child is _Layers) {
@@ -775,7 +772,7 @@ class _Layers {
 // This layer's [findAnnotation] can be controlled by the given arguments.
 class _TestAnnotatedLayer extends Layer {
   _TestAnnotatedLayer(this.value, {
-    @required this.opaque,
+    required this.opaque,
     this.offset = Offset.zero,
     this.size,
   });
@@ -801,10 +798,10 @@ class _TestAnnotatedLayer extends Layer {
   ///
   /// If [offset] is set, then the offset is applied to the size region before
   /// hit testing in [find].
-  final Size size;
+  final Size? size;
 
   @override
-  EngineLayer addToScene(SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
+  EngineLayer? addToScene(SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
     return null;
   }
 
@@ -812,14 +809,14 @@ class _TestAnnotatedLayer extends Layer {
   // [offset] & [size]. If it is hit, it adds [value] to result and returns
   // [opaque]; otherwise it directly returns false.
   @override
-  bool findAnnotations<S>(
+  bool findAnnotations<S extends Object>(
     AnnotationResult<S> result,
     Offset localPosition, {
-    bool onlyFirst,
+    required bool onlyFirst,
   }) {
     if (S != int)
       return false;
-    if (size != null && !(offset & size).contains(localPosition))
+    if (size != null && !(offset & size!).contains(localPosition))
       return false;
     final Object untypedValue = value;
     final S typedValue = untypedValue as S;

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -27,7 +25,7 @@ void main() {
     expect(inner.debugLayer, null);
     expect(boundary.isRepaintBoundary, isTrue);
     expect(boundary.debugLayer, isNotNull);
-    expect(boundary.debugLayer.attached, isTrue); // this time it painted...
+    expect(boundary.debugLayer!.attached, isTrue); // this time it painted...
 
     root.opacity = 0.0;
     pumpFrame(phase: EnginePhase.paint);
@@ -35,7 +33,7 @@ void main() {
     expect(inner.debugLayer, null);
     expect(boundary.isRepaintBoundary, isTrue);
     expect(boundary.debugLayer, isNotNull);
-    expect(boundary.debugLayer.attached, isFalse); // this time it did not.
+    expect(boundary.debugLayer!.attached, isFalse); // this time it did not.
 
     root.opacity = 0.5;
     pumpFrame(phase: EnginePhase.paint);
@@ -43,7 +41,7 @@ void main() {
     expect(inner.debugLayer, null);
     expect(boundary.isRepaintBoundary, isTrue);
     expect(boundary.debugLayer, isNotNull);
-    expect(boundary.debugLayer.attached, isTrue); // this time it did again!
+    expect(boundary.debugLayer!.attached, isTrue); // this time it did again!
   });
 
   test('updateSubtreeNeedsAddToScene propagates Layer.alwaysNeedsAddToScene up the tree', () {
@@ -410,7 +408,7 @@ void main() {
     void _testConflicts(
       PhysicalModelLayer layerA,
       PhysicalModelLayer layerB, {
-      @required int expectedErrorCount,
+      required int expectedErrorCount,
       bool enableCheck = true,
     }) {
       assert(expectedErrorCount != null);

--- a/packages/flutter/test/rendering/limited_box_test.dart
+++ b/packages/flutter/test/rendering/limited_box_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -25,7 +23,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context).textTheme.headline2;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),
@@ -69,7 +67,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context).textTheme.headline2;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),
@@ -120,7 +118,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context).textTheme.headline2;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),

--- a/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
@@ -14,17 +14,10 @@ import '../flutter_test_alternative.dart';
 import './mouse_tracking_test_utils.dart';
 
 typedef MethodCallHandler = Future<dynamic> Function(MethodCall call);
-
-TestMouseTrackerFlutterBinding? _binding = TestMouseTrackerFlutterBinding();
-
-void _ensureTestGestureBinding() {
-  _binding ??= TestMouseTrackerFlutterBinding();
-  assert(GestureBinding.instance != null);
-}
-
 typedef SimpleAnnotationFinder = Iterable<HitTestTarget> Function(Offset offset);
 
 void main() {
+  final TestMouseTrackerFlutterBinding _binding = TestMouseTrackerFlutterBinding();
   MethodCallHandler? _methodCallHandler;
 
   // Only one of `logCursors` and `cursorHandler` should be specified.
@@ -41,7 +34,7 @@ void main() {
       }
       : cursorHandler;
 
-    _binding!.setHitTest((BoxHitTestResult result, Offset position) {
+    _binding.setHitTest((BoxHitTestResult result, Offset position) {
       for (final HitTestTarget target in annotationFinder(position)) {
         result.addWithRawTransform(
           transform: Matrix4.identity(),
@@ -63,8 +56,7 @@ void main() {
   }
 
   setUp(() {
-    _ensureTestGestureBinding();
-    _binding!.postFrameCallbacks.clear();
+    _binding.postFrameCallbacks.clear();
     SystemChannels.mouseCursor.setMockMethodCallHandler((MethodCall call) async {
       if (_methodCallHandler != null)
         return _methodCallHandler!(call);
@@ -232,8 +224,8 @@ void main() {
 
     // Synthesize a new frame while changing annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    _binding!.scheduleMouseTrackerPostFrameCheck();
-    _binding!.flushPostFrameCallbacks(Duration.zero);
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    _binding.flushPostFrameCallbacks(Duration.zero);
 
     expect(logCursors, <_CursorUpdateDetails>[
       _CursorUpdateDetails.activateSystemCursor(device: 0, kind: SystemMouseCursors.grabbing.kind),
@@ -242,7 +234,7 @@ void main() {
 
     // Synthesize a new frame without changing annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    _binding!.scheduleMouseTrackerPostFrameCheck();
+    _binding.scheduleMouseTrackerPostFrameCheck();
 
     expect(logCursors, <_CursorUpdateDetails>[
     ]);

--- a/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui;
 import 'dart:ui' show PointerChange;
 
@@ -17,7 +15,7 @@ import './mouse_tracking_test_utils.dart';
 
 typedef MethodCallHandler = Future<dynamic> Function(MethodCall call);
 
-TestMouseTrackerFlutterBinding _binding = TestMouseTrackerFlutterBinding();
+TestMouseTrackerFlutterBinding? _binding = TestMouseTrackerFlutterBinding();
 
 void _ensureTestGestureBinding() {
   _binding ??= TestMouseTrackerFlutterBinding();
@@ -27,13 +25,13 @@ void _ensureTestGestureBinding() {
 typedef SimpleAnnotationFinder = Iterable<HitTestTarget> Function(Offset offset);
 
 void main() {
-  MethodCallHandler _methodCallHandler;
+  MethodCallHandler? _methodCallHandler;
 
   // Only one of `logCursors` and `cursorHandler` should be specified.
   void _setUpMouseTracker({
-    SimpleAnnotationFinder annotationFinder,
-    List<_CursorUpdateDetails> logCursors,
-    MethodCallHandler cursorHandler,
+    required SimpleAnnotationFinder annotationFinder,
+    List<_CursorUpdateDetails>? logCursors,
+    MethodCallHandler? cursorHandler,
   }) {
     assert(logCursors == null || cursorHandler == null);
     _methodCallHandler = logCursors != null
@@ -43,7 +41,7 @@ void main() {
       }
       : cursorHandler;
 
-    _binding.setHitTest((BoxHitTestResult result, Offset position) {
+    _binding!.setHitTest((BoxHitTestResult result, Offset position) {
       for (final HitTestTarget target in annotationFinder(position)) {
         result.addWithRawTransform(
           transform: Matrix4.identity(),
@@ -59,17 +57,17 @@ void main() {
   }
 
   void dispatchRemoveDevice([int device = 0]) {
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0), device: device),
     ]));
   }
 
   setUp(() {
     _ensureTestGestureBinding();
-    _binding.postFrameCallbacks.clear();
+    _binding!.postFrameCallbacks.clear();
     SystemChannels.mouseCursor.setMockMethodCallHandler((MethodCall call) async {
       if (_methodCallHandler != null)
-        return _methodCallHandler(call);
+        return _methodCallHandler!(call);
     });
   });
 
@@ -87,7 +85,7 @@ void main() {
       },
     );
 
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
     addTearDown(dispatchRemoveDevice);
@@ -97,14 +95,14 @@ void main() {
 
   test('pointer is added and removed out of any annotations', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    TestAnnotationTarget annotation;
+    TestAnnotationTarget? annotation;
     _setUpMouseTracker(
       annotationFinder: (Offset position) => <TestAnnotationTarget>[if (annotation != null) annotation],
       logCursors: logCursors,
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -115,7 +113,7 @@ void main() {
 
     // Pointer moves into the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -126,7 +124,7 @@ void main() {
 
     // Pointer moves within the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(10.0, 0.0)),
     ]));
 
@@ -136,7 +134,7 @@ void main() {
 
     // Pointer moves out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 0.0)),
     ]));
 
@@ -146,7 +144,7 @@ void main() {
     logCursors.clear();
 
     // Pointer is removed outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0)),
     ]));
 
@@ -156,7 +154,7 @@ void main() {
 
   test('pointer is added and removed in an annotation', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    TestAnnotationTarget annotation;
+    TestAnnotationTarget? annotation;
     _setUpMouseTracker(
       annotationFinder: (Offset position) => <TestAnnotationTarget>[if (annotation != null) annotation],
       logCursors: logCursors,
@@ -164,7 +162,7 @@ void main() {
 
     // Pointer is added in the annotation.
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -175,7 +173,7 @@ void main() {
 
     // Pointer moves out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -186,7 +184,7 @@ void main() {
 
     // Pointer moves around out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(10.0, 0.0)),
     ]));
 
@@ -196,7 +194,7 @@ void main() {
 
     // Pointer moves back into the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 0.0)),
     ]));
 
@@ -206,7 +204,7 @@ void main() {
     logCursors.clear();
 
     // Pointer is removed within the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0)),
     ]));
 
@@ -216,14 +214,14 @@ void main() {
 
   test('pointer change caused by new frames', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    TestAnnotationTarget annotation;
+    TestAnnotationTarget? annotation;
     _setUpMouseTracker(
       annotationFinder: (Offset position) => <TestAnnotationTarget>[if (annotation != null) annotation],
       logCursors: logCursors,
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -234,8 +232,8 @@ void main() {
 
     // Synthesize a new frame while changing annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    _binding.flushPostFrameCallbacks(Duration.zero);
+    _binding!.scheduleMouseTrackerPostFrameCheck();
+    _binding!.flushPostFrameCallbacks(Duration.zero);
 
     expect(logCursors, <_CursorUpdateDetails>[
       _CursorUpdateDetails.activateSystemCursor(device: 0, kind: SystemMouseCursors.grabbing.kind),
@@ -244,14 +242,14 @@ void main() {
 
     // Synthesize a new frame without changing annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    _binding.scheduleMouseTrackerPostFrameCheck();
+    _binding!.scheduleMouseTrackerPostFrameCheck();
 
     expect(logCursors, <_CursorUpdateDetails>[
     ]);
     logCursors.clear();
 
     // Pointer is removed outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0)),
     ]));
 
@@ -261,7 +259,7 @@ void main() {
 
   test('The first annotation with non-deferring cursor is used', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    List<TestAnnotationTarget> annotations;
+    late List<TestAnnotationTarget> annotations;
     _setUpMouseTracker(
       annotationFinder: (Offset position) sync* { yield* annotations; },
       logCursors: logCursors,
@@ -272,7 +270,7 @@ void main() {
       const TestAnnotationTarget(cursor: SystemMouseCursors.click),
       const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing),
     ];
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -282,14 +280,14 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
     ]));
   });
 
   test('Annotations with deferring cursors are ignored', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    List<TestAnnotationTarget> annotations;
+    late List<TestAnnotationTarget> annotations;
     _setUpMouseTracker(
       annotationFinder: (Offset position) sync* { yield* annotations; },
       logCursors: logCursors,
@@ -300,7 +298,7 @@ void main() {
       const TestAnnotationTarget(cursor: MouseCursor.defer),
       const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing),
     ];
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -310,21 +308,21 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
     ]));
   });
 
   test('Finding no annotation is equivalent to specifying default cursor', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    TestAnnotationTarget annotation;
+    TestAnnotationTarget? annotation;
     _setUpMouseTracker(
       annotationFinder: (Offset position) => <TestAnnotationTarget>[if (annotation != null) annotation],
       logCursors: logCursors,
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
 
@@ -335,7 +333,7 @@ void main() {
 
     // Pointer moved to an annotation specified with the default cursor
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.basic);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -345,7 +343,7 @@ void main() {
 
     // Pointer moved to no annotations
     annotation = null;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 0.0)),
     ]));
 
@@ -354,14 +352,14 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0)),
     ]));
   });
 
   test('Removing a pointer resets it back to the default cursor', () {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
-    TestAnnotationTarget annotation;
+    TestAnnotationTarget? annotation;
     _setUpMouseTracker(
       annotationFinder: (Offset position) => <TestAnnotationTarget>[if (annotation != null) annotation],
       logCursors: logCursors,
@@ -369,7 +367,7 @@ void main() {
 
     // Pointer is added to the annotation, then removed
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.click);
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
@@ -379,7 +377,7 @@ void main() {
 
     // Pointer is added out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
     addTearDown(dispatchRemoveDevice);
@@ -404,7 +402,7 @@ void main() {
     );
 
     // Pointers are added outside of the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0), device: 1),
       _pointerData(PointerChange.add, const Offset(0.0, 0.0), device: 2),
     ]));
@@ -418,7 +416,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 1 moved to cursor "click"
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(101.0, 0.0), device: 1),
     ]));
 
@@ -428,7 +426,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 2 moved to cursor "click"
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(102.0, 0.0), device: 2),
     ]));
 
@@ -438,7 +436,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 2 moved to cursor "forbidden"
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(202.0, 0.0), device: 2),
     ]));
 
@@ -472,8 +470,10 @@ class _CursorUpdateDetails extends MethodCall {
   _CursorUpdateDetails.wrap(MethodCall call)
     : super(call.method, Map<String, dynamic>.from(call.arguments as Map<dynamic, dynamic>));
 
-  _CursorUpdateDetails.activateSystemCursor({int device, String kind})
-    : this('activateSystemCursor', <String, dynamic>{'device': device, 'kind': kind});
+  _CursorUpdateDetails.activateSystemCursor({
+    required int device,
+    required String kind,
+  }) : this('activateSystemCursor', <String, dynamic>{'device': device, 'kind': kind});
   @override
   Map<String, dynamic> get arguments => super.arguments as Map<String, dynamic>;
 

--- a/packages/flutter/test/rendering/mouse_tracking_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_test.dart
@@ -14,19 +14,14 @@ import 'package:vector_math/vector_math_64.dart' show Matrix4;
 import '../flutter_test_alternative.dart';
 import './mouse_tracking_test_utils.dart';
 
-TestMouseTrackerFlutterBinding? _binding = TestMouseTrackerFlutterBinding();
 MouseTracker get _mouseTracker => RendererBinding.instance!.mouseTracker;
-
-void _ensureTestGestureBinding() {
-  _binding ??= TestMouseTrackerFlutterBinding();
-  assert(GestureBinding.instance != null);
-}
 
 typedef SimpleAnnotationFinder = Iterable<TestAnnotationEntry> Function(Offset offset);
 
 void main() {
+  final TestMouseTrackerFlutterBinding _binding = TestMouseTrackerFlutterBinding();
   void _setUpMouseAnnotationFinder(SimpleAnnotationFinder annotationFinder) {
-    _binding!.setHitTest((BoxHitTestResult result, Offset position) {
+    _binding.setHitTest((BoxHitTestResult result, Offset position) {
       for (final TestAnnotationEntry entry in annotationFinder(position)) {
         result.addWithRawTransform(
           transform: entry.transform,
@@ -78,8 +73,7 @@ void main() {
   }
 
   setUp(() {
-    _ensureTestGestureBinding();
-    _binding!.postFrameCallbacks.clear();
+    _binding.postFrameCallbacks.clear();
   });
 
   final Matrix4 translate10by20 = Matrix4.translationValues(10, 20, 0);
@@ -308,10 +302,10 @@ void main() {
 
     // Adding an annotation should trigger Enter event.
     isInHitRegion = true;
-    _binding!.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding!.postFrameCallbacks, hasLength(1));
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding.postFrameCallbacks, hasLength(1));
 
-    _binding!.flushPostFrameCallbacks(Duration.zero);
+    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0, 100)).transformed(translate10by20)),
     ]));
@@ -319,14 +313,14 @@ void main() {
 
     // Removing an annotation should trigger events.
     isInHitRegion = false;
-    _binding!.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding!.postFrameCallbacks, hasLength(1));
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding.postFrameCallbacks, hasLength(1));
 
-    _binding!.flushPostFrameCallbacks(Duration.zero);
+    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
   });
 
   test('should correctly handle when the annotation moves in or out of the pointer', () {
@@ -354,29 +348,29 @@ void main() {
 
     // During a frame, the annotation moves into the pointer.
     isInHitRegion = true;
-    expect(_binding!.postFrameCallbacks, hasLength(0));
-    _binding!.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding!.postFrameCallbacks, hasLength(1));
+    expect(_binding.postFrameCallbacks, hasLength(0));
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding.postFrameCallbacks, hasLength(1));
 
-    _binding!.flushPostFrameCallbacks(Duration.zero);
+    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
     events.clear();
 
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
 
     // During a frame, the annotation moves out of the pointer.
     isInHitRegion = false;
-    expect(_binding!.postFrameCallbacks, hasLength(0));
-    _binding!.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding!.postFrameCallbacks, hasLength(1));
+    expect(_binding.postFrameCallbacks, hasLength(0));
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding.postFrameCallbacks, hasLength(1));
 
-    _binding!.flushPostFrameCallbacks(Duration.zero);
+    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
   });
 
   test('should correctly handle when the pointer is added or removed on the annotation', () {
@@ -401,7 +395,7 @@ void main() {
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
 
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
@@ -411,7 +405,7 @@ void main() {
     ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 100.0)),
     ]));
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
@@ -437,7 +431,7 @@ void main() {
     ]));
     addTearDown(() => dispatchRemoveDevice());
 
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
     events.clear();
 
     // Moves the mouse into the region. Should trigger Enter.
@@ -445,7 +439,7 @@ void main() {
     ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 100.0)),
     ]));
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
       EventMatcher<PointerHoverEvent>(const PointerHoverEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
@@ -457,7 +451,7 @@ void main() {
     ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(200.0, 100.0)),
     ]));
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(200.0, 100.0)).transformed(translate10by20)),
     ]));
@@ -473,7 +467,7 @@ void main() {
     ]));
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
-    expect(_binding!.postFrameCallbacks, hasLength(0));
+    expect(_binding.postFrameCallbacks, hasLength(0));
   });
 
   test('should not flip out if not all mouse events are listened to', () {

--- a/packages/flutter/test/rendering/mouse_tracking_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui;
 import 'dart:ui' show PointerChange;
 
@@ -16,8 +14,8 @@ import 'package:vector_math/vector_math_64.dart' show Matrix4;
 import '../flutter_test_alternative.dart';
 import './mouse_tracking_test_utils.dart';
 
-TestMouseTrackerFlutterBinding _binding = TestMouseTrackerFlutterBinding();
-MouseTracker get _mouseTracker => RendererBinding.instance.mouseTracker;
+TestMouseTrackerFlutterBinding? _binding = TestMouseTrackerFlutterBinding();
+MouseTracker get _mouseTracker => RendererBinding.instance!.mouseTracker;
 
 void _ensureTestGestureBinding() {
   _binding ??= TestMouseTrackerFlutterBinding();
@@ -28,7 +26,7 @@ typedef SimpleAnnotationFinder = Iterable<TestAnnotationEntry> Function(Offset o
 
 void main() {
   void _setUpMouseAnnotationFinder(SimpleAnnotationFinder annotationFinder) {
-    _binding.setHitTest((BoxHitTestResult result, Offset position) {
+    _binding!.setHitTest((BoxHitTestResult result, Offset position) {
       for (final TestAnnotationEntry entry in annotationFinder(position)) {
         result.addWithRawTransform(
           transform: entry.transform,
@@ -48,7 +46,9 @@ void main() {
   // `logEvents`.
   // This annotation also contains a cursor with a value of `testCursor`.
   // The mouse tracker records the cursor requests it receives to `logCursors`.
-  TestAnnotationTarget _setUpWithOneAnnotation({List<PointerEvent> logEvents}) {
+  TestAnnotationTarget _setUpWithOneAnnotation({
+    required List<PointerEvent> logEvents
+  }) {
     final TestAnnotationTarget oneAnnotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) {
         if (logEvents != null)
@@ -72,14 +72,14 @@ void main() {
   }
 
   void dispatchRemoveDevice([int device = 0]) {
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 0.0), device: device),
     ]));
   }
 
   setUp(() {
     _ensureTestGestureBinding();
-    _binding.postFrameCallbacks.clear();
+    _binding!.postFrameCallbacks.clear();
   });
 
   final Matrix4 translate10by20 = Matrix4.translationValues(10, 20, 0);
@@ -122,7 +122,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
     // Pointer enters the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -135,7 +135,7 @@ void main() {
     listenerLogs.clear();
 
     // Pointer hovers the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -146,7 +146,7 @@ void main() {
     events.clear();
 
     // Pointer is removed while on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -157,7 +157,7 @@ void main() {
     listenerLogs.clear();
 
     // Pointer is added on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 301.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -175,7 +175,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
     // The first mouse is added on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
       _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
@@ -187,7 +187,7 @@ void main() {
     events.clear();
 
     // The second mouse is added on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 401.0), device: 1),
       _pointerData(PointerChange.hover, const Offset(1.0, 401.0), device: 1),
     ]));
@@ -199,7 +199,7 @@ void main() {
     events.clear();
 
     // The first mouse moves on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -209,7 +209,7 @@ void main() {
     events.clear();
 
     // The second mouse moves on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 501.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -219,7 +219,7 @@ void main() {
     events.clear();
 
     // The first mouse is removed while on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -229,7 +229,7 @@ void main() {
     events.clear();
 
     // The second mouse still moves on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 601.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -239,7 +239,7 @@ void main() {
     events.clear();
 
     // The second mouse is removed while on the annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 601.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -253,7 +253,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     _setUpWithOneAnnotation(logEvents: events);
 
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.down, const Offset(0.0, 101.0)),
     ]));
@@ -265,14 +265,14 @@ void main() {
     ]));
     events.clear();
 
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.move, const Offset(0.0, 201.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
     ]));
     events.clear();
 
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.up, const Offset(0.0, 301.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -281,7 +281,7 @@ void main() {
   });
 
   test('should correctly handle when the annotation appears or disappears on the pointer', () {
-    bool isInHitRegion;
+    late bool isInHitRegion;
     final List<Object> events = <PointerEvent>[];
     final TestAnnotationTarget annotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -297,7 +297,7 @@ void main() {
     isInHitRegion = false;
 
     // Connect a mouse when there is no annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -308,10 +308,10 @@ void main() {
 
     // Adding an annotation should trigger Enter event.
     isInHitRegion = true;
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
+    _binding!.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding!.postFrameCallbacks, hasLength(1));
 
-    _binding.flushPostFrameCallbacks(Duration.zero);
+    _binding!.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0, 100)).transformed(translate10by20)),
     ]));
@@ -319,18 +319,18 @@ void main() {
 
     // Removing an annotation should trigger events.
     isInHitRegion = false;
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
+    _binding!.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding!.postFrameCallbacks, hasLength(1));
 
-    _binding.flushPostFrameCallbacks(Duration.zero);
+    _binding!.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
   });
 
   test('should correctly handle when the annotation moves in or out of the pointer', () {
-    bool isInHitRegion;
+    late bool isInHitRegion;
     final List<Object> events = <PointerEvent>[];
     final TestAnnotationTarget annotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -346,7 +346,7 @@ void main() {
     isInHitRegion = false;
 
     // Connect a mouse.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -354,33 +354,33 @@ void main() {
 
     // During a frame, the annotation moves into the pointer.
     isInHitRegion = true;
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
+    _binding!.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding!.postFrameCallbacks, hasLength(1));
 
-    _binding.flushPostFrameCallbacks(Duration.zero);
+    _binding!.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
     events.clear();
 
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
 
     // During a frame, the annotation moves out of the pointer.
     isInHitRegion = false;
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
+    _binding!.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding!.postFrameCallbacks, hasLength(1));
 
-    _binding.flushPostFrameCallbacks(Duration.zero);
+    _binding!.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
   });
 
   test('should correctly handle when the pointer is added or removed on the annotation', () {
-    bool isInHitRegion;
+    late bool isInHitRegion;
     final List<Object> events = <PointerEvent>[];
     final TestAnnotationTarget annotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -397,28 +397,28 @@ void main() {
 
     // Connect a mouse in the region. Should trigger Enter.
     isInHitRegion = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
 
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
     events.clear();
 
     // Disconnect the mouse from the region. Should trigger Exit.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 100.0)),
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
     ]));
   });
 
   test('should correctly handle when the pointer moves in or out of the annotation', () {
-    bool isInHitRegion;
+    late bool isInHitRegion;
     final List<Object> events = <PointerEvent>[];
     final TestAnnotationTarget annotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -432,20 +432,20 @@ void main() {
     });
 
     isInHitRegion = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(200.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
 
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
     events.clear();
 
     // Moves the mouse into the region. Should trigger Enter.
     isInHitRegion = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 100.0)),
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerEnterEvent>(const PointerEnterEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
       EventMatcher<PointerHoverEvent>(const PointerHoverEvent(position: Offset(0.0, 100.0)).transformed(translate10by20)),
@@ -454,10 +454,10 @@ void main() {
 
     // Moves the mouse out of the region. Should trigger Exit.
     isInHitRegion = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(200.0, 100.0)),
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
       EventMatcher<PointerExitEvent>(const PointerExitEvent(position: Offset(200.0, 100.0)).transformed(translate10by20)),
     ]));
@@ -468,12 +468,12 @@ void main() {
     });
 
     // Connect a touch device, which should not be recognized by MouseTracker
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0), kind: PointerDeviceKind.touch),
     ]));
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
-    expect(_binding.postFrameCallbacks, hasLength(0));
+    expect(_binding!.postFrameCallbacks, hasLength(0));
   });
 
   test('should not flip out if not all mouse events are listened to', () {
@@ -494,7 +494,7 @@ void main() {
 
     isInHitRegionOne = false;
     isInHitRegionTwo = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]));
@@ -513,7 +513,7 @@ void main() {
     //   |  —————— |
     //   ———————————
 
-    bool isInB;
+    late bool isInB;
     final List<String> logs = <String>[];
     final TestAnnotationTarget annotationA = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => logs.add('enterA'),
@@ -535,7 +535,7 @@ void main() {
 
     // Starts out of A.
     isInB = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -543,7 +543,7 @@ void main() {
 
     // Moves into B within one frame.
     isInB = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 10.0)),
     ]));
     expect(logs, <String>['enterA', 'enterB', 'hoverB', 'hoverA']);
@@ -551,7 +551,7 @@ void main() {
 
     // Moves out of A within one frame.
     isInB = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 20.0)),
     ]));
     expect(logs, <String>['exitB', 'exitA']);
@@ -566,8 +566,8 @@ void main() {
     //   |      |  |      |
     //   ————————  ————————
 
-    bool isInA;
-    bool isInB;
+    late bool isInA;
+    late bool isInB;
     final List<String> logs = <String>[];
     final TestAnnotationTarget annotationA = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) => logs.add('enterA'),
@@ -590,7 +590,7 @@ void main() {
     // Starts within A.
     isInA = true;
     isInB = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -600,7 +600,7 @@ void main() {
     // Moves into B within one frame.
     isInA = false;
     isInB = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 10.0)),
     ]));
     expect(logs, <String>['exitA', 'enterB', 'hoverB']);
@@ -609,7 +609,7 @@ void main() {
     // Moves into A within one frame.
     isInA = true;
     isInB = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
     expect(logs, <String>['exitB', 'enterA', 'hoverA']);
@@ -725,7 +725,7 @@ class _EventListCriticalFieldsMatcher extends Matcher {
   bool matches(dynamic untypedItem, Map<dynamic, dynamic> matchState) {
     if (untypedItem is! Iterable<PointerEvent>)
       return false;
-    final Iterable<PointerEvent> item = untypedItem as Iterable<PointerEvent>;
+    final Iterable<PointerEvent> item = untypedItem;
     final Iterator<PointerEvent> iterator = item.iterator;
     if (item.length != _expected.length)
       return false;

--- a/packages/flutter/test/rendering/mutations_test.dart
+++ b/packages/flutter/test/rendering/mutations_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';

--- a/packages/flutter/test/rendering/non_render_object_root_test.dart
+++ b/packages/flutter/test/rendering/non_render_object_root_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -28,20 +26,20 @@ class RealRoot extends AbstractNode {
   @override
   void attach(Object owner) {
     super.attach(owner);
-    child?.attach(owner as PipelineOwner);
+    child.attach(owner as PipelineOwner);
   }
 
   @override
   void detach() {
     super.detach();
-    child?.detach();
+    child.detach();
   }
 
   @override
   PipelineOwner get owner => super.owner as PipelineOwner;
 
   void layout() {
-    child?.layout(BoxConstraints.tight(const Size(500.0, 500.0)));
+    child.layout(BoxConstraints.tight(const Size(500.0, 500.0)));
   }
 }
 

--- a/packages/flutter/test/rendering/non_render_object_root_test.dart
+++ b/packages/flutter/test/rendering/non_render_object_root_test.dart
@@ -11,16 +11,14 @@ import 'rendering_tester.dart';
 
 class RealRoot extends AbstractNode {
   RealRoot(this.child) {
-    if (child != null)
-      adoptChild(child);
+    adoptChild(child);
   }
 
   final RenderObject child;
 
   @override
   void redepthChildren() {
-    if (child != null)
-      redepthChild(child);
+    redepthChild(child);
   }
 
   @override

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -40,7 +40,7 @@ void main() {
 
   test('ensure errors processing render objects are well formatted', () {
     late FlutterErrorDetails errorDetails;
-    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) {
       errorDetails = details;
     };

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -41,8 +39,8 @@ void main() {
   });
 
   test('ensure errors processing render objects are well formatted', () {
-    FlutterErrorDetails errorDetails;
-    final FlutterExceptionHandler oldHandler = FlutterError.onError;
+    late FlutterErrorDetails errorDetails;
+    final FlutterExceptionHandler oldHandler = FlutterError.onError!;
     FlutterError.onError = (FlutterErrorDetails details) {
       errorDetails = details;
     };
@@ -103,37 +101,37 @@ void main() {
   });
 
   test('PaintingContext.pushClipRect reuses the layer', () {
-    _testPaintingContextLayerReuse<ClipRectLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<ClipRectLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushClipRect(true, offset, Rect.zero, painter, oldLayer: oldLayer as ClipRectLayer);
     });
   });
 
   test('PaintingContext.pushClipRRect reuses the layer', () {
-    _testPaintingContextLayerReuse<ClipRRectLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<ClipRRectLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushClipRRect(true, offset, Rect.zero, RRect.fromRectAndRadius(Rect.zero, const Radius.circular(1.0)), painter, oldLayer: oldLayer as ClipRRectLayer);
     });
   });
 
   test('PaintingContext.pushClipPath reuses the layer', () {
-    _testPaintingContextLayerReuse<ClipPathLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<ClipPathLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushClipPath(true, offset, Rect.zero, Path(), painter, oldLayer: oldLayer as ClipPathLayer);
     });
   });
 
   test('PaintingContext.pushColorFilter reuses the layer', () {
-    _testPaintingContextLayerReuse<ColorFilterLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<ColorFilterLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushColorFilter(offset, const ColorFilter.mode(Color.fromRGBO(0, 0, 0, 1.0), BlendMode.clear), painter, oldLayer: oldLayer as ColorFilterLayer);
     });
   });
 
   test('PaintingContext.pushTransform reuses the layer', () {
-    _testPaintingContextLayerReuse<TransformLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<TransformLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushTransform(true, offset, Matrix4.identity(), painter, oldLayer: oldLayer as TransformLayer);
     });
   });
 
   test('PaintingContext.pushOpacity reuses the layer', () {
-    _testPaintingContextLayerReuse<OpacityLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer) {
+    _testPaintingContextLayerReuse<OpacityLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushOpacity(offset, 100, painter, oldLayer: oldLayer as OpacityLayer);
     });
   });
@@ -154,7 +152,7 @@ void _testPaintingContextLayerReuse<L extends Layer>(_LayerTestPaintCallback pai
   expect(box.paintedLayers[0], same(box.paintedLayers[1]));
 }
 
-typedef _LayerTestPaintCallback = Layer Function(PaintingContextCallback painter, PaintingContext context, Offset offset, Layer oldLayer);
+typedef _LayerTestPaintCallback = Layer? Function(PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer);
 
 class _TestCustomLayerBox extends RenderBox {
   _TestCustomLayerBox(this.painter);
@@ -172,7 +170,7 @@ class _TestCustomLayerBox extends RenderBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final Layer paintedLayer = painter(super.paint, context, offset, layer);
+    final Layer paintedLayer = painter(super.paint, context, offset, layer)!;
     paintedLayers.add(paintedLayer);
     layer = paintedLayer as ContainerLayer;
   }
@@ -185,7 +183,10 @@ class TestRenderObject extends RenderObject {
   void debugAssertDoesMeetConstraints() { }
 
   @override
-  Rect get paintBounds => null;
+  Rect get paintBounds {
+    assert(false); // The test shouldn't call this.
+    return Rect.zero;
+  }
 
   @override
   void performLayout() { }
@@ -216,11 +217,17 @@ class TestThrowingRenderObject extends RenderObject {
   void debugAssertDoesMeetConstraints() { }
 
   @override
-  Rect get paintBounds => null;
+  Rect get paintBounds {
+    assert(false); // The test shouldn't call this.
+    return Rect.zero;
+  }
 
   @override
   void performResize() { }
 
   @override
-  Rect get semanticBounds => null;
+  Rect get semanticBounds {
+    assert(false); // The test shouldn't call this.
+    return Rect.zero;
+  }
 }

--- a/packages/flutter/test/rendering/offstage_test.dart
+++ b/packages/flutter/test/rendering/offstage_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';

--- a/packages/flutter/test/rendering/overflow_test.dart
+++ b/packages/flutter/test/rendering/overflow_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
@@ -13,7 +11,7 @@ import 'rendering_tester.dart';
 void main() {
   test('overflow should not affect baseline', () {
     RenderBox root, child, text;
-    double baseline1, baseline2, height1, height2;
+    late double baseline1, baseline2, height1, height2;
 
     root = RenderPositionedBox(
       child: RenderCustomPaint(
@@ -23,7 +21,7 @@ void main() {
         ),
         painter: TestCallbackPainter(
           onPaint: () {
-            baseline1 = child.getDistanceToBaseline(TextBaseline.alphabetic);
+            baseline1 = child.getDistanceToBaseline(TextBaseline.alphabetic)!;
             height1 = text.size.height;
           },
         ),
@@ -43,7 +41,7 @@ void main() {
         ),
         painter: TestCallbackPainter(
           onPaint: () {
-            baseline2 = child.getDistanceToBaseline(TextBaseline.alphabetic);
+            baseline2 = child.getDistanceToBaseline(TextBaseline.alphabetic)!;
             height2 = text.size.height;
           },
         ),

--- a/packages/flutter/test/rendering/paint_error_test.dart
+++ b/packages/flutter/test/rendering/paint_error_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -17,10 +15,10 @@ void main() {
   // the rendering_test.dart dependency of this test uses the bindings in not
   // compatible with existing tests in object_test.dart.
   test('reentrant paint error', () {
-    FlutterErrorDetails errorDetails;
+    late FlutterErrorDetails errorDetails;
     final RenderBox root = TestReentrantPaintingErrorRenderBox();
     layout(root, onErrors: () {
-      errorDetails = renderer.takeFlutterErrorDetails();
+      errorDetails = renderer.takeFlutterErrorDetails()!;
     });
     pumpFrame(phase: EnginePhase.paint);
 
@@ -64,7 +62,7 @@ void main() {
   });
 
   test('needsCompositingBitsUpdate paint error', () {
-    FlutterError flutterError;
+    late FlutterError flutterError;
     final RenderBox root = RenderRepaintBoundary(child: RenderSizedBox(const Size(100, 100)));
     try {
       layout(root);

--- a/packages/flutter/test/rendering/paragraph_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/paragraph_intrinsics_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui show TextBox;
 
 import 'package:flutter/gestures.dart';
@@ -22,9 +20,10 @@ const String _kText = "I polished up that handle so carefullee\nThat now I am th
 // which may return an empty list in some situations where Libtxt would return a list
 // containing an empty box.
 class RenderParagraphWithEmptySelectionBoxList extends RenderParagraph {
-  RenderParagraphWithEmptySelectionBoxList(InlineSpan text, {
-    TextDirection textDirection,
-    this.emptyListSelection,
+  RenderParagraphWithEmptySelectionBoxList(
+    InlineSpan text, {
+    required TextDirection textDirection,
+    required this.emptyListSelection,
   }) : super(text, textDirection: textDirection);
 
   TextSelection emptyListSelection;
@@ -65,7 +64,7 @@ void main() {
     );
     layout(paragraph);
 
-    final double height5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5));
+    final double height5 = paragraph.getFullHeightForCaret(const TextPosition(offset: 5))!;
     expect(height5, equals(10.0));
   });
 
@@ -136,7 +135,11 @@ void main() {
       softWrap: true,
     );
 
-    void relayoutWith({ int maxLines, bool softWrap, TextOverflow overflow }) {
+    void relayoutWith({
+      int? maxLines,
+      required bool softWrap,
+      required TextOverflow overflow,
+    }) {
       paragraph
         ..maxLines = maxLines
         ..softWrap = softWrap
@@ -211,7 +214,7 @@ void main() {
       textDirection: TextDirection.ltr,
     );
     layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
-    void layoutAt(int maxLines) {
+    void layoutAt(int? maxLines) {
       paragraph.maxLines = maxLines;
       pumpFrame();
     }
@@ -562,7 +565,7 @@ void main() {
     bool failed = false;
     try {
       paragraph.assembleSemanticsNode(SemanticsNode(), SemanticsConfiguration(), <SemanticsNode>[]);
-    } catch(e) {
+    } on AssertionError catch(e) {
       failed = true;
       expect(e.message, 'MultiTapGestureRecognizer is not supported.');
     }

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -565,7 +565,7 @@ void main() {
     bool failed = false;
     try {
       paragraph.assembleSemanticsNode(SemanticsNode(), SemanticsConfiguration(), <SemanticsNode>[]);
-    } on AssertionError catch(e) {
+    } on AssertionError catch (e) {
       failed = true;
       expect(e.message, 'MultiTapGestureRecognizer is not supported.');
     }

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -17,8 +15,8 @@ import 'rendering_tester.dart';
 void main() {
 
   group('PlatformViewRenderBox', () {
-    FakePlatformViewController fakePlatformViewController;
-    PlatformViewRenderBox platformViewRenderBox;
+    late FakePlatformViewController fakePlatformViewController;
+    late PlatformViewRenderBox platformViewRenderBox;
     setUp(() {
       renderer; // Initialize bindings
       fakePlatformViewController = FakePlatformViewController(0);
@@ -78,7 +76,7 @@ void main() {
       layout(platformViewRenderBox);
       pumpFrame(phase: EnginePhase.flushSemantics);
 
-      ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, const Offset(0, 0)),
         _pointerData(ui.PointerChange.hover, const Offset(10, 10)),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10)),
@@ -91,7 +89,7 @@ void main() {
       layout(platformViewRenderBox);
       pumpFrame(phase: EnginePhase.flushSemantics);
 
-      ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, const Offset(0, 0)),
         _pointerData(ui.PointerChange.hover, const Offset(10, 10)),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10)),

--- a/packages/flutter/test/rendering/positioned_box_test.dart
+++ b/packages/flutter/test/rendering/positioned_box_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 import 'dart:ui' as ui show Gradient, Image, ImageFilter;
 
@@ -26,7 +24,7 @@ void main() {
 
     layout(fittedBox, phase: EnginePhase.flushSemantics);
     final Matrix4 transform = Matrix4.identity();
-    fittedBox.applyPaintTransform(fittedBox.child, transform);
+    fittedBox.applyPaintTransform(fittedBox.child!, transform);
     expect(transform, Matrix4.zero());
 
     final BoxHitTestResult hitTestResult = BoxHitTestResult();
@@ -223,7 +221,7 @@ void main() {
     image = await boundary.toImage();
     expect(image.width, equals(20));
     expect(image.height, equals(20));
-    ByteData data = await image.toByteData();
+    ByteData data = (await image.toByteData())!;
 
     int getPixel(int x, int y) => data.getUint32((x + y * image.width) * 4);
 
@@ -237,7 +235,7 @@ void main() {
     image = await layer.toImage(Offset.zero & const Size(20.0, 20.0));
     expect(image.width, equals(20));
     expect(image.height, equals(20));
-    data = await image.toByteData();
+    data = (await image.toByteData())!;
     expect(getPixel(0, 0), equals(0x00000080));
     expect(getPixel(image.width - 1, 0 ), equals(0xffffffff));
 
@@ -245,7 +243,7 @@ void main() {
     image = await layer.toImage(const Offset(-10.0, -10.0) & const Size(30.0, 30.0));
     expect(image.width, equals(30));
     expect(image.height, equals(30));
-    data = await image.toByteData();
+    data = (await image.toByteData())!;
     expect(getPixel(0, 0), equals(0x00000000));
     expect(getPixel(10, 10), equals(0x00000080));
     expect(getPixel(image.width - 1, 0), equals(0x00000000));
@@ -255,7 +253,7 @@ void main() {
     image = await layer.toImage(const Offset(-10.0, -10.0) & const Size(30.0, 30.0), pixelRatio: 2.0);
     expect(image.width, equals(60));
     expect(image.height, equals(60));
-    data = await image.toByteData();
+    data = (await image.toByteData())!;
     expect(getPixel(0, 0), equals(0x00000000));
     expect(getPixel(20, 20), equals(0x00000080));
     expect(getPixel(image.width - 1, 0), equals(0x00000000));
@@ -600,7 +598,7 @@ void _testLayerReuse<L extends Layer>(RenderBox renderObject) {
   expect(L, isNot(Layer));
   expect(renderObject.debugLayer, null);
   layout(renderObject, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
-  final Layer layer = renderObject.debugLayer;
+  final Layer layer = renderObject.debugLayer!;
   expect(layer, isA<L>());
   expect(layer, isNotNull);
 
@@ -624,8 +622,8 @@ class _TestPathClipper extends CustomClipper<Path> {
 
 class _TestSemanticsUpdateRenderFractionalTranslation extends RenderFractionalTranslation {
   _TestSemanticsUpdateRenderFractionalTranslation({
-    @required Offset translation,
-    RenderBox child,
+    required Offset translation,
+    RenderBox? child,
   }) : super(translation: translation, child: child);
 
   int markNeedsSemanticsUpdateCallCount = 0;

--- a/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
+++ b/packages/flutter/test/rendering/proxy_getters_and_setters_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
@@ -53,8 +51,16 @@ void main() {
   });
 
   test('RenderShaderMask getters and setters', () {
-    final ShaderCallback callback1 = (Rect bounds) => null;
-    final ShaderCallback callback2 = (Rect bounds) => null;
+    final ShaderCallback callback1 = (Rect bounds) {
+      assert(false); // The test should not call this.
+      const LinearGradient gradient = LinearGradient(colors: <Color>[Colors.red]);
+      return gradient.createShader(Rect.zero);
+    };
+    final ShaderCallback callback2 = (Rect bounds) {
+      assert(false); // The test should not call this.
+      const LinearGradient gradient = LinearGradient(colors: <Color>[Colors.blue]);
+      return gradient.createShader(Rect.zero);
+    };
     final RenderShaderMask box = RenderShaderMask(shaderCallback: callback1);
     expect(box.shaderCallback, equals(callback1));
     box.shaderCallback = callback2;

--- a/packages/flutter/test/rendering/proxy_sliver_test.dart
+++ b/packages/flutter/test/rendering/proxy_sliver_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -69,7 +67,7 @@ void main() {
 
     expect(renderSliverOpacity.debugLayer, null);
     layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
-    final ContainerLayer layer = renderSliverOpacity.debugLayer;
+    final ContainerLayer layer = renderSliverOpacity.debugLayer!;
     expect(layer, isNotNull);
 
     // Mark for repaint otherwise pumpFrame is a noop.
@@ -152,7 +150,7 @@ void main() {
 
     expect(renderSliverAnimatedOpacity.debugLayer, null);
     layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
-    final ContainerLayer layer = renderSliverAnimatedOpacity.debugLayer;
+    final ContainerLayer layer = renderSliverAnimatedOpacity.debugLayer!;
     expect(layer, isNotNull);
 
     // Mark for repaint otherwise pumpFrame is a noop.

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
@@ -41,13 +39,13 @@ class TestTree {
       ),
     );
   }
-  RenderBox root;
-  RenderConstrainedBox child;
+  late RenderBox root;
+  late RenderConstrainedBox child;
   bool painted = false;
 }
 
 class MutableCompositor extends RenderProxyBox {
-  MutableCompositor({ RenderBox child }) : super(child);
+  MutableCompositor({ required RenderBox child }) : super(child);
   bool _alwaysComposite = false;
   @override
   bool get alwaysNeedsCompositing => _alwaysComposite;
@@ -77,9 +75,9 @@ class TestCompositingBitsTree {
       ),
     );
   }
-  RenderBox root;
-  MutableCompositor compositor;
-  RenderConstrainedBox child;
+  late RenderBox root;
+  late MutableCompositor compositor;
+  late RenderConstrainedBox child;
   bool painted = false;
 }
 

--- a/packages/flutter/test/rendering/relative_rect_test.dart
+++ b/packages/flutter/test/rendering/relative_rect_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 
@@ -48,7 +46,7 @@ void main() {
   test('RelativeRect.lerp', () {
     const RelativeRect r1 = RelativeRect.fill;
     const RelativeRect r2 = RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
-    final RelativeRect r3 = RelativeRect.lerp(r1, r2, 0.5);
+    final RelativeRect r3 = RelativeRect.lerp(r1, r2, 0.5)!;
     expect(r3, const RelativeRect.fromLTRB(5.0, 10.0, 15.0, 20.0));
   });
 }

--- a/packages/flutter/test/rendering/repaint_boundary_2_test.dart
+++ b/packages/flutter/test/rendering/repaint_boundary_2_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -17,7 +15,7 @@ void main() {
 }
 
 class RelayoutBoundariesCrash extends StatefulWidget {
-  const RelayoutBoundariesCrash({Key key}) : super(key: key);
+  const RelayoutBoundariesCrash({Key? key}) : super(key: key);
 
   @override
   RelayoutBoundariesCrashState createState() => RelayoutBoundariesCrashState();

--- a/packages/flutter/test/rendering/repaint_boundary_test.dart
+++ b/packages/flutter/test/rendering/repaint_boundary_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
@@ -92,9 +90,9 @@ void main() {
       child: faultyRenderObject,
     );
 
-    FlutterErrorDetails error;
+    late FlutterErrorDetails error;
     layout(opacity, phase: EnginePhase.flushSemantics, onErrors: () {
-      error = renderer.takeFlutterErrorDetails();
+      error = renderer.takeFlutterErrorDetails()!;
     });
     expect('${error.exception}', contains('Attempted to set a layer to a repaint boundary render object.'));
   });

--- a/packages/flutter/test/rendering/semantics_and_children_test.dart
+++ b/packages/flutter/test/rendering/semantics_and_children_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart' show TestVSync;

--- a/packages/flutter/test/rendering/simple_semantics_test.dart
+++ b/packages/flutter/test/rendering/simple_semantics_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';

--- a/packages/flutter/test/rendering/size_test.dart
+++ b/packages/flutter/test/rendering/size_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 

--- a/packages/flutter/test/rendering/sliver_cache_test.dart
+++ b/packages/flutter/test/rendering/sliver_cache_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 
@@ -880,25 +877,36 @@ void main() {
   });
 }
 
-void expectSliverConstraints({ RenderSliver sliver, double cacheOrigin, double remainingPaintExtent, double remainingCacheExtent, double scrollOffset }) {
+void expectSliverConstraints({
+  required RenderSliver sliver,
+  required double cacheOrigin,
+  required double remainingPaintExtent,
+  required double remainingCacheExtent,
+  required double scrollOffset,
+}) {
   expect(sliver.constraints.cacheOrigin, cacheOrigin, reason: 'cacheOrigin');
   expect(sliver.constraints.remainingPaintExtent, remainingPaintExtent, reason: 'remainingPaintExtent');
   expect(sliver.constraints.remainingCacheExtent, remainingCacheExtent, reason: 'remainingCacheExtent');
   expect(sliver.constraints.scrollOffset, scrollOffset, reason: 'scrollOffset');
 }
 
-void expectSliverGeometry({ RenderSliver sliver, double paintExtent, double cacheExtent, bool visible }) {
-  expect(sliver.geometry.paintExtent, paintExtent, reason: 'paintExtent');
-  expect(sliver.geometry.cacheExtent, cacheExtent, reason: 'cacheExtent');
-  expect(sliver.geometry.visible, visible, reason: 'visible');
+void expectSliverGeometry({
+  required RenderSliver sliver,
+  required double paintExtent,
+  required double cacheExtent,
+  required bool visible,
+}) {
+  expect(sliver.geometry!.paintExtent, paintExtent, reason: 'paintExtent');
+  expect(sliver.geometry!.cacheExtent, cacheExtent, reason: 'cacheExtent');
+  expect(sliver.geometry!.visible, visible, reason: 'visible');
 }
 
 class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
   TestRenderSliverBoxChildManager({
-    this.children,
+    required this.children,
   });
 
-  RenderSliverMultiBoxAdaptor _renderObject;
+  RenderSliverMultiBoxAdaptor? _renderObject;
   List<RenderBox> children;
 
   RenderSliverList createRenderSliverList() {
@@ -928,15 +936,15 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
     return _renderObject as RenderSliverGrid;
   }
 
-  int _currentlyUpdatingChildIndex;
+  int? _currentlyUpdatingChildIndex;
 
   @override
-  void createChild(int index, { @required RenderBox after }) {
+  void createChild(int index, { required RenderBox? after }) {
     if (index < 0 || index >= children.length)
       return;
     try {
       _currentlyUpdatingChildIndex = index;
-      _renderObject.insert(children[index], after: after);
+      _renderObject!.insert(children[index], after: after);
     } finally {
       _currentlyUpdatingChildIndex = null;
     }
@@ -944,19 +952,19 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
 
   @override
   void removeChild(RenderBox child) {
-    _renderObject.remove(child);
+    _renderObject!.remove(child);
   }
 
   @override
   double estimateMaxScrollOffset(
     SliverConstraints constraints, {
-    int firstIndex,
-    int lastIndex,
-    double leadingScrollOffset,
-    double trailingScrollOffset,
+    int? firstIndex,
+    int? lastIndex,
+    double? leadingScrollOffset,
+    double? trailingScrollOffset,
   }) {
-    assert(lastIndex >= firstIndex);
-    return children.length * (trailingScrollOffset - leadingScrollOffset) / (lastIndex - firstIndex + 1);
+    assert(lastIndex! >= firstIndex!);
+    return children.length * (trailingScrollOffset! - leadingScrollOffset!) / (lastIndex! - firstIndex! + 1);
   }
 
   @override

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 
@@ -48,10 +45,10 @@ void main() {
 
 class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
   TestRenderSliverBoxChildManager({
-    this.children,
+    required this.children,
   });
 
-  RenderSliverMultiBoxAdaptor _renderObject;
+  RenderSliverMultiBoxAdaptor? _renderObject;
   List<RenderBox> children;
 
   RenderSliverFillViewport createRenderSliverFillViewport() {
@@ -62,15 +59,15 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
     return _renderObject as RenderSliverFillViewport;
   }
 
-  int _currentlyUpdatingChildIndex;
+  int? _currentlyUpdatingChildIndex;
 
   @override
-  void createChild(int index, { @required RenderBox after }) {
+  void createChild(int index, { required RenderBox? after }) {
     if (index < 0 || index >= children.length)
       return;
     try {
       _currentlyUpdatingChildIndex = index;
-      _renderObject.insert(children[index], after: after);
+      _renderObject!.insert(children[index], after: after);
     } finally {
       _currentlyUpdatingChildIndex = null;
     }
@@ -78,19 +75,19 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
 
   @override
   void removeChild(RenderBox child) {
-    _renderObject.remove(child);
+    _renderObject!.remove(child);
   }
 
   @override
   double estimateMaxScrollOffset(
     SliverConstraints constraints, {
-    int firstIndex,
-    int lastIndex,
-    double leadingScrollOffset,
-    double trailingScrollOffset,
+    int? firstIndex,
+    int? lastIndex,
+    double? leadingScrollOffset,
+    double? trailingScrollOffset,
   }) {
-    assert(lastIndex >= firstIndex);
-    return children.length * (trailingScrollOffset - leadingScrollOffset) / (lastIndex - firstIndex + 1);
+    assert(lastIndex! >= firstIndex!);
+    return children.length * (trailingScrollOffset! - leadingScrollOffset!) / (lastIndex! - firstIndex! + 1);
   }
 
   @override

--- a/packages/flutter/test/rendering/sliver_persistent_header_test.dart
+++ b/packages/flutter/test/rendering/sliver_persistent_header_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import '../flutter_test_alternative.dart';
 
@@ -24,7 +22,7 @@ void main() {
     );
     layout(root);
 
-    expect(header.geometry.maxScrollObstructionExtent, 0);
+    expect(header.geometry!.maxScrollObstructionExtent, 0);
   });
 
   test('RenderSliverFloatingPinnedPersistentHeader maxScrollObstructionExtent is minExtent', () {
@@ -42,13 +40,13 @@ void main() {
     );
     layout(root);
 
-    expect(header.geometry.maxScrollObstructionExtent, 100.0);
+    expect(header.geometry!.maxScrollObstructionExtent, 100.0);
   });
 }
 
 class TestRenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersistentHeader {
   TestRenderSliverFloatingPersistentHeader({
-    RenderBox child,
+    required RenderBox child,
   }) : super(child: child, vsync: null, showOnScreenConfiguration: null);
 
   @override
@@ -60,7 +58,7 @@ class TestRenderSliverFloatingPersistentHeader extends RenderSliverFloatingPersi
 
 class TestRenderSliverFloatingPinnedPersistentHeader extends RenderSliverFloatingPinnedPersistentHeader {
   TestRenderSliverFloatingPinnedPersistentHeader({
-    RenderBox child,
+    required RenderBox child,
   }) : super(child: child, vsync: null, showOnScreenConfiguration: null);
 
   @override


### PR DESCRIPTION
## Description

This migrates several tests from the rendering library to NNBD.

## Related Issues

dart-lang/sdk#40146
#62886

## Tests

Pass!

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
