### PR TITLE
[flutter_tools] change the IntelliJ plugin detection logic.

### DIFF
--- a/packages/flutter_tools/lib/src/intellij/intellij.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij.dart
@@ -72,7 +72,7 @@ class IntelliJPlugins {
   ArchiveFile _findPluginXml(String packageName) {
     final List<String> mainJarPathList = <String>[];
     if (packageName.endsWith('.jar')) {
-      // package exists(checked in _hasPackage
+      // package exists (checked in _hasPackage)
       mainJarPathList.add(_fileSystem.path.join(pluginsPath, packageName));
     } else {
       final String packageLibPath =

--- a/packages/flutter_tools/lib/src/intellij/intellij.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij.dart
@@ -15,6 +15,25 @@ import '../doctor.dart';
 /// This searches on the provided plugin path for a JAR archive, then
 /// unzips it to parse the META-INF/plugin.xml for version information.
 ///
+/// In particular, the Intellij Flutter plugin has a different structure depending on the version.
+///
+/// For flutter-intellij plugin v49 or lower:
+///   flutter-intellij/lib/flutter-intellij.jar ( includes META-INF/plugin.xml )
+///
+/// For flutter-intellij plugin v50 or higher and for Intellij 2020.2:
+///   flutter-intellij/lib/flutter-intellij-X.Y.Z.jar
+///                        flutter-idea-X.Y.Z.jar ( includes META-INF/plugin.xml )
+///                        flutter-studio-X.Y.Z.jar
+///
+/// For flutter-intellij plugin v50 or higher and for Intellij 2020.3:
+///   flutter-intellij/lib/flutter-intellij-X.Y.Z.jar
+///                        flutter-idea-X.Y.Z.jar ( includes META-INF/plugin.xml )
+///
+/// where X.Y.Z is the version number.
+///
+/// Intellij Flutter plugin's files can be found here:
+///   https://plugins.jetbrains.com/plugin/9212-flutter/versions/stable
+///
 /// See also:
 ///   * [IntellijValidator], the validator base class that uses this to check
 ///     plugin versions.

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
@@ -69,6 +69,81 @@ void main() {
     expect(message.message, contains('recommended minimum version'));
   });
 
+  testWithoutContext('IntelliJPlugins can read the package version of the flutter-intellij 50.0+/IntelliJ 2020.2+ layout', () async {
+    final IntelliJPlugins plugins = IntelliJPlugins(_kPluginsPath, fileSystem: fileSystem);
+
+    final Archive flutterIdeaJarArchive = buildSingleFileArchive('META-INF/plugin.xml', r'''
+<idea-plugin version="2">
+<name>Flutter</name>
+<version>50.0</version>
+</idea-plugin>
+''');
+    writeFileCreatingDirectories(
+      fileSystem.path.join(_kPluginsPath, 'flutter-intellij', 'lib', 'flutter-idea-50.0.jar'),
+      ZipEncoder().encode(flutterIdeaJarArchive),
+    );
+    final Archive flutterIntellijJarArchive = buildSingleFileArchive('META-INF/MANIFEST.MF', r'''
+Manifest-Version: 1.0
+''');
+    writeFileCreatingDirectories(
+      fileSystem.path.join(_kPluginsPath, 'flutter-intellij', 'lib', 'flutter-intellij-50.0.jar'),
+      ZipEncoder().encode(flutterIntellijJarArchive),
+    );
+
+    final List<ValidationMessage> messages = <ValidationMessage>[];
+    plugins.validatePackage(messages,
+      <String>[
+        'flutter-intellij',
+        'flutter-intellij.jar',
+      ],
+      'Flutter', 'download-Flutter',
+      minVersion: IntelliJPlugins.kMinFlutterPluginVersion,
+    );
+
+    final ValidationMessage message = messages.firstWhere(
+            (ValidationMessage m) => m.message.startsWith('Flutter '));
+    expect(message.message, contains('Flutter plugin version 50.0'));
+  });
+
+  testWithoutContext('IntelliJPlugins can read the package version of the flutter-intellij 50.0+/IntelliJ 2020.2+ layout(priority is given to packages with the same prefix as packageName)', () async {
+    final IntelliJPlugins plugins = IntelliJPlugins(_kPluginsPath, fileSystem: fileSystem);
+
+    final Archive flutterIdeaJarArchive = buildSingleFileArchive('META-INF/plugin.xml', r'''
+<idea-plugin version="2">
+<name>Flutter</name>
+<version>50.0</version>
+</idea-plugin>
+''');
+    writeFileCreatingDirectories(
+      fileSystem.path.join(_kPluginsPath, 'flutter-intellij', 'lib', 'flutter-idea-50.0.jar'),
+      ZipEncoder().encode(flutterIdeaJarArchive),
+    );
+    final Archive flutterIntellijJarArchive = buildSingleFileArchive('META-INF/plugin.xml', r'''
+<idea-plugin version="2">
+<name>Flutter</name>
+<version>51.0</version>
+</idea-plugin>
+''');
+    writeFileCreatingDirectories(
+      fileSystem.path.join(_kPluginsPath, 'flutter-intellij', 'lib', 'flutter-intellij-50.0.jar'),
+      ZipEncoder().encode(flutterIntellijJarArchive),
+    );
+
+    final List<ValidationMessage> messages = <ValidationMessage>[];
+    plugins.validatePackage(messages,
+      <String>[
+        'flutter-intellij',
+        'flutter-intellij.jar',
+      ],
+      'Flutter', 'download-Flutter',
+      minVersion: IntelliJPlugins.kMinFlutterPluginVersion,
+    );
+
+    final ValidationMessage message = messages.firstWhere(
+            (ValidationMessage m) => m.message.startsWith('Flutter '));
+    expect(message.message, contains('Flutter plugin version 51.0'));
+  });
+
   testWithoutContext('IntelliJPlugins not found displays a link to their download site', () async {
     final IntelliJPlugins plugins = IntelliJPlugins(_kPluginsPath, fileSystem: fileSystem);
 
@@ -94,11 +169,8 @@ void main() {
     final IntelliJPlugins plugins = IntelliJPlugins(_kPluginsPath, fileSystem: fileSystem);
 
     final Archive dartJarArchive =
-    buildSingleFileArchive('META-INF/plugin.xml', r'''
-<idea-plugin version="2">
-<name>Dart</name>
-<version>162.2485</version>
-</idea-plugin>
+    buildSingleFileArchive('META-INF/MANIFEST.MF', r'''
+Manifest-Version: 1.0
 ''');
     writeFileCreatingDirectories(
       fileSystem.path.join(_kPluginsPath, 'Dart', 'lib', 'Other.jar'),


### PR DESCRIPTION
## Description

This PR suggests improving the IntelliJ plugin "jar" detection logic.

Previously:
The IntelliJ Flutter plugin was contained `flutter-intellij.jar`.
Currently:
It is named `flutter-intellij-X.Y.Z.jar` and does not contain `META-INF/plugin.xml`.
`META-INF/plugin.xml` is included in `flutter-idea-X.Y.Z.jar`.

So this PR changes the rules for searching the plugin's jar file.
Concretely, it looks for the jar file containing `META-INF/plugin.xml` in the plugin's package directory and reads the package version from its `META-INF/plugin.xml`.

## Related Issues

[#67918] (already fixed and closed via #67931)

## Tests

I added the following tests:

packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
- 'IntelliJPlugins can read the package version of the flutter-intellij 50.0+/IntelliJ 2020.2+ layout'
- 'IntelliJPlugins can read the package version of the flutter-intellij 50.0+/IntelliJ 2020.2+ layout(priority is given to packages with the same prefix as packageName)'

I changed the following test:
- 'IntelliJPlugins does not crash if no plugin file found'

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
