### PR TITLE
[flutter_tools] use random access file to write http responses

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1662,9 +1662,9 @@ class ArtifactUpdater {
     if (response.statusCode != HttpStatus.ok) {
       throw Exception(response.statusCode);
     }
-    await response.forEach((List<int> chunk) {
-      file.writeAsBytesSync(chunk, mode: FileMode.append);
-    });
+    final RandomAccessFile randomAccessFile = file.openSync(mode: FileMode.writeOnly);
+    await response.forEach(randomAccessFile.writeFromSync);
+    randomAccessFile.closeSync();
   }
 
   /// Create a temporary file and invoke [onTemporaryFile] with the file as


### PR DESCRIPTION
## Description

This should be faster than using write with an append mode since the file does not need to be opened each time.

Functionally equivalent and already covered by unit tests.