### PR TITLE
Replace MockUsage with Usage.test in build tests

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -190,6 +190,7 @@ class _DefaultUsage implements Usage {
     String logFile,
     AnalyticsFactory analyticsIOFactory,
     @required bool runningOnBot,
+    SystemClock clock,
   }) {
     final FlutterVersion flutterVersion = globals.flutterVersion;
     final String version = versionOverride ?? flutterVersion.getVersionString(redactUnknownBranches: true);
@@ -198,6 +199,7 @@ class _DefaultUsage implements Usage {
     final bool usingLogFile = logFilePath != null && logFilePath.isNotEmpty;
 
     analyticsIOFactory ??= _defaultAnalyticsIOFactory;
+    _clock = clock ?? globals.systemClock;
 
     if (// To support testing, only allow other signals to supress analytics
         // when analytics are not being shunted to a file.
@@ -273,12 +275,14 @@ class _DefaultUsage implements Usage {
 
   _DefaultUsage.test() :
       _suppressAnalytics = false,
-      _analytics = AnalyticsMock(true);
+      _analytics = AnalyticsMock(true),
+      _clock = SystemClock.fixed(DateTime(2020, 10, 8));
 
   Analytics _analytics;
 
   bool _printedWelcome = false;
   bool _suppressAnalytics = false;
+  SystemClock _clock;
 
   @override
   bool get isFirstRun => _analytics.firstRun;
@@ -310,7 +314,7 @@ class _DefaultUsage implements Usage {
 
     final Map<String, String> paramsWithLocalTime = <String, String>{
       ...?parameters,
-      cdKey(CustomDimensions.localTime): formatDateTime(globals.systemClock.now()),
+      cdKey(CustomDimensions.localTime): formatDateTime(_clock.now()),
     };
     _analytics.sendScreenView(command, parameters: paramsWithLocalTime);
   }
@@ -329,7 +333,7 @@ class _DefaultUsage implements Usage {
 
     final Map<String, String> paramsWithLocalTime = <String, String>{
       ...?parameters,
-      cdKey(CustomDimensions.localTime): formatDateTime(globals.systemClock.now()),
+      cdKey(CustomDimensions.localTime): formatDateTime(_clock.now()),
     };
 
     _analytics.sendEvent(

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -272,8 +272,8 @@ class _DefaultUsage implements Usage {
   }
 
   _DefaultUsage.test() :
-      _suppressAnalytics = true,
-      _analytics = AnalyticsMock();
+      _suppressAnalytics = false,
+      _analytics = AnalyticsMock(true);
 
   Analytics _analytics;
 

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -190,7 +190,6 @@ class _DefaultUsage implements Usage {
     String logFile,
     AnalyticsFactory analyticsIOFactory,
     @required bool runningOnBot,
-    SystemClock clock,
   }) {
     final FlutterVersion flutterVersion = globals.flutterVersion;
     final String version = versionOverride ?? flutterVersion.getVersionString(redactUnknownBranches: true);
@@ -199,7 +198,7 @@ class _DefaultUsage implements Usage {
     final bool usingLogFile = logFilePath != null && logFilePath.isNotEmpty;
 
     analyticsIOFactory ??= _defaultAnalyticsIOFactory;
-    _clock = clock ?? globals.systemClock;
+    _clock = globals.systemClock;
 
     if (// To support testing, only allow other signals to supress analytics
         // when analytics are not being shunted to a file.

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
@@ -400,16 +398,14 @@ set(BINARY_NAME "fizz_bar")
       ..createSync(recursive: true)
       ..writeAsBytesSync(List<int>.filled(10000, 0));
 
-    await runZoned(() async {
-      await createTestCommandRunner(command).run(
+    // Capture Usage.test() events.
+    final StringBuffer buffer = await capturedConsolePrint(() =>
+      createTestCommandRunner(command).run(
         const <String>['build', 'linux', '--no-pub', '--analyze-size']
-      );
-    }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-      // Capture Usage.test() events.
-      testLogger.printTrace(line);
-    }));
+      )
+    );
 
-    expect(testLogger.statusText, contains('A summary of your Linux bundle analysis can be found at'));
+    expect(buffer.toString(), contains('A summary of your Linux bundle analysis can be found at'));
     expect(testLogger.traceText, contains('event {category: code-size-analysis, action: linux, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
@@ -15,7 +17,6 @@ import 'package:flutter_tools/src/commands/build_linux.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
@@ -45,12 +46,12 @@ void main() {
 
   FileSystem fileSystem;
   ProcessManager processManager;
-  MockUsage usage;
+  Usage usage;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     Cache.flutterRoot = _kTestFlutterRoot;
-    usage = MockUsage();
+    usage = Usage.test();
   });
 
   // Creates the mock files necessary to look like a Flutter project.
@@ -399,11 +400,17 @@ set(BINARY_NAME "fizz_bar")
       ..createSync(recursive: true)
       ..writeAsBytesSync(List<int>.filled(10000, 0));
 
-    await createTestCommandRunner(command).run(
-      const <String>['build', 'linux', '--no-pub', '--analyze-size']
-    );
+    await runZoned(() async {
+      await createTestCommandRunner(command).run(
+        const <String>['build', 'linux', '--no-pub', '--analyze-size']
+      );
+    }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+      // Capture Usage.test() events.
+      testLogger.printTrace(line);
+    }));
+
     expect(testLogger.statusText, contains('A summary of your Linux bundle analysis can be found at'));
-    verify(usage.sendEvent('code-size-analysis', 'linux')).called(1);
+    expect(testLogger.traceText, contains('event {category: code-size-analysis, action: linux, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -412,5 +419,3 @@ set(BINARY_NAME "fizz_bar")
     Usage: () => usage,
   });
 }
-
-class MockUsage extends Mock implements Usage {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -405,8 +405,8 @@ set(BINARY_NAME "fizz_bar")
       )
     );
 
-    expect(buffer.toString(), contains('A summary of your Linux bundle analysis can be found at'));
-    expect(testLogger.traceText, contains('event {category: code-size-analysis, action: linux, label: null, value: null, cd33:'));
+    expect(testLogger.statusText, contains('A summary of your Linux bundle analysis can be found at'));
+    expect(buffer.toString(), contains('event {category: code-size-analysis, action: linux, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -329,17 +329,16 @@ void main() {
     fileSystem.file('build/macos/Build/Products/Release/Runner.app/App')
       ..createSync(recursive: true)
       ..writeAsBytesSync(List<int>.generate(10000, (int index) => 0));
-    await runZoned(() async {
-      await createTestCommandRunner(command).run(
+
+    // Capture Usage.test() events.
+    final StringBuffer buffer = await capturedConsolePrint(() =>
+      createTestCommandRunner(command).run(
         const <String>['build', 'macos', '--no-pub', '--analyze-size']
-      );
-    }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-      // Capture Usage.test() events.
-      testLogger.printTrace(line);
-    }));
+      )
+    );
 
     expect(testLogger.statusText, contains('A summary of your macOS bundle analysis can be found at'));
-    expect(testLogger.traceText, contains('event {category: code-size-analysis, action: macos, label: null, value: null, cd33:'));
+    expect(buffer.toString(), contains('event {category: code-size-analysis, action: macos, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -405,17 +403,15 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
       }),
     ]);
 
-    await runZoned(() async {
-      await createTestCommandRunner(command).run(
+    // Capture Usage.test() events.
+    final StringBuffer buffer = await capturedConsolePrint(() =>
+      createTestCommandRunner(command).run(
         const <String>['windows', '--no-pub', '--analyze-size']
-      );
-    }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-      // Capture Usage.test() events.
-      testLogger.printTrace(line);
-    }));
+      )
+    );
 
     expect(testLogger.statusText, contains('A summary of your Windows bundle analysis can be found at'));
-    expect(testLogger.traceText, contains('event {category: code-size-analysis, action: windows, label: null, value: null, cd33:'));
+    expect(buffer.toString(), contains('event {category: code-size-analysis, action: windows, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -81,9 +81,7 @@ void main() {
     });
 
     testUsingContext('printStatus should log to stdout when logToStdout is enabled', () async {
-      final StringBuffer buffer = StringBuffer();
-
-      await runZoned<Future<void>>(() async {
+      final StringBuffer buffer = await capturedConsolePrint(() {
         final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
         final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
         daemon = Daemon(
@@ -93,11 +91,8 @@ void main() {
           logToStdout: true,
         );
         globals.printStatus('daemon.logMessage test');
-        // Service the event loop.
-        await Future<void>.value();
-      }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-        buffer.writeln(line);
-      }));
+        return Future<void>.value();
+      });
 
       expect(buffer.toString().trim(), 'daemon.logMessage test');
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -384,11 +384,7 @@ void main() {
             '--no-hot',
           ]), isNull)
         );
-        // Allow any CustomDimensions.localTime (cd33) timestamp.
-        final RegExp usageRegexp = RegExp(
-          'screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: .*, viewName: run'
-        );
-        expect(buffer.toString(), matches(usageRegexp));
+        expect(buffer.toString(), contains('screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: 2020-10-08 00:00:00.000 -0700, viewName: run'));
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => artifacts,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -384,7 +384,11 @@ void main() {
             '--no-hot',
           ]), isNull)
         );
-        expect(buffer.toString(), contains('screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: 2020-10-08 00:00:00.000 -0700, viewName: run'));
+        // Allow any CustomDimensions.localTime (cd33) timestamp.
+        final RegExp usageRegexp = RegExp(
+          'screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: .*, viewName: run'
+        );
+        expect(buffer.toString(), matches(usageRegexp));
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => artifacts,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -376,21 +376,19 @@ void main() {
           ..writeAsStringSync('# Hello, World');
         globals.fs.currentDirectory = tempDir;
 
-        await runZoned(() async {
-          await expectToolExitLater(createTestCommandRunner(command).run(<String>[
+        // Capture Usage.test() events.
+        final StringBuffer buffer = await capturedConsolePrint(() =>
+          expectToolExitLater(createTestCommandRunner(command).run(<String>[
             'run',
             '--no-pub',
             '--no-hot',
-          ]), isNull);
-        }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-          // Capture Usage.test() events.
-          testLogger.printTrace(line);
-        }));
+          ]), isNull)
+        );
         // Allow any CustomDimensions.localTime (cd33) timestamp.
         final RegExp usageRegexp = RegExp(
           'screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: .*, viewName: run'
         );
-        expect(testLogger.traceText, matches(usageRegexp));
+        expect(buffer.toString(), matches(usageRegexp));
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => artifacts,

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -92,6 +92,18 @@ CommandRunner<void> createTestCommandRunner([ FlutterCommand command ]) {
   return runner;
 }
 
+/// Capture console print events into a string buffer.
+Future<StringBuffer> capturedConsolePrint(Future<void> Function() body) async {
+  final StringBuffer buffer = StringBuffer();
+  await runZoned<Future<void>>(() async {
+    // Service the event loop.
+    await body();
+  }, zoneSpecification: ZoneSpecification(print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+    buffer.writeln(line);
+  }));
+  return buffer;
+}
+
 /// Matcher for functions that throw [AssertionError].
 final Matcher throwsAssertionError = throwsA(isA<AssertionError>());
 


### PR DESCRIPTION
## Description

Leverage `AnalyticsMock` logging feature to capture usage events from `Usage.test()` by redirecting its console `print` to a string buffer.  Replace a few `MockUsage` instances.

## Related Issues

https://github.com/flutter/flutter/pull/67598#discussion_r501899905