### PR TITLE
Revert "Flutter driver patch: export finder factory"

### DIFF
--- a/packages/flutter_driver/lib/flutter_driver.dart
+++ b/packages/flutter_driver/lib/flutter_driver.dart
@@ -13,7 +13,6 @@
 /// Protractor (Angular), Espresso (Android) or Earl Gray (iOS).
 library flutter_driver;
 
-export 'src/common/create_finder_factory.dart';
 export 'src/common/diagnostics_tree.dart';
 export 'src/common/enum_util.dart';
 export 'src/common/error.dart';


### PR DESCRIPTION
Reverts flutter/flutter#67769

_This breaks the tree._

`dart:ui` members cannot be exported from a library that should be used on the VM.

```
2020-10-09T15:09:06.657776: stdout: [   +1 ms] executing: /Users/flutter/.cocoon/flutter/bin/cache/dart-sdk/bin/dart --no-sound-null-safety /Users/flutter/.cocoon/flutter/dev/benchmarks/macrobenchmarks/test_driver/large_image_changer_test.dart --packages=/Users/flutter/.cocoon/flutter/dev/benchmarks/macrobenchmarks/.packages -rexpanded
2020-10-09T15:09:18.896846: stderr: [+12238 ms] ../../../packages/flutter_test/lib/src/_goldens_io.dart:9:8: Error: Not found: 'dart:ui'
stderr: [        ] import 'dart:ui';
stderr: [        ]        ^
stderr: [        ] ../../../packages/flutter_test/lib/src/accessibility.dart:8:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.896946: stderr: [        ] import 'dart:ui' as ui;
stderr: [        ]        ^
2020-10-09T15:09:18.897098: stderr: [        ] ../../../packages/flutter_test/lib/src/animation_sheet.dart:6:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.897191: stderr: [        ] import 'dart:ui' as ui;
stderr: [        ]        ^
2020-10-09T15:09:18.897295: stderr: [        ] ../../../packages/flutter_test/lib/src/binding.dart:7:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.897344: stderr: [        ] import 'dart:ui' as ui;
2020-10-09T15:09:18.897466: stderr: [        ]        ^
stderr: [        ] ../../../packages/flutter_test/lib/src/frame_timing_summarizer.dart:5:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.897616: stderr: [        ] import 'dart:ui';
stderr: [        ]        ^
2020-10-09T15:09:18.897763: stderr: [        ] ../../../packages/flutter_test/lib/src/image.dart:7:8: Error: Not found: 'dart:ui'
stderr: [        ] import 'dart:ui' as ui;
2020-10-09T15:09:18.897917: stderr: [        ]        ^
stderr: [        ] ../../../packages/flutter_test/lib/src/matchers.dart:7:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.898002: stderr: [        ] import 'dart:ui' as ui;
2020-10-09T15:09:18.898067: stderr: [        ]        ^
2020-10-09T15:09:18.898110: stderr: [        ] ../../../packages/flutter_test/lib/src/matchers.dart:8:8: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.898260: stderr: [        ] import 'dart:ui';
stderr: [        ]        ^
2020-10-09T15:09:18.898344: stderr: [        ] ../../../packages/flutter_test/lib/src/test_pointer.dart:10:1: Error: Not found: 'dart:ui'
2020-10-09T15:09:18.898396: stderr: [        ] export 'dart:ui' show Offset;
2020-10-09T15:09:18.898541: stderr: [        ] ^
```

TBR @dnfield 