### PR TITLE
Fix new analyzer rule failure

### DIFF
--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -107,17 +107,15 @@ void main() {
     expect(find.text('Add'), findsNothing);
 
     // Test hover for tooltip.
-    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture!.addPointer();
-    addTearDown(() => gesture?.removePointer());
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(() => gesture.removePointer());
     await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
     await tester.pumpAndSettle();
 
     expect(find.text('Add'), findsOneWidget);
 
     await gesture.moveTo(Offset.zero);
-    await gesture.removePointer();
-    gesture = null;
     await tester.pumpAndSettle();
 
     expect(find.text('Add'), findsNothing);
@@ -144,9 +142,9 @@ void main() {
     expect(find.text('Add'), findsNothing);
 
     // Test hover for tooltip.
-    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture!.addPointer();
-    addTearDown(() => gesture?.removePointer());
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(() => gesture.removePointer());
     await tester.pumpAndSettle();
     await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
     await tester.pumpAndSettle();
@@ -154,8 +152,6 @@ void main() {
     expect(find.text('Add'), findsOneWidget);
 
     await gesture.moveTo(Offset.zero);
-    await gesture.removePointer();
-    gesture = null;
     await tester.pumpAndSettle();
 
     expect(find.text('Add'), findsNothing);


### PR DESCRIPTION
## Description

My NNBD test conversion PR (https://github.com/flutter/flutter/pull/67558) caused a failure with a new lint rule in an engine roll [here](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8866988080592092160/+/steps/prepare_environment/0/steps/Analyze/0/steps/analyze/0/stdout).  This PR fixes the lint failure.

## Related Issues

https://github.com/flutter/flutter/pull/67558