### PR TITLE
[flutter_tools] check asset files while the tool waits for the frontend_server compile

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -507,6 +507,9 @@ class DevFS {
     // this will produce a full dill. Subsequent invocations will produce incremental
     // dill files that depend on the invalidated files.
     _logger.printTrace('Compiling dart to kernel with ${invalidatedFiles.length} updated files');
+
+    // Await the compiler response after checking if the bundle is updated. This allows the file
+    // stating to be done while waiting for the frontend_server response.
     final Future<CompilerOutput> pendingCompilerOutput = generator.recompile(
       mainUri,
       invalidatedFiles,
@@ -519,6 +522,8 @@ class DevFS {
       final String assetBuildDirPrefix = _asUriPath(getAssetBuildDirectory());
       final String assetDirectory = getAssetBuildDirectory();
       bundle.entries.forEach((String archivePath, DevFSContent content) {
+        // If the content is backed by a real file, isModified will file stat and return true if
+        // it was modified since the last time this was called.
         if (!content.isModified || bundleFirstUpload) {
           return;
         }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -499,12 +499,24 @@ class DevFS {
 
     // Update modified files
     final Map<Uri, DevFSContent> dirtyEntries = <Uri, DevFSContent>{};
-
     int syncedBytes = 0;
+    if (fullRestart) {
+      generator.reset();
+    }
+    // On a full restart, or on an initial compile for the attach based workflow,
+    // this will produce a full dill. Subsequent invocations will produce incremental
+    // dill files that depend on the invalidated files.
+    _logger.printTrace('Compiling dart to kernel with ${invalidatedFiles.length} updated files');
+    final Future<CompilerOutput> pendingCompilerOutput = generator.recompile(
+      mainUri,
+      invalidatedFiles,
+      outputPath: dillOutputPath ?? getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation),
+      packageConfig: packageConfig,
+    );
     if (bundle != null) {
-      final String assetBuildDirPrefix = _asUriPath(getAssetBuildDirectory());
       // The tool writes the assets into the AssetBundle working dir so that they
       // are in the same location in DevFS and the iOS simulator.
+      final String assetBuildDirPrefix = _asUriPath(getAssetBuildDirectory());
       final String assetDirectory = getAssetBuildDirectory();
       bundle.entries.forEach((String archivePath, DevFSContent content) {
         if (!content.isModified || bundleFirstUpload) {
@@ -521,19 +533,7 @@ class DevFS {
         }
       });
     }
-    if (fullRestart) {
-      generator.reset();
-    }
-    // On a full restart, or on an initial compile for the attach based workflow,
-    // this will produce a full dill. Subsequent invocations will produce incremental
-    // dill files that depend on the invalidated files.
-    _logger.printTrace('Compiling dart to kernel with ${invalidatedFiles.length} updated files');
-    final CompilerOutput compilerOutput = await generator.recompile(
-      mainUri,
-      invalidatedFiles,
-      outputPath: dillOutputPath ?? getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation),
-      packageConfig: packageConfig,
-    );
+    final CompilerOutput compilerOutput = await pendingCompilerOutput;
     if (compilerOutput == null || compilerOutput.errorCount > 0) {
       return UpdateFSReport(success: false);
     }


### PR DESCRIPTION
## Description

On every hot reload, the flutter tool must file stat each asset in the bundle. With a large number of assets or a slow file system, this can take 20 - 30 ms. Do this operation while the flutter tool is waiting for a response from the frontend_server.

No tests updated since this is only a timing update. Any difference in behavior will be shown on benchmarks