### PR TITLE
Make "field" in FormState not a private member

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -184,13 +184,11 @@ class FormState extends State<Form> {
     });
   }
 
-  /// Can manually register [FormFieldState].
-  void register(FormFieldState<dynamic> field) {
+  void _register(FormFieldState<dynamic> field) {
     fields.add(field);
   }
 
-  /// Can manually unregister [FormFieldState].
-  void unregister(FormFieldState<dynamic> field) {
+  void _unregister(FormFieldState<dynamic> field) {
     fields.remove(field);
   }
 
@@ -506,7 +504,7 @@ class FormFieldState<T> extends State<FormField<T>> {
 
   @override
   void deactivate() {
-    Form.of(context)?.unregister(this);
+    Form.of(context)?._unregister(this);
     super.deactivate();
   }
 
@@ -526,7 +524,7 @@ class FormFieldState<T> extends State<FormField<T>> {
           break;
       }
     }
-    Form.of(context)?.register(this);
+    Form.of(context)?._register(this);
     return widget.builder(this);
   }
 }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -162,7 +162,9 @@ class Form extends StatefulWidget {
 class FormState extends State<Form> {
   int _generation = 0;
   bool _hasInteractedByUser = false;
-  final Set<FormFieldState<dynamic>> _fields = <FormFieldState<dynamic>>{};
+
+  /// Can access [FormFieldState] in public
+  final Set<FormFieldState<dynamic>> fields = <FormFieldState<dynamic>>{};
 
   // Called when a form field has changed. This will cause all form fields
   // to rebuild, useful if form fields have interdependencies.
@@ -171,7 +173,7 @@ class FormState extends State<Form> {
       widget.onChanged!();
 
 
-    _hasInteractedByUser = _fields
+    _hasInteractedByUser = fields
         .any((FormFieldState<dynamic> field) => field._hasInteractedByUser);
     _forceRebuild();
   }
@@ -182,12 +184,14 @@ class FormState extends State<Form> {
     });
   }
 
-  void _register(FormFieldState<dynamic> field) {
-    _fields.add(field);
+  /// Can manually register [FormFieldState].
+  void register(FormFieldState<dynamic> field) {
+    fields.add(field);
   }
 
-  void _unregister(FormFieldState<dynamic> field) {
-    _fields.remove(field);
+  /// Can manually unregister [FormFieldState].
+  void unregister(FormFieldState<dynamic> field) {
+    fields.remove(field);
   }
 
   @override
@@ -217,7 +221,7 @@ class FormState extends State<Form> {
 
   /// Saves every [FormField] that is a descendant of this [Form].
   void save() {
-    for (final FormFieldState<dynamic> field in _fields)
+    for (final FormFieldState<dynamic> field in fields)
       field.save();
   }
 
@@ -229,7 +233,7 @@ class FormState extends State<Form> {
   /// If the form's [Form.autovalidateMode] property is [AutovalidateMode.always],
   /// the fields will all be revalidated after being reset.
   void reset() {
-    for (final FormFieldState<dynamic> field in _fields)
+    for (final FormFieldState<dynamic> field in fields)
       field.reset();
     _hasInteractedByUser = false;
     _fieldDidChange();
@@ -247,7 +251,7 @@ class FormState extends State<Form> {
 
   bool _validate() {
     bool hasError = false;
-    for (final FormFieldState<dynamic> field in _fields)
+    for (final FormFieldState<dynamic> field in fields)
       hasError = !field.validate() || hasError;
     return !hasError;
   }
@@ -502,7 +506,7 @@ class FormFieldState<T> extends State<FormField<T>> {
 
   @override
   void deactivate() {
-    Form.of(context)?._unregister(this);
+    Form.of(context)?.unregister(this);
     super.deactivate();
   }
 
@@ -522,7 +526,7 @@ class FormFieldState<T> extends State<FormField<T>> {
           break;
       }
     }
-    Form.of(context)?._register(this);
+    Form.of(context)?.register(this);
     return widget.builder(this);
   }
 }


### PR DESCRIPTION
## Description

When access the `Form` with `GlobalKey<FormState>` we cannot access registered `FormFieldState` in the key to determine which `FormFieldState` has validated error.

### Use case

Scroll to the first `FormFieldState` that error occurred.

```dart
formKey.currentState.​validate​();
​Scrollable​.​ensureVisible​(formKey.currentState.fields.first.context,
        duration​:​ ​Duration​(milliseconds​:​ ​500​));
```


## Related Issues

Due to https://github.com/flutter/flutter/issues/67283

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
