### PR TITLE
Fixed a problem where the Vsync could not be found

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -238,7 +238,7 @@ class AnimationController extends Animation<double>
     this.lowerBound = 0.0,
     this.upperBound = 1.0,
     this.animationBehavior = AnimationBehavior.normal,
-    required TickerProvider vsync,
+    @required TickerProvider vsync,
   }) : assert(lowerBound != null),
        assert(upperBound != null),
        assert(upperBound >= lowerBound),


### PR DESCRIPTION
## Description
Fixed a problem where the comparison parameter Vsync could not be found in animationcontroller.
Modify line 242 from [required tickerprovider Vsync,] to [@ required tickerprovider Vsync,]

## Tests
This problem exists in flutter stable 1.22.1, which I found by updating to the latest version at 16:06 p.m. Beijing time on October 9, 2020.