### PR TITLE
Revert "Pass RouteSettings to the internal Route in showCupertinoModalPopup"

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -1031,9 +1031,6 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 /// The `semanticsDismissible` argument is used to determine whether the
 /// semantics of the modal barrier are included in the semantics tree.
 ///
-/// The `routeSettings` argument is used to provide [RouteSettings] to the
-/// created Route.
-///
 /// The `builder` argument typically builds a [CupertinoActionSheet] widget.
 /// Content below the widget is dimmed with a [ModalBarrier]. The widget built
 /// by the `builder` does not share a context with the location that
@@ -1057,7 +1054,6 @@ Future<T> showCupertinoModalPopup<T>({
   bool barrierDismissible = true,
   bool useRootNavigator = true,
   bool? semanticsDismissible,
-  RouteSettings? routeSettings,
 }) {
   assert(useRootNavigator != null);
   return Navigator.of(context, rootNavigator: useRootNavigator)!.push(
@@ -1068,7 +1064,6 @@ Future<T> showCupertinoModalPopup<T>({
       builder: builder,
       filter: filter,
       semanticsDismissible: semanticsDismissible,
-      settings: routeSettings,
     ),
   );
 }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1345,38 +1345,6 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets('showCupertinoModalPopup passes RouteSettings to PopupRoute', (WidgetTester tester) async {
-    final RouteSettingsObserver routeSettingsObserver = RouteSettingsObserver();
-
-    await tester.pumpWidget(CupertinoApp(
-      navigatorObservers: <NavigatorObserver>[routeSettingsObserver],
-      home: Navigator(
-        onGenerateRoute: (RouteSettings settings) {
-          return PageRouteBuilder<dynamic>(
-            pageBuilder: (BuildContext context, Animation<double> _,
-                Animation<double> __) {
-              return GestureDetector(
-                onTap: () async {
-                  await showCupertinoModalPopup<void>(
-                    context: context,
-                    builder: (BuildContext context) => const SizedBox(),
-                    routeSettings: const RouteSettings(name: '/modal'),
-                  );
-                },
-                child: const Text('tap'),
-              );
-            },
-          );
-        },
-      ),
-    ));
-
-    // Open the dialog.
-    await tester.tap(find.text('tap'));
-
-    expect(routeSettingsObserver.routeName, '/modal');
-  });
-
   testWidgets('showCupertinoModalPopup transparent barrier color is transparent', (WidgetTester tester) async {
     const Color _kTransparentColor = Color(0x00000000);
 
@@ -1684,18 +1652,6 @@ class DialogObserver extends NavigatorObserver {
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     if (route.toString().contains('_DialogRoute')) {
       dialogCount++;
-    }
-    super.didPush(route, previousRoute);
-  }
-}
-
-class RouteSettingsObserver extends NavigatorObserver {
-  String routeName;
-
-  @override
-  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
-    if (route.toString().contains('_CupertinoModalPopupRoute')) {
-      routeName = route.settings.name;
     }
     super.didPush(route, previousRoute);
   }


### PR DESCRIPTION
Reverts flutter/flutter#56024

```
All pubspecs were up to date.
▌23:02:17▐ ELAPSED TIME: 1.143s for bin/flutter update-packages --verify-only in .
▌23:02:17▐ Dart analysis...
▌23:02:17▐ RUNNING: cd .; bin/flutter analyze --dartdocs --flutter-repo
Analyzing 3 directories...                                      

  error • Non-nullable instance field 'routeName' must be initialized • packages/flutter/test/cupertino/route_test.dart:1693:10 • not_initialized_non_nullable_instance_field
  error • 'RouteSettingsObserver.didPush' ('void Function(Route<dynamic>, Route<dynamic>)') isn't a valid override of 'NavigatorObserver.didPush' ('void Function(Route<dynamic>, Route<dynamic>?)') • packages/flutter/test/cupertino/route_test.dart:1696:8 • invalid_override
  error • A value of type 'String?' can't be assigned to a variable of type 'String' • packages/flutter/test/cupertino/route_test.dart:1698:19 • invalid_assignment

3 issues found. (ran in 119.6s)
```
TBR @goderbauer 