### PR TITLE
[flutter_tools] do not measure progress timeout

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -143,7 +143,6 @@ Future<void> main(List<String> args) async {
           outputPreferences: globals.outputPreferences,
           terminal: globals.terminal,
           stdio: globals.stdio,
-          timeoutConfiguration: timeoutConfiguration,
         );
         return loggerFactory.createLogger(
           daemon: daemon,
@@ -163,17 +162,14 @@ class LoggerFactory {
     @required Terminal terminal,
     @required Stdio stdio,
     @required OutputPreferences outputPreferences,
-    @required TimeoutConfiguration timeoutConfiguration,
     StopwatchFactory stopwatchFactory = const StopwatchFactory(),
   }) : _terminal = terminal,
        _stdio = stdio,
-       _timeoutConfiguration = timeoutConfiguration,
        _stopwatchFactory = stopwatchFactory,
        _outputPreferences = outputPreferences;
 
   final Terminal _terminal;
   final Stdio _stdio;
-  final TimeoutConfiguration _timeoutConfiguration;
   final StopwatchFactory _stopwatchFactory;
   final OutputPreferences _outputPreferences;
 
@@ -190,7 +186,6 @@ class LoggerFactory {
         terminal: _terminal,
         stdio: _stdio,
         outputPreferences: _outputPreferences,
-        timeoutConfiguration: _timeoutConfiguration,
         stopwatchFactory: _stopwatchFactory,
       );
     } else {
@@ -198,7 +193,6 @@ class LoggerFactory {
         terminal: _terminal,
         stdio: _stdio,
         outputPreferences: _outputPreferences,
-        timeoutConfiguration: _timeoutConfiguration,
         stopwatchFactory: _stopwatchFactory
       );
     }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -63,7 +63,6 @@ class AndroidDevice extends Device {
     @required Platform platform,
     @required AndroidSdk androidSdk,
     @required FileSystem fileSystem,
-    TimeoutConfiguration timeoutConfiguration = const TimeoutConfiguration(),
     AndroidConsoleSocketFactory androidConsoleSocketFactory = kAndroidConsoleSocketFactory,
   }) : _logger = logger,
        _processManager = processManager,
@@ -71,7 +70,6 @@ class AndroidDevice extends Device {
        _platform = platform,
        _fileSystem = fileSystem,
        _androidConsoleSocketFactory = androidConsoleSocketFactory,
-       _timeoutConfiguration = timeoutConfiguration,
        _processUtils = ProcessUtils(logger: logger, processManager: processManager),
        super(
          id,
@@ -87,7 +85,6 @@ class AndroidDevice extends Device {
   final FileSystem _fileSystem;
   final ProcessUtils _processUtils;
   final AndroidConsoleSocketFactory _androidConsoleSocketFactory;
-  final TimeoutConfiguration _timeoutConfiguration;
 
   final String productID;
   final String modelID;
@@ -176,12 +173,12 @@ class AndroidDevice extends Device {
       try {
         await console
             .connect()
-            .timeout(_timeoutConfiguration.fastOperation,
+            .timeout(const Duration(seconds: 2),
                 onTimeout: () => throw TimeoutException('Connection timed out'));
 
         return await console
             .getAvdName()
-            .timeout(_timeoutConfiguration.fastOperation,
+            .timeout(const Duration(seconds: 2),
                 onTimeout: () => throw TimeoutException('"avd name" timed out'));
       } finally {
         console.destroy();
@@ -416,7 +413,6 @@ class AndroidDevice extends Device {
 
     final Status status = _logger.startProgress(
       'Installing ${_fileSystem.path.relative(app.file.path)}...',
-      timeout: _timeoutConfiguration.slowOperation,
     );
     final RunResult installResult = await _processUtils.run(
       adbCommandForDevice(<String>[

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -177,7 +177,6 @@ class AndroidDevices extends PollingDeviceDiscovery {
             logger: _logger,
             platform: _platform,
             processManager: _processManager,
-            timeoutConfiguration: const TimeoutConfiguration(),
           ));
         }
       } else {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -136,7 +136,6 @@ Future<File> getGradleAppOut(AndroidProject androidProject) async {
 Future<void> checkGradleDependencies() async {
   final Status progress = globals.logger.startProgress(
     'Ensuring gradle dependencies are up to date...',
-    timeout: timeoutConfiguration.slowOperation,
   );
   final FlutterProject flutterProject = FlutterProject.current();
   await processUtils.run(<String>[
@@ -167,8 +166,7 @@ void createSettingsAarGradle(Directory androidDirectory) {
   final String currentFileContent = currentSettingsFile.readAsStringSync();
 
   final String newSettingsRelativeFile = globals.fs.path.relative(newSettingsFile.path);
-  final Status status = globals.logger.startProgress('✏️  Creating `$newSettingsRelativeFile`...',
-      timeout: timeoutConfiguration.fastOperation);
+  final Status status = globals.logger.startProgress('✏️  Creating `$newSettingsRelativeFile`...');
 
   final String flutterRoot = globals.fs.path.absolute(Cache.flutterRoot);
   final File legacySettingsDotGradleFiles = globals.fs.file(globals.fs.path.join(flutterRoot, 'packages','flutter_tools',
@@ -270,7 +268,6 @@ Future<void> buildGradleApp({
 
   final Status status = globals.logger.startProgress(
     "Running Gradle task '$assembleTask'...",
-    timeout: timeoutConfiguration.slowOperation,
     multilineOutput: true,
   );
 
@@ -571,7 +568,6 @@ Future<void> buildGradleAar({
   final String aarTask = getAarTaskFor(buildInfo);
   final Status status = globals.logger.startProgress(
     "Running Gradle task '$aarTask'...",
-    timeout: timeoutConfiguration.slowOperation,
     multilineOutput: true,
   );
 

--- a/packages/flutter_tools/lib/src/aot.dart
+++ b/packages/flutter_tools/lib/src/aot.dart
@@ -69,7 +69,6 @@ class AotBuilder {
       final String typeName = globals.artifacts.getEngineType(platform, buildInfo.mode);
       status = globals.logger.startProgress(
         'Building AOT snapshot in ${getFriendlyModeName(buildInfo.mode)} mode ($typeName)...',
-        timeout: timeoutConfiguration.slowOperation,
       );
     }
 

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -534,7 +534,6 @@ class Cache {
   Future<bool> doesRemoteExist(String message, Uri url) async {
     final Status status = _logger.startProgress(
       message,
-      timeout: timeoutConfiguration.slowOperation,
     );
     bool exists;
     try {
@@ -1075,8 +1074,7 @@ class AndroidMavenArtifacts extends ArtifactSet {
     );
     gradleUtils.injectGradleWrapperIfNeeded(tempDir);
 
-    final Status status = globals.logger.startProgress('Downloading Android Maven dependencies...',
-        timeout: timeoutConfiguration.slowOperation);
+    final Status status = globals.logger.startProgress('Downloading Android Maven dependencies...');
     final File gradle = tempDir.childFile(
         globals.platform.isWindows ? 'gradlew.bat' : 'gradlew',
       );
@@ -1593,7 +1591,6 @@ class ArtifactUpdater {
     while (retries > 0) {
       status = _logger.startProgress(
         message,
-        timeout: null, // This will take a variable amount of time based on network connectivity.
       );
       try {
         _ensureExists(tempFile.parent);

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -102,7 +102,7 @@ class AnalyzeContinuously extends AnalyzeBase {
       if (!firstAnalysis) {
         logger.printStatus('\n');
       }
-      analysisStatus = logger.startProgress('Analyzing $analysisTarget...', timeout: timeoutConfiguration.slowOperation);
+      analysisStatus = logger.startProgress('Analyzing $analysisTarget...');
       analyzedPaths.clear();
       analysisTimer = Stopwatch()..start();
     } else {

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -137,7 +137,6 @@ class AnalyzeOnce extends AnalyzeBase {
       progress = argResults['preamble'] as bool
           ? logger.startProgress(
             'Analyzing $message...',
-            timeout: timeoutConfiguration.slowOperation,
           )
           : null;
 

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -207,7 +207,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       }
 
       final Status status = globals.logger.startProgress(
-        ' └─Moving to ${globals.fs.path.relative(modeDirectory.path)}', timeout: timeoutConfiguration.slowOperation);
+        ' └─Moving to ${globals.fs.path.relative(modeDirectory.path)}');
       try {
         // Delete the intermediaries since they would have been copied into our
         // output frameworks.
@@ -230,7 +230,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   /// vendored framework caching.
   @visibleForTesting
   void produceFlutterPodspec(BuildMode mode, Directory modeDirectory, { bool force = false }) {
-    final Status status = globals.logger.startProgress(' ├─Creating Flutter.podspec...', timeout: timeoutConfiguration.fastOperation);
+    final Status status = globals.logger.startProgress(' ├─Creating Flutter.podspec...');
     try {
       final GitTagVersion gitTagVersion = _flutterVersion.gitTagVersion;
       if (!force && (gitTagVersion.x == null || gitTagVersion.y == null || gitTagVersion.z == null || gitTagVersion.commits != 0)) {
@@ -290,7 +290,6 @@ end
   ) async {
     final Status status = globals.logger.startProgress(
       ' ├─Populating Flutter.framework...',
-      timeout: timeoutConfiguration.slowOperation,
     );
     final String engineCacheFlutterFrameworkDirectory = globals.artifacts.getArtifactPath(
       Artifact.flutterFramework,
@@ -347,7 +346,6 @@ end
 
     final Status status = globals.logger.startProgress(
       ' ├─Building App.framework...',
-      timeout: timeoutConfiguration.slowOperation,
     );
     try {
       Target target;
@@ -411,7 +409,8 @@ end
     Directory outputDirectory,
   ) async {
     final Status status = globals.logger.startProgress(
-      ' ├─Building plugins...', timeout: timeoutConfiguration.slowOperation);
+      ' ├─Building plugins...'
+    );
     try {
       // Regardless of the last "flutter build" build mode,
       // copy the corresponding engine.
@@ -572,7 +571,6 @@ end
 
       final Status status = globals.logger.startProgress(
         ' ├─Creating $frameworkBinaryName.xcframework...',
-        timeout: timeoutConfiguration.slowOperation,
       );
       try {
         if (buildInfo.mode == BuildMode.debug) {

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -67,7 +67,6 @@ class CleanCommand extends FlutterCommand {
     }
     final Status xcodeStatus = globals.logger.startProgress(
       'Cleaning Xcode workspace...',
-      timeout: timeoutConfiguration.slowOperation,
     );
     try {
       final Directory xcodeWorkspace = xcodeProject.xcodeWorkspace;
@@ -95,7 +94,6 @@ class CleanCommand extends FlutterCommand {
     }
     final Status deletionStatus = globals.logger.startProgress(
       'Deleting ${file.basename}...',
-      timeout: timeoutConfiguration.fastOperation,
     );
     try {
       file.deleteSync(recursive: true);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1025,8 +1025,6 @@ class NotifyingLogger extends DelegatingLogger {
     assert(timeout != null);
     printStatus(message);
     return SilentStatus(
-      timeout: timeout,
-      timeoutConfiguration: timeoutConfiguration,
       stopwatch: Stopwatch(),
     );
   }
@@ -1161,8 +1159,6 @@ class AppRunLogger extends DelegatingLogger {
     );
 
     _status = SilentStatus(
-      timeout: timeout,
-      timeoutConfiguration: timeoutConfiguration,
       onFinish: () {
         _status = null;
         _sendProgressEvent(

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -146,7 +146,6 @@ class UpdatePackagesCommand extends FlutterCommand {
   Future<void> _downloadCoverageData() async {
     final Status status = globals.logger.startProgress(
       'Downloading lcov data for package:flutter...',
-      timeout: timeoutConfiguration.slowOperation,
     );
     final String urlBase = globals.platform.environment['FLUTTER_STORAGE_BASE_URL'] ?? 'https://storage.googleapis.com';
     final Uri coverageUri = Uri.parse('$urlBase/flutter_infra/flutter/coverage/lcov.info');

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -111,7 +111,6 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         platform: globals.platform,
         xcodeProjectInterpreter: globals.xcodeProjectInterpreter,
-        timeoutConfiguration: timeoutConfiguration,
       ),
       CocoaPodsValidator: () => CocoaPodsValidator(
         globals.cocoaPods,
@@ -197,13 +196,11 @@ Future<T> runInContext<T>(
             terminal: globals.terminal,
             stdio: globals.stdio,
             outputPreferences: globals.outputPreferences,
-            timeoutConfiguration: timeoutConfiguration,
           )
         : StdoutLogger(
             terminal: globals.terminal,
             stdio: globals.stdio,
             outputPreferences: globals.outputPreferences,
-            timeoutConfiguration: timeoutConfiguration,
           ),
       MacOSWorkflow: () => MacOSWorkflow(
         featureFlags: featureFlags,
@@ -243,7 +240,6 @@ Future<T> runInContext<T>(
       ShutdownHooks: () => ShutdownHooks(logger: globals.logger),
       Stdio: () => Stdio(),
       SystemClock: () => const SystemClock(),
-      TimeoutConfiguration: () => const TimeoutConfiguration(),
       Usage: () => Usage(
         runningOnBot: runningOnBot,
       ),

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -198,7 +198,6 @@ class _DefaultPub implements Pub {
       final String command = upgrade ? 'upgrade' : 'get';
       final Status status = _logger.startProgress(
         'Running "flutter pub $command" in ${_fileSystem.path.basename(directory)}...',
-        timeout: const TimeoutConfiguration().slowOperation,
       );
       final bool verbose = _logger.isVerbose;
       final List<String> args = <String>[

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -301,9 +301,6 @@ class Doctor {
     for (final ValidatorTask validatorTask in startValidatorTasks()) {
       final DoctorValidator validator = validatorTask.validator;
       final Status status = Status.withSpinner(
-        timeout: timeoutConfiguration.fastOperation,
-        slowWarningCallback: () => validator.slowWarning,
-        timeoutConfiguration: timeoutConfiguration,
         stopwatch: Stopwatch(),
         terminal: globals.terminal,
       );

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -103,7 +103,6 @@ Future<void> _genSnapshot(
   int result;
   final Status status = globals.logger.startProgress(
     'Compiling Fuchsia application to native code...',
-    timeout: null,
   );
   try {
     result = await processUtils.stream(command, trace: true);

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -328,7 +328,6 @@ class FuchsiaDevice extends Device {
     final String appName = FlutterProject.current().manifest.appName;
     final Status status = globals.logger.startProgress(
       'Starting Fuchsia application $appName...',
-      timeout: null,
     );
     FuchsiaPackageServer fuchsiaPackageServer;
     bool serverRegistered = false;
@@ -756,7 +755,6 @@ class FuchsiaIsolateDiscoveryProtocol {
     }
     _status ??= globals.logger.startProgress(
       'Waiting for a connection from $_isolateName on ${_device.name}...',
-      timeout: null, // could take an arbitrary amount of time
     );
     unawaited(_findIsolate());  // Completes the _foundUri Future.
     return _foundUri.future.then((Uri uri) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -71,7 +71,6 @@ class FuchsiaKernelCompiler {
     ];
     final Status status = globals.logger.startProgress(
       'Building Fuchsia application...',
-      timeout: null,
     );
     int result;
     try {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -395,8 +395,8 @@ class IOSDevice extends Device {
     ];
 
     final Status installStatus = _logger.startProgress(
-        'Installing and launching...',
-        timeout: timeoutConfiguration.slowOperation);
+      'Installing and launching...',
+    );
     try {
       ProtocolDiscovery observatoryDiscovery;
       int installationResult = 1;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -302,7 +302,6 @@ Future<XcodeBuildResult> buildXcodeProject({
           initialBuildStatus = null;
           buildSubStatus = globals.logger.startProgress(
             line,
-            timeout: timeoutConfiguration.slowOperation,
             progressIndicatorPadding: kDefaultStatusPadding - 7,
           );
         }
@@ -331,7 +330,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   final Stopwatch sw = Stopwatch()..start();
-  initialBuildStatus = globals.logger.startProgress('Running Xcode build...', timeout: timeoutConfiguration.slowOperation);
+  initialBuildStatus = globals.logger.startProgress('Running Xcode build...');
 
   final RunResult buildResult = await _runBuildWithRetries(buildCommands, app);
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -327,8 +327,6 @@ class XcodeProjectInterpreter {
     Duration timeout = const Duration(minutes: 1),
   }) async {
     final Status status = Status.withSpinner(
-      timeout: const TimeoutConfiguration().fastOperation,
-      timeoutConfiguration: const TimeoutConfiguration(),
       stopwatch: Stopwatch(),
       terminal: _terminal,
     );

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -576,9 +576,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
     final Stopwatch timer = Stopwatch()..start();
     final Status status = globals.logger.startProgress(
       'Performing hot restart...',
-      timeout: supportsServiceProtocol
-          ? timeoutConfiguration.fastOperation
-          : timeoutConfiguration.slowOperation,
       progressId: 'hot.restart',
     );
 
@@ -731,7 +728,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
     );
     final Status devFSStatus = globals.logger.startProgress(
       'Syncing files to device ${device.device.name}...',
-      timeout: timeoutConfiguration.fastOperation,
     );
     final UpdateFSReport report = await device.devFS.update(
       mainUri: await _generateEntrypoint(

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -46,7 +46,6 @@ Future<void> buildLinux(
 
   final Status status = globals.logger.startProgress(
     'Building Linux application...',
-    timeout: null,
   );
   try {
     final String buildModeName = getNameForBuildMode(buildInfo.mode ?? BuildMode.release);

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -79,7 +79,6 @@ Future<void> buildMacOS({
   final Stopwatch sw = Stopwatch()..start();
   final Status status = globals.logger.startProgress(
     'Building macOS application...',
-    timeout: null,
   );
   int result;
   try {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -83,15 +83,13 @@ class CocoaPods {
     @required XcodeProjectInterpreter xcodeProjectInterpreter,
     @required Logger logger,
     @required Platform platform,
-    @required TimeoutConfiguration timeoutConfiguration,
   }) : _fileSystem = fileSystem,
       _processManager = processManager,
       _xcodeProjectInterpreter = xcodeProjectInterpreter,
       _logger = logger,
       _platform = platform,
       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
-      _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
-      _timeoutConfiguration = timeoutConfiguration;
+      _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform);
 
   final FileSystem _fileSystem;
   final ProcessManager _processManager;
@@ -100,7 +98,6 @@ class CocoaPods {
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
   final Logger _logger;
   final Platform _platform;
-  final TimeoutConfiguration _timeoutConfiguration;
 
   Future<String> _versionText;
 
@@ -342,7 +339,7 @@ class CocoaPods {
   }
 
   Future<void> _runPodInstall(XcodeBasedProject xcodeProject, String engineDirectory) async {
-    final Status status = _logger.startProgress('Running pod install...', timeout: _timeoutConfiguration.slowOperation);
+    final Status status = _logger.startProgress('Running pod install...');
     final ProcessResult result = await _processManager.run(
       <String>['pod', 'install', '--verbose'],
       workingDirectory: _fileSystem.path.dirname(xcodeProject.podfile.path),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -670,7 +670,6 @@ class FlutterDevice {
   }) async {
     final Status devFSStatus = globals.logger.startProgress(
       'Syncing files to device ${device.name}...',
-      timeout: timeoutConfiguration.fastOperation,
     );
     UpdateFSReport report;
     try {
@@ -1089,7 +1088,6 @@ abstract class ResidentRunner {
 
     final Status status = globals.logger.startProgress(
       'Taking screenshot for ${device.device.name}...',
-      timeout: timeoutConfiguration.fastOperation,
     );
     final File outputFile = globals.fsUtils.getUniqueFile(
       globals.fs.currentDirectory,
@@ -1237,7 +1235,6 @@ abstract class ResidentRunner {
       // This will wait for at least one flutter view before returning.
       final Status status = globals.logger.startProgress(
         'Waiting for ${device.device.name} to report its views...',
-        timeout: const Duration(milliseconds: 200),
       );
       try {
         await device.vmService.getFlutterViews();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -697,7 +697,6 @@ class HotRunner extends ResidentRunner {
     if (!silent) {
       status = globals.logger.startProgress(
         'Performing hot restart...',
-        timeout: timeoutConfiguration.fastOperation,
         progressId: 'hot.restart',
       );
     }
@@ -748,7 +747,6 @@ class HotRunner extends ResidentRunner {
   }) async {
     Status status = globals.logger.startProgress(
       'Performing hot reload...',
-      timeout: timeoutConfiguration.fastOperation,
       progressId: 'hot.reload',
     );
     OperationResult result;
@@ -763,7 +761,6 @@ class HotRunner extends ResidentRunner {
           status?.cancel();
           status = globals.logger.startProgress(
             message,
-            timeout: timeoutConfiguration.slowOperation,
             progressId: 'hot.reload',
           );
         },

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -43,7 +43,6 @@ class Tracing {
     if (awaitFirstFrame) {
       final Status status = _logger.startProgress(
         'Waiting for application to render first frame...',
-        timeout: null,
       );
       try {
         final Completer<void> whenFirstFrameRendered = Completer<void>();

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -42,7 +42,7 @@ Future<void> buildWeb(
     outputDirectory.createSync(recursive: true);
   }
   await injectPlugins(flutterProject, checkProjects: true);
-  final Status status = globals.logger.startProgress('Compiling $target for the Web...', timeout: null);
+  final Status status = globals.logger.startProgress('Compiling $target for the Web...');
   final Stopwatch sw = Stopwatch()..start();
   try {
     final BuildResult result = await globals.buildSystem.build(const WebServiceWorker(), Environment(

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -56,7 +56,6 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
   final Directory buildDirectory = globals.fs.directory(getWindowsBuildDirectory());
   final Status status = globals.logger.startProgress(
     'Building Windows application...',
-    timeout: null,
   );
   try {
     await _runCmakeGeneration(cmakePath, buildDirectory, windowsProject.cmakeFile.parent);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -674,8 +674,6 @@ class StreamLogger extends Logger {
   }) {
     _log('[progress] $message');
     return SilentStatus(
-      timeout: timeout,
-      timeoutConfiguration: timeoutConfiguration,
       stopwatch: Stopwatch(),
     )..start();
   }

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -474,7 +474,6 @@ AndroidDevice setUpAndroidDevice({
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     processManager: processManager ?? FakeProcessManager.any(),
     androidConsoleSocketFactory: androidConsoleSocketFactory,
-    timeoutConfiguration: const TimeoutConfiguration(),
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -51,7 +51,6 @@ void main() {
       terminal: Terminal.test(supportsColor: true),
       stdio: MockStdio(),
       outputPreferences: OutputPreferences.test(),
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
     final ArtifactUpdater artifactUpdater = ArtifactUpdater(
       fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show jsonEncode;
 
 import 'package:flutter_tools/executable.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -33,7 +32,6 @@ void main() {
       terminal: Terminal.test(),
       stdio: mocks.MockStdio(),
       outputPreferences: OutputPreferences.test(),
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
 
     expect(loggerFactory.createLogger(
@@ -155,19 +153,16 @@ void main() {
     _throwsInvocationFor(() => fakeLogger.sendEvent(message, eventArgs)),
     );
 
-    const Duration timeout = Duration(seconds: 12);
     const String progressId = 'progressId';
     const bool multilineOutput = true;
     const int progressIndicatorPadding = kDefaultStatusPadding * 2;
     expect(
       () => delegatingLogger.startProgress(message,
-        timeout: timeout,
         progressId: progressId,
         multilineOutput: multilineOutput,
         progressIndicatorPadding: progressIndicatorPadding,
       ),
       _throwsInvocationFor(() => fakeLogger.startProgress(message,
-          timeout: timeout,
           progressId: progressId,
           multilineOutput: multilineOutput,
           progressIndicatorPadding: progressIndicatorPadding,
@@ -279,7 +274,6 @@ void main() {
       ),
       stdio: stdio,
       outputPreferences: OutputPreferences.test(),
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
     logger.printStatus('message');
     logger.printError('error message');
@@ -320,7 +314,6 @@ void main() {
       ),
       stdio: stdio,
       outputPreferences: OutputPreferences.test(),
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
     logger.printStatus('message');
     logger.printError('error message');
@@ -359,7 +352,6 @@ void main() {
       ),
       stdio: stdio,
       outputPreferences: OutputPreferences.test(),
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
     logger.printStatus('message');
     logger.printError('error message');
@@ -441,11 +433,9 @@ void main() {
 
           ansiStatus = AnsiStatus(
             message: 'Hello world',
-            timeout: const Duration(seconds: 2),
             padding: 20,
             onFinish: () => called += 1,
             stdio: mockStdio,
-            timeoutConfiguration: const TimeoutConfiguration(),
             stopwatch: stopwatchFactory.createStopwatch(),
             terminal: terminal,
           );
@@ -456,9 +446,7 @@ void main() {
           mockStopwatch = FakeStopwatch();
           FakeAsync().run((FakeAsync time) {
             final AnsiSpinner ansiSpinner = AnsiSpinner(
-              timeout: const Duration(hours: 10),
               stdio: mockStdio,
-              timeoutConfiguration: const TimeoutConfiguration(),
               stopwatch: stopwatchFactory.createStopwatch(),
               terminal: terminal,
             )..start();
@@ -487,35 +475,6 @@ void main() {
           expect(done, isTrue);
         });
 
-        testWithoutContext('AnsiSpinner works (2)', () async {
-          bool done = false;
-          mockStopwatch = FakeStopwatch();
-          FakeAsync().run((FakeAsync time) {
-            final AnsiSpinner ansiSpinner = AnsiSpinner(
-              timeout: const Duration(seconds: 2),
-              stdio: mockStdio,
-              timeoutConfiguration: const TimeoutConfiguration(),
-              stopwatch: mockStopwatch,
-              terminal: terminal,
-            )..start();
-            mockStopwatch.elapsed = const Duration(seconds: 1);
-            doWhileAsync(time, () => ansiSpinner.ticks < 10); // one second
-
-            expect(ansiSpinner.seemsSlow, isFalse);
-            expect(outputStdout().join('\n'), isNot(contains('This is taking an unexpectedly long time.')));
-            mockStopwatch.elapsed = const Duration(seconds: 3);
-            doWhileAsync(time, () => ansiSpinner.ticks < 30); // three seconds
-
-            expect(ansiSpinner.seemsSlow, isTrue);
-            // Check the 2nd line to verify there's a newline before the warning
-            expect(outputStdout()[1], contains('This is taking an unexpectedly long time.'));
-            ansiSpinner.stop();
-            expect(outputStdout().join('\n'), isNot(contains('(!)')));
-            done = true;
-          });
-          expect(done, isTrue);
-        });
-
         testWithoutContext('Stdout startProgress on colored terminal', () async {
           bool done = false;
           FakeAsync().run((FakeAsync time) {
@@ -523,13 +482,11 @@ void main() {
               terminal: coloredTerminal,
               stdio: mockStdio,
               outputPreferences: OutputPreferences.test(showColor: true),
-              timeoutConfiguration: const TimeoutConfiguration(),
               stopwatchFactory: stopwatchFactory,
             );
             final Status status = logger.startProgress(
               'Hello',
               progressId: null,
-              timeout: const TimeoutConfiguration().slowOperation,
               progressIndicatorPadding: 20, // this minus the "Hello" equals the 15 below.
             );
             expect(outputStderr().length, equals(1));
@@ -563,12 +520,10 @@ void main() {
               terminal: coloredTerminal,
               stdio: mockStdio,
               outputPreferences: OutputPreferences.test(showColor: true),
-              timeoutConfiguration: const TimeoutConfiguration(),
               stopwatchFactory: stopwatchFactory,
             );
             final Status status = logger.startProgress(
               "Knock Knock, Who's There",
-              timeout: const Duration(days: 10),
               progressIndicatorPadding: 10,
             );
             logger.printStatus('Rude Interrupting Cow');
@@ -593,38 +548,6 @@ void main() {
               '\b\b\b\b\b\b\b\b' // clearing the clearing of the spinner
               '    5.0s\n', // replacing it with the time
             );
-            done = true;
-          });
-          expect(done, isTrue);
-        });
-
-        testWithoutContext('AnsiStatus works', () {
-          bool done = false;
-          FakeAsync().run((FakeAsync time) {
-            ansiStatus.start();
-            mockStopwatch.elapsed = const Duration(seconds: 1);
-            doWhileAsync(time, () => ansiStatus.ticks < 10); // one second
-
-            expect(ansiStatus.seemsSlow, isFalse);
-            expect(outputStdout().join('\n'), isNot(contains('This is taking an unexpectedly long time.')));
-            expect(outputStdout().join('\n'), isNot(contains('(!)')));
-            mockStopwatch.elapsed = const Duration(seconds: 3);
-            doWhileAsync(time, () => ansiStatus.ticks < 30); // three seconds
-
-            expect(ansiStatus.seemsSlow, isTrue);
-            expect(outputStdout().join('\n'), contains('This is taking an unexpectedly long time.'));
-
-            // Test that the number of '\b' is correct.
-            for (final String line in outputStdout()) {
-              int currLength = 0;
-              for (int i = 0; i < line.length; i += 1) {
-                currLength += line[i] == '\b' ? -1 : 1;
-                expect(currLength, isNonNegative, reason: 'The following line has overflow backtraces:\n' + jsonEncode(line));
-              }
-            }
-
-            ansiStatus.stop();
-            expect(outputStdout().join('\n'), contains('(!)'));
             done = true;
           });
           expect(done, isTrue);
@@ -724,11 +647,9 @@ void main() {
       called = 0;
       summaryStatus = SummaryStatus(
         message: 'Hello world',
-        timeout: const TimeoutConfiguration().slowOperation,
         padding: 20,
         onFinish: () => called++,
         stdio: mockStdio,
-        timeoutConfiguration: const TimeoutConfiguration(),
         stopwatch: FakeStopwatch(),
       );
     });
@@ -744,7 +665,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printError('0123456789' * 15);
       final List<String> lines = outputStderr();
@@ -774,7 +694,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printError('0123456789' * 15, indent: 5);
       final List<String> lines = outputStderr();
@@ -798,7 +717,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printError('0123456789' * 15, hangingIndent: 5);
       final List<String> lines = outputStderr();
@@ -822,7 +740,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printError('0123456789' * 15, indent: 4, hangingIndent: 5);
       final List<String> lines = outputStderr();
@@ -846,7 +763,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus('0123456789' * 15);
       final List<String> lines = outputStdout();
@@ -867,7 +783,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus('0123456789' * 15, indent: 5);
       final List<String> lines = outputStdout();
@@ -890,8 +805,7 @@ void main() {
           platform: _kNoAnsiPlatform,
         ),
         stdio: mockStdio,
-        outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
+        outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false)
       );
       logger.printStatus('0123456789' * 15, hangingIndent: 5);
       final List<String> lines = outputStdout();
@@ -915,7 +829,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40, showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus('0123456789' * 15, indent: 4, hangingIndent: 5);
       final List<String> lines = outputStdout();
@@ -939,7 +852,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(showColor: true),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printError('Pants on fire!');
       final List<String> lines = outputStderr();
@@ -957,7 +869,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences:  OutputPreferences.test(showColor: true),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus('All good.');
 
@@ -975,7 +886,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(showColor: true),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus(
         null,
@@ -999,7 +909,6 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
       logger.printStatus(
         null,
@@ -1024,12 +933,10 @@ void main() {
           ),
           stdio: mockStdio,
           outputPreferences: OutputPreferences.test(showColor: false),
-          timeoutConfiguration: const TimeoutConfiguration(),
         );
         final Status status = logger.startProgress(
           'Hello',
           progressId: null,
-          timeout: const TimeoutConfiguration().slowOperation,
           progressIndicatorPadding: 20, // this minus the "Hello" equals the 15 below.
         );
         expect(outputStderr().length, equals(1));
@@ -1046,11 +953,9 @@ void main() {
     testWithoutContext('SummaryStatus works when canceled', () async {
       final SummaryStatus summaryStatus = SummaryStatus(
         message: 'Hello world',
-        timeout: const TimeoutConfiguration().slowOperation,
         padding: 20,
         onFinish: () => called++,
         stdio: mockStdio,
-        timeoutConfiguration: const TimeoutConfiguration(),
         stopwatch: FakeStopwatch(),
       );
       summaryStatus.start();
@@ -1105,10 +1010,9 @@ void main() {
         ),
         stdio: mockStdio,
         outputPreferences: OutputPreferences.test(showColor: false),
-        timeoutConfiguration: const TimeoutConfiguration(),
       );
-      logger.startProgress('AAA', timeout: const TimeoutConfiguration().fastOperation).stop();
-      logger.startProgress('BBB', timeout: const TimeoutConfiguration().fastOperation).stop();
+      logger.startProgress('AAA').stop();
+      logger.startProgress('BBB').stop();
       final List<String> output = outputStdout();
 
       expect(output.length, equals(3));
@@ -1129,12 +1033,11 @@ void main() {
           ),
           stdio: mockStdio,
           outputPreferences: OutputPreferences.test(),
-          timeoutConfiguration: const TimeoutConfiguration(),
         ),
         stopwatchFactory: FakeStopwatchFactory(),
       );
-      logger.startProgress('AAA', timeout: const TimeoutConfiguration().fastOperation).stop();
-      logger.startProgress('BBB', timeout: const TimeoutConfiguration().fastOperation).stop();
+      logger.startProgress('AAA').stop();
+      logger.startProgress('BBB').stop();
 
       expect(outputStdout(), <Matcher>[
         matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] AAA$'),
@@ -1153,8 +1056,8 @@ void main() {
         ),
         outputPreferences: OutputPreferences.test(),
       );
-      logger.startProgress('AAA', timeout: const TimeoutConfiguration().fastOperation).stop();
-      logger.startProgress('BBB', timeout: const TimeoutConfiguration().fastOperation).stop();
+      logger.startProgress('AAA').stop();
+      logger.startProgress('BBB').stop();
 
       expect(logger.statusText, 'AAA\nBBB\n');
     });

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -71,7 +71,6 @@ void main() {
       logger: logger,
       platform: FakePlatform(),
       xcodeProjectInterpreter: mockXcodeProjectInterpreter,
-      timeoutConfiguration: const TimeoutConfiguration(),
     );
     pretendPodVersionIs('1.8.0');
     fileSystem.file(fileSystem.path.join(

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -22,7 +22,6 @@ final ProcessUtils processUtils = ProcessUtils(processManager: processManager, l
   ),
   stdio: stdio,
   outputPreferences: OutputPreferences.test(wrapText: true),
-  timeoutConfiguration: const TimeoutConfiguration(),
 ));
 final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -126,7 +126,6 @@ void testUsingContext(
           Usage: () => FakeUsage(),
           XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter(),
           FileSystem: () => LocalFileSystemBlockingSetCurrentDirectory(),
-          TimeoutConfiguration: () => const TimeoutConfiguration(),
           PlistParser: () => FakePlistParser(),
           Signals: () => FakeSignals(),
           Pub: () => ThrowingPub(), // prevent accidentally using pub.


### PR DESCRIPTION
## Description

Currently the flutter tool Progress indicator has the capability to show a warning if it takes longer than a specified timeout, with null timeout meaning forever.

Unfortunately we do not really keep track of whether these timeouts are accurate. For example, the speed of hot reload depends on how many libraries are being reloaded and the speed of the device. Showing the warning "This is taking longer than expected" is pure "feels bad" because we can't actually make it go faster.

Originally I added timeout configuration to allow the g3 timeouts to be much longer. I think the correct choice that I did not realize at the time was simply to remove the timeouts, because they are inaccurate. 

Note: a new of the test expectations were not resilient to updates in the time format, they've been adjusted 