### PR TITLE
Work around the glibc bug that causes rare Chrome crashes

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -165,7 +165,7 @@
          "repo":"flutter",
          "task_name":"linux_web_tests",
          "enabled":true,
-         "run_if":["dev/", "packages/flutter/", "packages/flutter_goldens_client/", "packages/flutter_goldens/", "packages/flutter_test/", "packages/flutter_tools/lib/src/test/", "packages/flutter_web_plugins/", "bin/"]
+         "run_if":["dev/", "packages/", "bin/"]
       },
       {
          "name":"Linux web_integration_tests",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -4,160 +4,160 @@
          "name":"Linux analyze",
          "repo":"flutter",
          "task_name":"linux_analyze",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux build_aar_module_test",
          "repo":"flutter",
          "task_name":"linux_build_aar_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux customer_testing",
          "repo":"flutter",
          "task_name":"linux_customer_testing",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux build_tests",
          "repo":"flutter",
          "task_name":"linux_build_tests",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux docs",
          "repo":"flutter",
          "task_name":"linux_docs",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_drive/", "packages/flutter_localizations/", "bin/"]
       },
       {
          "name":"Linux framework_tests",
          "repo":"flutter",
          "task_name":"linux_framework_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
       },
       {
          "name":"Linux firebase_abstract_method_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_abstract_method_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux firebase_android_embedding_v2_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_android_embedding_v2_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux firebase_release_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_release_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux fuchsia_precache",
          "repo":"flutter",
          "task_name":"linux_fuchsia_precache",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux gradle_fast_start_test",
          "repo":"flutter",
          "task_name":"linux_gradle_fast_start_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_jetifier_test",
          "repo":"flutter",
          "task_name":"linux_gradle_jetifier_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_non_android_plugin_test",
          "repo":"flutter",
          "task_name":"linux_gradle_non_android_plugin_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_bundle_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_bundle_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_fat_apk_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_fat_apk_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_light_apk_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_light_apk_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_r8_test",
          "repo":"flutter",
          "task_name":"linux_gradle_r8_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux module_host_with_custom_build_test",
          "repo":"flutter",
          "task_name":"linux_module_host_with_custom_build_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux module_custom_host_app_name_test",
          "repo":"flutter",
          "task_name":"linux_module_custom_host_app_name_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux module_test",
          "repo":"flutter",
          "task_name":"linux_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux plugin_dependencies_test",
          "repo":"flutter",
          "task_name":"linux_plugin_dependencies_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux plugin_test",
          "repo":"flutter",
          "task_name":"linux_plugin_test",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux tool_tests",
          "repo":"flutter",
          "task_name":"linux_tool_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/flutter_tools/", "bin/"]
       },
       {
          "name":"Linux web_benchmarks_html",
          "repo":"flutter",
          "task_name":"linux_web_benchmarks_html",
-         "enabled":false,
+         "enabled":true,
          "run_if": ["dev/**", "bin/**"]
       },
       {
@@ -171,264 +171,264 @@
          "name":"Linux web_integration_tests",
          "repo":"flutter",
          "task_name":"linux_web_integration_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_tools/", "packages/flutter_web_plugins/", "bin/"]
       },
       {
          "name":"Linux web_smoke_test",
          "repo":"flutter",
          "task_name":"linux_web_smoke_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["examples/hello_world/**" ,"dev/**", "packages/flutter/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "packages/flutter_web_plugins/**", "bin/**"]
       },
       {
          "name":"Mac build_aar_module_test",
          "repo":"flutter",
          "task_name":"mac_build_aar_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac build_ios_framework_module_test",
          "repo":"flutter",
          "task_name":"mac_build_ios_framework_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac build_tests",
          "repo":"flutter",
          "task_name":"mac_build_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac customer_testing",
          "repo":"flutter",
          "task_name":"mac_customer_testing",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Mac framework_tests",
          "repo":"flutter",
          "task_name":"mac_framework_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "packages/flutter/**", "packages/flutter_goldens/**", "packages/flutter_goldens_client/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "bin/**"]
       },
       {
          "name":"Mac gradle_fast_start_test",
          "repo":"flutter",
          "task_name":"mac_gradle_fast_start_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_jetifier_test",
          "repo":"flutter",
          "task_name":"mac_gradle_jetifier_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_non_android_plugin_test",
          "repo":"flutter",
          "task_name":"mac_gradle_non_android_plugin_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_bundle_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_bundle_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_fat_apk_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_fat_apk_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_light_apk_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_light_apk_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_r8_test",
          "repo":"flutter",
          "task_name":"mac_gradle_r8_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_custom_host_app_name_test",
          "repo":"flutter",
          "task_name":"mac_module_custom_host_app_name_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_host_with_custom_build_test",
          "repo":"flutter",
          "task_name":"mac_module_host_with_custom_build_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_test",
          "repo":"flutter",
          "task_name":"mac_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_test_ios",
          "repo":"flutter",
          "task_name":"mac_module_test_ios",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_dependencies_test",
          "repo":"flutter",
          "task_name":"mac_plugin_dependencies_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_lint_mac",
          "repo":"flutter",
          "task_name":"mac_plugin_lint_mac",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_test",
          "repo":"flutter",
          "task_name":"mac_plugin_lint_mac",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac tool_tests",
          "repo":"flutter",
          "task_name":"mac_tool_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows build_tests",
          "repo": "flutter",
          "task_name": "win_build_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "bin/"]
       },
       {
          "name": "Windows customer_testing",
          "repo": "flutter",
          "task_name": "win_customer_testing",
-         "enabled":false
+         "enabled":true
       },
       {
          "name": "Windows framework_tests",
          "repo": "flutter",
          "task_name": "win_framework_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
       },
       {
          "name": "Windows gradle_fast_start_test",
          "repo": "flutter",
          "task_name": "win_gradle_fast_start_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_jetifier_test",
          "repo": "flutter",
          "task_name": "win_gradle_jetifier_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_non_android_plugin_test",
          "repo": "flutter",
          "task_name": "win_gradle_non_android_plugin_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_plugin_bundle_test",
          "repo": "flutter",
          "task_name": "win_gradle_plugin_bundle_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_plugin_light_apk_test",
          "repo": "flutter",
          "task_name": "win_gradle_plugin_light_apk_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_r8_test",
          "repo": "flutter",
          "task_name": "win_gradle_r8_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_custom_host_app_name_test",
          "repo": "flutter",
          "task_name": "win_module_custom_host_app_name_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_test",
          "repo": "flutter",
          "task_name": "win_module_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_host_with_custom_build_test",
          "repo": "flutter",
          "task_name": "win_module_host_with_custom_build_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows plugin_dependencies_test",
          "repo": "flutter",
          "task_name": "win_plugin_dependencies_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows plugin_test",
          "repo": "flutter",
          "task_name": "win_plugin_test",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/**", "bin/**"]
       },
       {
         "name": "Windows tool_tests",
         "repo": "flutter",
         "task_name": "win_tool_tests",
-        "enabled":false
+        "enabled":true
       }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -4,160 +4,160 @@
          "name":"Linux analyze",
          "repo":"flutter",
          "task_name":"linux_analyze",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux build_aar_module_test",
          "repo":"flutter",
          "task_name":"linux_build_aar_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux customer_testing",
          "repo":"flutter",
          "task_name":"linux_customer_testing",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux build_tests",
          "repo":"flutter",
          "task_name":"linux_build_tests",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux docs",
          "repo":"flutter",
          "task_name":"linux_docs",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_drive/", "packages/flutter_localizations/", "bin/"]
       },
       {
          "name":"Linux framework_tests",
          "repo":"flutter",
          "task_name":"linux_framework_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
       },
       {
          "name":"Linux firebase_abstract_method_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_abstract_method_smoke_test",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux firebase_android_embedding_v2_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_android_embedding_v2_smoke_test",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux firebase_release_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_release_smoke_test",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux fuchsia_precache",
          "repo":"flutter",
          "task_name":"linux_fuchsia_precache",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux gradle_fast_start_test",
          "repo":"flutter",
          "task_name":"linux_gradle_fast_start_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_jetifier_test",
          "repo":"flutter",
          "task_name":"linux_gradle_jetifier_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_non_android_plugin_test",
          "repo":"flutter",
          "task_name":"linux_gradle_non_android_plugin_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_bundle_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_bundle_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_fat_apk_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_fat_apk_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_plugin_light_apk_test",
          "repo":"flutter",
          "task_name":"linux_gradle_plugin_light_apk_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux gradle_r8_test",
          "repo":"flutter",
          "task_name":"linux_gradle_r8_test",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Linux module_host_with_custom_build_test",
          "repo":"flutter",
          "task_name":"linux_module_host_with_custom_build_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux module_custom_host_app_name_test",
          "repo":"flutter",
          "task_name":"linux_module_custom_host_app_name_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux module_test",
          "repo":"flutter",
          "task_name":"linux_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux plugin_dependencies_test",
          "repo":"flutter",
          "task_name":"linux_plugin_dependencies_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux plugin_test",
          "repo":"flutter",
          "task_name":"linux_plugin_test",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
          "name":"Linux tool_tests",
          "repo":"flutter",
          "task_name":"linux_tool_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "packages/flutter_tools/", "bin/"]
       },
       {
          "name":"Linux web_benchmarks_html",
          "repo":"flutter",
          "task_name":"linux_web_benchmarks_html",
-         "enabled":true,
+         "enabled":false,
          "run_if": ["dev/**", "bin/**"]
       },
       {
@@ -171,264 +171,264 @@
          "name":"Linux web_integration_tests",
          "repo":"flutter",
          "task_name":"linux_web_integration_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_tools/", "packages/flutter_web_plugins/", "bin/"]
       },
       {
          "name":"Linux web_smoke_test",
          "repo":"flutter",
          "task_name":"linux_web_smoke_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["examples/hello_world/**" ,"dev/**", "packages/flutter/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "packages/flutter_web_plugins/**", "bin/**"]
       },
       {
          "name":"Mac build_aar_module_test",
          "repo":"flutter",
          "task_name":"mac_build_aar_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac build_ios_framework_module_test",
          "repo":"flutter",
          "task_name":"mac_build_ios_framework_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac build_tests",
          "repo":"flutter",
          "task_name":"mac_build_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac customer_testing",
          "repo":"flutter",
          "task_name":"mac_customer_testing",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Mac framework_tests",
          "repo":"flutter",
          "task_name":"mac_framework_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "packages/flutter/**", "packages/flutter_goldens/**", "packages/flutter_goldens_client/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "bin/**"]
       },
       {
          "name":"Mac gradle_fast_start_test",
          "repo":"flutter",
          "task_name":"mac_gradle_fast_start_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_jetifier_test",
          "repo":"flutter",
          "task_name":"mac_gradle_jetifier_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_non_android_plugin_test",
          "repo":"flutter",
          "task_name":"mac_gradle_non_android_plugin_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_bundle_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_bundle_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_fat_apk_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_fat_apk_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_plugin_light_apk_test",
          "repo":"flutter",
          "task_name":"mac_gradle_plugin_light_apk_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac gradle_r8_test",
          "repo":"flutter",
          "task_name":"mac_gradle_r8_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_custom_host_app_name_test",
          "repo":"flutter",
          "task_name":"mac_module_custom_host_app_name_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_host_with_custom_build_test",
          "repo":"flutter",
          "task_name":"mac_module_host_with_custom_build_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_test",
          "repo":"flutter",
          "task_name":"mac_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac module_test_ios",
          "repo":"flutter",
          "task_name":"mac_module_test_ios",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_dependencies_test",
          "repo":"flutter",
          "task_name":"mac_plugin_dependencies_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_lint_mac",
          "repo":"flutter",
          "task_name":"mac_plugin_lint_mac",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac plugin_test",
          "repo":"flutter",
          "task_name":"mac_plugin_lint_mac",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name":"Mac tool_tests",
          "repo":"flutter",
          "task_name":"mac_tool_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows build_tests",
          "repo": "flutter",
          "task_name": "win_build_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "bin/"]
       },
       {
          "name": "Windows customer_testing",
          "repo": "flutter",
          "task_name": "win_customer_testing",
-         "enabled":true
+         "enabled":false
       },
       {
          "name": "Windows framework_tests",
          "repo": "flutter",
          "task_name": "win_framework_tests",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
       },
       {
          "name": "Windows gradle_fast_start_test",
          "repo": "flutter",
          "task_name": "win_gradle_fast_start_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_jetifier_test",
          "repo": "flutter",
          "task_name": "win_gradle_jetifier_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_non_android_plugin_test",
          "repo": "flutter",
          "task_name": "win_gradle_non_android_plugin_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_plugin_bundle_test",
          "repo": "flutter",
          "task_name": "win_gradle_plugin_bundle_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_plugin_light_apk_test",
          "repo": "flutter",
          "task_name": "win_gradle_plugin_light_apk_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows gradle_r8_test",
          "repo": "flutter",
          "task_name": "win_gradle_r8_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_custom_host_app_name_test",
          "repo": "flutter",
          "task_name": "win_module_custom_host_app_name_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_test",
          "repo": "flutter",
          "task_name": "win_module_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows module_host_with_custom_build_test",
          "repo": "flutter",
          "task_name": "win_module_host_with_custom_build_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows plugin_dependencies_test",
          "repo": "flutter",
          "task_name": "win_plugin_dependencies_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
          "name": "Windows plugin_test",
          "repo": "flutter",
          "task_name": "win_plugin_test",
-         "enabled":true,
+         "enabled":false,
          "run_if":["dev/**", "bin/**"]
       },
       {
         "name": "Windows tool_tests",
         "repo": "flutter",
         "task_name": "win_tool_tests",
-        "enabled":true
+        "enabled":false
       }
    ]
 }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter_tools/src/web/chrome.dart';
+
 import '../asset.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -161,6 +163,23 @@ class TestCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    if (stringArg('platform') == 'chrome') {
+      for (int i = 0; i < 1000; i++) {
+        print('>>> Launch $i');
+        final ChromiumLauncher launcher = ChromiumLauncher(
+          browserFinder: findChromeExecutable,
+          fileSystem: globals.fs,
+          operatingSystemUtils: globals.os,
+          platform:  globals.platform,
+          processManager: globals.processManager,
+          logger: globals.logger,
+        );
+        final Chromium chromium = await launcher.launch('http://localhost:8888');
+        await chromium.close();
+      }
+      return FlutterCommandResult.success();
+    }
+
     if (!globals.fs.isFileSync('pubspec.yaml')) {
       throwToolExit(
         'Error: No pubspec.yaml file found in the current working directory.\n'

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -163,23 +163,6 @@ class TestCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (stringArg('platform') == 'chrome') {
-      for (int i = 0; i < 2000; i++) {
-        print('>>> Launch $i');
-        final ChromiumLauncher launcher = ChromiumLauncher(
-          browserFinder: findChromeExecutable,
-          fileSystem: globals.fs,
-          operatingSystemUtils: globals.os,
-          platform:  globals.platform,
-          processManager: globals.processManager,
-          logger: globals.logger,
-        );
-        final Chromium chromium = await launcher.launch('http://localhost:8888', headless: true);
-        await chromium.close();
-      }
-      return FlutterCommandResult.success();
-    }
-
     if (!globals.fs.isFileSync('pubspec.yaml')) {
       throwToolExit(
         'Error: No pubspec.yaml file found in the current working directory.\n'

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -164,7 +164,7 @@ class TestCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     if (stringArg('platform') == 'chrome') {
-      for (int i = 0; i < 1000; i++) {
+      for (int i = 0; i < 2000; i++) {
         print('>>> Launch $i');
         final ChromiumLauncher launcher = ChromiumLauncher(
           browserFinder: findChromeExecutable,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -4,8 +4,6 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter_tools/src/web/chrome.dart';
-
 import '../asset.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -174,7 +174,7 @@ class TestCommand extends FlutterCommand {
           processManager: globals.processManager,
           logger: globals.logger,
         );
-        final Chromium chromium = await launcher.launch('http://localhost:8888');
+        final Chromium chromium = await launcher.launch('http://localhost:8888', headless: true);
         await chromium.close();
       }
       return FlutterCommandResult.success();

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -168,6 +168,12 @@ class ChromiumLauncher {
     }
 
     final String chromeExecutable = _browserFinder(_platform, _fileSystem);
+
+    if (_logger.isVerbose) {
+      final ProcessResult versionResult = await _processManager.run(<String>[chromeExecutable, '--version']);
+      _logger.printTrace('Using ${versionResult.stdout}');
+    }
+
     final Directory userDataDir = _fileSystem.systemTempDirectory
       .createTempSync('flutter_tools_chrome_device.');
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -247,7 +247,7 @@ class ChromiumLauncher {
       final Process process = await _processManager.start(args);
 
       bool exited = false;
-      unawaited(process.exitCode.then((int exitCode) {
+      unawaited(process.exitCode.whenComplete(() {
         exited = true;
       }));
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -218,7 +218,7 @@ class ChromiumLauncher {
         _cacheUserSessionInformation(userDataDir, cacheDir);
       }));
     }
-    return await _connect(Chromium._(
+    return _connect(Chromium._(
       port,
       ChromeConnection('localhost', port),
       url: url,

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -310,7 +310,7 @@ void main() {
         skipCheck: true,
         headless: true,
       ),
-      throwsToolExit(message: 'Failed to spawn: example_chrome'),
+      throwsToolExit(message: 'Failed to launch browser.'),
     );
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -81,7 +81,7 @@ void main() {
         processManager,
         chromeLauncher,
       ),
-      throwsToolExit(),
+      throwsToolExit(message: 'Only one instance of chrome can be started'),
     );
   });
 
@@ -209,13 +209,17 @@ void main() {
     localStorageContentsDirectory.childFile('LOCK').writeAsBytesSync(<int>[]);
     localStorageContentsDirectory.childFile('LOG').writeAsStringSync('contents');
 
-    processManager.addCommand(FakeCommand(command: const <String>[
-      'example_chrome',
-      '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-      '--remote-debugging-port=1234',
-      ...kChromeArgs,
-      'example_url',
-    ], completer: exitCompleter));
+    processManager.addCommand(FakeCommand(
+      command: const <String>[
+        'example_chrome',
+        '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+        '--remote-debugging-port=1234',
+        ...kChromeArgs,
+        'example_url',
+      ],
+      completer: exitCompleter,
+      stderr: kDevtoolsStderr,
+    ));
 
     await chromeLauncher.launch(
       'example_url',
@@ -243,6 +247,71 @@ void main() {
 
     expect(storageDir.childFile('LOG'), exists);
     expect(storageDir.childFile('LOG').readAsStringSync(), 'contents');
+  });
+
+  testWithoutContext('can retry launch when glibc bug happens', () async {
+    const List<String> args = <String>[
+      'example_chrome',
+      '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+      '--remote-debugging-port=1234',
+      ...kChromeArgs,
+      '--headless',
+      '--disable-gpu',
+      '--no-sandbox',
+      '--window-size=2400,1800',
+      'example_url',
+    ];
+
+    // Pretend to hit glibc bug 3 times.
+    for (int i = 0; i < 3; i++) {
+      processManager.addCommand(const FakeCommand(
+        command: args,
+        stderr: 'Inconsistency detected by ld.so: ../elf/dl-tls.c: 493: '
+                '_dl_allocate_tls_init: Assertion `listp->slotinfo[cnt].gen '
+                '<= GL(dl_tls_generation)\' failed!',
+      ));
+    }
+
+    // Succeed on the 4th try.
+    processManager.addCommand(const FakeCommand(
+      command: args,
+      stderr: kDevtoolsStderr,
+    ));
+
+    expect(
+      () async => await chromeLauncher.launch(
+        'example_url',
+        skipCheck: true,
+        headless: true,
+      ),
+      returnsNormally,
+    );
+  });
+
+  testWithoutContext('gives up retrying when a non-glibc error happens', () async {
+    processManager.addCommand(const FakeCommand(
+      command: <String>[
+        'example_chrome',
+        '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+        '--remote-debugging-port=1234',
+        ...kChromeArgs,
+        '--headless',
+        '--disable-gpu',
+        '--no-sandbox',
+        '--window-size=2400,1800',
+        'example_url',
+      ],
+      stderr: 'nothing in the std error indicating glibc error',
+    ));
+
+    expect(
+      () async => await chromeLauncher.launch(
+        'example_url',
+        skipCheck: true,
+        headless: true,
+      ),
+      throwsToolExit(message: 'Failed to spawn: example_chrome'),
+    );
   });
 }
 


### PR DESCRIPTION
## Description

Due to https://sourceware.org/bugzilla/show_bug.cgi?id=19329 once every few thousands times Chrome fails to launch, crashing with exit code 127.

This PR works around that issue by checking for an error message specific to that bug and relaunching Chrome. With this change a test run that launched Chrome 18000 times was 100% green, when previously that many attempts would be 100% red.

Other changes:

- When in verbose mode print the version of Chromium.
- Change `try_builders.json` to always run tests whenever anything under `packages/` changes.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67454
