### PR TITLE
[flutter_tools] create Status only through logger

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1055,6 +1055,15 @@ class NotifyingLogger extends Logger {
   // This method is only relevant for terminals.
   @override
   void clear() { }
+
+  @override
+  Status createStatus() {
+   return SilentStatus(
+      timeout: null,
+      stopwatch: Stopwatch(),
+      timeoutConfiguration: const TimeoutConfiguration(),
+    );
+  }
 }
 
 /// A running application, started by this daemon.

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -293,7 +293,6 @@ Future<T> runInContext<T>(
         processManager: globals.processManager,
         platform: globals.platform,
         fileSystem: globals.fs,
-        terminal: globals.terminal,
         usage: globals.flutterUsage,
       ),
     },

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -297,13 +297,7 @@ class Doctor {
 
     for (final ValidatorTask validatorTask in startValidatorTasks()) {
       final DoctorValidator validator = validatorTask.validator;
-      final Status status = Status.withSpinner(
-        timeout: timeoutConfiguration.fastOperation,
-        slowWarningCallback: () => validator.slowWarning,
-        timeoutConfiguration: timeoutConfiguration,
-        stopwatch: Stopwatch(),
-        terminal: globals.terminal,
-      );
+      final Status status = _logger.createStatus();
       ValidationResult result;
       try {
         result = await validatorTask.result;

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -12,7 +12,6 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
-import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -235,11 +234,9 @@ class XcodeProjectInterpreter {
     @required ProcessManager processManager,
     @required Logger logger,
     @required FileSystem fileSystem,
-    @required Terminal terminal,
     @required Usage usage,
   }) : _platform = platform,
       _fileSystem = fileSystem,
-      _terminal = terminal,
       _logger = logger,
       _processUtils = ProcessUtils(logger: logger, processManager: processManager),
       _usage = usage;
@@ -247,7 +244,6 @@ class XcodeProjectInterpreter {
   final Platform _platform;
   final FileSystem _fileSystem;
   final ProcessUtils _processUtils;
-  final Terminal _terminal;
   final Logger _logger;
   final Usage _usage;
 
@@ -326,12 +322,7 @@ class XcodeProjectInterpreter {
     String scheme,
     Duration timeout = const Duration(minutes: 1),
   }) async {
-    final Status status = Status.withSpinner(
-      timeout: const TimeoutConfiguration().fastOperation,
-      timeoutConfiguration: const TimeoutConfiguration(),
-      stopwatch: Stopwatch(),
-      terminal: _terminal,
-    );
+    final Status status = _logger.createStatus();
     final List<String> showBuildSettingsCommand = <String>[
       _executable,
       '-project',

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -707,6 +707,7 @@ class StreamLogger extends Logger {
   @override
   bool get hasTerminal => false;
 
+
   @override
   void clear() => _log('[stdout] ${globals.terminal.clearScreen()}\n');
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -707,7 +707,6 @@ class StreamLogger extends Logger {
   @override
   bool get hasTerminal => false;
 
-
   @override
   void clear() => _log('[stdout] ${globals.terminal.clearScreen()}\n');
 }

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/build.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -200,7 +199,6 @@ void main() {
             processManager: processManager,
             logger: logger,
             fileSystem: fileSystem,
-            terminal: Terminal.test(),
             usage: Usage.test(),
           ),
         ),

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -35,16 +34,12 @@ void main() {
       platform = FakePlatform(operatingSystem: 'macos');
       final FileSystem fileSystem = MemoryFileSystem.test();
       fileSystem.file(xcodebuild).createSync(recursive: true);
-      final AnsiTerminal terminal = MockAnsiTerminal();
-      logger = BufferLogger.test(
-        terminal: terminal
-      );
+      logger = BufferLogger.test();
       xcodeProjectInterpreter = XcodeProjectInterpreter(
         logger: logger,
         fileSystem: fileSystem,
         platform: platform,
         processManager: processManager,
-        terminal: terminal,
         usage: null,
       );
     });
@@ -80,23 +75,18 @@ void main() {
   FakePlatform platform;
   FileSystem fileSystem;
   BufferLogger logger;
-  AnsiTerminal terminal;
 
   setUp(() {
     fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
     platform = FakePlatform(operatingSystem: 'macos');
     fileSystem = MemoryFileSystem.test();
     fileSystem.file(xcodebuild).createSync(recursive: true);
-    terminal = MockAnsiTerminal();
-    logger = BufferLogger.test(
-      terminal: terminal
-    );
+    logger = BufferLogger.test();
     xcodeProjectInterpreter = XcodeProjectInterpreter(
       logger: logger,
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: terminal,
       usage: null,
     );
   });
@@ -176,7 +166,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: terminal,
       usage: Usage.test(),
     );
     fileSystem.file(xcodebuild).deleteSync();
@@ -317,7 +306,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: terminal,
       usage: Usage.test(),
     );
 
@@ -340,7 +328,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: terminal,
       usage: Usage.test(),
     );
 
@@ -894,7 +881,3 @@ flutter:
 
 class MockLocalEngineArtifacts extends Mock implements LocalEngineArtifacts {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
-class MockAnsiTerminal extends Mock implements AnsiTerminal {
-  @override
-  bool get supportsColor => false;
-}

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -845,6 +845,11 @@ class DelegateLogger implements Logger {
 
   @override
   void clear() => delegate.clear();
+
+  @override
+  Status createStatus() {
+    return delegate.createStatus();
+  }
 }
 
 /// An implementation of the Cache which does not download or require locking.


### PR DESCRIPTION
## Description

The logger interface has the dependencies needed to create a Status object without reaching for globals. Remove Status.withSpinner and add a createSpinner API to the Logger. Replace the two places in the tool that used withSpinner.