### PR TITLE
[flutter_tools] enable SWR optimization for beta channel

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -250,7 +250,7 @@ const Feature singleWidgetReload = Feature(
   ),
   beta: FeatureChannelSetting(
     available: true,
-    enabledByDefault: false,
+    enabledByDefault: true,
   ),
   stable: FeatureChannelSetting(
     available: true,


### PR DESCRIPTION
## Description

This feature needs more open source measurements on the performance changes. Since its been enabled for 2 weeks now with no awful bug reports, lets make sure it gets in the next beta.
