### PR TITLE
Replace obsolete FlatButton reference in flutter_driver extension_test.dart

### DIFF
--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -891,7 +891,7 @@ void main() {
           children: <Widget>[
             const Text('Foo', key: ValueKey<String>('Text1')),
             const Text('Bar', key: ValueKey<String>('Text2')),
-            FlatButton(
+            TextButton(
               child: const Text('Whatever'),
               key: const ValueKey<String>('Button'),
               onPressed: () {},


### PR DESCRIPTION
Replaced FlatButton with TextButton in  packages/flutter_driver/test/src/real_tests/extension_test.dart per flutter/flutter#59702.