### PR TITLE
Implement documented behavior of WidgetsApp.builder

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -568,14 +568,15 @@ class WidgetsApp extends StatefulWidget {
   final List<NavigatorObserver>? navigatorObservers;
 
   /// {@template flutter.widgets.widgetsApp.builder}
-  /// A builder for inserting widgets above the [Navigator] but below the other
-  /// widgets created by the [WidgetsApp] widget, or for replacing the
-  /// [Navigator] entirely.
+  /// A builder for inserting widgets above the [Navigator] or - when the
+  /// [WidgetsApp.router] constructor is used - above the [Router] but below the
+  /// other widgets created by the [WidgetsApp] widget, or for replacing the
+  /// [Navigator]/[Router] entirely.
   ///
   /// For example, from the [BuildContext] passed to this method, the
   /// [Directionality], [Localizations], [DefaultTextStyle], [MediaQuery], etc,
   /// are all available. They can also be overridden in a way that impacts all
-  /// the routes in the [Navigator].
+  /// the routes in the [Navigator] or [Router].
   ///
   /// This is rarely useful, but can be used in applications that wish to
   /// override those defaults, e.g. to force the application into right-to-left
@@ -586,18 +587,22 @@ class WidgetsApp extends StatefulWidget {
   /// [Localizations], consider [onGenerateTitle] instead.
   ///
   /// The [builder] callback is passed two arguments, the [BuildContext] (as
-  /// `context`) and a [Navigator] widget (as `child`).
+  /// `context`) and a [Navigator] or [Router] widget (as `child`).
   ///
-  /// If no routes are provided using [home], [routes], [onGenerateRoute], or
-  /// [onUnknownRoute], the `child` will be null, and it is the responsibility
-  /// of the [builder] to provide the application's routing machinery.
+  /// If no routes are provided to the regular [WidgetsApp] constructor using
+  /// [home], [routes], [onGenerateRoute], or [onUnknownRoute], the `child` will
+  /// be null, and it is the responsibility of the [builder] to provide the
+  /// application's routing machinery.
   ///
-  /// If routes _are_ provided using one or more of those properties, then
-  /// `child` is not null, and the returned value should include the `child` in
-  /// the widget subtree; if it does not, then the application will have no
-  /// navigator and the [navigatorKey], [home], [routes], [onGenerateRoute],
-  /// [onUnknownRoute], [initialRoute], and [navigatorObservers] properties will
-  /// have no effect.
+  /// If routes _are_ provided to the regular [WidgetsApp] constructor using one
+  /// or more of those properties or if the [WidgetsApp.router] constructor is
+  /// used, then `child` is not null, and the returned value should include the
+  /// `child` in the widget subtree; if it does not, then the application will
+  /// have no [Navigator] or [Router] and the routing related properties (i.e.
+  /// [navigatorKey], [home], [routes], [onGenerateRoute], [onUnknownRoute],
+  /// [initialRoute], [navigatorObservers], [routeInformationProvider],
+  /// [backButtonDispatcher], [routerDelegate], and [routeInformationParser])
+  /// are ignored.
   ///
   /// If [builder] is null, it is as if a builder was specified that returned
   /// the `child` directly. If it is null, routes must be provided using one of
@@ -605,8 +610,9 @@ class WidgetsApp extends StatefulWidget {
   ///
   /// Unless a [Navigator] is provided, either implicitly from [builder] being
   /// null, or by a [builder] including its `child` argument, or by a [builder]
-  /// explicitly providing a [Navigator] of its own, widgets and APIs such as
-  /// [Hero], [Navigator.push] and [Navigator.pop], will not function.
+  /// explicitly providing a [Navigator] of its own, or by the [routerDelegate]
+  /// building one, widgets and APIs such as [Hero], [Navigator.push] and
+  /// [Navigator.pop], will not function.
   /// {@endtemplate}
   final TransitionBuilder? builder;
 

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -985,13 +985,13 @@ void main() {
     expect(find.text('popped'), findsOneWidget);
   });
 
-  testWidgets('MaterialApp.build can build without Navigator', (WidgetTester tester) async {
+  testWidgets('MaterialApp.builder can build app without a Navigator', (WidgetTester tester) async {
     Widget builderChild;
     await tester.pumpWidget(MaterialApp(
-        builder: (BuildContext context, Widget child) {
-          builderChild = child;
-          return Container();
-        }
+      builder: (BuildContext context, Widget child) {
+        builderChild = child;
+        return Container();
+      },
     ));
     expect(builderChild, isNull);
   });

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -984,6 +984,17 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('popped'), findsOneWidget);
   });
+
+  testWidgets('MaterialApp.build can build without Navigator', (WidgetTester tester) async {
+    Widget builderChild;
+    await tester.pumpWidget(MaterialApp(
+        builder: (BuildContext context, Widget child) {
+          builderChild = child;
+          return Container();
+        }
+    ));
+    expect(builderChild, isNull);
+  });
 }
 
 class MockAccessibilityFeature implements AccessibilityFeatures {


### PR DESCRIPTION
## Description

_Story Time..._

This all began with me wondering, "Why is the `child` parameter of [`MaterialApp.builder`](https://master-api.flutter.dev/flutter/material/MaterialApp/builder.html) nullable?" Luckily, the documentation had the answer:

> If no routes are provided using home, routes, onGenerateRoute, or onUnknownRoute, the child will be null, and it is the responsibility of the builder to provide the application's routing machinery.

Cool, I thought. Except when I wrote a test for it, it wouldn't pass:

```dart
  testWidgets('MaterialApp.build can build without Navigator', (WidgetTester tester) async {
    Widget builderChild;
    await tester.pumpWidget(MaterialApp(
        builder: (BuildContext context, Widget child) {
          builderChild = child;
          return Container();
        }
    ));
    expect(builderChild, isNull);
  });
```

Looking at the code of WidgetsApp, it turns out that we are always instantiating a Navigator and passing it to the builder. Unfortunately, since none of the arguments for the Navigator are provided to the MaterialApp, this Navigator is actually not buildable and would crash the app if inserted into the widget tree.

Some historic digging showed that https://github.com/flutter/flutter/pull/22161 from 2 years ago accidentally changed the logic to always instantiate a Navigator even when it shouldn't (e.g. because the Navigator is not build-able with the provided information).

This PR restores the old behavior as documented: If not enough information are presented to build a Navigator, none is instantiated.

## Related Issues

n/a

## Tests

I added the following tests:

 * added test mentioned above.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
