### PR TITLE
[flutter_tools] validate that SkSL bundle path exists

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -775,6 +775,10 @@ abstract class FlutterCommand extends Command<void> {
       ? stringArg(FlutterOptions.kBundleSkSLPathOption)
       : null;
 
+    if (bundleSkSLPath != null && !globals.fs.isFileSync(bundleSkSLPath)) {
+      throwToolExit('No SkSL shader bundle found at $bundleSkSLPath.');
+    }
+
     final String performanceMeasurementFile = argParser.options.containsKey(FlutterOptions.kPerformanceMeasurementFile)
       ? stringArg(FlutterOptions.kPerformanceMeasurementFile)
       : null;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -279,6 +279,8 @@ void main() {
     ]);
     fileSystem.file('lib/other.dart')
       .createSync(recursive: true);
+    fileSystem.file('foo/bar.sksl.json')
+      .createSync(recursive: true);
 
     await createTestCommandRunner(command).run(
       const <String>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -229,6 +229,8 @@ void main() {
     createMinimalMockProjectFiles();
     fileSystem.file('lib/other.dart')
       .createSync(recursive: true);
+    fileSystem.file('foo/bar.sksl.json')
+      .createSync(recursive: true);
 
     await createTestCommandRunner(command).run(
       const <String>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -286,6 +286,8 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
     ]);
     fileSystem.file(fileSystem.path.join('lib', 'other.dart'))
       .createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('foo', 'bar.sksl.json'))
+      .createSync(recursive: true);
 
     await createTestCommandRunner(command).run(
       const <String>[

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -185,18 +185,17 @@ void main() {
   });
 
   testWithoutContext('will load bootstrap script before starting', () async {
-    final String flutterBin =
-        fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     final File bootstrap = fileSystem.file(fileSystem.path.join(
-        getFlutterRoot(),
-        'bin',
-        'internal',
-        platform.isWindows ? 'bootstrap.bat' : 'bootstrap.sh'));
+      getFlutterRoot(),
+      'bin',
+      'internal',
+      platform.isWindows ? 'bootstrap.bat' : 'bootstrap.sh'),
+    );
 
     try {
       bootstrap.writeAsStringSync('echo TESTING 1 2 3');
-
       final ProcessResult result = await processManager.run(<String>[
         flutterBin,
         ...getLocalEngineArguments(),
@@ -206,5 +205,20 @@ void main() {
     } finally {
       bootstrap.deleteSync();
     }
+  });
+
+  testWithoutContext('Providing sksl bundle with missing file with tool exit', () async {
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final String helloWorld = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'build',
+      'apk',
+      '--bundle-sksl-path=foo/bar/baz.json', // This file does not exist.
+    ], workingDirectory: helloWorld);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('No SkSL shader bundle found at foo/bar/baz.json'));
   });
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/61772

tool exit if there is no file at the path provided when building/running with sksl