### PR TITLE
fail when chromedriver installation fails

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -189,10 +189,9 @@ task:
         - git clone https://github.com/flutter/web_installers.git
         - cd web_installers/packages/web_drivers/
         - pub get
-        - dart lib/web_driver_installer.dart &
-        - sleep 20
+        - dart lib/web_driver_installer.dart chromedriver --install-only
         - chromedriver/chromedriver --port=4444 &
-        - sleep 5
+        - sleep 1
         - cd ../../../examples/hello_world/
         - flutter drive --target=test_driver/smoke_web_engine.dart -d web-server --profile --browser-name=chrome
 


### PR DESCRIPTION
## Description

- Fail when chromedriver installation fails.
- Remove the race between `web_driver_installer.dart` and `sleep 5`

## Related Issues

https://github.com/flutter/flutter/issues/67560
