### PR TITLE
Detect ARM macOS arch with sysctl hw.optional.arm64

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -328,7 +328,7 @@ abstract class IOSApp extends ApplicationPackage {
   }
 
   static Future<IOSApp> fromIosProject(IosProject project, BuildInfo buildInfo) {
-    if (getCurrentHostPlatform() != HostPlatform.darwin_x64) {
+    if (!globals.platform.isMacOS) {
       return null;
     }
     if (!project.exists) {

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -485,7 +485,7 @@ TargetPlatform _currentHostPlatform(Platform platform) {
 
 HostPlatform _currentHostPlatformAsHost(Platform platform) {
   if (platform.isMacOS) {
-    return HostPlatform.darwin_x64;
+    return HostPlatform.darwin_x86;
   }
   if (platform.isLinux) {
     return HostPlatform.linux_x64;
@@ -653,7 +653,7 @@ class LocalEngineArtifacts implements Artifacts {
     final HostPlatform hostPlatform = _currentHostPlatformAsHost(_platform);
     if (hostPlatform == HostPlatform.linux_x64) {
       return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
-    } else if (hostPlatform == HostPlatform.darwin_x64) {
+    } else if (hostPlatform == HostPlatform.darwin_x86) {
       return _fileSystem.path.join(engineOutPath, 'flutter_tester');
     } else if (hostPlatform == HostPlatform.windows_x64) {
       return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -485,7 +485,7 @@ TargetPlatform _currentHostPlatform(Platform platform) {
 
 HostPlatform _currentHostPlatformAsHost(Platform platform) {
   if (platform.isMacOS) {
-    return HostPlatform.darwin_x86;
+    return HostPlatform.darwin_x64;
   }
   if (platform.isLinux) {
     return HostPlatform.linux_x64;
@@ -653,7 +653,7 @@ class LocalEngineArtifacts implements Artifacts {
     final HostPlatform hostPlatform = _currentHostPlatformAsHost(_platform);
     if (hostPlatform == HostPlatform.linux_x64) {
       return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
-    } else if (hostPlatform == HostPlatform.darwin_x86) {
+    } else if (hostPlatform == HostPlatform.darwin_x64) {
       return _fileSystem.path.join(engineOutPath, 'flutter_tester');
     } else if (hostPlatform == HostPlatform.windows_x64) {
       return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -256,11 +256,21 @@ class _PosixUtils extends OperatingSystemUtils {
           _processUtils.runSync(<String>['sw_vers', '-productName']),
           _processUtils.runSync(<String>['sw_vers', '-productVersion']),
           _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
-          _processUtils.runSync(<String>['uname', '-m']),
         ];
         if (results.every((RunResult result) => result.exitCode == 0)) {
-          _name = '${results[0].stdout.trim()} ${results[1].stdout
-              .trim()} ${results[2].stdout.trim()} ${results[3].stdout.trim()}';
+          _name =
+              '${results[0].stdout.trim()} ${results[1].stdout.trim()} ${results[2].stdout.trim()}';
+        }
+        // Check for Apple Silicon ARM architecture, which requires macOS 11.
+        final RunResult arm64Check =
+            _processUtils.runSync(<String>['sysctl', 'hw.optional.arm64']);
+        // hw.optional.arm64 is unavailable on < macOS 11 and exits with 1, assume x86 on failure.
+        // On arm64 stdout is "sysctl hw.optional.arm64: 1"
+        if (arm64Check.exitCode == 0 &&
+            arm64Check.stdout.trim().endsWith('1')) {
+          _name += ' arm64';
+        } else {
+          _name += ' x86_64';
         }
       }
       _name ??= super.name;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -265,26 +265,26 @@ class MacOSUtils extends _PosixUtils {
     @required Platform platform,
     @required ProcessManager processManager,
   }) : super(
-    fileSystem: fileSystem,
-    logger: logger,
-    platform: platform,
-    processManager: processManager,
-  );
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        );
 
   String _name;
 
   @override
   String get name {
     if (_name == null) {
-        final List<RunResult> results = <RunResult>[
-          _processUtils.runSync(<String>['sw_vers', '-productName']),
-          _processUtils.runSync(<String>['sw_vers', '-productVersion']),
-          _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
-        ];
-        if (results.every((RunResult result) => result.exitCode == 0)) {
-          _name =
-          '${results[0].stdout.trim()} ${results[1].stdout.trim()} ${results[2].stdout.trim()} ${getNameForDarwinArch(hardwareArchitecture)}';
-        }
+      final List<RunResult> results = <RunResult>[
+        _processUtils.runSync(<String>['sw_vers', '-productName']),
+        _processUtils.runSync(<String>['sw_vers', '-productVersion']),
+        _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
+      ];
+      if (results.every((RunResult result) => result.exitCode == 0)) {
+        _name =
+            '${results[0].stdout.trim()} ${results[1].stdout.trim()} ${results[2].stdout.trim()} ${getNameForDarwinArch(hardwareArchitecture)}';
+      }
       _name ??= super.name;
     }
     return _name;
@@ -298,11 +298,10 @@ class MacOSUtils extends _PosixUtils {
   DarwinArch get hardwareArchitecture {
     if (_hardwareArchitecture == null) {
       final RunResult arm64Check =
-      _processUtils.runSync(<String>['sysctl', 'hw.optional.arm64']);
+          _processUtils.runSync(<String>['sysctl', 'hw.optional.arm64']);
       // hw.optional.arm64 is unavailable on < macOS 11 and exits with 1, assume x86 on failure.
       // On arm64 stdout is "sysctl hw.optional.arm64: 1"
-      if (arm64Check.exitCode == 0 &&
-          arm64Check.stdout.trim().endsWith('1')) {
+      if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
         _hardwareArchitecture = DarwinArch.arm64;
       } else {
         _hardwareArchitecture = DarwinArch.x86_64;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -308,7 +308,7 @@ class _MacOSUtils extends _PosixUtils {
       if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
         _hostPlatform = HostPlatform.darwin_arm;
       } else {
-        _hostPlatform = HostPlatform.darwin_x86;
+        _hostPlatform = HostPlatform.darwin_x64;
       }
     }
     return _hostPlatform;

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -397,15 +397,18 @@ bool isEmulatorBuildMode(BuildMode mode) {
 }
 
 enum HostPlatform {
-  darwin_x64,
+  darwin_x86,
+  darwin_arm,
   linux_x64,
   windows_x64,
 }
 
 String getNameForHostPlatform(HostPlatform platform) {
   switch (platform) {
-    case HostPlatform.darwin_x64:
-      return 'darwin-x64';
+    case HostPlatform.darwin_x86:
+      return 'darwin-x86';
+    case HostPlatform.darwin_arm:
+      return 'darwin-arm';
     case HostPlatform.linux_x64:
       return 'linux-x64';
     case HostPlatform.windows_x64:
@@ -418,6 +421,7 @@ String getNameForHostPlatform(HostPlatform platform) {
 enum TargetPlatform {
   android,
   ios,
+  // darwin_arm64 not yet supported, macOS desktop targets run in Rosetta as x86.
   darwin_x64,
   linux_x64,
   windows_x64,
@@ -610,7 +614,7 @@ String fuchsiaArchForTargetPlatform(TargetPlatform targetPlatform) {
 
 HostPlatform getCurrentHostPlatform() {
   if (globals.platform.isMacOS) {
-    return HostPlatform.darwin_x64;
+    return HostPlatform.darwin_x86;
   }
   if (globals.platform.isLinux) {
     return HostPlatform.linux_x64;

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -397,7 +397,7 @@ bool isEmulatorBuildMode(BuildMode mode) {
 }
 
 enum HostPlatform {
-  darwin_x86,
+  darwin_x64,
   darwin_arm,
   linux_x64,
   windows_x64,
@@ -405,8 +405,8 @@ enum HostPlatform {
 
 String getNameForHostPlatform(HostPlatform platform) {
   switch (platform) {
-    case HostPlatform.darwin_x86:
-      return 'darwin-x86';
+    case HostPlatform.darwin_x64:
+      return 'darwin-x64';
     case HostPlatform.darwin_arm:
       return 'darwin-arm';
     case HostPlatform.linux_x64:
@@ -614,7 +614,7 @@ String fuchsiaArchForTargetPlatform(TargetPlatform targetPlatform) {
 
 HostPlatform getCurrentHostPlatform() {
   if (globals.platform.isMacOS) {
-    return HostPlatform.darwin_x86;
+    return HostPlatform.darwin_x64;
   }
   if (globals.platform.isLinux) {
     return HostPlatform.linux_x64;

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -22,9 +21,11 @@ const String kPath2 = '/another/bin/$kExecutable';
 
 void main() {
   MockProcessManager mockProcessManager;
+  FakeProcessManager fakeProcessManager;
 
   setUp(() {
     mockProcessManager = MockProcessManager();
+    fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
   });
 
   OperatingSystemUtils createOSUtils(Platform platform) {
@@ -32,28 +33,50 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),
       platform: platform,
-      processManager: mockProcessManager,
+      processManager: fakeProcessManager,
     );
   }
 
   group('which on POSIX', () {
     testWithoutContext('returns null when executable does not exist', () async {
-      when(mockProcessManager.runSync(<String>['which', kExecutable]))
-          .thenReturn(ProcessResult(0, 1, null, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            kExecutable,
+          ],
+          exitCode: 1,
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       expect(utils.which(kExecutable), isNull);
     });
 
     testWithoutContext('returns exactly one result', () async {
-      when(mockProcessManager.runSync(<String>['which', 'foo']))
-          .thenReturn(ProcessResult(0, 0, kPath1, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            'foo',
+          ],
+          stdout: kPath1,
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       expect(utils.which(kExecutable).path, kPath1);
     });
 
     testWithoutContext('returns all results for whichAll', () async {
-      when(mockProcessManager.runSync(<String>['which', '-a', kExecutable]))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            '-a',
+            kExecutable,
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       final List<File> result = utils.whichAll(kExecutable);
       expect(result, hasLength(2));
@@ -66,27 +89,55 @@ void main() {
     testWithoutContext('throws tool exit if where throws an argument error', () async {
       when(mockProcessManager.runSync(<String>['where', kExecutable]))
           .thenThrow(ArgumentError('Cannot find executable for where'));
-      final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'windows'),
+        processManager: mockProcessManager,
+      );
 
       expect(() => utils.which(kExecutable), throwsA(isA<ToolExit>()));
     });
+
     testWithoutContext('returns null when executable does not exist', () async {
-      when(mockProcessManager.runSync(<String>['where', kExecutable]))
-          .thenReturn(ProcessResult(0, 1, null, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            kExecutable,
+          ],
+          exitCode: 1,
+        ),
+      );
+
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       expect(utils.which(kExecutable), isNull);
     });
 
     testWithoutContext('returns exactly one result', () async {
-      when(mockProcessManager.runSync(<String>['where', 'foo']))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            'foo',
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       expect(utils.which(kExecutable).path, kPath1);
     });
 
     testWithoutContext('returns all results for whichAll', () async {
-      when(mockProcessManager.runSync(<String>['where', kExecutable]))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            kExecutable,
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       final List<File> result = utils.whichAll(kExecutable);
       expect(result, hasLength(2));
@@ -95,34 +146,94 @@ void main() {
     });
   });
 
-  testWithoutContext('macos name', () async {
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-productName'],
-    )).thenReturn(ProcessResult(0, 0, 'product', ''));
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-productVersion'],
-    )).thenReturn(ProcessResult(0, 0, 'version', ''));
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-buildVersion'],
-    )).thenReturn(ProcessResult(0, 0, 'build', ''));
-    when(mockProcessManager.runSync(
-      <String>['uname', '-m'],
-    )).thenReturn(ProcessResult(0, 0, 'arch', ''));
-    final MockFileSystem fileSystem = MockFileSystem();
-    final OperatingSystemUtils utils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'macos'),
-      processManager: mockProcessManager,
-    );
-    expect(utils.name, 'product version build arch');
+  testWithoutContext('macos ARM name', () async {
+    fakeProcessManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-productName',
+        ],
+        stdout: 'product',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-productVersion',
+        ],
+        stdout: 'version',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-buildVersion',
+        ],
+        stdout: 'build',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        stdout: 'hw.optional.arm64: 1',
+      ),
+    ]);
+
+    final OperatingSystemUtils utils =
+        createOSUtils(FakePlatform(operatingSystem: 'macos'));
+    expect(utils.name, 'product version build arm64');
+  });
+
+  testWithoutContext('macos x86 name', () async {
+    fakeProcessManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-productName',
+        ],
+        stdout: 'product',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-productVersion',
+        ],
+        stdout: 'version',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sw_vers',
+          '-buildVersion',
+        ],
+        stdout: 'build',
+      ),
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        exitCode: 1,
+      ),
+    ]);
+
+    final OperatingSystemUtils utils =
+        createOSUtils(FakePlatform(operatingSystem: 'macos'));
+    expect(utils.name, 'product version build x86_64');
   });
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
-    when(mockProcessManager.runSync(
-      <String>['unzip', '-o', '-q', null, '-d', null],
-    )).thenReturn(ProcessResult(0, 1, '', exceptionMessage));
+
+    fakeProcessManager.addCommand(
+      const FakeCommand(command: <String>[
+        'unzip',
+        '-o',
+        '-q',
+        null,
+        '-d',
+        null,
+      ], exitCode: 1, stderr: exceptionMessage),
+    );
+
     final MockFileSystem fileSystem = MockFileSystem();
     final MockFile mockFile = MockFile();
     final MockDirectory mockDirectory = MockDirectory();
@@ -134,7 +245,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(operatingSystem: 'linux'),
-      processManager: mockProcessManager,
+      processManager: fakeProcessManager,
     );
 
     expect(

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -147,8 +147,26 @@ void main() {
     });
   });
 
-  group('macos architecture', () {
-    testWithoutContext('ARM', () async {
+  group('host platform', () {
+    testWithoutContext('unknown defaults to Linux', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'fuchsia'));
+      expect(utils.hostPlatform, HostPlatform.linux_x64);
+    });
+
+    testWithoutContext('Windows', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      expect(utils.hostPlatform, HostPlatform.windows_x64);
+    });
+
+    testWithoutContext('Linux', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'linux'));
+      expect(utils.hostPlatform, HostPlatform.linux_x64);
+    });
+
+    testWithoutContext('macOS ARM', () async {
       fakeProcessManager.addCommand(
         const FakeCommand(
           command: <String>[
@@ -159,9 +177,9 @@ void main() {
         ),
       );
 
-      final MacOSUtils utils =
-      createOSUtils(FakePlatform(operatingSystem: 'macos')) as MacOSUtils;
-      expect(utils.hardwareArchitecture, DarwinArch.arm64);
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_arm);
     });
 
     testWithoutContext('macOS 11 x86', () async {
@@ -175,9 +193,9 @@ void main() {
           ),
           );
 
-      final MacOSUtils utils =
-      createOSUtils(FakePlatform(operatingSystem: 'macos')) as MacOSUtils;
-      expect(utils.hardwareArchitecture, DarwinArch.x86_64);
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_x86);
     });
 
     testWithoutContext('macOS 10 x86', () async {
@@ -191,12 +209,12 @@ void main() {
           ),
           );
 
-      final MacOSUtils utils =
-      createOSUtils(FakePlatform(operatingSystem: 'macos')) as MacOSUtils;
-      expect(utils.hardwareArchitecture, DarwinArch.x86_64);
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_x86);
     });
 
-    testWithoutContext('ARM name', () async {
+    testWithoutContext('macOS ARM name', () async {
       fakeProcessManager.addCommands(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -230,10 +248,10 @@ void main() {
 
       final OperatingSystemUtils utils =
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build arm64');
+      expect(utils.name, 'product version build darwin-arm');
     });
 
-    testWithoutContext('x86 name', () async {
+    testWithoutContext('macOS x86 name', () async {
       fakeProcessManager.addCommands(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -267,7 +285,7 @@ void main() {
 
       final OperatingSystemUtils utils =
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build x86_64');
+      expect(utils.name, 'product version build darwin-x86_64');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -195,7 +195,7 @@ void main() {
 
       final OperatingSystemUtils utils =
       createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.hostPlatform, HostPlatform.darwin_x86);
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
     });
 
     testWithoutContext('macOS 10 x86', () async {
@@ -211,7 +211,7 @@ void main() {
 
       final OperatingSystemUtils utils =
       createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.hostPlatform, HostPlatform.darwin_x86);
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
     });
 
     testWithoutContext('macOS ARM name', () async {
@@ -285,7 +285,7 @@ void main() {
 
       final OperatingSystemUtils utils =
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build darwin-x86');
+      expect(utils.name, 'product version build darwin-x64');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -285,7 +285,7 @@ void main() {
 
       final OperatingSystemUtils utils =
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build darwin-x86_64');
+      expect(utils.name, 'product version build darwin-x86');
     });
   });
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/time.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
@@ -293,6 +294,9 @@ class MockSimControl extends Mock implements SimControl {
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
   @override
   ProcessResult makeExecutable(File file) => null;
+
+  @override
+  HostPlatform hostPlatform = HostPlatform.linux_x64;
 
   @override
   void chmod(FileSystemEntity entity, String mode) { }


### PR DESCRIPTION
## Description
Detect whether we're running on an x86 or ARM Mac.  `uname -m` returns `x86_64` on an ARM Mac from `flutter` since it's running in Rosetta.

Instead, switch to `sysctl hw.optional.arm64`, which returns `sysctl hw.optional.arm64: 1` on an ARM mac in both Rosetta and non-Rosetta mode.  On non-ARM this command fails `sysctl: unknown oid 'hw.optional.arm64'` and and exits 1.

Create a new `HostPlatform.darwin_arm` value, and expose it in OperatingSystemUtils.

## Related Issues

https://github.com/flutter/flutter/issues/65976

## Tests

Added a test for x86 and ARM.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*