### PR TITLE
[Material] Use primary color for selected rows and checkboxes in DataTable

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -689,8 +689,6 @@ class DataTable extends StatelessWidget {
   static const double _dividerThickness = 1.0;
 
   static const Duration _sortArrowAnimationDuration = Duration(milliseconds: 150);
-  static const Color _grey100Opacity = Color(0x0A000000); // Grey 100 as opacity instead of solid color
-  static const Color _grey300Opacity = Color(0x1E000000); // Dark theme variant is just a guess.
 
   Widget _buildCheckbox({
     required BuildContext context,
@@ -862,13 +860,8 @@ class DataTable extends StatelessWidget {
       ?? theme.dataTableTheme.dataRowColor;
     final MaterialStateProperty<Color?> defaultRowColor = MaterialStateProperty.resolveWith(
       (Set<MaterialState> states) {
-        if (states.contains(MaterialState.selected)) {
-          // The color has to be transparent so you can see the ink on
-          // the [Material].
-          // TODO(perclasson): Align with Material specs, use translucent primary color: https://github.com/flutter/flutter/issues/64314.
-          return (Theme.of(context)!.brightness == Brightness.light) ?
-            _grey100Opacity : _grey300Opacity;
-        }
+        if (states.contains(MaterialState.selected))
+          return theme.colorScheme.primary.withOpacity(0.08);
         return null;
       },
     );

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -692,7 +692,6 @@ class DataTable extends StatelessWidget {
 
   Widget _buildCheckbox({
     required BuildContext context,
-    required Color activeColor,
     required bool? checked,
     required VoidCallback? onRowTap,
     required ValueChanged<bool?>? onCheckboxChanged,
@@ -712,7 +711,9 @@ class DataTable extends StatelessWidget {
         ),
         child: Center(
           child: Checkbox(
-            activeColor: activeColor,
+            // TODO(per): Remove when Checkbox has theme, https://github.com/flutter/flutter/issues/53420.
+            activeColor: themeData.colorScheme.primary,
+            checkColor: themeData.colorScheme.onPrimary,
             value: checked,
             onChanged: onCheckboxChanged,
             tristate: tristate,
@@ -921,7 +922,6 @@ class DataTable extends StatelessWidget {
       tableColumns[0] = FixedColumnWidth(effectiveHorizontalMargin + Checkbox.width + effectiveHorizontalMargin / 2.0);
       tableRows[0].children![0] = _buildCheckbox(
         context: context,
-        activeColor: theme.accentColor,
         checked: someChecked ? null : allChecked,
         onRowTap: null,
         onCheckboxChanged: (bool? checked) => _handleSelectAll(checked, someChecked),
@@ -932,7 +932,6 @@ class DataTable extends StatelessWidget {
       for (final DataRow row in rows) {
         tableRows[rowIndex].children![0] = _buildCheckbox(
           context: context,
-          activeColor: theme.accentColor,
           checked: row.selected,
           onRowTap: () => row.onSelectChanged != null ? row.onSelectChanged!(!row.selected) : null ,
           onCheckboxChanged: row.onSelectChanged,

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1232,6 +1232,40 @@ void main() {
     );
   });
 
+  testWidgets('DataRow renders checkbox with colors from Theme', (WidgetTester tester) async {
+    final ThemeData _themeData = ThemeData.light();
+    Widget buildTable() {
+      return MaterialApp(
+        theme: _themeData,
+        home: Material(
+          child: DataTable(
+            columns: const <DataColumn>[
+              DataColumn(
+                label: Text('Column1'),
+              ),
+            ],
+            rows: <DataRow>[
+              DataRow(
+                onSelectChanged: (bool? checked) {},
+                cells: const <DataCell>[
+                  DataCell(Text('Content1')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    Checkbox lastCheckbox() {
+      return tester.widgetList<Checkbox>(find.byType(Checkbox)).last;
+    }
+
+    await tester.pumpWidget(buildTable());
+    expect(lastCheckbox().activeColor, _themeData.colorScheme.primary);
+    expect(lastCheckbox().checkColor, _themeData.colorScheme.onPrimary);
+  });
+
   testWidgets('DataRow renders custom colors when selected', (WidgetTester tester) async {
     const Color selectedColor = Colors.green;
     const Color defaultColor = Colors.red;

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1190,6 +1190,48 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 1));
   });
 
+  testWidgets('DataRow renders default selected row colors', (WidgetTester tester) async {
+    final ThemeData _themeData = ThemeData.light();
+    Widget buildTable({bool selected = false}) {
+      return MaterialApp(
+        theme: _themeData,
+        home: Material(
+          child: DataTable(
+            columns: const <DataColumn>[
+              DataColumn(
+                label: Text('Column1'),
+              ),
+            ],
+            rows: <DataRow>[
+              DataRow(
+                onSelectChanged: (bool? checked) {},
+                selected: selected,
+                cells: const <DataCell>[
+                  DataCell(Text('Content1')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    BoxDecoration lastTableRowBoxDecoration() {
+      final Table table = tester.widget(find.byType(Table));
+      final TableRow tableRow = table.children.last;
+      return tableRow.decoration! as BoxDecoration;
+    }
+
+    await tester.pumpWidget(buildTable(selected: false));
+    expect(lastTableRowBoxDecoration().color, null);
+
+    await tester.pumpWidget(buildTable(selected: true));
+    expect(
+      lastTableRowBoxDecoration().color,
+      _themeData.colorScheme.primary.withOpacity(0.08),
+    );
+  });
+
   testWidgets('DataRow renders custom colors when selected', (WidgetTester tester) async {
     const Color selectedColor = Colors.green;
     const Color defaultColor = Colors.red;


### PR DESCRIPTION
## Description

### Light Theme
According to Material specs we should use the 8% overlay color (https://material.io/design/interaction/states.html#selected) for selected states:
<img src="https://lh3.googleusercontent.com/s6e-HpH_g550E7VD166NsgBKrGLD6CuBKOGSdJ6IPyKm-NSf8D1JYVVsLz9q2vLv_KTekIi6nw6ZEgacbNe85dm4OrPYCFplkCFtYEw=w1064-v0" width="500" />

### Dark Theme
In a dark theme, states should use the same overlay values as their default (or light) theme (https://material.io/design/color/dark-theme.html#states).

### Screenshots

| Light Theme  | Dark Theme |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1770678/95755814-254ef200-0ca5-11eb-9bc0-0f270132de83.png" width="500" /> | <img src="https://user-images.githubusercontent.com/1770678/95755830-28e27900-0ca5-11eb-96a5-69f52129f7d5.png" width="500" />  |

## Related Issues

Closes https://github.com/flutter/flutter/issues/64314

## Tests

I added the following tests:

- DataRow renders default selected row colors
- DataRow renders checkbox with colors from Theme

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
