### PR TITLE
[flutter_tools] support powershell style help request

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -61,6 +61,11 @@ import 'src/web/web_runner.dart';
 Future<void> main(List<String> args) async {
   final bool veryVerbose = args.contains('-vv');
   final bool verbose = args.contains('-v') || args.contains('--verbose') || veryVerbose;
+  // Support the -? Powershell help idiom.
+  final int powershellHelpIndex = args.indexOf('-?');
+  if (powershellHelpIndex != -1) {
+    args[powershellHelpIndex] = '-h';
+  }
 
   final bool doctor = (args.isNotEmpty && args.first == 'doctor') ||
       (args.length == 2 && verbose && args.last == 'doctor');

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -33,6 +33,21 @@ void main() {
     expect(result.stdout, isNot(contains('exiting with code 0')));
   });
 
+  testWithoutContext('Flutter help is shown with -? command line argument', () async {
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      '-?',
+    ]);
+
+    // Development tools.
+    expect(result.stdout, contains(
+      'Run "flutter help <command>" for more information about a command.\n'
+      'Run "flutter help -v" for verbose help output, including less commonly used options.'
+    ));
+  });
+
   testWithoutContext('flutter doctor is not verbose', () async {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[


### PR DESCRIPTION
## Description

I've seen a number of crash reports due to the tool treating -? as a positional argument and not a help command (trying to use it as a directory for flutter create). Since this is commonly a help request for Powershell commands, treat it like providing -h.

Fixes https://github.com/flutter/flutter/issues/67232