### PR TITLE
make router assert more strict

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -245,7 +245,12 @@ class Router<T> extends StatefulWidget {
     this.routeInformationParser,
     required this.routerDelegate,
     this.backButtonDispatcher,
-  })  : assert(routeInformationProvider == null || routeInformationParser != null),
+  })  : assert(
+          (routeInformationProvider == null) == (routeInformationParser == null),
+          'You must provide both routeInformationProvider and routeInformationParser '
+          'if this router parses route information. Otheriwse, they should both '
+          'be null.'
+        ),
         assert(routerDelegate != null),
         super(key: key);
 

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -118,6 +118,50 @@ void main() {
     expect(find.text('popped'), findsOneWidget);
   });
 
+  testWidgets('Router throw when passes only routeInformationProvider', (WidgetTester tester) async {
+    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
+    provider.value = const RouteInformation(
+      location: 'initial',
+    );
+    try {
+      Router<RouteInformation>(
+        routeInformationProvider: provider,
+        routerDelegate: SimpleRouterDelegate(
+          builder: (BuildContext context, RouteInformation information) {
+            return Text(information.location);
+          },
+        ),
+      );
+    } on AssertionError catch(e) {
+      expect(
+        e.message,
+        'You must provide both routeInformationProvider and '
+        'routeInformationParser if this router parses route information. '
+        'Otheriwse, they should both be null.'
+      );
+    }
+  });
+
+  testWidgets('Router throw when passes only routeInformationParser', (WidgetTester tester) async {
+    try {
+      Router<RouteInformation>(
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: SimpleRouterDelegate(
+          builder: (BuildContext context, RouteInformation information) {
+            return Text(information.location);
+          },
+        ),
+      );
+    } on AssertionError catch(e) {
+      expect(
+        e.message,
+        'You must provide both routeInformationProvider and '
+        'routeInformationParser if this router parses route information. '
+        'Otheriwse, they should both be null.'
+      );
+    }
+  });
+
   testWidgets('PopNavigatorRouterDelegateMixin works', (WidgetTester tester) async {
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
     provider.value = const RouteInformation(


### PR DESCRIPTION
## Description

We should not allow user to pass in only route information provider or route information parser. They either provide both or none.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
