### PR TITLE
Purge persistent cache for perf test runs

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -746,6 +746,7 @@ class PerfTestWithSkSL extends PerfTest {
         'run',
         '--verbose',
         '--verbose-system-logs',
+        '--purge-persistent-cache',
         '--profile',
         if (cacheSkSL) '--cache-sksl',
         '-d', _device.deviceId,


### PR DESCRIPTION
Without this, different devicelab tests may interfere with each other as
`flutter run` will try to reuse the installed app by previous tests, and
th persistent cache generated by the previous tests may stop the SkSL
persistent cache generation of the current test, and thus make the tests
flaky.

Previously, we mainly observed this flakiness on ios32 tests because
there's only 1 machine to run io32 tests and the chance of interference
is high.

This fixes https://github.com/flutter/flutter/issues/66473
