### PR TITLE
fix dart docs for build

### DIFF
--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -14,7 +14,7 @@
 /// See also:
 ///
 ///  * [How to Write a Flutter Web Plugin](https://medium.com/flutter/how-to-write-a-flutter-web-plugin-5e26c689ea1), a Medium article
-///    describing how the [url_launcher] package was created using [flutter_web_plugins].
+///    describing how the `url_launcher` package was created using [flutter_web_plugins].
 library flutter_web_plugins;
 
 export 'src/plugin_event_channel.dart';

--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -28,12 +28,12 @@ import 'plugin_registry.dart';
 ///
 /// The first method is `listen`. When called, it begins forwarding
 /// messages to the framework side when they are added to the
-/// [controller]. This triggers the [onListen] callback on the
-/// [controller].
+/// [controller]. This triggers the [StreamController.onListen] callback
+/// on the [controller].
 ///
 /// The other method is `cancel`. When called, it stops forwarding
-/// events to the framework. This triggers the [onCancel] callback on
-/// the [controller].
+/// events to the framework. This triggers the [StreamController.onCancel]
+/// callback on the [controller].
 ///
 /// Events added to the [controller] when the framework is not
 /// subscribed are silently discarded.


### PR DESCRIPTION
## Description

```
Executing: (cd dev/docs ; /tmp/flutter sdk/bin/cache/dart-sdk/bin/pub global run dartdoc --allow-tools --enable-experiment=non-nullable --no-validate-links --link-to-source-excludes ../../bin/cache --link-to-source-root ../.. --link-to-source-uri-template https://github.com/flutter/flutter/blob/master/%f%#L%l% --inject-html --use-base-href --header styles.html --header analytics.html --header survey.html --header snippets.html --header opensearch.html --footer-text lib/footer.html --allow-warnings-in-packages Flutter,platform_integration,flutter_web_plugins,flutter,flutter_goldens,fuchsia_remote_debug_protocol,flutter_driver,flutter_test,flutter_localizations --exclude-packages analyzer,args,barback,cli_util,csslib,flutter_goldens,flutter_goldens_client,front_end,fuchsia_remote_debug_protocol,glob,html,http_multi_server,io,isolate,js,kernel,logging,mime,mockito,node_preamble,plugin,shelf,shelf_packages_handler,shelf_static,shelf_web_socket,utf,watcher,yaml --exclude package:Flutter/temp_doc.dart,package:http/browser_client.dart,package:intl/intl_browser.dart,package:matcher/mirror_matchers.dart,package:quiver/io.dart,package:quiver/mirrors.dart,package:vm_service_client/vm_service_client.dart,package:web_socket_channel/html.dart --favicon=favicon.ico --package-order flutter,Dart,platform_integration,flutter_test,flutter_driver --auto-include-dependencies)
dartdoc:stdout: Documenting Flutter...
dartdoc:stderr:   warning: undefined directive: '&quot;id&quot;:item.itemId,', from services.MethodChannel.invokeMethod: (file:///tmp/flutter%20sdk/packages/flutter/lib/src/services/platform_channel.dart:331:14)
dartdoc:stdout: Initialized dartdoc with 126 libraries in 143.0 seconds
dartdoc:stderr:   error: unresolved doc reference [url_launcher], from flutter_web_plugins: (file:///tmp/flutter%20sdk/packages/flutter_web_plugins/lib/flutter_web_plugins.dart:18:9)
dartdoc:stdout: Generating docs for library animation from package:flutter/animation.dart...
dartdoc:stdout: Generating docs for library cupertino from package:flutter/cupertino.dart...
dartdoc:stdout: Generating docs for library foundation from package:flutter/foundation.dart...
dartdoc:stdout: Generating docs for library gestures from package:flutter/gestures.dart...
dartdoc:stdout: Generating docs for library material from package:flutter/material.dart...
dartdoc:stdout: Generating docs for library painting from package:flutter/painting.dart...
dartdoc:stdout: Generating docs for library physics from package:flutter/physics.dart...
dartdoc:stdout: Generating docs for library rendering from package:flutter/rendering.dart...
dartdoc:stdout: Generating docs for library scheduler from package:flutter/scheduler.dart...
dartdoc:stdout: Generating docs for library semantics from package:flutter/semantics.dart...
dartdoc:stdout: Generating docs for library services from package:flutter/services.dart...
dartdoc:stdout: Generating docs for library widgets from package:flutter/widgets.dart...
dartdoc:stdout: Generating docs for library dart:async from dart:async...
dartdoc:stdout: Generating docs for library dart:collection from dart:collection...
dartdoc:stdout: Generating docs for library dart:convert from dart:convert...
dartdoc:stdout: Generating docs for library dart:core from dart:core...
dartdoc:stdout: Generating docs for library dart:developer from dart:developer...
dartdoc:stdout: Generating docs for library dart:ffi from dart:ffi...
dartdoc:stdout: Generating docs for library dart:html from dart:html...
dartdoc:stdout: Generating docs for library dart:io from dart:io...
dartdoc:stdout: Generating docs for library dart:isolate from dart:isolate...
dartdoc:stdout: Generating docs for library dart:js from dart:js...
dartdoc:stdout: Generating docs for library dart:js_util from dart:js_util...
dartdoc:stdout: Generating docs for library dart:math from dart:math...
dartdoc:stdout: Generating docs for library dart:typed_data from dart:typed_data...
dartdoc:stdout: Generating docs for library dart:ui from dart:ui...
dartdoc:stdout: Generating docs for library Android from package:platform_integration/android.dart...
dartdoc:stdout: Generating docs for library iOS from package:platform_integration/ios.dart...
dartdoc:stdout: Generating docs for library flutter_test from package:flutter_test/flutter_test.dart...
dartdoc:stdout: Generating docs for library flutter_driver from package:flutter_driver/flutter_driver.dart...
dartdoc:stdout: Generating docs for library flutter_driver_extension from package:flutter_driver/driver_extension.dart...
dartdoc:stdout: Generating docs for library flutter_localizations from package:flutter_localizations/flutter_localizations.dart...
dartdoc:stdout: Generating docs for library flutter_web_plugins from package:flutter_web_plugins/flutter_web_plugins.dart...
dartdoc:stderr:   error: unresolved doc reference [onListen], from flutter_web_plugins.PluginEventChannel: (file:///tmp/flutter%20sdk/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart:40:7)
dartdoc:stderr:   error: unresolved doc reference [onCancel], from flutter_web_plugins.PluginEventChannel: (file:///tmp/flutter%20sdk/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart:40:7)
dartdoc:stdout: Generating docs for library archive from package:archive/archive.dart...
dartdoc:stdout: Generating docs for library archive_io from package:archive/archive_io.dart...
dartdoc:stdout: Generating docs for library async from package:async/async.dart...
dartdoc:stdout: Generating docs for library boolean_selector from package:boolean_selector/boolean_selector.dart...
dartdoc:stdout: Generating docs for library characters from package:characters/characters.dart...
dartdoc:stdout: Generating docs for library charcode from package:charcode/charcode.dart...
dartdoc:stdout: Generating docs for library charcode.ascii.dollar_lowercase from package:charcode/ascii.dart...
dartdoc:stdout: Generating docs for library charcode.htmlentity.dollar_lowercase from package:charcode/html_entity.dart...
dartdoc:stdout: Generating docs for library clock from package:clock/clock.dart...
dartdoc:stdout: Generating docs for library collection from package:collection/collection.dart...
dartdoc:stdout: Generating docs for library dart.pkg.collection.algorithms from package:collection/algorithms.dart...
dartdoc:stdout: Generating docs for library dart.pkg.collection.equality from package:collection/equality.dart...
dartdoc:stdout: Generating docs for library dart.pkg.collection.iterable_zip from package:collection/iterable_zip.dart...
dartdoc:stdout: Generating docs for library dart.pkg.collection.priority_queue from package:collection/priority_queue.dart...
dartdoc:stdout: Generating docs for library dart.pkg.collection.wrappers from package:collection/wrappers.dart...
dartdoc:stdout: Generating docs for library convert from package:convert/convert.dart...
dartdoc:stdout: Generating docs for library crypto from package:crypto/crypto.dart...
dartdoc:stdout: Generating docs for library fake_async from package:fake_async/fake_async.dart...
dartdoc:stdout: Generating docs for library chroot from package:file/chroot.dart...
dartdoc:stdout: Generating docs for library file from package:file/file.dart...
dartdoc:stdout: Generating docs for library local from package:file/local.dart...
dartdoc:stdout: Generating docs for library memory from package:file/memory.dart...
dartdoc:stdout: Generating docs for library date_symbol_data_custom from package:intl/date_symbol_data_custom.dart...
dartdoc:stdout: Generating docs for library date_symbol_data_file from package:intl/date_symbol_data_file.dart...
dartdoc:stdout: Generating docs for library date_symbol_data_http_request from package:intl/date_symbol_data_http_request.dart...
dartdoc:stdout: Generating docs for library date_symbol_data_local from package:intl/date_symbol_data_local.dart...
dartdoc:stdout: Generating docs for library date_symbols from package:intl/date_symbols.dart...
dartdoc:stdout: Generating docs for library date_time_patterns from package:intl/date_time_patterns.dart...
dartdoc:stdout: Generating docs for library intl from package:intl/intl.dart...
dartdoc:stdout: Generating docs for library intl_standalone from package:intl/intl_standalone.dart...
dartdoc:stdout: Generating docs for library locale from package:intl/locale.dart...
dartdoc:stdout: Generating docs for library message_format from package:intl/message_format.dart...
dartdoc:stdout: Generating docs for library message_lookup_by_library from package:intl/message_lookup_by_library.dart...
dartdoc:stdout: Generating docs for library number_symbol_data from package:intl/number_symbols_data.dart...
dartdoc:stdout: Generating docs for library number_symbols from package:intl/number_symbols.dart...
dartdoc:stdout: Generating docs for library error_code from package:json_rpc_2/error_code.dart...
dartdoc:stdout: Generating docs for library json_rpc_2 from package:json_rpc_2/json_rpc_2.dart...
dartdoc:stdout: Generating docs for library matcher from package:matcher/matcher.dart...
dartdoc:stdout: Generating docs for library meta from package:meta/meta.dart...
dartdoc:stdout: Generating docs for library meta_dart2js from package:meta/dart2js.dart...
dartdoc:stdout: Generating docs for library meta_meta from package:meta/meta_meta.dart...
dartdoc:stdout: Generating docs for library path from package:path/path.dart...
dartdoc:stdout: Generating docs for library platform from package:platform/platform.dart...
dartdoc:stdout: Generating docs for library process from package:process/process.dart...
dartdoc:stdout: Generating docs for library pub_semver from package:pub_semver/pub_semver.dart...
dartdoc:stdout: Generating docs for library source_span from package:source_span/source_span.dart...
dartdoc:stdout: Generating docs for library stack_trace from package:stack_trace/stack_trace.dart...
dartdoc:stdout: Generating docs for library isolate_channel from package:stream_channel/isolate_channel.dart...
dartdoc:stdout: Generating docs for library stream_channel from package:stream_channel/stream_channel.dart...
dartdoc:stdout: Generating docs for library string_scanner from package:string_scanner/string_scanner.dart...
dartdoc:stdout: Generating docs for library sync.http from package:sync_http/sync_http.dart...
dartdoc:stdout: Generating docs for library term_glyph from package:term_glyph/term_glyph.dart...
dartdoc:stdout: Generating docs for library test_api from package:test_api/test_api.dart...
dartdoc:stdout: Generating docs for library test_api.backend from package:test_api/backend.dart...
dartdoc:stdout: Generating docs for library test_api.fake from package:test_api/fake.dart...
dartdoc:stdout: Generating docs for library typed_data from package:typed_data/typed_data.dart...
dartdoc:stdout: Generating docs for library typed_data.typed_buffers from package:typed_data/typed_buffers.dart...
dartdoc:stdout: Generating docs for library hash from package:vector_math/hash.dart...
dartdoc:stdout: Generating docs for library vector_math from package:vector_math/vector_math.dart...
dartdoc:stdout: Generating docs for library vector_math_64 from package:vector_math/vector_math_64.dart...
dartdoc:stdout: Generating docs for library vector_math_geometry from package:vector_math/vector_math_geometry.dart...
dartdoc:stdout: Generating docs for library vector_math_lists from package:vector_math/vector_math_lists.dart...
dartdoc:stdout: Generating docs for library vector_math_operations from package:vector_math/vector_math_operations.dart...
dartdoc:stdout: Generating docs for library web_socket_channel from package:web_socket_channel/web_socket_channel.dart...
dartdoc:stdout: Generating docs for library web_socket_channel.io from package:web_socket_channel/io.dart...
dartdoc:stdout: Generating docs for library web_socket_channel.status from package:web_socket_channel/status.dart...
dartdoc:stdout: Generating docs for library webdriver.core from package:webdriver/async_core.dart...
dartdoc:stdout: Generating docs for library webdriver.core from package:webdriver/core.dart...
dartdoc:stdout: Generating docs for library webdriver.html from package:webdriver/async_html.dart...
dartdoc:stdout: Generating docs for library webdriver.io from package:webdriver/io.dart...
dartdoc:stdout: Generating docs for library webdriver.io from package:webdriver/async_io.dart...
dartdoc:stdout: Generating docs for library webdriver.support.async from package:webdriver/support/async.dart...
dartdoc:stdout: Generating docs for library webdriver.support.firefox_profile from package:webdriver/support/firefox_profile.dart...
dartdoc:stdout: Generating docs for library webdriver.support.forwarder from package:webdriver/support/forwarder.dart...
dartdoc:stdout: Generating docs for library webdriver.support.stdio_stepper from package:webdriver/support/stdio_stepper.dart...
dartdoc:stdout: Generating docs for library webdriver.sync_core from package:webdriver/sync_core.dart...
dartdoc:stdout: Generating docs for library webdriver.sync_io from package:webdriver/sync_io.dart...
dartdoc:stderr: found 1 warning and 3 errors
dartdoc:stdout: Documented 110 public libraries in 715.1 seconds
dartdoc:stderr:
dartdoc:stderr: dartdoc failed: dartdoc encountered 3 errors while processing..
dartdoc:stderr: #0      Dartdoc.generateDocs (package:dartdoc/dartdoc.dart:232:9)
dartdoc:stderr: <asynchronous suspension>
dartdoc:stderr: #1      Dartdoc.executeGuarded.<anonymous closure> (package:dartdoc/dartdoc.dart:501:15)
dartdoc:stderr: #2      _rootRun (dart:async/zone.dart:1190:13)
dartdoc:stderr: #3      _CustomZone.run (dart:async/zone.dart:1093:19)
dartdoc:stderr: #4      _runZoned (dart:async/zone.dart:1630:10)
dartdoc:stderr: #5      runZonedGuarded (dart:async/zone.dart:1618:12)
dartdoc:stderr: #6      Dartdoc.executeGuarded (package:dartdoc/dartdoc.dart:499:5)
dartdoc:stderr: #7      main (file:///root/.pub-cache/hosted/pub.dartlang.org/dartdoc-0.34.0/bin/dartdoc.dart:26:11)
dartdoc:stderr: <asynchronous suspension>
dartdoc:stderr: #8      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:299:32)
dartdoc:stderr: #9      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```

Fix the errors surfaced by the docs shard.