### PR TITLE
Make TextTheme attributes non-nullable.

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -126,7 +126,7 @@ class MaterialBanner extends StatelessWidget {
     final Color backgroundColor = this.backgroundColor
         ?? bannerTheme.backgroundColor
         ?? theme!.colorScheme.surface;
-    final TextStyle? textStyle = contentTextStyle
+    final TextStyle textStyle = contentTextStyle
         ?? bannerTheme.contentTextStyle
         ?? theme!.textTheme.bodyText2;
 
@@ -145,7 +145,7 @@ class MaterialBanner extends StatelessWidget {
                   ),
                 Expanded(
                   child: DefaultTextStyle(
-                    style: textStyle!,
+                    style: textStyle,
                     child: content,
                   ),
                 ),

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -509,7 +509,7 @@ class ChipThemeData with Diagnosticable {
     final ChipThemeData defaultData = ChipThemeData.fromDefaults(
       secondaryColor: defaultTheme.primaryColor,
       brightness: defaultTheme.brightness,
-      labelStyle: defaultTheme.textTheme.bodyText1!,
+      labelStyle: defaultTheme.textTheme.bodyText1,
     );
     properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: defaultData.backgroundColor));
     properties.add(ColorProperty('deleteIconColor', deleteIconColor, defaultValue: defaultData.deleteIconColor));

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -175,7 +175,7 @@ class CircleAvatar extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final ThemeData theme = Theme.of(context)!;
-    TextStyle textStyle = theme.primaryTextTheme.subtitle1!.copyWith(color: foregroundColor);
+    TextStyle textStyle = theme.primaryTextTheme.subtitle1.copyWith(color: foregroundColor);
     Color? effectiveBackgroundColor = backgroundColor;
     if (effectiveBackgroundColor == null) {
       switch (ThemeData.estimateBrightnessForColor(textStyle.color!)) {

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -737,7 +737,7 @@ class DataTable extends StatelessWidget {
 
     final TextStyle effectiveHeadingTextStyle = headingTextStyle
       ?? themeData.dataTableTheme.headingTextStyle
-      ?? themeData.textTheme.subtitle2!;
+      ?? themeData.textTheme.subtitle2;
     final double effectiveHeadingRowHeight = headingRowHeight
       ?? themeData.dataTableTheme.headingRowHeight
       ?? _headingRowHeight;
@@ -792,7 +792,7 @@ class DataTable extends StatelessWidget {
 
     final TextStyle effectiveDataTextStyle = dataTextStyle
       ?? themeData.dataTableTheme.dataTextStyle
-      ?? themeData.textTheme.bodyText2!;
+      ?? themeData.textTheme.bodyText2;
     final double effectiveDataRowHeight = dataRowHeight
       ?? themeData.dataTableTheme.dataRowHeight
       ?? kMinInteractiveDimension;

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -485,7 +485,7 @@ class AlertDialog extends StatelessWidget {
           bottom: effectiveTitlePadding.bottom,
         ),
         child: DefaultTextStyle(
-          style: titleTextStyle ?? dialogTheme.titleTextStyle ?? theme.textTheme.headline6!,
+          style: titleTextStyle ?? dialogTheme.titleTextStyle ?? theme.textTheme.headline6,
           child: Semantics(
             child: title,
             namesRoute: label == null,
@@ -505,7 +505,7 @@ class AlertDialog extends StatelessWidget {
           bottom: effectiveContentPadding.bottom,
         ),
         child: DefaultTextStyle(
-          style: contentTextStyle ?? dialogTheme.contentTextStyle ?? theme.textTheme.subtitle1!,
+          style: contentTextStyle ?? dialogTheme.contentTextStyle ?? theme.textTheme.subtitle1,
           child: content!,
         ),
       );
@@ -840,7 +840,7 @@ class SimpleDialog extends StatelessWidget {
           bottom: children == null ? effectiveTitlePadding.bottom * paddingScaleFactor : effectiveTitlePadding.bottom,
         ),
         child: DefaultTextStyle(
-          style: titleTextStyle ?? DialogTheme.of(context).titleTextStyle ?? theme.textTheme.headline6!,
+          style: titleTextStyle ?? DialogTheme.of(context).titleTextStyle ?? theme.textTheme.headline6,
           child: Semantics(namesRoute: true, child: title),
         ),
       );

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -91,7 +91,7 @@ class DrawerHeader extends StatelessWidget {
         duration: duration,
         curve: curve,
         child: child == null ? null : DefaultTextStyle(
-          style: theme!.textTheme.bodyText1!,
+          style: theme!.textTheme.bodyText1,
           child: MediaQuery.removePadding(
             context: context,
             removeTop: true,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1239,7 +1239,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Similarly, we don't reduce the height of the button so much that its icon
   // would be clipped.
   double get _denseButtonHeight {
-    final double fontSize = _textStyle!.fontSize ?? Theme.of(context)!.textTheme.subtitle1!.fontSize!;
+    final double fontSize = _textStyle!.fontSize ?? Theme.of(context)!.textTheme.subtitle1.fontSize!;
     return math.max(fontSize, math.max(widget.iconSize, _kDenseButtonHeight));
   }
 

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -256,7 +256,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ThemeData theme = Theme.of(context)!;
     _borderColorTween.end = theme.dividerColor;
     _headerColorTween
-      ..begin = theme.textTheme.subtitle1!.color
+      ..begin = theme.textTheme.subtitle1.color
       ..end = theme.accentColor;
     _iconColorTween
       ..begin = theme.unselectedWidgetColor

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -371,7 +371,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
 
           final double opacity = settings.toolbarOpacity;
           if (opacity > 0.0) {
-            TextStyle titleStyle = theme.primaryTextTheme.headline6!;
+            TextStyle titleStyle = theme.primaryTextTheme.headline6;
             titleStyle = titleStyle.copyWith(
               color: titleStyle.color!.withOpacity(opacity)
             );

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -93,7 +93,7 @@ class GridTileBar extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       DefaultTextStyle(
-                        style: darkTheme.textTheme.subtitle1!,
+                        style: darkTheme.textTheme.subtitle1,
                         softWrap: false,
                         overflow: TextOverflow.ellipsis,
                         child: title!,
@@ -110,7 +110,7 @@ class GridTileBar extends StatelessWidget {
               else if (title != null || subtitle != null)
                 Expanded(
                   child: DefaultTextStyle(
-                    style: darkTheme.textTheme.subtitle1!,
+                    style: darkTheme.textTheme.subtitle1,
                     softWrap: false,
                     overflow: TextOverflow.ellipsis,
                     child: title ?? subtitle!,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2074,7 +2074,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   // The base style for the inline label or hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
   TextStyle _getInlineStyle(ThemeData themeData) {
-    return themeData.textTheme.subtitle1!.merge(widget.baseStyle)
+    return themeData.textTheme.subtitle1.merge(widget.baseStyle)
       .copyWith(color: decoration!.enabled ? themeData.hintColor : themeData.disabledColor);
   }
 
@@ -2082,7 +2082,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final Color color = decoration!.errorText != null
       ? decoration!.errorStyle?.color ?? themeData.errorColor
       : _getActiveColor(themeData);
-    final TextStyle style = themeData.textTheme.subtitle1!.merge(widget.baseStyle);
+    final TextStyle style = themeData.textTheme.subtitle1.merge(widget.baseStyle);
     // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
     // Setting TextStyle.height to 1 ensures that the label's height will equal
     // its font size.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -980,14 +980,14 @@ class ListTile extends StatelessWidget {
     if (tileTheme != null) {
       switch (tileTheme.style) {
         case ListTileStyle.drawer:
-          style = theme.textTheme.bodyText1!;
+          style = theme.textTheme.bodyText1;
           break;
         case ListTileStyle.list:
-          style = theme.textTheme.subtitle1!;
+          style = theme.textTheme.subtitle1;
           break;
       }
     } else {
-      style = theme.textTheme.subtitle1!;
+      style = theme.textTheme.subtitle1;
     }
     final Color? color = _textColor(theme, tileTheme, style.color);
     return _isDenseLayout(tileTheme)
@@ -996,7 +996,7 @@ class ListTile extends StatelessWidget {
   }
 
   TextStyle _subtitleTextStyle(ThemeData theme, ListTileTheme? tileTheme) {
-    final TextStyle style = theme.textTheme.bodyText2!;
+    final TextStyle style = theme.textTheme.bodyText2;
     final Color? color = _textColor(theme, tileTheme, theme.textTheme.caption!.color);
     return _isDenseLayout(tileTheme)
       ? style.copyWith(color: color, fontSize: 12.0)

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -368,7 +368,7 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
     Widget? contents = widget.child;
     if (contents != null) {
       contents = AnimatedDefaultTextStyle(
-        style: widget.textStyle ?? Theme.of(context)!.textTheme.bodyText2!,
+        style: widget.textStyle ?? Theme.of(context)!.textTheme.bodyText2,
         duration: widget.animationDuration,
         child: contents,
       );

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -453,8 +453,8 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
       color: defaultSelectedIconTheme?.color ?? theme.colorScheme.primary,
       opacity: defaultSelectedIconTheme?.opacity ?? 1.0,
     );
-    final TextStyle unselectedLabelTextStyle = theme.textTheme.bodyText1!.copyWith(color: baseUnselectedColor).merge(widget.unselectedLabelTextStyle ?? navigationRailTheme.unselectedLabelTextStyle);
-    final TextStyle selectedLabelTextStyle = theme.textTheme.bodyText1!.copyWith(color: baseSelectedColor).merge(widget.selectedLabelTextStyle ?? navigationRailTheme.selectedLabelTextStyle);
+    final TextStyle unselectedLabelTextStyle = theme.textTheme.bodyText1.copyWith(color: baseUnselectedColor).merge(widget.unselectedLabelTextStyle ?? navigationRailTheme.unselectedLabelTextStyle);
+    final TextStyle selectedLabelTextStyle = theme.textTheme.bodyText1.copyWith(color: baseSelectedColor).merge(widget.selectedLabelTextStyle ?? navigationRailTheme.selectedLabelTextStyle);
     final double groupAlignment = widget.groupAlignment ?? navigationRailTheme.groupAlignment ?? -1.0;
     final NavigationRailLabelType labelType = widget.labelType ?? navigationRailTheme.labelType ?? NavigationRailLabelType.none;
 

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -438,8 +438,8 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                   // These typographic styles aren't quite the regular ones. We pick the closest ones from the regular
                   // list and then tweak them appropriately.
                   // See https://material.io/design/components/data-tables.html#tables-within-cards
-                  style: _selectedRowCount > 0 ? themeData.textTheme.subtitle1!.copyWith(color: themeData.accentColor)
-                                               : themeData.textTheme.headline6!.copyWith(fontWeight: FontWeight.w400),
+                  style: _selectedRowCount > 0 ? themeData.textTheme.subtitle1.copyWith(color: themeData.accentColor)
+                                               : themeData.textTheme.headline6.copyWith(fontWeight: FontWeight.w400),
                   child: IconTheme.merge(
                     data: const IconThemeData(
                       opacity: 0.54

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -395,7 +395,7 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
                           child: Text(
                             widget.title,
                             overflow: TextOverflow.ellipsis,
-                            style: textTheme.subtitle2?.copyWith(
+                            style: textTheme.subtitle2.copyWith(
                               color: controlColor,
                             ),
                           ),
@@ -1165,7 +1165,7 @@ class _YearPickerState extends State<_YearPicker> {
     } else {
       textColor = colorScheme.onSurface.withOpacity(0.87);
     }
-    final TextStyle? itemStyle = textTheme.bodyText1?.apply(color: textColor);
+    final TextStyle itemStyle = textTheme.bodyText1.apply(color: textColor);
 
     BoxDecoration? decoration;
     if (isSelected) {

--- a/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_range_picker.dart
@@ -426,7 +426,7 @@ class _DayHeaders extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context)!;
     final ColorScheme colorScheme = themeData.colorScheme;
-    final TextStyle textStyle = themeData.textTheme.subtitle2!.apply(color: colorScheme.onSurface);
+    final TextStyle textStyle = themeData.textTheme.subtitle2.apply(color: colorScheme.onSurface);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context)!;
     final List<Widget> labels = _getDayHeaders(textStyle, localizations);
 
@@ -728,7 +728,7 @@ class _MonthItemState extends State<_MonthItem> {
     if (isSelectedDayStart || isSelectedDayEnd) {
       // The selected start and end dates gets a circle background
       // highlight, and a contrasting text color.
-      itemStyle = textTheme.bodyText2?.apply(color: colorScheme.onPrimary);
+      itemStyle = textTheme.bodyText2.apply(color: colorScheme.onPrimary);
       decoration = BoxDecoration(
         color: colorScheme.primary,
         shape: BoxShape.circle,
@@ -752,11 +752,11 @@ class _MonthItemState extends State<_MonthItem> {
         textDirection: textDirection,
       );
     } else if (isDisabled) {
-      itemStyle = textTheme.bodyText2?.apply(color: colorScheme.onSurface.withOpacity(0.38));
+      itemStyle = textTheme.bodyText2.apply(color: colorScheme.onSurface.withOpacity(0.38));
     } else if (utils.isSameDay(widget.currentDate, dayToBuild)) {
       // The current day gets a different text color and a circle stroke
       // border.
-      itemStyle = textTheme.bodyText2?.apply(color: colorScheme.primary);
+      itemStyle = textTheme.bodyText2.apply(color: colorScheme.primary);
       decoration = BoxDecoration(
         border: Border.all(color: colorScheme.primary, width: 1),
         shape: BoxShape.circle,
@@ -901,7 +901,7 @@ class _MonthItemState extends State<_MonthItem> {
           child: ExcludeSemantics(
             child: Text(
               localizations.formatMonthYear(widget.displayedMonth),
-              style: textTheme.bodyText2!.apply(color: themeData.colorScheme.onSurface),
+              style: textTheme.bodyText2.apply(color: themeData.colorScheme.onSurface),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/material/pickers/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_deprecated.dart
@@ -273,10 +273,10 @@ class DayPicker extends StatelessWidget {
             shape: BoxShape.circle,
           );
         } else if (disabled) {
-          itemStyle = themeData.textTheme.bodyText2!.copyWith(color: themeData.disabledColor);
+          itemStyle = themeData.textTheme.bodyText2.copyWith(color: themeData.disabledColor);
         } else if (currentDate.year == year && currentDate.month == month && currentDate.day == day) {
           // The current day gets a different text color.
-          itemStyle = themeData.textTheme.bodyText1!.copyWith(color: themeData.accentColor);
+          itemStyle = themeData.textTheme.bodyText1.copyWith(color: themeData.accentColor);
         }
 
         Widget dayWidget = Container(
@@ -687,7 +687,7 @@ class _YearPickerState extends State<YearPicker> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context)!;
-    final TextStyle? style = themeData.textTheme.bodyText2;
+    final TextStyle style = themeData.textTheme.bodyText2;
     return ListView.builder(
       dragStartBehavior: widget.dragStartBehavior,
       controller: scrollController,
@@ -696,8 +696,8 @@ class _YearPickerState extends State<YearPicker> {
       itemBuilder: (BuildContext context, int index) {
         final int year = widget.firstDate.year + index;
         final bool isSelected = year == widget.selectedDate.year;
-        final TextStyle? itemStyle = isSelected
-          ? themeData.textTheme.headline5!.copyWith(color: themeData.accentColor)
+        final TextStyle itemStyle = isSelected
+          ? themeData.textTheme.headline5.copyWith(color: themeData.accentColor)
           : style;
         return InkWell(
           key: ValueKey<int>(year),

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -370,9 +370,9 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
     final Color dateColor = colorScheme.brightness == Brightness.light
       ? colorScheme.onPrimary
       : colorScheme.onSurface;
-    final TextStyle? dateStyle = orientation == Orientation.landscape
-      ? textTheme.headline5?.copyWith(color: dateColor)
-      : textTheme.headline4?.copyWith(color: dateColor);
+    final TextStyle dateStyle = orientation == Orientation.landscape
+      ? textTheme.headline5.copyWith(color: dateColor)
+      : textTheme.headline4.copyWith(color: dateColor);
 
     final Widget actions = Container(
       alignment: AlignmentDirectional.centerEnd,

--- a/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
@@ -487,11 +487,11 @@ class _CalendarRangePickerDialog extends StatelessWidget {
     final Color headerDisabledForeground = headerForeground.withOpacity(0.38);
     final String startDateText = utils.formatRangeStartDate(localizations, selectedStartDate, selectedEndDate);
     final String endDateText = utils.formatRangeEndDate(localizations, selectedStartDate, selectedEndDate, DateTime.now());
-    final TextStyle? headlineStyle = textTheme.headline5;
-    final TextStyle? startDateStyle = headlineStyle?.apply(
+    final TextStyle headlineStyle = textTheme.headline5;
+    final TextStyle startDateStyle = headlineStyle.apply(
       color: selectedStartDate != null ? headerForeground : headerDisabledForeground
     );
-    final TextStyle? endDateStyle = headlineStyle?.apply(
+    final TextStyle endDateStyle = headlineStyle.apply(
       color: selectedEndDate != null ? headerForeground : headerDisabledForeground
     );
     final TextStyle saveButtonStyle = textTheme.button!.apply(
@@ -639,9 +639,9 @@ class _InputDateRangePickerDialog extends StatelessWidget {
     final Color dateColor = colorScheme.brightness == Brightness.light
       ? colorScheme.onPrimary
       : colorScheme.onSurface;
-    final TextStyle? dateStyle = orientation == Orientation.landscape
-      ? textTheme.headline5?.apply(color: dateColor)
-      : textTheme.headline4?.apply(color: dateColor);
+    final TextStyle dateStyle = orientation == Orientation.landscape
+      ? textTheme.headline5.apply(color: dateColor)
+      : textTheme.headline4.apply(color: dateColor);
     final String dateText = _formatDateRange(context, selectedStartDate, selectedEndDate, currentDate!);
     final String semanticDateText = selectedStartDate != null && selectedEndDate != null
       ? '${localizations.formatMediumDate(selectedStartDate!)} – ${localizations.formatMediumDate(selectedEndDate!)}'

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -308,7 +308,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context)!;
     final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
-    TextStyle style = widget.textStyle ?? popupMenuTheme.textStyle ?? theme.textTheme.subtitle1!;
+    TextStyle style = widget.textStyle ?? popupMenuTheme.textStyle ?? theme.textTheme.subtitle1;
 
     if (!widget.enabled)
       style = style.copyWith(color: theme.disabledColor);

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -627,7 +627,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       overlayShape: sliderTheme.overlayShape ?? _defaultOverlayShape,
       rangeValueIndicatorShape: valueIndicatorShape,
       showValueIndicator: sliderTheme.showValueIndicator ?? _defaultShowValueIndicator,
-      valueIndicatorTextStyle: sliderTheme.valueIndicatorTextStyle ?? theme.textTheme.bodyText1!.copyWith(
+      valueIndicatorTextStyle: sliderTheme.valueIndicatorTextStyle ?? theme.textTheme.bodyText1.copyWith(
         color: theme.colorScheme.onPrimary,
       ),
       minThumbSeparation: sliderTheme.minThumbSeparation ?? _defaultMinThumbSeparation,

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -687,7 +687,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
       overlayShape: sliderTheme.overlayShape ?? _defaultOverlayShape,
       valueIndicatorShape: valueIndicatorShape,
       showValueIndicator: sliderTheme.showValueIndicator ?? _defaultShowValueIndicator,
-      valueIndicatorTextStyle: sliderTheme.valueIndicatorTextStyle ?? theme.textTheme.bodyText1!.copyWith(
+      valueIndicatorTextStyle: sliderTheme.valueIndicatorTextStyle ?? theme.textTheme.bodyText1.copyWith(
         color: theme.colorScheme.onPrimary,
       ),
     );

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -420,7 +420,7 @@ class _SnackBarState extends State<SnackBar> {
       snackBarTheme: snackBarTheme,
     );
 
-    final TextStyle? contentTextStyle = snackBarTheme.contentTextStyle ?? inverseTheme.textTheme.subtitle1;
+    final TextStyle contentTextStyle = snackBarTheme.contentTextStyle ?? inverseTheme.textTheme.subtitle1;
     final SnackBarBehavior snackBarBehavior = widget.behavior ?? snackBarTheme.behavior ?? SnackBarBehavior.fixed;
     final bool isFloatingSnackBar = snackBarBehavior == SnackBarBehavior.floating;
     final double horizontalPadding = isFloatingSnackBar ? 16.0 : 24.0;
@@ -444,7 +444,7 @@ class _SnackBarState extends State<SnackBar> {
             child: Container(
               padding: const EdgeInsets.symmetric(vertical: _singleLineVerticalPadding),
               child: DefaultTextStyle(
-                style: contentTextStyle!,
+                style: contentTextStyle,
                 child: widget.content,
               ),
             ),

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -464,13 +464,13 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       case StepState.indexed:
       case StepState.editing:
       case StepState.complete:
-        return textTheme.bodyText1!;
+        return textTheme.bodyText1;
       case StepState.disabled:
-        return textTheme.bodyText1!.copyWith(
+        return textTheme.bodyText1.copyWith(
           color: _isDark() ? _kDisabledDark : _kDisabledLight
         );
       case StepState.error:
-        return textTheme.bodyText1!.copyWith(
+        return textTheme.bodyText1.copyWith(
           color: _isDark() ? _kErrorDark : _kErrorLight
         );
     }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -170,12 +170,12 @@ class _TabStyle extends AnimatedWidget {
     // the same value of inherit. Force that to be inherit=true here.
     final TextStyle defaultStyle = (labelStyle
       ?? tabBarTheme.labelStyle
-      ?? themeData.primaryTextTheme.bodyText1!
+      ?? themeData.primaryTextTheme.bodyText1
     ).copyWith(inherit: true);
     final TextStyle defaultUnselectedStyle = (unselectedLabelStyle
       ?? tabBarTheme.unselectedLabelStyle
       ?? labelStyle
-      ?? themeData.primaryTextTheme.bodyText1!
+      ?? themeData.primaryTextTheme.bodyText1
     ).copyWith(inherit: true);
     final TextStyle textStyle = selected
       ? TextStyle.lerp(defaultStyle, defaultUnselectedStyle, animation.value)!
@@ -183,7 +183,7 @@ class _TabStyle extends AnimatedWidget {
 
     final Color selectedColor = labelColor
        ?? tabBarTheme.labelColor
-       ?? themeData.primaryTextTheme.bodyText1!.color!;
+       ?? themeData.primaryTextTheme.bodyText1.color!;
     final Color unselectedColor = unselectedLabelColor
       ?? tabBarTheme.unselectedLabelColor
       ?? selectedColor.withAlpha(0xB2); // 70% alpha

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1084,7 +1084,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
     final ThemeData theme = Theme.of(context)!;
     final TextSelectionThemeData selectionTheme = TextSelectionTheme.of(context);
-    final TextStyle style = theme.textTheme.subtitle1!.merge(widget.style);
+    final TextStyle style = theme.textTheme.subtitle1.merge(widget.style);
     final Brightness keyboardAppearance = widget.keyboardAppearance ?? theme.primaryColorBrightness;
     final TextEditingController controller = _effectiveController;
     final FocusNode focusNode = _effectiveFocusNode;

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -181,50 +181,52 @@ class TextTheme with Diagnosticable {
          (display4 == null && display3 == null && display2 == null && display1 == null && headline == null && title == null &&
           subhead == null && subtitle == null &&
           body2 == null && body1 == null), 'Cannot mix 2014 and 2018 terms in call to TextTheme() constructor.'),
-       headline1 = headline1 ?? display4,
-       headline2 = headline2 ?? display3,
-       headline3 = headline3 ?? display2,
-       headline4 = headline4 ?? display1,
-       headline5 = headline5 ?? headline,
-       headline6 = headline6 ?? title,
-       subtitle1 = subtitle1 ?? subhead,
-       subtitle2 = subtitle2 ?? subtitle,
-       bodyText1 = bodyText1 ?? body2,
-       bodyText2 = bodyText2 ?? body1;
+       // Because of the assert above, the const TextStyle default constructors
+       // wil never be called, but it allows us to make the fields non-nullable.
+       headline1 = headline1 ?? display4 ?? const TextStyle(),
+       headline2 = headline2 ?? display3 ?? const TextStyle(),
+       headline3 = headline3 ?? display2 ?? const TextStyle(),
+       headline4 = headline4 ?? display1 ?? const TextStyle(),
+       headline5 = headline5 ?? headline ?? const TextStyle(),
+       headline6 = headline6 ?? title ?? const TextStyle(),
+       subtitle1 = subtitle1 ?? subhead ?? const TextStyle(),
+       subtitle2 = subtitle2 ?? subtitle ?? const TextStyle(),
+       bodyText1 = bodyText1 ?? body2 ?? const TextStyle(),
+       bodyText2 = bodyText2 ?? body1 ?? const TextStyle();
 
   /// Extremely large text.
-  final TextStyle? headline1;
+  final TextStyle headline1;
 
   /// Very, very large text.
   ///
   /// Used for the date in the dialog shown by [showDatePicker].
-  final TextStyle? headline2;
+  final TextStyle headline2;
 
   /// Very large text.
-  final TextStyle? headline3;
+  final TextStyle headline3;
 
   /// Large text.
-  final TextStyle? headline4;
+  final TextStyle headline4;
 
   /// Used for large text in dialogs (e.g., the month and year in the dialog
   /// shown by [showDatePicker]).
-  final TextStyle? headline5;
+  final TextStyle headline5;
 
   /// Used for the primary text in app bars and dialogs (e.g., [AppBar.title]
   /// and [AlertDialog.title]).
-  final TextStyle? headline6;
+  final TextStyle headline6;
 
   /// Used for the primary text in lists (e.g., [ListTile.title]).
-  final TextStyle? subtitle1;
+  final TextStyle subtitle1;
 
   /// For medium emphasis text that's a little smaller than [subtitle1].
-  final TextStyle? subtitle2;
+  final TextStyle subtitle2;
 
   /// Used for emphasizing text that would otherwise be [bodyText2].
-  final TextStyle? bodyText1;
+  final TextStyle bodyText1;
 
   /// The default text style for [Material].
-  final TextStyle? bodyText2;
+  final TextStyle bodyText2;
 
   /// Used for auxiliary text associated with images.
   final TextStyle? caption;
@@ -524,16 +526,16 @@ class TextTheme with Diagnosticable {
     if (other == null)
       return this;
     return copyWith(
-      headline1: headline1?.merge(other.headline1) ?? other.headline1,
-      headline2: headline2?.merge(other.headline2) ?? other.headline2,
-      headline3: headline3?.merge(other.headline3) ?? other.headline3,
-      headline4: headline4?.merge(other.headline4) ?? other.headline4,
-      headline5: headline5?.merge(other.headline5) ?? other.headline5,
-      headline6: headline6?.merge(other.headline6) ?? other.headline6,
-      subtitle1: subtitle1?.merge(other.subtitle1) ?? other.subtitle1,
-      subtitle2: subtitle2?.merge(other.subtitle2) ?? other.subtitle2,
-      bodyText1: bodyText1?.merge(other.bodyText1) ?? other.bodyText1,
-      bodyText2: bodyText2?.merge(other.bodyText2) ?? other.bodyText2,
+      headline1: headline1.merge(other.headline1),
+      headline2: headline2.merge(other.headline2),
+      headline3: headline3.merge(other.headline3),
+      headline4: headline4.merge(other.headline4),
+      headline5: headline5.merge(other.headline5),
+      headline6: headline6.merge(other.headline6),
+      subtitle1: subtitle1.merge(other.subtitle1),
+      subtitle2: subtitle2.merge(other.subtitle2),
+      bodyText1: bodyText1.merge(other.bodyText1),
+      bodyText2: bodyText2.merge(other.bodyText2),
       caption: caption?.merge(other.caption) ?? other.caption,
       button: button?.merge(other.button) ?? other.button,
       overline: overline?.merge(other.overline) ?? other.overline,
@@ -561,7 +563,7 @@ class TextTheme with Diagnosticable {
     TextDecorationStyle? decorationStyle,
   }) {
     return TextTheme(
-      headline1: headline1?.apply(
+      headline1: headline1.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -570,7 +572,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline2: headline2?.apply(
+      headline2: headline2.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -579,7 +581,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline3: headline3?.apply(
+      headline3: headline3.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -588,7 +590,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline4: headline4?.apply(
+      headline4: headline4.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -597,7 +599,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline5: headline5?.apply(
+      headline5: headline5.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -606,7 +608,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline6: headline6?.apply(
+      headline6: headline6.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -615,7 +617,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      subtitle1: subtitle1?.apply(
+      subtitle1: subtitle1.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -624,7 +626,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      subtitle2: subtitle2?.apply(
+      subtitle2: subtitle2.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -633,7 +635,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      bodyText1: bodyText1?.apply(
+      bodyText1: bodyText1.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -642,7 +644,7 @@ class TextTheme with Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      bodyText2: bodyText2?.apply(
+      bodyText2: bodyText2.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -409,7 +409,7 @@ class ThemeData with Diagnosticable {
     chipTheme ??= ChipThemeData.fromDefaults(
       secondaryColor: primaryColor,
       brightness: colorScheme.brightness,
-      labelStyle: textTheme.bodyText1!,
+      labelStyle: textTheme.bodyText1,
     );
     dialogTheme ??= const DialogTheme();
     floatingActionButtonTheme ??= const FloatingActionButtonThemeData();

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -282,7 +282,7 @@ class _HourMinuteControl extends StatelessWidget {
               ? themeData.colorScheme.primary.withOpacity(isDark ? 0.24 : 0.12)
               : themeData.colorScheme.onSurface.withOpacity(0.12);
         });
-    final TextStyle style = timePickerTheme.hourMinuteTextStyle ?? themeData.textTheme.headline2!;
+    final TextStyle style = timePickerTheme.hourMinuteTextStyle ?? themeData.textTheme.headline2;
     final ShapeBorder shape = timePickerTheme.hourMinuteShape ?? _kDefaultShape;
 
     final Set<MaterialState> states = isSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
@@ -402,7 +402,7 @@ class _StringFragment extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context)!;
     final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
-    final TextStyle hourMinuteStyle = timePickerTheme.hourMinuteTextStyle ?? theme.textTheme.headline2!;
+    final TextStyle hourMinuteStyle = timePickerTheme.hourMinuteTextStyle ?? theme.textTheme.headline2;
     final Color textColor = timePickerTheme.hourMinuteTextColor ?? theme.colorScheme.onSurface;
 
     return ExcludeSemantics(
@@ -547,7 +547,7 @@ class _DayPeriodControl extends StatelessWidget {
     final Set<MaterialState> amStates = amSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
     final bool pmSelected = !amSelected;
     final Set<MaterialState> pmStates = pmSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
-    final TextStyle textStyle = timePickerTheme.dayPeriodTextStyle ?? Theme.of(context)!.textTheme.subtitle1!;
+    final TextStyle textStyle = timePickerTheme.dayPeriodTextStyle ?? Theme.of(context)!.textTheme.subtitle1;
     final TextStyle amStyle = textStyle.copyWith(
       color: MaterialStateProperty.resolveAs(textColor, amStates),
     );
@@ -1150,7 +1150,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
   ];
 
   _TappableLabel _buildTappableLabel(TextTheme textTheme, Color color, int value, String label, VoidCallback onTap) {
-    final TextStyle style = textTheme.bodyText1!.copyWith(color: color);
+    final TextStyle style = textTheme.bodyText1.copyWith(color: color);
     final double labelScaleFactor = math.min(MediaQuery.of(context)!.textScaleFactor, 2.0);
     return _TappableLabel(
       value: value,
@@ -1411,7 +1411,7 @@ class _TimePickerInputState extends State<_TimePickerInput> {
     final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context)!.timeOfDayFormat(alwaysUse24HourFormat: media.alwaysUse24HourFormat);
     final bool use24HourDials = hourFormat(of: timeOfDayFormat) != HourFormat.h;
     final ThemeData theme = Theme.of(context)!;
-    final TextStyle hourMinuteStyle = TimePickerTheme.of(context).hourMinuteTextStyle ?? theme.textTheme.headline2!;
+    final TextStyle hourMinuteStyle = TimePickerTheme.of(context).hourMinuteTextStyle ?? theme.textTheme.headline2;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
@@ -1512,7 +1512,7 @@ class _TimePickerInputState extends State<_TimePickerInput> {
           if (hourHasError || minuteHasError)
             Text(
               MaterialLocalizations.of(context)!.invalidTimeLabel,
-              style: theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.error),
+              style: theme.textTheme.bodyText2.copyWith(color: theme.colorScheme.error),
             )
           else
             const SizedBox(height: 2.0),

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -811,7 +811,7 @@ class _ToggleButton extends StatelessWidget {
       currentFillColor = theme.colorScheme.surface.withOpacity(0.0);
     }
 
-    final TextStyle currentTextStyle = textStyle ?? toggleButtonsTheme.textStyle ?? theme.textTheme.bodyText2!;
+    final TextStyle currentTextStyle = textStyle ?? toggleButtonsTheme.textStyle ?? theme.textTheme.bodyText2;
     final BoxConstraints currentConstraints = constraints ?? toggleButtonsTheme.constraints ?? const BoxConstraints(minWidth: kMinInteractiveDimension, minHeight: kMinInteractiveDimension);
 
     final Widget result = ClipRRect(

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -373,7 +373,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     TextStyle defaultTextStyle;
     BoxDecoration defaultDecoration;
     if (theme.brightness == Brightness.dark) {
-      defaultTextStyle = theme.textTheme.bodyText2!.copyWith(
+      defaultTextStyle = theme.textTheme.bodyText2.copyWith(
         color: Colors.black,
       );
       defaultDecoration = BoxDecoration(
@@ -381,7 +381,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         borderRadius: const BorderRadius.all(Radius.circular(4)),
       );
     } else {
-      defaultTextStyle = theme.textTheme.bodyText2!.copyWith(
+      defaultTextStyle = theme.textTheme.bodyText2.copyWith(
         color: Colors.white,
       );
       defaultDecoration = BoxDecoration(
@@ -515,7 +515,7 @@ class _TooltipOverlay extends StatelessWidget {
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: height),
               child: DefaultTextStyle(
-                style: Theme.of(context)!.textTheme.bodyText2!,
+                style: Theme.of(context)!.textTheme.bodyText2,
                 child: Container(
                   decoration: decoration,
                   padding: padding,

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -147,7 +147,7 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 2.0),
               child: DefaultTextStyle(
-                style: theme.primaryTextTheme.bodyText1!,
+                style: theme.primaryTextTheme.bodyText1,
                 overflow: TextOverflow.ellipsis,
                 child: widget.accountName!,
               ),
@@ -159,7 +159,7 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 2.0),
               child: DefaultTextStyle(
-                style: theme.primaryTextTheme.bodyText2!,
+                style: theme.primaryTextTheme.bodyText2,
                 overflow: TextOverflow.ellipsis,
                 child: widget.accountEmail!,
               ),

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -169,7 +169,7 @@ void main() {
   testWidgets('ChipThemeData generates correct opacities for defaults', (WidgetTester tester) async {
     const Color customColor1 = Color(0xcafefeed);
     const Color customColor2 = Color(0xdeadbeef);
-    final TextStyle customStyle = ThemeData.fallback().textTheme.bodyText1!.copyWith(color: customColor2);
+    final TextStyle customStyle = ThemeData.fallback().textTheme.bodyText1.copyWith(color: customColor2);
 
     final ChipThemeData lightTheme = ChipThemeData.fromDefaults(
       secondaryColor: customColor1,
@@ -230,7 +230,7 @@ void main() {
     final ChipThemeData chipThemeBlack = ChipThemeData.fromDefaults(
       secondaryColor: Colors.black,
       brightness: Brightness.dark,
-      labelStyle: ThemeData.fallback().textTheme.bodyText1!.copyWith(color: Colors.black),
+      labelStyle: ThemeData.fallback().textTheme.bodyText1.copyWith(color: Colors.black),
     ).copyWith(
       elevation: 1.0,
       labelPadding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -242,7 +242,7 @@ void main() {
     final ChipThemeData chipThemeWhite = ChipThemeData.fromDefaults(
       secondaryColor: Colors.white,
       brightness: Brightness.light,
-      labelStyle: ThemeData.fallback().textTheme.bodyText1!.copyWith(color: Colors.white),
+      labelStyle: ThemeData.fallback().textTheme.bodyText1.copyWith(color: Colors.white),
     ).copyWith(
       padding: const EdgeInsets.all(2.0),
       labelPadding: const EdgeInsets.only(top: 8.0, bottom: 8.0),

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -117,7 +117,7 @@ void main() {
     expect(decoration.color, equals(theme.primaryColorLight));
 
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
-    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.headline6!.color));
+    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.headline6.color));
   });
 
   testWidgets('CircleAvatar with dark theme', (WidgetTester tester) async {
@@ -142,7 +142,7 @@ void main() {
     expect(decoration.color, equals(theme.primaryColorDark));
 
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
-    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.headline6!.color));
+    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.headline6.color));
   });
 
   testWidgets('CircleAvatar text does not expand with textScaleFactor', (WidgetTester tester) async {

--- a/packages/flutter/test/material/inherited_theme_test.dart
+++ b/packages/flutter/test/material/inherited_theme_test.dart
@@ -316,7 +316,7 @@ void main() {
     BorderSide dividerBorder() {
       final BoxDecoration decoration = tester.widget<Container>(
         find.descendant(of: find.byType(Divider), matching: find.byType(Container)).first,
-      ).decoration as BoxDecoration;
+      ).decoration! as BoxDecoration;
       return decoration.border!.bottom;
     }
 

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -66,7 +66,7 @@ void main() {
     await tester.pump(); // start gesture
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
     expect(
       box,
       paints
@@ -118,7 +118,7 @@ void main() {
     await tester.tapAt(tapDownOffset);
     await tester.pump(); // start gesture
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
 
     bool offsetsAreClose(Offset a, Offset b) => (a - b).distance < 1.0;
     bool radiiAreClose(double a, double b) => (a - b).abs() < 1.0;
@@ -194,7 +194,7 @@ void main() {
     await tester.pump(); // start gesture
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
     expect(
       box,
       paints
@@ -326,7 +326,7 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pump();
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
 
     // ripplePattern always add a translation of topLeft.
     expect(box, ripplePattern(30.0, 0));
@@ -422,7 +422,7 @@ void main() {
     await gesture.moveTo(const Offset(0.0, 0.0));
     await gesture.up(); // generates a tap cancel
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as RenderBox;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
     expect(box, paints..everything((Symbol method, List<dynamic> arguments) {
       if (method != #drawCircle)
         return true;

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1187,7 +1187,7 @@ void main() {
             textDirection: textDirection,
             child: PopupMenuTheme(
               data: PopupMenuTheme.of(context).copyWith(
-                textStyle: Theme.of(context)!.textTheme.subtitle1!.copyWith(fontSize: fontSize),
+                textStyle: Theme.of(context)!.textTheme.subtitle1.copyWith(fontSize: fontSize),
               ),
               child: child!,
             ),

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -23,7 +23,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),
@@ -67,7 +67,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),
@@ -118,7 +118,7 @@ void main() {
           home: Builder(
             builder: (BuildContext context) {
               const String character = '骨';
-              final TextStyle style = Theme.of(context)!.textTheme.headline2!;
+              final TextStyle style = Theme.of(context)!.textTheme.headline2;
               return Scaffold(
                 body: Container(
                   padding: const EdgeInsets.all(48.0),


### PR DESCRIPTION
## Description

This changes the `TextTheme` values for themes to all be non-nullable instead of nullable. The constructor allows for either the legacy names or the new names to be used, but in the end, because of asserts, one or the other of them must be defined. Because of that, it's allowable to provide a default-constructed `TextStyle` as a fallback if both are null (which can't happen), so that the values can all be non-nullable.

## Tests

- Updated tests to not test for nullability of these themes.
