### PR TITLE
[flutter_tools] always run build tests on presubmit

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -199,8 +199,7 @@
          "name":"Mac build_tests",
          "repo":"flutter",
          "task_name":"mac_build_tests",
-         "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "enabled":true
       },
       {
          "name":"Mac customer_testing",
@@ -331,8 +330,7 @@
          "name": "Windows build_tests",
          "repo": "flutter",
          "task_name": "win_build_tests",
-         "enabled":true,
-         "run_if":["dev/", "bin/"]
+         "enabled":true
       },
       {
          "name": "Windows customer_testing",


### PR DESCRIPTION
## Description

These tests are the minimum checks that an application can build on each of the various host platforms. It should be run presubmit because it is reasonably fast and will prevent a red devicelab. (And also because not all developers will have access to the host hardware to test this locally);
