### PR TITLE
Improve the document of pageView and ListView

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -581,7 +581,7 @@ class PageView extends StatefulWidget {
   /// child that could possibly be displayed in the page view, instead of just
   /// those children that are actually visible.
   ///
-  /// If the children [List] is going to be mutated,
+  /// If the [children] is going to be mutated,
   /// please refer to [SliverChildListDelegate.children] to avoid traps.
   ///
   /// {@template flutter.widgets.pageView.allowImplicitScrolling}

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -581,6 +581,9 @@ class PageView extends StatefulWidget {
   /// child that could possibly be displayed in the page view, instead of just
   /// those children that are actually visible.
   ///
+  /// If the children [list] is going to be mutated,
+  /// please refer to [SliverChildListDelegate.children] to avoid traps.
+  ///
   /// {@template flutter.widgets.pageView.allowImplicitScrolling}
   /// The [allowImplicitScrolling] parameter must not be null. If true, the
   /// [PageView] will participate in accessibility scrolling more like a

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -581,8 +581,9 @@ class PageView extends StatefulWidget {
   /// child that could possibly be displayed in the page view, instead of just
   /// those children that are actually visible.
   ///
-  /// If the [children] is going to be mutated,
-  /// please refer to [SliverChildListDelegate.children] to avoid traps.
+  /// Like other widgets in the framework, this widget expects that
+  /// the [children] list will not be mutated after it has been passed in here.
+  /// See the documentation at [SliverChildListDelegate.children] for more details.
   ///
   /// {@template flutter.widgets.pageView.allowImplicitScrolling}
   /// The [allowImplicitScrolling] parameter must not be null. If true, the

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -581,7 +581,7 @@ class PageView extends StatefulWidget {
   /// child that could possibly be displayed in the page view, instead of just
   /// those children that are actually visible.
   ///
-  /// If the children [list] is going to be mutated,
+  /// If the children [List] is going to be mutated,
   /// please refer to [SliverChildListDelegate.children] to avoid traps.
   ///
   /// {@template flutter.widgets.pageView.allowImplicitScrolling}

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1042,7 +1042,7 @@ class ListView extends BoxScrollView {
   /// child that could possibly be displayed in the list view instead of just
   /// those children that are actually visible.
   ///
-  /// If the children [list] is going to be mutated,
+  /// If the children [List] is going to be mutated,
   /// please refer to [SliverChildListDelegate.children] to avoid traps.
   ///
   /// It is usually more efficient to create children on demand using

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1042,6 +1042,9 @@ class ListView extends BoxScrollView {
   /// child that could possibly be displayed in the list view instead of just
   /// those children that are actually visible.
   ///
+  /// If the children [list] is going to be mutated,
+  /// please refer to [SliverChildListDelegate.children] to avoid traps.
+  ///
   /// It is usually more efficient to create children on demand using
   /// [ListView.builder] because it will create the widget children lazily as necessary.
   ///

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1042,8 +1042,9 @@ class ListView extends BoxScrollView {
   /// child that could possibly be displayed in the list view instead of just
   /// those children that are actually visible.
   ///
-  /// If the [children] is going to be mutated,
-  /// please refer to [SliverChildListDelegate.children] to avoid traps.
+  /// Like other widgets in the framework, this widget expects that
+  /// the [children] list will not be mutated after it has been passed in here.
+  /// See the documentation at [SliverChildListDelegate.children] for more details.
   ///
   /// It is usually more efficient to create children on demand using
   /// [ListView.builder] because it will create the widget children lazily as necessary.

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1042,7 +1042,7 @@ class ListView extends BoxScrollView {
   /// child that could possibly be displayed in the list view instead of just
   /// those children that are actually visible.
   ///
-  /// If the children [List] is going to be mutated,
+  /// If the [children] is going to be mutated,
   /// please refer to [SliverChildListDelegate.children] to avoid traps.
   ///
   /// It is usually more efficient to create children on demand using

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -647,11 +647,11 @@ class SliverChildListDelegate extends SliverChildDelegate {
   ///
   ///   void someHandler() {
   ///     setState(() {
-  ///         _children.add(...);
+  ///         _children.add(ChildWidget());
   ///     });
   ///   }
   ///
-  ///   Widget build(...) {
+  ///   Widget build(BuildContext context) {
   ///     // Reusing `List<Widget> _children` here is problematic.
   ///     return PageView(children: _children);
   ///   }
@@ -672,13 +672,13 @@ class SliverChildListDelegate extends SliverChildDelegate {
   ///     setState(() {
   ///       // The key here allows Flutter to reuse the underlying render
   ///       // objects even if the children list is recreated.
-  ///       _children.add(ChildWidget(key: ...));
+  ///       _children.add(ChildWidget(key: UniqueKey()));
   ///     });
   ///   }
   ///
-  ///   Widget build(...) {
+  ///   Widget build(BuildContext context) {
   ///     // Always create a new list of children as a Widget is immutable.
-  ///     return PageView(children: List.from(_children));
+  ///     return PageView(children: List<Widget>.from(_children));
   ///   }
   /// }
   /// ```

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -626,6 +626,62 @@ class SliverChildListDelegate extends SliverChildDelegate {
   final SemanticIndexCallback semanticIndexCallback;
 
   /// The widgets to display.
+  ///
+  /// If this list is going to be mutated, it is usually wise to put a [Key] on
+  /// each of the child widgets, so that the framework can match old
+  /// configurations to new configurations and maintain the underlying render
+  /// objects.
+  ///
+  /// Also, a [Widget] in Flutter is immutable, so directly modifying the
+  /// [children] such as `someWidget.children.add(...)` or
+  /// as the example code below will result in incorrect behaviors. Whenever the
+  /// children list is modified, a new list object should be provided.
+  ///
+  /// ```dart
+  /// class SomeWidgetState extends State<SomeWidget> {
+  ///   List<Widget> _children;
+  ///
+  ///   void initState() {
+  ///     _children = [];
+  ///   }
+  ///
+  ///   void someHandler() {
+  ///     setState(() {
+  ///         _children.add(...);
+  ///     });
+  ///   }
+  ///
+  ///   Widget build(...) {
+  ///     // Reusing `List<Widget> _children` here is problematic.
+  ///     return PageView(children: _children);
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The following code corrects the problem mentioned above.
+  ///
+  /// ```dart
+  /// class SomeWidgetState extends State<SomeWidget> {
+  ///   List<Widget> _children;
+  ///
+  ///   void initState() {
+  ///     _children = [];
+  ///   }
+  ///
+  ///   void someHandler() {
+  ///     setState(() {
+  ///       // The key here allows Flutter to reuse the underlying render
+  ///       // objects even if the children list is recreated.
+  ///       _children.add(ChildWidget(key: ...));
+  ///     });
+  ///   }
+  ///
+  ///   Widget build(...) {
+  ///     // Always create a new list of children as a Widget is immutable.
+  ///     return PageView(children: List.from(_children));
+  ///   }
+  /// }
+  /// ```
   final List<Widget> children;
 
   /// A map to cache key to index lookup for children.

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -634,29 +634,9 @@ class SliverChildListDelegate extends SliverChildDelegate {
   ///
   /// Also, a [Widget] in Flutter is immutable, so directly modifying the
   /// [children] such as `someWidget.children.add(...)` or
-  /// as the example code below will result in incorrect behaviors. Whenever the
+  /// passing a reference of the original list value to the [children] parameter
+  /// will result in incorrect behaviors. Whenever the
   /// children list is modified, a new list object should be provided.
-  ///
-  /// ```dart
-  /// class SomeWidgetState extends State<SomeWidget> {
-  ///   List<Widget> _children;
-  ///
-  ///   void initState() {
-  ///     _children = [];
-  ///   }
-  ///
-  ///   void someHandler() {
-  ///     setState(() {
-  ///         _children.add(ChildWidget());
-  ///     });
-  ///   }
-  ///
-  ///   Widget build(BuildContext context) {
-  ///     // Reusing `List<Widget> _children` here is problematic.
-  ///     return PageView(children: _children);
-  ///   }
-  /// }
-  /// ```
   ///
   /// The following code corrects the problem mentioned above.
   ///


### PR DESCRIPTION
## Description

Add more documents like this: https://master-api.flutter.dev/flutter/widgets/MultiChildRenderObjectWidget/children.html to avoid traps when passing the `children` parameters with a reference `List` type. 

@dnfield 

## Related Issues

Fixes #67461 

## Tests

I added the following tests:

Not needed, just update the documents.