### PR TITLE
prevent pageView scrolling when calling ensureVisible

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -341,17 +341,9 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
     RenderObject? targetRenderObject,
   }) {
     // Since the _PagePosition is intended to cover the available space within
-    // its viewport, stop trying to move the target render object to the center
-    // - otherwise, could end up changing which page is visible and moving the
-    // targetRenderObject out of the viewport.
-    return super.ensureVisible(
-      object,
-      alignment: alignment,
-      duration: duration,
-      curve: curve,
-      alignmentPolicy: alignmentPolicy,
-      targetRenderObject: null,
-    );
+    // its viewport, stop trying to any scroll, otherwise, could end up changing
+    // which page is visible and moving the render object out of the viewport.
+    return Future<void>.value();
   }
 
   @override

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1007,7 +1007,7 @@ void main() {
     expect(targetMidLeftPage1, findsOneWidget);
   });
 
-  testWidgets('ensureVisible does not move PageViews when there are objects between nested scrollable', (WidgetTester tester) async {
+  testWidgets('ensureVisible does not move PageViews when there are objects between pageView and target object', (WidgetTester tester) async {
     final PageController controller = PageController();
     int count = 0;
 


### PR DESCRIPTION
## Description

When there are other objects between the `target` and the `pageView`, calling `ensureVisiblemay` may cause the `pageView` to scroll(Looks like shaken). If the object is large enough, the `pageView`'s page may change at that time, which is not the expected result.

Actually, this issue has nothing to do with the #67773, it existed before this change. But the solution is also applicable to solve this problem.

CC @dnfield 

## Related Issues

Fixes #67981 

## Tests

I added the following tests:

See files.