### PR TITLE
[gestures] make stylus pointer types use touch pan/drag slop

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -2115,9 +2115,9 @@ class PointerCancelEvent extends PointerEvent with _PointerEventDescription, _Co
 double computeHitSlop(PointerDeviceKind kind) {
   switch (kind) {
     case PointerDeviceKind.mouse:
+      return kPrecisePointerHitSlop;
     case PointerDeviceKind.stylus:
     case PointerDeviceKind.invertedStylus:
-      return kPrecisePointerHitSlop;
     case PointerDeviceKind.unknown:
     case PointerDeviceKind.touch:
       return kTouchSlop;
@@ -2128,9 +2128,9 @@ double computeHitSlop(PointerDeviceKind kind) {
 double computePanSlop(PointerDeviceKind kind) {
   switch (kind) {
     case PointerDeviceKind.mouse:
+      return kPrecisePointerPanSlop;
     case PointerDeviceKind.stylus:
     case PointerDeviceKind.invertedStylus:
-      return kPrecisePointerPanSlop;
     case PointerDeviceKind.unknown:
     case PointerDeviceKind.touch:
       return kPanSlop;
@@ -2141,9 +2141,9 @@ double computePanSlop(PointerDeviceKind kind) {
 double computeScaleSlop(PointerDeviceKind kind) {
   switch (kind) {
     case PointerDeviceKind.mouse:
+      return kPrecisePointerScaleSlop;
     case PointerDeviceKind.stylus:
     case PointerDeviceKind.invertedStylus:
-      return kPrecisePointerScaleSlop;
     case PointerDeviceKind.unknown:
     case PointerDeviceKind.touch:
       return kScaleSlop;

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -38,20 +38,20 @@ void main() {
 
   test('computed hit slop values are based on pointer device kind', () {
     expect(computeHitSlop(PointerDeviceKind.mouse), kPrecisePointerHitSlop);
-    expect(computeHitSlop(PointerDeviceKind.stylus), kPrecisePointerHitSlop);
-    expect(computeHitSlop(PointerDeviceKind.invertedStylus), kPrecisePointerHitSlop);
+    expect(computeHitSlop(PointerDeviceKind.stylus), kTouchSlop);
+    expect(computeHitSlop(PointerDeviceKind.invertedStylus), kTouchSlop);
     expect(computeHitSlop(PointerDeviceKind.touch), kTouchSlop);
     expect(computeHitSlop(PointerDeviceKind.unknown), kTouchSlop);
 
     expect(computePanSlop(PointerDeviceKind.mouse), kPrecisePointerPanSlop);
-    expect(computePanSlop(PointerDeviceKind.stylus), kPrecisePointerPanSlop);
-    expect(computePanSlop(PointerDeviceKind.invertedStylus), kPrecisePointerPanSlop);
+    expect(computePanSlop(PointerDeviceKind.stylus), kPanSlop);
+    expect(computePanSlop(PointerDeviceKind.invertedStylus), kPanSlop);
     expect(computePanSlop(PointerDeviceKind.touch), kPanSlop);
     expect(computePanSlop(PointerDeviceKind.unknown), kPanSlop);
 
     expect(computeScaleSlop(PointerDeviceKind.mouse), kPrecisePointerScaleSlop);
-    expect(computeScaleSlop(PointerDeviceKind.stylus), kPrecisePointerScaleSlop);
-    expect(computeScaleSlop(PointerDeviceKind.invertedStylus), kPrecisePointerScaleSlop);
+    expect(computeScaleSlop(PointerDeviceKind.stylus), kScaleSlop);
+    expect(computeScaleSlop(PointerDeviceKind.invertedStylus), kScaleSlop);
     expect(computeScaleSlop(PointerDeviceKind.touch), kScaleSlop);
     expect(computeScaleSlop(PointerDeviceKind.unknown), kScaleSlop);
   });


### PR DESCRIPTION
## Description

A user reported that they could not drag/pan/scale correctly anymore. Revert the stylus values to the old settings.


Fixes https://github.com/flutter/flutter/issues/67869