### PR TITLE
[flutter_tools] dont allow creating package name that is invalid

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -132,12 +132,9 @@ class CreateCommand extends FlutterCommand {
       defaultsTo: 'kotlin',
       allowed: <String>['java', 'kotlin'],
     );
-    // TODO(egarciad): Remove this flag. https://github.com/flutter/flutter/issues/52363
     argParser.addFlag(
-      'androidx',
+      'skip-checks',
       hide: true,
-      negatable: true,
-      help: 'Deprecated. Setting this flag has no effect.',
     );
   }
 
@@ -394,9 +391,11 @@ class CreateCommand extends FlutterCommand {
     }
 
     final String projectName = stringArg('project-name') ?? globals.fs.path.basename(projectDirPath);
-    error = _validateProjectName(projectName);
-    if (error != null) {
-      throwToolExit(error);
+    if (!boolArg('skip-checks')) {
+      error = _validateProjectName(projectName);
+      if (error != null) {
+        throwToolExit(error);
+      }
     }
 
     final Map<String, dynamic> templateContext = _createTemplateContext(

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -887,7 +887,8 @@ const Set<String> _packageDependencies = <String>{
   'yaml',
 };
 
-// A valid Dart identifier.
+// A valid Dart identifier that can be used for a package, i.e. no
+// capital letters.
 // https://dart.dev/guides/language/language-tour#important-concepts
 final RegExp _identifierRegExp = RegExp('[a-z_][a-z0-9_]*');
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -889,7 +889,7 @@ const Set<String> _packageDependencies = <String>{
 
 // A valid Dart identifier.
 // https://dart.dev/guides/language/language-tour#important-concepts
-final RegExp _identifierRegExp = RegExp('[a-zA-Z_][a-zA-Z0-9_]*');
+final RegExp _identifierRegExp = RegExp('[a-z_][a-z0-9_]*');
 
 // non-contextual dart keywords.
 //' https://dart.dev/guides/language/language-tour#keywords

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -133,7 +133,9 @@ class CreateCommand extends FlutterCommand {
       allowed: <String>['java', 'kotlin'],
     );
     argParser.addFlag(
-      'skip-checks',
+      'skip-name-checks',
+      help: 'integration test only parameter to allow creating applications/plugins with '
+        'invalid names.',
       hide: true,
     );
   }
@@ -391,7 +393,7 @@ class CreateCommand extends FlutterCommand {
     }
 
     final String projectName = stringArg('project-name') ?? globals.fs.path.basename(projectDirPath);
-    if (!boolArg('skip-checks')) {
+    if (!boolArg('skip-name-checks')) {
       error = _validateProjectName(projectName);
       if (error != null) {
         throwToolExit(error);

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2087,7 +2087,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', '--skip-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('windows');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2054,7 +2054,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', '--skip-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('linux');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2054,7 +2054,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', '--skip-checks', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', '--skip-name-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('linux');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';
@@ -2087,7 +2087,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', '--skip-checks', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', '--skip-name-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('windows');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';

--- a/packages/flutter_tools/test/general.shard/create_config_test.dart
+++ b/packages/flutter_tools/test/general.shard/create_config_test.dart
@@ -16,5 +16,7 @@ void main() {
     expect(isValidPackageName('foo_bar'), true);
     expect(isValidPackageName('_foo_bar'), true);
     expect(isValidPackageName('fizz93'), true);
+
+    expect(isValidPackageName('Foo_bar'), false);
   });
 }


### PR DESCRIPTION
## Description

According to https://dart.dev/tools/pub/pubspec#name , uppercase is not permitted for package names.

Also fix https://github.com/flutter/flutter/issues/52363 cause why not