### PR TITLE
Build xcarchive command

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -166,6 +166,29 @@ Future<void> main() async {
         if (!await localNetworkUsageFound(outputAppPath)) {
           throw TaskResult.failure('Debug bundle is missing NSLocalNetworkUsageDescription');
         }
+
+        section('Clean build');
+
+        await inDirectory(flutterProject.rootPath, () async {
+          await flutter('clean');
+        });
+
+        section('Archive');
+
+        await inDirectory(flutterProject.rootPath, () async {
+          await flutter('build', options: <String>[
+            'xcarchive',
+          ]);
+        });
+
+        checkDirectoryExists(path.join(
+          flutterProject.rootPath,
+          'build',
+          'ios',
+          'archive',
+          'Runner.xcarchive',
+          'Products',
+        ));
       });
 
       return TaskResult.success(null);

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -379,6 +379,12 @@ class BuildableIOSApp extends IOSApp {
   @override
   String get deviceBundlePath => _buildAppPath('iphoneos');
 
+  // Xcode uses this path for the final archive bundle location,
+  // not a top-level output directory.
+  // Specifying `build/ios/archive/Runner` will result in `build/ios/archive/Runner.xcarchive`.
+  String get archiveBundlePath
+    => globals.fs.path.join(getIosBuildDirectory(), 'archive', globals.fs.path.withoutExtension(_hostAppBundleName));
+
   String _buildAppPath(String type) {
     return globals.fs.path.join(getIosBuildDirectory(), type, _hostAppBundleName);
   }

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -28,6 +28,7 @@ class BuildCommand extends FlutterCommand {
       buildSystem: globals.buildSystem,
       verboseHelp: verboseHelp,
     ));
+    addSubcommand(BuildIOSArchiveCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildWebCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildMacosCommand(verboseHelp: verboseHelp));

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -21,7 +21,6 @@ import 'build.dart';
 /// .ipas, see https://flutter.dev/docs/deployment/ios.
 class BuildIOSCommand extends _BuildIOSSubCommand {
   BuildIOSCommand({ @required bool verboseHelp }) : super(verboseHelp: verboseHelp) {
-    addBuildModeFlags(defaultToRelease: true);
     argParser
       ..addFlag('config-only',
         help: 'Update the project configuration without performing a build. '
@@ -43,15 +42,6 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 
   @override
   final String description = 'Build an iOS application bundle (Mac OS X host only).';
-
-  @override
-  BuildInfo get buildInfo {
-    // Side effect: ensure defaultBuildMode is set before build info is derived.
-    defaultBuildMode = forSimulator ? BuildMode.debug : BuildMode.release;
-    _buildInfo ??= getBuildInfo();
-    return _buildInfo;
-  }
-  BuildInfo _buildInfo;
 
   @override
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.build;
@@ -79,13 +69,6 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final String description = 'Build an iOS archive bundle (Mac OS X host only).';
 
   @override
-  BuildInfo get buildInfo {
-    _buildInfo ??= getBuildInfo(forcedBuildMode: BuildMode.release);
-    return _buildInfo;
-  }
-  BuildInfo _buildInfo;
-
-  @override
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.archive;
 
   @override
@@ -102,6 +85,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   _BuildIOSSubCommand({ @required bool verboseHelp }) {
     addTreeShakeIconsFlag();
     addSplitDebugInfoOption();
+    addBuildModeFlags(defaultToRelease: true);
     usesTargetOption();
     usesFlavorOption();
     usesPubOption();
@@ -122,7 +106,6 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     DevelopmentArtifact.iOS,
   };
 
-  BuildInfo get buildInfo;
   XcodeBuildAction get xcodeBuildAction;
   bool get forSimulator;
   bool get configOnly;
@@ -130,6 +113,9 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    defaultBuildMode = forSimulator ? BuildMode.debug : BuildMode.release;
+    final BuildInfo buildInfo = getBuildInfo();
+
     if (!globals.platform.isMacOS) {
       throwToolExit('Building for iOS is only supported on macOS.');
     }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -96,7 +96,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   bool codesign = true,
   String deviceID,
   bool configOnly = false,
-  XcodeBuildAction buildAction,
+  XcodeBuildAction buildAction = XcodeBuildAction.build,
 }) async {
   if (!upgradePbxProjWithFlutterAssets(app.project, globals.logger)) {
     return XcodeBuildResult(success: false);
@@ -583,6 +583,9 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
   }
 }
 
+/// xcodebuild <buildaction> parameter (see man xcodebuild for details).
+///
+/// `clean`, `test`, `analyze`, and `install` are not supported.
 enum XcodeBuildAction { build, archive }
 
 extension XcodeBuildActionExtension on XcodeBuildAction {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_xcarchive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_xcarchive_test.dart
@@ -1,0 +1,216 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/testbed.dart';
+
+class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInterpreter {
+  @override
+  Future<Map<String, String>> getBuildSettings(
+      String projectPath, {
+        String scheme,
+        Duration timeout = const Duration(minutes: 1),
+      }) async {
+    return <String, String>{
+      'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+      'DEVELOPMENT_TEAM': 'abc',
+    };
+  }
+}
+
+final Platform macosPlatform = FakePlatform(
+  operatingSystem: 'macos',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
+final Platform notMacosPlatform = FakePlatform(
+  operatingSystem: 'linux',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
+
+void main() {
+  FileSystem fileSystem;
+  MockUsage usage;
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+    usage = MockUsage();
+  });
+
+  // Sets up the minimal mock project files necessary to look like a Flutter project.
+  void createCoreMockProjectFiles() {
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
+  }
+
+  // Sets up the minimal mock project files necessary for iOS builds to succeed.
+  void createMinimalMockProjectFiles() {
+    fileSystem.directory(fileSystem.path.join('ios', 'Runner.xcodeproj')).createSync(recursive: true);
+    fileSystem.directory(fileSystem.path.join('ios', 'Runner.xcworkspace')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('ios', 'Runner.xcodeproj', 'project.pbxproj')).createSync();
+    createCoreMockProjectFiles();
+  }
+
+  const FakeCommand xattrCommand = FakeCommand(command: <String>[
+    'xattr', '-r', '-d', 'com.apple.FinderInfo', '/ios'
+  ]);
+
+  // Creates a FakeCommand for the xcodebuild call to build the app
+  // in the given configuration.
+  FakeCommand setUpMockXcodeBuildHandler({ bool verbose = false, bool showBuildSettings = false, void Function() onRun }) {
+    return FakeCommand(
+      command: <String>[
+        '/usr/bin/env',
+        'xcrun',
+        'xcodebuild',
+        '-configuration', 'Release',
+        if (verbose)
+          'VERBOSE_SCRIPT_LOGGING=YES'
+        else
+          '-quiet',
+        '-workspace', 'Runner.xcworkspace',
+        '-scheme', 'Runner',
+        'BUILD_DIR=/build/ios',
+        '-sdk', 'iphoneos',
+        'FLUTTER_SUPPRESS_ANALYTICS=true',
+        'COMPILER_INDEX_STORE_ENABLE=NO',
+        '-archivePath', '/build/ios/archive/Runner',
+        'archive',
+        if (showBuildSettings)
+          '-showBuildSettings',
+      ],
+      stdout: 'STDOUT STUFF',
+      onRun: onRun,
+    );
+  }
+
+  testUsingContext('xcarchive build fails when there is no ios project', () async {
+    final BuildCommand command = BuildCommand();
+    createCoreMockProjectFiles();
+
+    expect(createTestCommandRunner(command).run(
+      const <String>['build', 'xcarchive', '--no-pub']
+    ), throwsToolExit(message: 'Application not configured for iOS'));
+  }, overrides: <Type, Generator>{
+    Platform: () => macosPlatform,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('xcarchive build fails on non-macOS platform', () async {
+    final BuildCommand command = BuildCommand();
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+
+    expect(createTestCommandRunner(command).run(
+      const <String>['build', 'xcarchive', '--no-pub']
+    ), throwsToolExit());
+  }, overrides: <Type, Generator>{
+    Platform: () => notMacosPlatform,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('xcarchive build invokes xcode build', () async {
+    final BuildCommand command = BuildCommand();
+    createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'xcarchive', '--no-pub']
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      xattrCommand,
+      setUpMockXcodeBuildHandler(),
+      setUpMockXcodeBuildHandler(showBuildSettings: true),
+    ]),
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('xcarchive build invokes xcode build with verbosity', () async {
+    final BuildCommand command = BuildCommand();
+    createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'xcarchive', '--no-pub', '-v']
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      xattrCommand,
+      setUpMockXcodeBuildHandler(verbose: true),
+      setUpMockXcodeBuildHandler(verbose: true, showBuildSettings: true),
+    ]),
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('Performs code size analysis and sends analytics', () async {
+    final BuildCommand command = BuildCommand();
+    createMinimalMockProjectFiles();
+
+    fileSystem.file('build/ios/Release-iphoneos/Runner.app/Frameworks/App.framework/App')
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(List<int>.generate(10000, (int index) => 0));
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'xcarchive', '--no-pub', '--analyze-size']
+    );
+
+    expect(testLogger.statusText, contains('A summary of your iOS bundle analysis can be found at'));
+    verify(usage.sendEvent('code-size-analysis', 'ios')).called(1);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      xattrCommand,
+      setUpMockXcodeBuildHandler(onRun: () {
+        fileSystem.file('build/flutter_size_01/snapshot.arm64.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''[
+{
+  "l": "dart:_internal",
+  "c": "SubListIterable",
+  "n": "[Optimized] skip",
+  "s": 2400
+}
+          ]''');
+        fileSystem.file('build/flutter_size_01/trace.arm64.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{}');
+      }),
+      setUpMockXcodeBuildHandler(showBuildSettings: true),
+    ]),
+    Platform: () => macosPlatform,
+    FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
+    Usage: () => usage,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+}
+
+class MockUsage extends Mock implements Usage {}

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -29,6 +29,7 @@ void main() {
       BuildWebCommand(verboseHelp: false),
       BuildApkCommand(verboseHelp: false),
       BuildIOSCommand(verboseHelp: false),
+      BuildIOSArchiveCommand(verboseHelp: false),
       BuildAppBundleCommand(verboseHelp: false),
       BuildFuchsiaCommand(verboseHelp: false),
       BuildAarCommand(verboseHelp: false),


### PR DESCRIPTION
## Description

Create a new `flutter build xcarchive` command.  It's close to the same as `flutter build ios` but with `archive` tacked onto the end of the `xcodebuild` command.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66619
Part of https://github.com/flutter/flutter/issues/13065
Follow up documentation at https://github.com/flutter/website/issues/4852.

## Tests

build_xcarchive_test, added a check to ios_content_validation_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*