### PR TITLE
Add test for TabBarView

### DIFF
--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -7,11 +7,12 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
 
 Future<void> pumpTest(
   WidgetTester tester,

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -8,6 +8,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/scheduler/ticker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -917,6 +918,93 @@ void main() {
     expect(targetMidRightPage1, findsOneWidget);
     expect(targetMidLeftPage1, findsOneWidget);
   });
+
+  testWidgets('ensureVisible does not move TabViews', (WidgetTester tester) async {
+    final TickerProvider vsync = TestTickerProvider();
+    final TabController controller = TabController(
+      length: 3,
+      vsync: vsync,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TabBarView(
+          controller: controller,
+          children: List<ListView>.generate(
+            3,
+            (int pageIndex) {
+              return ListView(
+                key: Key('list_$pageIndex'),
+                children: List<Widget>.generate(
+                  100,
+                  (int listIndex) {
+                    return Row(
+                      children: <Widget>[
+                        Container(
+                          key: Key('${pageIndex}_${listIndex}_0'),
+                          color: Colors.red,
+                          width: 200,
+                          height: 10,
+                        ),
+                        Container(
+                          key: Key('${pageIndex}_${listIndex}_1'),
+                          color: Colors.blue,
+                          width: 200,
+                          height: 10,
+                        ),
+                        Container(
+                          key: Key('${pageIndex}_${listIndex}_2'),
+                          color: Colors.green,
+                          width: 200,
+                          height: 10,
+                        ),
+                      ]
+                    );
+                  }
+                ),
+              );
+            }
+          )
+        ),
+      ),
+    );
+
+    final Finder targetMidRightPage0 = find.byKey(const Key('0_25_2'));
+    final Finder targetMidRightPage1 = find.byKey(const Key('1_25_2'));
+    final Finder targetMidLeftPage1 = find.byKey(const Key('1_25_0'));
+
+    expect(find.byKey(const Key('list_0')), findsOneWidget);
+    expect(find.byKey(const Key('list_1')), findsNothing);
+    expect(targetMidRightPage0, findsOneWidget);
+    expect(targetMidRightPage1, findsNothing);
+    expect(targetMidLeftPage1, findsNothing);
+
+    await tester.ensureVisible(targetMidRightPage0);
+    await tester.pumpAndSettle();
+    expect(targetMidRightPage0, findsOneWidget);
+    expect(targetMidRightPage1, findsNothing);
+    expect(targetMidLeftPage1, findsNothing);
+
+    controller.index = 1;
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('list_0')), findsNothing);
+    expect(find.byKey(const Key('list_1')), findsOneWidget);
+    await tester.ensureVisible(targetMidRightPage1);
+    await tester.pumpAndSettle();
+
+    expect(targetMidRightPage0, findsNothing);
+    expect(targetMidRightPage1, findsOneWidget);
+    expect(targetMidLeftPage1, findsOneWidget);
+
+    await tester.ensureVisible(targetMidLeftPage1);
+    await tester.pumpAndSettle();
+
+    expect(targetMidRightPage0, findsNothing);
+    expect(targetMidRightPage1, findsOneWidget);
+    expect(targetMidLeftPage1, findsOneWidget);
+  });
 }
 
 // ignore: must_be_immutable
@@ -949,4 +1037,12 @@ class ExtraSuperPessimisticScrollPhysics extends ScrollPhysics {
   ScrollPhysics applyTo(ScrollPhysics ancestor) {
     return ExtraSuperPessimisticScrollPhysics(parent: buildParent(ancestor));
   }
+}
+
+class TestTickerProvider extends TickerProvider {
+  @override
+  Ticker createTicker(TickerCallback onTick) {
+    return Ticker(onTick);
+  }
+
 }

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/src/scheduler/ticker.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -7,8 +7,8 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1045,5 +1045,4 @@ class TestTickerProvider extends TickerProvider {
   Ticker createTicker(TickerCallback onTick) {
     return Ticker(onTick);
   }
-
 }


### PR DESCRIPTION
Follow up on #67773 

Just adds a test for TabBarViews. Implementation currently relies on PageView and isn't broken, but just in case that changes this test would catch regressions for ensureVisible.

@xu-baolin 