### PR TITLE
Fix TextField bug when the formatter repeatedly format

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2215,7 +2215,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (value == _value) {
       // Please note that the setter will not notify subscribers if set duplicate values.
       // If the value was modified by the formatter, the remote should be notified to keep in sync,
-      // otherwise, it will short-circuit.
+      // if not modified, it will short-circuit.
       _updateRemoteEditingValueIfNeeded();
     } else {
       // Setting _value here ensures the selection and composing region info is passed.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2212,8 +2212,16 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _lastFormattedValue = value;
     }
 
-    // Setting _value here ensures the selection and composing region info is passed.
-    _value = value;
+    if (value == _value) {
+      // Please note that the setter will not notify subscribers if set duplicate values.
+      // If the value was modified by the formatter, the remote should be notified to keep in sync,
+      // otherwise, it will short-circuit.
+      _updateRemoteEditingValueIfNeeded();
+    } else {
+      // Setting _value here ensures the selection and composing region info is passed.
+      _value = value;
+    }
+
     // Use the last formatted value when an identical repeat pass is detected.
     if (isRepeat && textChanged && _lastFormattedValue != null) {
       _value = _lastFormattedValue!;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2213,7 +2213,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
 
     if (value == _value) {
-      // Please note that the setter will not notify subscribers if set duplicate values.
       // If the value was modified by the formatter, the remote should be notified to keep in sync,
       // if not modified, it will short-circuit.
       _updateRemoteEditingValueIfNeeded();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4998,7 +4998,7 @@ void main() {
     );
   });
 
-  testWidgets('Synchronous test of local and remote editing values (#2)', (WidgetTester tester) async {
+  testWidgets('Send text input state to engine when the input formatter rejects user input', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/67828
     final List<MethodCall> log = <MethodCall>[];
     SystemChannels.textInput.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -5055,19 +5055,12 @@ void main() {
       text: 'I will be modified by the formatter.',
     ));
     expect(log.length, 1);
-    MethodCall methodCall = log[0];
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditingState', arguments: <String, dynamic>{
-        'text': 'Flutter is the best!',
-        'selectionBase': -1,
-        'selectionExtent': -1,
-        'selectionAffinity': 'TextAffinity.downstream',
-        'selectionIsDirectional': false,
-        'composingBase': -1,
-        'composingExtent': -1,
-      }),
-    );
+    expect(log, contains(matchesMethodCall(
+      'TextInput.setEditingState',
+      args: allOf(
+        containsPair('text', 'Flutter is the best!'),
+      ),
+    )));
 
     log.clear();
 
@@ -5075,19 +5068,12 @@ void main() {
       text: 'I will be modified by the formatter.',
     ));
     expect(log.length, 1);
-    methodCall = log[0];
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditingState', arguments: <String, dynamic>{
-        'text': 'Flutter is the best!',
-        'selectionBase': -1,
-        'selectionExtent': -1,
-        'selectionAffinity': 'TextAffinity.downstream',
-        'selectionIsDirectional': false,
-        'composingBase': -1,
-        'composingExtent': -1,
-      }),
-    );
+    expect(log, contains(matchesMethodCall(
+      'TextInput.setEditingState',
+      args: allOf(
+        containsPair('text', 'Flutter is the best!'),
+      ),
+    )));
   });
 
   testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4998,6 +4998,98 @@ void main() {
     );
   });
 
+  testWidgets('Synchronous test of local and remote editing values (#2)', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/67828
+    final List<MethodCall> log = <MethodCall>[];
+    SystemChannels.textInput.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+    final TextInputFormatter formatter = TextInputFormatter.withFunction((TextEditingValue oldValue, TextEditingValue newValue) {
+      return const TextEditingValue(text: 'Flutter is the best!');
+    });
+    final TextEditingController controller = TextEditingController();
+
+    final FocusNode focusNode = FocusNode(debugLabel: 'EditableText Focus Node');
+    Widget builder() {
+      return StatefulBuilder(
+        builder: (BuildContext context, StateSetter setter) {
+          return MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(devicePixelRatio: 1.0),
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: Center(
+                  child: Material(
+                    child: EditableText(
+                      controller: controller,
+                      focusNode: focusNode,
+                      style: textStyle,
+                      cursorColor: Colors.red,
+                      backgroundCursorColor: Colors.red,
+                      keyboardType: TextInputType.multiline,
+                      inputFormatters: <TextInputFormatter>[
+                        formatter,
+                      ],
+                      onChanged: (String value) { },
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    }
+
+    await tester.pumpWidget(builder());
+    await tester.tap(find.byType(EditableText));
+    await tester.showKeyboard(find.byType(EditableText));
+    await tester.pump();
+
+    log.clear();
+
+    final EditableTextState state = tester.firstState(find.byType(EditableText));
+
+    // setEditingState is called when remote value modified by the formatter.
+    state.updateEditingValue(const TextEditingValue(
+      text: 'I will be modified by the formatter.',
+    ));
+    expect(log.length, 1);
+    MethodCall methodCall = log[0];
+    expect(
+      methodCall,
+      isMethodCall('TextInput.setEditingState', arguments: <String, dynamic>{
+        'text': 'Flutter is the best!',
+        'selectionBase': -1,
+        'selectionExtent': -1,
+        'selectionAffinity': 'TextAffinity.downstream',
+        'selectionIsDirectional': false,
+        'composingBase': -1,
+        'composingExtent': -1,
+      }),
+    );
+
+    log.clear();
+
+    state.updateEditingValue(const TextEditingValue(
+      text: 'I will be modified by the formatter.',
+    ));
+    expect(log.length, 1);
+    methodCall = log[0];
+    expect(
+      methodCall,
+      isMethodCall('TextInput.setEditingState', arguments: <String, dynamic>{
+        'text': 'Flutter is the best!',
+        'selectionBase': -1,
+        'selectionExtent': -1,
+        'selectionAffinity': 'TextAffinity.downstream',
+        'selectionIsDirectional': false,
+        'composingBase': -1,
+        'composingExtent': -1,
+      }),
+    );
+  });
+
   testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(text: testText);
     controller.selection = const TextSelection(


### PR DESCRIPTION
## Description

Fix a regressing bug introduced by https://github.com/flutter/flutter/commit/0d945a1a5643ab9d1091e9bc56aed4b281f05463

The engine was not notified when the formatter repeatedly format.

So sorry to introduced this bug, I added a test case to ensure that no mistake will be made again.

@justinmc @LongCatIsLooong please review, thanks.

## Related Issues

Fixes #67828 
Fixes #67236
Fixes #67262 
Fixes #67895 

## Tests

I added the following tests:

"Send text input state to engine when the input formatter rejects user input" in editable text test.
