### PR TITLE
[flutter_tools] do not crash validator if intellij JAR file is missing

### DIFF
--- a/packages/flutter_tools/lib/src/intellij/intellij.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij.dart
@@ -73,11 +73,14 @@ class IntelliJPlugins {
     final String jarPath = packageName.endsWith('.jar')
         ? _fileSystem.path.join(pluginsPath, packageName)
         : _fileSystem.path.join(pluginsPath, packageName, 'lib', '$packageName.jar');
+    final File file = _fileSystem.file(jarPath);
+    if (!file.existsSync()) {
+      return null;
+    }
     try {
-      final Archive archive =
-          ZipDecoder().decodeBytes(_fileSystem.file(jarPath).readAsBytesSync());
-      final ArchiveFile file = archive.findFile('META-INF/plugin.xml');
-      final String content = utf8.decode(file.content as List<int>);
+      final Archive archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+      final ArchiveFile archiveFile = archive.findFile('META-INF/plugin.xml');
+      final String content = utf8.decode(archiveFile.content as List<int>);
       const String versionStartTag = '<version>';
       final int start = content.indexOf(versionStartTag);
       final int end = content.indexOf('</version>', start);

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
@@ -89,6 +89,27 @@ void main() {
     expect(message.message, contains('Flutter plugin can be installed from'));
     expect(message.contextUrl, isNotNull);
   });
+
+  testWithoutContext('IntelliJPlugins does not crash if no plugin file found', () async {
+    final IntelliJPlugins plugins = IntelliJPlugins(_kPluginsPath, fileSystem: fileSystem);
+
+    final Archive dartJarArchive =
+    buildSingleFileArchive('META-INF/plugin.xml', r'''
+<idea-plugin version="2">
+<name>Dart</name>
+<version>162.2485</version>
+</idea-plugin>
+''');
+    writeFileCreatingDirectories(
+      fileSystem.path.join(_kPluginsPath, 'Dart', 'lib', 'Other.jar'),
+      ZipEncoder().encode(dartJarArchive),
+    );
+
+    expect(
+      () => plugins.validatePackage(<ValidationMessage>[], <String>['Dart'], 'Dart', 'download-Dart'),
+      returnsNormally,
+    );
+  });
 }
 
 const String _kPluginsPath = '/data/intellij/plugins';


### PR DESCRIPTION
## Description

This failure has been happening for a while but was covered by the overly broad catch. Removing that revealed that newer intellij versions have a different plugins file. The tool still can't find the file, but it won't crash now

Fixes https://github.com/flutter/flutter/issues/67918