### PR TITLE
Add publish-port flag to disable mDNS port discovery

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -55,7 +55,7 @@ class DriveCommand extends RunCommandBase {
   }) {
     requiresPubspecYaml();
     addEnableExperimentation(hide: !verboseHelp);
-    addPublishObservatoryPort(enabledByDefault: false, verboseHelp: verboseHelp);
+    addPublishPort(enabledByDefault: false, verboseHelp: verboseHelp);
     argParser
       ..addFlag('keep-app-running',
         defaultsTo: null,
@@ -217,7 +217,7 @@ class DriveCommand extends RunCommandBase {
             : DebuggingOptions.enabled(
               getBuildInfo(),
               port: stringArg('web-port'),
-              disableObservatoryPublication: disableObservatoryPublication,
+              disablePortPublication: disablePortPublication,
             ),
           stayResident: false,
           urlTunneller: null,
@@ -503,7 +503,7 @@ Future<LaunchResult> _startApp(
       command.getBuildInfo(),
       startPaused: true,
       hostVmServicePort: webUri != null ? command.hostVmservicePort : 0,
-      disableObservatoryPublication: command.disableObservatoryPublication,
+      disablePortPublication: command.disablePortPublication,
       ddsPort: command.ddsPort,
       verboseSystemLogs: command.verboseSystemLogs,
       cacheSkSL: command.cacheSkSL,

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -55,6 +55,7 @@ class DriveCommand extends RunCommandBase {
   }) {
     requiresPubspecYaml();
     addEnableExperimentation(hide: !verboseHelp);
+    addPublishObservatoryPort(enabledByDefault: false, verboseHelp: verboseHelp);
     argParser
       ..addFlag('keep-app-running',
         defaultsTo: null,
@@ -215,7 +216,8 @@ class DriveCommand extends RunCommandBase {
             )
             : DebuggingOptions.enabled(
               getBuildInfo(),
-              port: stringArg('web-port')
+              port: stringArg('web-port'),
+              disableObservatoryPublication: disableObservatoryPublication,
             ),
           stayResident: false,
           urlTunneller: null,
@@ -501,6 +503,7 @@ Future<LaunchResult> _startApp(
       command.getBuildInfo(),
       startPaused: true,
       hostVmServicePort: webUri != null ? command.hostVmservicePort : 0,
+      disableObservatoryPublication: command.disableObservatoryPublication,
       ddsPort: command.ddsPort,
       verboseSystemLogs: command.verboseSystemLogs,
       cacheSkSL: command.cacheSkSL,

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -55,6 +55,10 @@ class DriveCommand extends RunCommandBase {
   }) {
     requiresPubspecYaml();
     addEnableExperimentation(hide: !verboseHelp);
+
+    // By default, the drive app should not publish the VM service port over mDNS
+    // to prevent a local network permission dialog on iOS 14+,
+    // which cannot be accepted or dismissed in a CI environment.
     addPublishPort(enabledByDefault: false, verboseHelp: verboseHelp);
     argParser
       ..addFlag('keep-app-running',

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -97,6 +97,7 @@ class RunCommand extends RunCommandBase {
     usesFilesystemOptions(hide: !verboseHelp);
     usesExtraFrontendOptions();
     addEnableExperimentation(hide: !verboseHelp);
+    addPublishObservatoryPort(enabledByDefault: true, verboseHelp: verboseHelp);
     argParser
       ..addFlag('start-paused',
         negatable: false,
@@ -407,6 +408,7 @@ class RunCommand extends RunCommandBase {
         purgePersistentCache: purgePersistentCache,
         deviceVmServicePort: deviceVmservicePort,
         hostVmServicePort: hostVmservicePort,
+        disableObservatoryPublication: disableObservatoryPublication,
         ddsPort: ddsPort,
         verboseSystemLogs: boolArg('verbose-system-logs'),
         initializePlatform: boolArg('web-initialize-platform'),

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -97,6 +97,10 @@ class RunCommand extends RunCommandBase {
     usesFilesystemOptions(hide: !verboseHelp);
     usesExtraFrontendOptions();
     addEnableExperimentation(hide: !verboseHelp);
+
+    // By default, the app should to publish the VM service port over mDNS.
+    // This will allow subsequent "flutter attach" commands to connect to the VM
+    // without needing to know the port.
     addPublishPort(enabledByDefault: true, verboseHelp: verboseHelp);
     argParser
       ..addFlag('start-paused',

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -97,7 +97,7 @@ class RunCommand extends RunCommandBase {
     usesFilesystemOptions(hide: !verboseHelp);
     usesExtraFrontendOptions();
     addEnableExperimentation(hide: !verboseHelp);
-    addPublishObservatoryPort(enabledByDefault: true, verboseHelp: verboseHelp);
+    addPublishPort(enabledByDefault: true, verboseHelp: verboseHelp);
     argParser
       ..addFlag('start-paused',
         negatable: false,
@@ -408,7 +408,7 @@ class RunCommand extends RunCommandBase {
         purgePersistentCache: purgePersistentCache,
         deviceVmServicePort: deviceVmservicePort,
         hostVmServicePort: hostVmservicePort,
-        disableObservatoryPublication: disableObservatoryPublication,
+        disablePortPublication: disablePortPublication,
         ddsPort: ddsPort,
         verboseSystemLogs: boolArg('verbose-system-logs'),
         initializePlatform: boolArg('web-initialize-platform'),

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -813,7 +813,7 @@ class DebuggingOptions {
     this.useTestFonts = false,
     this.verboseSystemLogs = false,
     this.hostVmServicePort,
-    this.disableObservatoryPublication = false,
+    this.disablePortPublication = false,
     this.deviceVmServicePort,
     this.ddsPort,
     this.initializePlatform = true,
@@ -856,7 +856,7 @@ class DebuggingOptions {
       purgePersistentCache = false,
       verboseSystemLogs = false,
       hostVmServicePort = null,
-      disableObservatoryPublication = false,
+      disablePortPublication = false,
       deviceVmServicePort = null,
       ddsPort = null,
       vmserviceOutFile = null,
@@ -886,7 +886,7 @@ class DebuggingOptions {
   final bool initializePlatform;
   final int hostVmServicePort;
   final int deviceVmServicePort;
-  final bool disableObservatoryPublication;
+  final bool disablePortPublication;
   final int ddsPort;
   final String port;
   final String hostname;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -813,6 +813,7 @@ class DebuggingOptions {
     this.useTestFonts = false,
     this.verboseSystemLogs = false,
     this.hostVmServicePort,
+    this.disableObservatoryPublication = false,
     this.deviceVmServicePort,
     this.ddsPort,
     this.initializePlatform = true,
@@ -855,6 +856,7 @@ class DebuggingOptions {
       purgePersistentCache = false,
       verboseSystemLogs = false,
       hostVmServicePort = null,
+      disableObservatoryPublication = false,
       deviceVmServicePort = null,
       ddsPort = null,
       vmserviceOutFile = null,
@@ -884,6 +886,7 @@ class DebuggingOptions {
   final bool initializePlatform;
   final int hostVmServicePort;
   final int deviceVmServicePort;
+  final bool disableObservatoryPublication;
   final int ddsPort;
   final String port;
   final String hostname;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -368,7 +368,7 @@ class IOSDevice extends Device {
       '--enable-service-port-fallback',
       '--disable-service-auth-codes',
       '--observatory-port=$assumedObservatoryPort',
-      if (debuggingOptions.disableObservatoryPublication) '--disable-observatory-publication',
+      if (debuggingOptions.disablePortPublication) '--disable-observatory-publication',
       if (debuggingOptions.startPaused) '--start-paused',
       if (dartVmFlags.isNotEmpty) '--dart-flags="$dartVmFlags"',
       if (debuggingOptions.useTestFonts) '--use-test-fonts',

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -22,7 +22,6 @@ import '../convert.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
 import '../macos/xcode.dart';
-import '../mdns_discovery.dart';
 import '../project.dart';
 import '../protocol_discovery.dart';
 import '../vmservice.dart';
@@ -454,7 +453,6 @@ class IOSDevice extends Device {
       _logger.printTrace('Application launched on the device. Waiting for observatory port.');
       final FallbackDiscovery fallbackDiscovery = FallbackDiscovery(
         logger: _logger,
-        mDnsObservatoryDiscovery: debuggingOptions.disableObservatoryPublication ? null : MDnsObservatoryDiscovery.instance,
         portForwarder: portForwarder,
         protocolDiscovery: observatoryDiscovery,
         flutterUsage: globals.flutterUsage,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -369,6 +369,7 @@ class IOSDevice extends Device {
       '--enable-service-port-fallback',
       '--disable-service-auth-codes',
       '--observatory-port=$assumedObservatoryPort',
+      if (debuggingOptions.disableObservatoryPublication) '--disable-observatory-publication',
       if (debuggingOptions.startPaused) '--start-paused',
       if (dartVmFlags.isNotEmpty) '--dart-flags="$dartVmFlags"',
       if (debuggingOptions.useTestFonts) '--use-test-fonts',
@@ -453,7 +454,7 @@ class IOSDevice extends Device {
       _logger.printTrace('Application launched on the device. Waiting for observatory port.');
       final FallbackDiscovery fallbackDiscovery = FallbackDiscovery(
         logger: _logger,
-        mDnsObservatoryDiscovery: MDnsObservatoryDiscovery.instance,
+        mDnsObservatoryDiscovery: debuggingOptions.disableObservatoryPublication ? null : MDnsObservatoryDiscovery.instance,
         portForwarder: portForwarder,
         protocolDiscovery: observatoryDiscovery,
         flutterUsage: globals.flutterUsage,

--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -161,7 +161,7 @@ class FallbackDiscovery {
       await Future<void>.delayed(_pollingDelay);
       attempts += 1;
     }
-    _logger.printTrace('Failed to connect directly, falling back to mDNS');
+    _logger.printTrace('Failed to connect directly, falling back to log scanning');
     _sendFailureEvent(firstException, assumedDevicePort);
     return null;
   }

--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -8,7 +8,6 @@ import 'package:vm_service/vm_service.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../device.dart';
-import '../mdns_discovery.dart';
 import '../protocol_discovery.dart';
 import '../reporting/reporting.dart';
 
@@ -17,38 +16,23 @@ typedef VmServiceConnector = Future<VmService> Function(String, {Log log});
 /// A protocol for discovery of a vmservice on an attached iOS device with
 /// multiple fallbacks.
 ///
-/// On versions of iOS 13 and greater, libimobiledevice can no longer listen to
-/// logs directly. The only way to discover an active observatory is through the
-/// mDNS protocol. However, there are a number of circumstances where this breaks
-/// down, such as when the device is connected to certain wifi networks or with
-/// certain hotspot connections enabled.
-///
-/// If [mDnsObservatoryDiscovery] is null, mDNS fallback is skipped.
-///
-/// Another approach to discover a vmservice is to attempt to assign a
+/// First, it tries to discover a vmservice by assigning a
 /// specific port and then attempt to connect. This may fail if the port is
 /// not available. This port value should be either random, or otherwise
 /// generated with application specific input. This reduces the chance of
 /// accidentally connecting to another running flutter application.
 ///
-/// Finally, if neither of the above approaches works, we can still attempt
-/// to parse logs.
-///
-/// To improve the overall resilience of the process, this class combines the
-/// three discovery strategies. First it assigns a port and attempts to connect.
-/// Then if this fails it falls back to mDNS, then finally attempting to scan
-/// logs.
+/// If that does not work, attempt to scan logs from the attached debugger
+/// and parse the connected port logged by the engine.
 class FallbackDiscovery {
   FallbackDiscovery({
     @required DevicePortForwarder portForwarder,
-    @required MDnsObservatoryDiscovery mDnsObservatoryDiscovery,
     @required Logger logger,
     @required ProtocolDiscovery protocolDiscovery,
     @required Usage flutterUsage,
     @required VmServiceConnector vmServiceConnectUri,
     Duration pollingDelay,
   }) : _logger = logger,
-       _mDnsObservatoryDiscovery = mDnsObservatoryDiscovery,
        _portForwarder = portForwarder,
        _protocolDiscovery = protocolDiscovery,
        _flutterUsage = flutterUsage,
@@ -58,7 +42,6 @@ class FallbackDiscovery {
   static const String _kEventName = 'ios-handshake';
 
   final DevicePortForwarder _portForwarder;
-  final MDnsObservatoryDiscovery _mDnsObservatoryDiscovery;
   final Logger _logger;
   final ProtocolDiscovery _protocolDiscovery;
   final Usage _flutterUsage;
@@ -99,42 +82,13 @@ class FallbackDiscovery {
     } on Exception catch (err) {
       _logger.printTrace(err.toString());
     }
-    _logger.printTrace('Failed to connect with log scanning, falling back to mDNS');
+    _logger.printTrace('Failed to connect with log scanning');
     UsageEvent(
       _kEventName,
       'log-failure',
       flutterUsage: _flutterUsage,
     ).send();
 
-    // On iOS 14+, mDNS prompts a local network permission dialog,
-    // which cannot be accepted or dismissed in a CI environment.
-    // Skip mDNS discovery if the app was told not to publish the port.
-    if (_mDnsObservatoryDiscovery != null) {
-      try {
-        final Uri result = await _mDnsObservatoryDiscovery.getObservatoryUri(
-          packageId,
-          device,
-          usesIpv6: usesIpv6,
-          hostVmservicePort: hostVmservicePort,
-        );
-        if (result != null) {
-          UsageEvent(
-            _kEventName,
-            'mdns-success',
-            flutterUsage: _flutterUsage,
-          ).send();
-          return result;
-        }
-      } on Exception catch (err) {
-        _logger.printTrace(err.toString());
-      }
-      _logger.printTrace('Failed to connect with mDNS');
-      UsageEvent(
-        _kEventName,
-        'mdns-failure',
-        flutterUsage: _flutterUsage,
-      ).send();
-    }
     return null;
   }
 

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -51,6 +51,7 @@ class MDnsObservatoryDiscovery {
   /// it will return that instance's information regardless of what application
   /// the Observatory instance is for.
   // TODO(jonahwilliams): use `deviceVmservicePort` to filter mdns results.
+  @visibleForTesting
   Future<MDnsObservatoryDiscoveryResult> query({String applicationId, int deviceVmservicePort}) async {
     globals.printTrace('Checking for advertised Dart observatories...');
     try {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -369,6 +369,17 @@ abstract class FlutterCommand extends Command<void> {
     return null;
   }
 
+  void addPublishObservatoryPort({ bool enabledByDefault = true, bool verboseHelp = false }) {
+    argParser.addFlag('publish-observatory-port',
+        negatable: true,
+        hide: !verboseHelp,
+        help: 'Publish the observatory URL over mDNS. Disable to prevent the'
+            'local network permission app dialog in debug and profile build modes (iOS devices only.)',
+        defaultsTo: enabledByDefault);
+  }
+
+  bool get disableObservatoryPublication => !boolArg('publish-observatory-port');
+
   void usesIpv6Flag() {
     argParser.addFlag(ipv6Flag,
       hide: true,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -369,16 +369,16 @@ abstract class FlutterCommand extends Command<void> {
     return null;
   }
 
-  void addPublishObservatoryPort({ bool enabledByDefault = true, bool verboseHelp = false }) {
-    argParser.addFlag('publish-observatory-port',
+  void addPublishPort({ bool enabledByDefault = true, bool verboseHelp = false }) {
+    argParser.addFlag('publish-port',
         negatable: true,
         hide: !verboseHelp,
-        help: 'Publish the observatory URL over mDNS. Disable to prevent the'
+        help: 'Publish the VM service port over mDNS. Disable to prevent the'
             'local network permission app dialog in debug and profile build modes (iOS devices only.)',
         defaultsTo: enabledByDefault);
   }
 
-  bool get disableObservatoryPublication => !boolArg('publish-observatory-port');
+  bool get disablePortPublication => !boolArg('publish-port');
 
   void usesIpv6Flag() {
     argParser.addFlag(ipv6Flag,

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -711,7 +711,7 @@ void main() {
 
       testOptionThatDefaultsToFalse(
         '--publish-observatory-port',
-            () => !debuggingOptions.disableObservatoryPublication,
+            () => !debuggingOptions.disablePortPublication,
       );
     });
   });

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -710,7 +710,7 @@ void main() {
       );
 
       testOptionThatDefaultsToFalse(
-        '--publish-observatory-port',
+        '--publish-port',
             () => !debuggingOptions.disablePortPublication,
       );
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -708,6 +708,11 @@ void main() {
         '--purge-persistent-cache',
         () => debuggingOptions.purgePersistentCache,
       );
+
+      testOptionThatDefaultsToFalse(
+        '--publish-observatory-port',
+            () => !debuggingOptions.disableObservatoryPublication,
+      );
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
@@ -168,6 +168,31 @@ void main() {
       packageName: 'hello',
     ), Uri.parse('http://localhost:5678'));
   });
+
+  testWithoutContext('Skips mDNS observation if not requested', () async {
+    when(mockVmService.getVM()).thenThrow(Exception());
+    when(mockPrototcolDiscovery.uri).thenAnswer((Invocation invocation) async => null);
+
+    final FallbackDiscovery fallbackDiscoveryNoMDNS = FallbackDiscovery(
+      logger: logger,
+      mDnsObservatoryDiscovery: null,
+      portForwarder: mockPortForwarder,
+      protocolDiscovery: mockPrototcolDiscovery,
+      flutterUsage: Usage.test(),
+      vmServiceConnectUri: (String uri, {Log log}) async {
+        return mockVmService;
+      },
+      pollingDelay: Duration.zero,
+    );
+    expect(await fallbackDiscoveryNoMDNS.discover(
+      assumedDevicePort: 23,
+      device: null,
+      hostVmservicePort: 1,
+      packageId: 'hello',
+      usesIpv6: false,
+      packageName: 'hello',
+    ), isNull);
+  });
 }
 
 class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -387,7 +387,7 @@ void main() {
         BuildInfo.debug,
         startPaused: true,
         disableServiceAuthCodes: true,
-        disableObservatoryPublication: true,
+        disablePortPublication: true,
         dartFlags: '--foo',
         enableSoftwareRendering: true,
         skiaDeterministicRendering: true,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -21,7 +21,6 @@ import 'package:flutter_tools/src/ios/fallback_discovery.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
-import 'package:flutter_tools/src/mdns_discovery.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
@@ -123,132 +122,7 @@ void main() {
     verify(devicePortForwarder.dispose()).called(1);
   });
 
-  // Still uses context for analytics and mDNS.
-  testUsingContext('IOSDevice.startApp succeeds in debug mode via mDNS discovery when log reading fails', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
-      kAttachDebuggerCommand,
-    ]);
-    final IOSDevice device = setUpIOSDevice(
-      processManager: processManager,
-      fileSystem: fileSystem,
-      vmServiceConnector: (String string, {Log log}) async {
-        throw const io.SocketException(
-          'OS Error: Connection refused, errno = 61, address = localhost, port '
-          '= 58943',
-        );
-      },
-    );
-    final IOSApp iosApp = PrebuiltIOSApp(
-      projectBundleId: 'app',
-      bundleName: 'Runner',
-      bundleDir: fileSystem.currentDirectory,
-    );
-    final Uri uri = Uri(
-      scheme: 'http',
-      host: '127.0.0.1',
-      port: 1234,
-      path: 'observatory',
-    );
-
-    device.portForwarder = const NoOpDevicePortForwarder();
-    device.setLogReader(iosApp, FakeDeviceLogReader());
-
-    when(MDnsObservatoryDiscovery.instance.getObservatoryUri(
-      any,
-      any,
-      usesIpv6: anyNamed('usesIpv6'),
-      hostVmservicePort: anyNamed('hostVmservicePort')
-    )).thenAnswer((Invocation invocation) async => uri);
-
-    final LaunchResult launchResult = await device.startApp(iosApp,
-      prebuiltApplication: true,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
-      fallbackThrottleTimeout: const Duration(milliseconds: 10),
-    );
-
-    verify(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-success')).called(1);
-    expect(launchResult.started, true);
-    expect(launchResult.hasObservatory, true);
-    expect(await device.stopApp(iosApp), false);
-  }, overrides: <Type, Generator>{
-    MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
-    Usage: () => MockUsage(),
-  });
-
-  testUsingContext('IOSDevice.startApp can skip mDNS discovery', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
-      FakeCommand(
-        command: <String>[
-          'script',
-          '-t',
-          '0',
-          '/dev/null',
-          'Artifact.iosDeploy.TargetPlatform.ios',
-          '--id',
-          '123',
-          '--bundle',
-          '/',
-          '--debug',
-          '--no-wifi',
-          '--args',
-          <String>[
-            '--enable-dart-profiling',
-            '--enable-service-port-fallback',
-            '--disable-service-auth-codes',
-            '--observatory-port=60700',
-            '--disable-observatory-publication',
-            '--enable-checked-mode',
-            '--verify-entry-points',
-          ].join(' '),
-        ], environment: const <String, String>{
-        'PATH': '/usr/bin:null',
-        'DYLD_LIBRARY_PATH': '/path/to/libraries',
-      },
-        stdout: '(lldb)     run\nsuccess',
-      ),
-    ]);
-    final IOSDevice device = setUpIOSDevice(
-      processManager: processManager,
-      fileSystem: fileSystem,
-      vmServiceConnector: (String string, {Log log}) async {
-        throw const io.SocketException(
-          'OS Error: Connection refused, errno = 61, address = localhost, port '
-              '= 58943',
-        );
-      },
-    );
-    final IOSApp iosApp = PrebuiltIOSApp(
-      projectBundleId: 'app',
-      bundleName: 'Runner',
-      bundleDir: fileSystem.currentDirectory,
-    );
-
-    device.portForwarder = const NoOpDevicePortForwarder();
-    device.setLogReader(iosApp, FakeDeviceLogReader());
-
-    final LaunchResult launchResult = await device.startApp(iosApp,
-      prebuiltApplication: true,
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, disableObservatoryPublication: true),
-      platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
-      fallbackThrottleTimeout: const Duration(milliseconds: 10),
-    );
-
-    verifyNever(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-success'));
-    verifyNever(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-failure'));
-    expect(launchResult.started, false);
-    expect(launchResult.hasObservatory, false);
-  }, overrides: <Type, Generator>{
-    Usage: () => MockUsage(),
-  });
-
-  // Still uses context for analytics and mDNS.
+  // Still uses context for analytics.
   testUsingContext('IOSDevice.startApp attaches in debug mode via log reading on iOS 13+', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
@@ -292,14 +166,12 @@ void main() {
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, true);
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'log-success')).called(1);
-    verifyNever(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-failure'));
     expect(await device.stopApp(iosApp), false);
   }, overrides: <Type, Generator>{
-    MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
     Usage: () => MockUsage(),
   });
 
-  // Still uses context for analytics and mDNS.
+  // Still uses context for analytics.
   testUsingContext('IOSDevice.startApp launches in debug mode via log reading on <iOS 13', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
@@ -344,14 +216,12 @@ void main() {
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, true);
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'log-success')).called(1);
-    verifyNever(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-failure'));
     expect(await device.stopApp(iosApp), false);
   }, overrides: <Type, Generator>{
-    MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
     Usage: () => MockUsage(),
   });
 
-  // Still uses context for analytics and mDNS.
+  // Still uses context for analytics.
   testUsingContext('IOSDevice.startApp fails in debug mode when Observatory URI is malformed', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
@@ -401,9 +271,7 @@ void main() {
       value: anyNamed('value'),
     )).called(1);
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'log-failure')).called(1);
-    verify(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-failure')).called(1);
     }, overrides: <Type, Generator>{
-      MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
       Usage: () => MockUsage(),
     });
 
@@ -440,7 +308,7 @@ void main() {
     Usage: () => MockUsage(),
   });
 
-  // Still uses context for analytics and mDNS.
+  // Still uses context for analytics.
   testUsingContext('IOSDevice.startApp forwards all supported debugging options', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
@@ -541,7 +409,6 @@ void main() {
     expect(await device.stopApp(iosApp), false);
     expect(processManager.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
-    MDnsObservatoryDiscovery: () => MockMDnsObservatoryDiscovery(),
     Usage: () => MockUsage(),
   });
 }
@@ -596,6 +463,5 @@ IOSDevice setUpIOSDevice({
 class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
 class MockDeviceLogReader extends Mock implements DeviceLogReader  {}
 class MockUsage extends Mock implements Usage {}
-class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}
 class MockVmService extends Mock implements VmService {}
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}


### PR DESCRIPTION
## Description

Add a `publish-port` flag to `run` and `drive`.  Default to on for `run` and off for `drive`.
This will tell the engine to not use mDNS to publish the observatory port, which means the local network permission popup won't be blocking the app on `drive` on iOS 14, which is particularly important in a CI environment.
As of https://github.com/flutter/flutter/pull/66092 log scanning should be sufficient to parse the port without the mDNS fallback, so remove it.

## Related Issues

Framework part of flutter/flutter#65207
Engine launch flag PR at https://github.com/flutter/engine/pull/21632

## Tests

drive_test, fallback_discovery_test, ios_device_start_prebuilt_test.
Manual testing showed `flutter drive` didn't show the permission prompt on iOS 14, and the tests passed.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*