### PR TITLE
Avoid skipping variable initialization using case.

### DIFF
--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
@@ -173,7 +173,7 @@ Win32Window::MessageHandler(HWND hwnd,
 
       return 0;
     }
-    case WM_SIZE:
+    case WM_SIZE: {
       RECT rect = GetClientArea();
       if (child_content_ != nullptr) {
         // Size and position the child window.
@@ -181,6 +181,7 @@ Win32Window::MessageHandler(HWND hwnd,
                    rect.bottom - rect.top, TRUE);
       }
       return 0;
+    }
 
     case WM_ACTIVATE:
       if (child_content_ != nullptr) {


### PR DESCRIPTION
## Description

This is a very minor syntax fix for the Windows C++ wrapper: it needs another scope to avoid skipping the initialization of a variable (rect) in one of the case sections of a switch; without this fix, you get the following error with good/working compilers.

```
runner/win32_window.cpp:185:5: error: cannot jump from switch statement to this case label
    case WM_ACTIVATE:
    ^
runner/win32_window.cpp:177:12: note: jump bypasses variable initialization
      RECT rect = GetClientArea();
           ^
1 error generated.
```

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
