### PR TITLE
fix build analysis errors

### DIFF
--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -256,7 +256,7 @@ void main() {
     DefaultTextStyle textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1'));
     IconTheme iconTheme = tester.widget(find.widgetWithIcon(IconTheme, const IconData(1)));
 
-    expect(textStyle.style!.color, isSameColorAs(CupertinoColors.white));
+    expect(textStyle.style.color, isSameColorAs(CupertinoColors.white));
     expect(iconTheme.data.color, CupertinoColors.activeBlue);
 
     await tester.tap(find.widgetWithIcon(IconTheme, const IconData(1)));
@@ -265,7 +265,7 @@ void main() {
     textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1'));
     iconTheme = tester.widget(find.widgetWithIcon(IconTheme, const IconData(1)));
 
-    expect(textStyle.style!.color, CupertinoColors.activeBlue);
+    expect(textStyle.style.color, CupertinoColors.activeBlue);
     expect(iconTheme.data.color, isSameColorAs(CupertinoColors.white));
   });
 
@@ -300,7 +300,7 @@ void main() {
       DefaultTextStyle textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
       IconThemeData iconTheme = IconTheme.of(tester.element(find.byIcon(const IconData(1))));
 
-      expect(textStyle.style!.color, isSameColorAs(CupertinoColors.black));
+      expect(textStyle.style.color, isSameColorAs(CupertinoColors.black));
       expect(iconTheme.color, isSameColorAs(CupertinoColors.systemBlue.darkColor));
 
       await tester.tap(find.byIcon(const IconData(1)));
@@ -310,7 +310,7 @@ void main() {
       textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
       iconTheme = IconTheme.of(tester.element(find.byIcon(const IconData(1))));
 
-      expect(textStyle.style!.color, isSameColorAs(CupertinoColors.systemBlue.darkColor));
+      expect(textStyle.style.color, isSameColorAs(CupertinoColors.systemBlue.darkColor));
       expect(iconTheme.color, isSameColorAs(CupertinoColors.black));
     },
   );
@@ -348,7 +348,7 @@ void main() {
     IconTheme iconTheme = tester.widget(find.widgetWithIcon(IconTheme, const IconData(1)));
 
     expect(getRenderSegmentedControl(tester).borderColor, CupertinoColors.black);
-    expect(textStyle.style!.color, CupertinoColors.lightBackgroundGray);
+    expect(textStyle.style.color, CupertinoColors.lightBackgroundGray);
     expect(iconTheme.data.color, CupertinoColors.activeGreen.color);
     expect(getBackgroundColor(tester, 0), CupertinoColors.activeGreen.color);
     expect(getBackgroundColor(tester, 1), CupertinoColors.lightBackgroundGray);
@@ -359,7 +359,7 @@ void main() {
     textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1'));
     iconTheme = tester.widget(find.widgetWithIcon(IconTheme, const IconData(1)));
 
-    expect(textStyle.style!.color, CupertinoColors.activeGreen.color);
+    expect(textStyle.style.color, CupertinoColors.activeGreen.color);
     expect(iconTheme.data.color, CupertinoColors.lightBackgroundGray);
     expect(getBackgroundColor(tester, 0), CupertinoColors.lightBackgroundGray);
     expect(getBackgroundColor(tester, 1), CupertinoColors.activeGreen.color);

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -254,7 +254,7 @@ void main() {
 
       DefaultTextStyle textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
 
-      expect(textStyle.style!.fontWeight, FontWeight.w500);
+      expect(textStyle.style.fontWeight, FontWeight.w500);
 
       await tester.tap(find.byIcon(const IconData(1)));
       await tester.pump();
@@ -263,7 +263,7 @@ void main() {
       textStyle = tester.widget(find.widgetWithText(DefaultTextStyle, 'Child 1').first);
 
       expect(groupValue, 1);
-      expect(textStyle.style!.fontWeight, FontWeight.normal);
+      expect(textStyle.style.fontWeight, FontWeight.normal);
     },
   );
 

--- a/packages/flutter/test/cupertino/tab_test.dart
+++ b/packages/flutter/test/cupertino/tab_test.dart
@@ -245,7 +245,7 @@ void main() {
           builder: (BuildContext context) => CupertinoButton(
             child: const Text('home'),
             onPressed: () {
-              Navigator.of(context).restorablePushNamed('/2');
+              Navigator.of(context)!.restorablePushNamed('/2');
             },
           ),
           routes: <String, WidgetBuilder>{
@@ -269,7 +269,7 @@ void main() {
     expect(find.text('home'), findsNothing);
     expect(find.text('second route'), findsOneWidget);
 
-    Navigator.of(tester.element(find.text('second route'))).pop();
+    Navigator.of(tester.element(find.text('second route')))!.pop();
     await tester.pumpAndSettle();
 
     expect(find.text('home'), findsOneWidget);
@@ -280,7 +280,7 @@ void main() {
     expect(find.text('home'), findsNothing);
     expect(find.text('second route'), findsOneWidget);
 
-    Navigator.of(tester.element(find.text('second route'))).pop();
+    Navigator.of(tester.element(find.text('second route')))!.pop();
     await tester.pumpAndSettle();
 
     expect(find.text('home'), findsOneWidget);


### PR DESCRIPTION
## Description

Fixes the following analysis errors:

```
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:259:27 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:268:27 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:303:29 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:313:29 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:351:27 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/segmented_control_test.dart:362:27 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/sliding_segmented_control_test.dart:257:29 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter/test/cupertino/sliding_segmented_control_test.dart:266:29 • unnecessary_non_null_assertion
  error • An expression whose value can be 'null' must be null-checked before it can be dereferenced • packages/flutter/test/cupertino/tab_test.dart:248:15 • unchecked_use_of_nullable_value
  error • An expression whose value can be 'null' must be null-checked before it can be dereferenced • packages/flutter/test/cupertino/tab_test.dart:272:5 • unchecked_use_of_nullable_value
  error • An expression whose value can be 'null' must be null-checked before it can be dereferenced • packages/flutter/test/cupertino/tab_test.dart:283:5 • unchecked_use_of_nullable_value


```
