### PR TITLE
[flutter_tools] delete applicationPackageStore

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -412,52 +412,6 @@ class PrebuiltIOSApp extends IOSApp {
   String get _bundlePath => bundleDir.path;
 }
 
-class ApplicationPackageStore {
-  ApplicationPackageStore({ this.android, this.iOS, this.fuchsia });
-
-  AndroidApk android;
-  IOSApp iOS;
-  FuchsiaApp fuchsia;
-  LinuxApp linux;
-  MacOSApp macOS;
-  WindowsApp windows;
-
-  Future<ApplicationPackage> getPackageForPlatform(
-    TargetPlatform platform,
-    BuildInfo buildInfo,
-  ) async {
-    switch (platform) {
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.android_x86:
-        android ??= await AndroidApk.fromAndroidProject(FlutterProject.current().android);
-        return android;
-      case TargetPlatform.ios:
-        iOS ??= await IOSApp.fromIosProject(FlutterProject.current().ios, buildInfo);
-        return iOS;
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-        fuchsia ??= FuchsiaApp.fromFuchsiaProject(FlutterProject.current().fuchsia);
-        return fuchsia;
-      case TargetPlatform.darwin_x64:
-        macOS ??= MacOSApp.fromMacOSProject(FlutterProject.current().macos);
-        return macOS;
-      case TargetPlatform.linux_x64:
-        linux ??= LinuxApp.fromLinuxProject(FlutterProject.current().linux);
-        return linux;
-      case TargetPlatform.windows_x64:
-        windows ??= WindowsApp.fromWindowsProject(FlutterProject.current().windows);
-        return windows;
-      case TargetPlatform.tester:
-      case TargetPlatform.web_javascript:
-        return null;
-    }
-    return null;
-  }
-}
-
 class _Entry {
   _Element parent;
   int level;

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -134,7 +134,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
 
     final BuildableIOSApp app = await applicationPackages.getPackageForPlatform(
       TargetPlatform.ios,
-      buildInfo,
+      buildInfo: buildInfo,
     ) as BuildableIOSApp;
 
     if (app == null) {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -467,7 +467,7 @@ Future<LaunchResult> _startApp(
   await appStopper(command);
 
   final ApplicationPackage package = await command.applicationPackages
-      .getPackageForPlatform(await command.device.targetPlatform, command.getBuildInfo());
+    .getPackageForPlatform(await command.device.targetPlatform, buildInfo: command.getBuildInfo());
 
   final Map<String, dynamic> platformArgs = <String, dynamic>{};
   if (command.traceStartup) {
@@ -555,7 +555,7 @@ Future<bool> _stopApp(DriveCommand command) async {
   globals.printTrace('Stopping application.');
   final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(
     await command.device.targetPlatform,
-    command.getBuildInfo(),
+    buildInfo: command.getBuildInfo(),
   );
   final bool stopped = await command.device.stopApp(package, userIdentifier: command.userIdentifier);
   await command._deviceLogSubscription?.cancel();

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -49,7 +49,6 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   Future<FlutterCommandResult> runCommand() async {
     final ApplicationPackage package = await applicationPackages.getPackageForPlatform(
       await device.targetPlatform,
-      null, // Build info isn't relevant for install, will use whatever bundle was built last.
     );
 
     if (uninstallOnly) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -820,7 +820,7 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   void setupApplicationPackages() {
-    applicationPackages ??= ApplicationPackageStore();
+    applicationPackages ??= ApplicationPackageFactory.instance;
   }
 
   /// The path to send to Google Analytics. Return null here to disable
@@ -1146,7 +1146,7 @@ abstract class FlutterCommand extends Command<void> {
     return help;
   }
 
-  ApplicationPackageStore applicationPackages;
+  ApplicationPackageFactory applicationPackages;
 
   /// Gets the parsed command-line option named [name] as `bool`.
   bool boolArg(String name) => argResults[name] as bool;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -20,7 +20,6 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 // Defined globally for mocks to use.
@@ -145,7 +144,6 @@ void main() {
 
   testUsingContext('Fuchsia build parts fit together right', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     const String appName = 'app_name';
     fileSystem
         .file(fileSystem.path.join('fuchsia', 'meta', '$appName.cmx'))

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -20,7 +20,6 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -97,7 +96,6 @@ void main() {
 
   testUsingContext('Builds a web bundle - end to end', () async {
     final BuildCommand buildCommand = BuildCommand();
-    applyMocksToCommand(buildCommand);
     final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
     final List<String> dependencies = <String>[
       fileSystem.path.join('packages', 'flutter_tools', 'lib', 'src', 'build_system', 'targets', 'web.dart'),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -16,7 +16,6 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 const String flutterRoot = r'C:\flutter';
@@ -116,7 +115,6 @@ void main() {
   testUsingContext('Windows build fails when there is no vcvars64.bat', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
 
     expect(createTestCommandRunner(command).run(
@@ -132,7 +130,6 @@ void main() {
   testUsingContext('Windows build fails when there is no windows project', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockCoreProjectFiles();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -149,7 +146,6 @@ void main() {
   testUsingContext('Windows build fails on non windows platform', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -166,7 +162,6 @@ void main() {
   testUsingContext('Windows build does not spew stdout to status logger', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -192,7 +187,6 @@ void main() {
   testUsingContext('Windows build extracts errors from stdout', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -249,7 +243,6 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
   testUsingContext('Windows verbose build sets VERBOSE_SCRIPT_LOGGING', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -276,7 +269,6 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
   testUsingContext('Windows build invokes build and writes generated files', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -342,7 +334,6 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
   testUsingContext('Windows profile build passes Profile configuration', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 
@@ -378,7 +369,6 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
   testUsingContext('Performs code size analysis and sends analytics', () async {
     final BuildWindowsCommand command = BuildWindowsCommand()
       ..visualStudioOverride = mockVisualStudio;
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
     when(mockVisualStudio.cmakePath).thenReturn(cmakePath);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
@@ -15,7 +15,6 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 
 void main() {
   FileSystem fileSystem;
@@ -53,7 +52,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     expect(createTestCommandRunner(command).run(const <String>['downgrade']),
       throwsToolExit(message: 'Flutter is not currently on a known channel.'));
@@ -79,7 +77,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     expect(createTestCommandRunner(command).run(const <String>['downgrade']),
       throwsToolExit(message:
@@ -108,7 +105,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     expect(createTestCommandRunner(command).run(const <String>['downgrade']),
       throwsToolExit(message: 'Failed to parse version for downgrade'));
@@ -127,7 +123,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     when(terminal.promptForCharInput(
       const <String>['y', 'n'],
@@ -158,7 +153,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     when(terminal.promptForCharInput(
       const <String>['y', 'n'],
@@ -192,7 +186,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(const <String>['downgrade']);
 
@@ -237,7 +230,6 @@ void main() {
       flutterVersion: flutterVersion,
       logger: bufferLogger,
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(const <String>['downgrade']);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
+import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -22,7 +23,6 @@ import 'package:flutter_tools/src/vmservice.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
-import '../../src/mocks.dart';
 
 void main() {
   group('drive', () {
@@ -37,7 +37,6 @@ void main() {
 
     setUp(() {
       command = DriveCommand();
-      applyMocksToCommand(command);
       fs = MemoryFileSystem.test();
       tempDir = fs.systemTempDirectory.createTempSync('flutter_drive_test.');
       fs.currentDirectory = tempDir;
@@ -55,6 +54,7 @@ void main() {
       appStopper = (DriveCommand command) {
         throw 'Unexpected call to appStopper';
       };
+      command.applicationPackages = FakeApplicationPackageFactory();
     });
 
     tearDown(() {
@@ -871,3 +871,9 @@ class MockDevice extends Mock implements Device {
 class MockAndroidDevice extends Mock implements AndroidDevice { }
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService { }
 class MockLaunchResult extends Mock implements LaunchResult { }
+class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFactory {
+  @override
+  Future<ApplicationPackage> getPackageForPlatform(TargetPlatform platform, {BuildInfo buildInfo, File applicationBinary}) {
+    return null;
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/install.dart';
 import 'package:mockito/mockito.dart';
@@ -18,7 +21,7 @@ void main() {
 
     testUsingContext('returns 0 when Android is connected and ready for an install', () async {
       final InstallCommand command = InstallCommand();
-      applyMocksToCommand(command);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final MockAndroidDevice device = MockAndroidDevice();
       when(device.isAppInstalled(any, userIdentifier: anyNamed('userIdentifier')))
@@ -34,7 +37,7 @@ void main() {
 
     testUsingContext('returns 1 when targeted device is not Android with --device-user', () async {
       final InstallCommand command = InstallCommand();
-      applyMocksToCommand(command);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final MockIOSDevice device = MockIOSDevice();
       when(device.isAppInstalled(any, userIdentifier: anyNamed('userIdentifier')))
@@ -51,7 +54,7 @@ void main() {
 
     testUsingContext('returns 0 when iOS is connected and ready for an install', () async {
       final InstallCommand command = InstallCommand();
-      applyMocksToCommand(command);
+      command.applicationPackages = FakeApplicationPackageFactory(FakeIOSApp());
 
       final MockIOSDevice device = MockIOSDevice();
       when(device.isAppInstalled(any)).thenAnswer((_) async => false);
@@ -64,3 +67,16 @@ void main() {
     });
   });
 }
+
+class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFactory {
+  FakeApplicationPackageFactory(this.app);
+
+  final ApplicationPackage app;
+
+  @override
+  Future<ApplicationPackage> getPackageForPlatform(TargetPlatform platform, {BuildInfo buildInfo, File applicationBinary}) async {
+    return app;
+  }
+}
+class FakeIOSApp extends Fake implements IOSApp {}
+class FakeAndroidApk extends Fake implements AndroidApk {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -11,7 +11,6 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -38,7 +37,6 @@ void main() {
       platform: platform,
       featureFlags: TestFeatureFlags(),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache']);
 
     expect(Cache.isLocked(), isTrue);
@@ -60,7 +58,6 @@ void main() {
       featureFlags: TestFeatureFlags(),
       platform: platform,
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache']);
 
     expect(Cache.isLocked(), isFalse);
@@ -75,7 +72,6 @@ void main() {
       featureFlags: TestFeatureFlags(isWebEnabled: true),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--web', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -91,7 +87,6 @@ void main() {
       featureFlags: TestFeatureFlags(isWebEnabled: false),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--web', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -106,7 +101,6 @@ void main() {
       featureFlags: TestFeatureFlags(isMacOSEnabled: true),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -122,7 +116,6 @@ void main() {
       featureFlags: TestFeatureFlags(isMacOSEnabled: false),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -137,7 +130,6 @@ void main() {
       featureFlags: TestFeatureFlags(isWindowsEnabled: true),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -153,7 +145,6 @@ void main() {
       featureFlags: TestFeatureFlags(isWindowsEnabled: false),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -168,7 +159,6 @@ void main() {
       featureFlags: TestFeatureFlags(isLinuxEnabled: true),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -184,7 +174,6 @@ void main() {
       featureFlags: TestFeatureFlags(isLinuxEnabled: false),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
@@ -199,7 +188,6 @@ void main() {
       featureFlags: TestFeatureFlags(isWebEnabled: false),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
 
     expect(createTestCommandRunner(command).run(const <String>['precache',
       '--no-android',
@@ -220,7 +208,6 @@ void main() {
       ),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(
       const <String>[
         'precache',
@@ -256,7 +243,6 @@ void main() {
       featureFlags: TestFeatureFlags(),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(
       const <String>[
         'precache',
@@ -279,7 +265,6 @@ void main() {
       featureFlags: TestFeatureFlags(),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(
       const <String>[
         'precache',
@@ -304,7 +289,6 @@ void main() {
       featureFlags: TestFeatureFlags(),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(
       const <String>[
@@ -334,7 +318,6 @@ void main() {
       ),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(
       const <String>[
@@ -365,7 +348,6 @@ void main() {
       featureFlags: TestFeatureFlags(),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(
       const <String>[
@@ -391,7 +373,6 @@ void main() {
         },
       ),
     );
-    applyMocksToCommand(command);
 
     await createTestCommandRunner(command).run(
       const <String>[
@@ -419,7 +400,6 @@ void main() {
       ),
       platform: FakePlatform(environment: <String, String>{}),
     );
-    applyMocksToCommand(command);
     await createTestCommandRunner(command).run(const <String>['precache', '--force']);
 
     verify(cache.clearStampFiles()).called(1);

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -31,7 +31,6 @@ import '../../src/testbed.dart';
 
 void main() {
   group('run', () {
-    MockApplicationPackageFactory mockApplicationPackageFactory;
     MockDeviceManager mockDeviceManager;
     FileSystem fileSystem;
 
@@ -40,14 +39,12 @@ void main() {
     });
 
     setUp(() {
-      mockApplicationPackageFactory = MockApplicationPackageFactory();
       mockDeviceManager = MockDeviceManager();
       fileSystem = MemoryFileSystem.test();
     });
 
     testUsingContext('fails when target not found', () async {
       final RunCommand command = RunCommand();
-      applyMocksToCommand(command);
       try {
         await createTestCommandRunner(command).run(<String>['run', '-t', 'abc123', '--no-pub']);
         fail('Expect exception');
@@ -66,7 +63,6 @@ void main() {
       fileSystem.file('.packages').createSync();
 
       final RunCommand command = RunCommand();
-      applyMocksToCommand(command);
       try {
         await createTestCommandRunner(command).run(<String>[
           'run',
@@ -95,7 +91,6 @@ void main() {
         ..createSync(recursive: true);
 
       final RunCommand command = RunCommand();
-      applyMocksToCommand(command);
       try {
         await createTestCommandRunner(command).run(<String>[
           'run',
@@ -123,7 +118,6 @@ void main() {
         .createSync(recursive: true);
 
       final RunCommand command = RunCommand();
-      applyMocksToCommand(command);
       try {
         await createTestCommandRunner(command).run(<String>[
           'run',
@@ -173,7 +167,6 @@ void main() {
 
       testUsingContext('exits with a user message when no supported devices attached', () async {
         final RunCommand command = RunCommand();
-        applyMocksToCommand(command);
 
         const List<Device> noDevices = <Device>[];
         when(mockDeviceManager.getDevices()).thenAnswer(
@@ -222,7 +215,6 @@ void main() {
         when(mockDeviceManager.deviceDiscoverers).thenReturn(<DeviceDiscovery>[]);
 
         final RunCommand command = RunCommand();
-        applyMocksToCommand(command);
         await expectLater(createTestCommandRunner(command).run(<String>[
           'run',
           '--no-pub',
@@ -238,7 +230,6 @@ void main() {
 
       testUsingContext('shows unsupported devices when no supported devices are found',  () async {
         final RunCommand command = RunCommand();
-        applyMocksToCommand(command);
 
         final MockDevice mockDevice = MockDevice(TargetPlatform.android_arm);
         when(mockDevice.isLocalEmulator).thenAnswer((Invocation invocation) => Future<bool>.value(true));
@@ -294,7 +285,6 @@ void main() {
 
       testUsingContext('updates cache before checking for devices', () async {
         final RunCommand command = RunCommand();
-        applyMocksToCommand(command);
 
         // Called as part of requiredArtifacts()
         when(mockDeviceManager.getDevices()).thenAnswer(
@@ -331,7 +321,6 @@ void main() {
           mockDeviceManager.findTargetDevices(any, timeout: anyNamed('timeout')),
         ]);
       }, overrides: <Type, Generator>{
-        ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Cache: () => mockCache,
         DeviceManager: () => mockDeviceManager,
         FileSystem: () => fs,
@@ -340,7 +329,6 @@ void main() {
 
       testUsingContext('passes device target platform to usage', () async {
         final RunCommand command = RunCommand();
-        applyMocksToCommand(command);
         final MockDevice mockDevice = MockDevice(TargetPlatform.ios);
         when(mockDevice.supportsRuntimeMode(any)).thenAnswer((Invocation invocation) => true);
         when(mockDevice.isLocalEmulator).thenAnswer((Invocation invocation) => Future<bool>.value(false));
@@ -390,7 +378,6 @@ void main() {
         );
         expect(buffer.toString(), matches(usageRegexp));
       }, overrides: <Type, Generator>{
-        ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => artifacts,
         Cache: () => mockCache,
         DeviceManager: () => mockDeviceManager,
@@ -433,7 +420,6 @@ void main() {
           expect(e.exitCode, FakeDevice.kSuccess);
         }
       }, overrides: <Type, Generator>{
-        ApplicationPackageFactory: () => mockApplicationPackageFactory,
         DeviceManager: () => mockDeviceManager,
       });
 
@@ -449,7 +435,6 @@ void main() {
           expect(e.exitCode, FakeDevice.kSuccess);
         }
       }, overrides: <Type, Generator>{
-        ApplicationPackageFactory: () => mockApplicationPackageFactory,
         DeviceManager: () => mockDeviceManager,
       });
 
@@ -466,7 +451,6 @@ void main() {
           expect(e.exitCode, FakeDevice.kSuccess);
         }
       }, overrides: <Type, Generator>{
-        ApplicationPackageFactory: () => mockApplicationPackageFactory,
         DeviceManager: () => mockDeviceManager,
       });
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -37,7 +37,6 @@ void main() {
       fileSystem: fileSystem,
       dwarfSymbolizationService: mockDwarfSymbolizationService,
     );
-    applyMocksToCommand(command);
   });
 
   testUsingContext('Regression test for type error in codec', () async {
@@ -81,7 +80,7 @@ void main() {
     expect(result, throwsToolExit(message: ''));
   });
 
-  testUsingContext('symbolize succeedes when DwarfSymbolizationService does not throw', () async {
+  testUsingContext('symbolize succeeds when DwarfSymbolizationService does not throw', () async {
     fileSystem.file('app.debug').writeAsBytesSync(<int>[1, 2, 3]);
     fileSystem.file('foo.stack').writeAsStringSync('hello');
 

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -18,7 +18,6 @@ import 'package:process/process.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/mocks.dart';
 
 void main() {
   group('UpgradeCommandRunner', () {
@@ -331,7 +330,6 @@ void main() {
 
         testUsingContext('upgrade continue prints welcome message', () async {
           final UpgradeCommand upgradeCommand = UpgradeCommand(fakeCommandRunner);
-          applyMocksToCommand(upgradeCommand);
 
           await createTestCommandRunner(upgradeCommand).run(
             <String>[

--- a/packages/flutter_tools/test/general.shard/base/logs_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logs_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_tools/src/commands/logs.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 
 void main() {
   group('logs', () {
@@ -22,7 +21,6 @@ void main() {
 
     testUsingContext('fail with a bad device id', () async {
       final LogsCommand command = LogsCommand();
-      applyMocksToCommand(command);
       try {
         await createTestCommandRunner(command).run(<String>['-d', 'abc123', 'logs']);
         fail('Expect exception');

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -8,7 +8,6 @@ import 'dart:io' as io show IOSink, ProcessSignal, Stdout, StdoutException;
 
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart' show AndroidSdk;
-import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
@@ -21,7 +20,6 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config.dart';
 import 'package:process/process.dart';
@@ -34,31 +32,6 @@ final Generator kNoColorTerminalPlatform = () {
     const LocalPlatform()
   )..stdoutSupportsAnsi = false;
 };
-
-class MockApplicationPackageStore extends ApplicationPackageStore {
-  MockApplicationPackageStore() : super(
-    android: AndroidApk(
-      id: 'io.flutter.android.mock',
-      file: globals.fs.file('/mock/path/to/android/SkyShell.apk'),
-      versionCode: 1,
-      launchActivity: 'io.flutter.android.mock.MockActivity',
-    ),
-    iOS: BuildableIOSApp(MockIosProject(), MockIosProject.bundleId, MockIosProject.appBundleName),
-  );
-}
-
-class MockApplicationPackageFactory extends Mock implements ApplicationPackageFactory {
-  final MockApplicationPackageStore _store = MockApplicationPackageStore();
-
-  @override
-  Future<ApplicationPackage> getPackageForPlatform(
-    TargetPlatform platform, {
-    BuildInfo buildInfo,
-    File applicationBinary,
-  }) async {
-    return _store.getPackageForPlatform(platform, buildInfo);
-  }
-}
 
 /// An SDK installation with several SDK levels (19, 22, 23).
 class MockAndroidSdk extends Mock implements AndroidSdk {
@@ -616,10 +589,6 @@ class MockIOSSimulator extends Mock implements IOSSimulator {
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) => true;
-}
-
-void applyMocksToCommand(FlutterCommand command) {
-  command.applicationPackages = MockApplicationPackageStore();
 }
 
 /// Common functionality for tracking mock interaction.


### PR DESCRIPTION
## Description

This class is entirely superseded by the application package factory. Only drive and install use it, and removing it from drive will allow use-application-binary support.
