### PR TITLE
[flutter_tool] prepend module name on Windows ps1 script

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -76,9 +76,9 @@ If (Get-Command 7z -errorAction SilentlyContinue) {
 } ElseIf (Get-Command 7za -errorAction SilentlyContinue) {
     # Use 7-Zip's standalone version 7za.exe, if available.
     & 7za x $dartSdkZip "-o$cachePath" -bd | Out-Null
-} ElseIf (Get-Command Expand-Archive -errorAction SilentlyContinue) {
+} ElseIf (Get-Command Microsoft.PowerShell.Archive\Expand-Archive -errorAction SilentlyContinue) {
     # Use PowerShell's built-in unzipper, if available (requires PowerShell 5+).
-    Expand-Archive $dartSdkZip -DestinationPath $cachePath
+    Microsoft.PowerShell.Archive\Expand-Archive $dartSdkZip -DestinationPath $cachePath
 } Else {
     # As last resort: fall back to the Windows GUI.
     $shell = New-Object -com shell.application


### PR DESCRIPTION
## Description

Incase different powershell module is installed over the default name

Fixes https://github.com/flutter/flutter/issues/22896