### PR TITLE
[NNBD] Migrate some Widgets tests

### DIFF
--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
@@ -342,7 +340,7 @@ Future<void> eventFiring(WidgetTester tester) async {
 }
 
 class StringCollector extends StreamBuilderBase<String, List<String>> {
-  const StringCollector({ Key key, Stream<String> stream }) : super(key: key, stream: stream);
+  const StringCollector({ Key? key, Stream<String>? stream }) : super(key: key, stream: stream);
 
   @override
   List<String> initial() => <String>[];

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -57,7 +55,7 @@ void main() {
     const TextField client1 = TextField(autofillHints: <String>['1']);
     TextField client2 = const TextField(autofillHints: <String>[]);
 
-    StateSetter setState;
+    late StateSetter setState;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -170,7 +168,7 @@ void main() {
   });
 
   testWidgets('disposing AutofillGroups', (WidgetTester tester) async {
-    StateSetter setState;
+    late StateSetter setState;
     const Key group1 = Key('group1');
     const Key group2 = Key('group2');
     const Key group3 = Key('group3');

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 
 class Leaf extends StatefulWidget {
-  const Leaf({ Key key, this.child }) : super(key: key);
+  const Leaf({ required Key key, required this.child }) : super(key: key);
   final Widget child;
   @override
   _LeafState createState() => _LeafState();
@@ -18,7 +16,7 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  KeepAliveHandle _handle;
+  KeepAliveHandle? _handle;
 
   @override
   void deactivate() {
@@ -32,7 +30,7 @@ class _LeafState extends State<Leaf> {
     if (_keepAlive) {
       if (_handle == null) {
         _handle = KeepAliveHandle();
-        KeepAliveNotification(_handle).dispatch(context);
+        KeepAliveNotification(_handle!).dispatch(context);
       }
     } else {
       _handle?.release();
@@ -44,13 +42,13 @@ class _LeafState extends State<Leaf> {
   Widget build(BuildContext context) {
     if (_keepAlive && _handle == null) {
       _handle = KeepAliveHandle();
-      KeepAliveNotification(_handle).dispatch(context);
+      KeepAliveNotification(_handle!).dispatch(context);
     }
     return widget.child;
   }
 }
 
-List<Widget> generateList(Widget child, { @required bool impliedMode }) {
+List<Widget> generateList(Widget child, { required bool impliedMode }) {
   return List<Widget>.generate(
     100,
     (int index) {
@@ -66,7 +64,7 @@ List<Widget> generateList(Widget child, { @required bool impliedMode }) {
   );
 }
 
-void tests({ @required bool impliedMode }) {
+void tests({ required bool impliedMode }) {
   testWidgets('AutomaticKeepAlive with ListView with itemExtent', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
@@ -95,7 +93,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(true);
     await tester.drag(find.byType(ListView), const Offset(0.0, 300.0)); // back to top
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
@@ -105,7 +103,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61), skipOffstage: false), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
@@ -145,7 +143,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(true);
     await tester.drag(find.byType(ListView), const Offset(0.0, 300.0)); // back to top
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
@@ -155,7 +153,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61), skipOffstage: false), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
@@ -197,7 +195,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(true);
     await tester.drag(find.byType(GridView), const Offset(0.0, 300.0)); // back to top
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
@@ -207,7 +205,7 @@ void tests({ @required bool impliedMode }) {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(60)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(61), skipOffstage: false), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(90), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(60).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(60).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(30)), findsOneWidget);
@@ -273,7 +271,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(0).currentState!.setKeepAlive(true);
     await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0)); // move to bottom
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0), skipOffstage: false), findsOneWidget);
@@ -282,7 +280,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
-    const GlobalObjectKey<_LeafState>(1).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(1).currentState!.setKeepAlive(true);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0), skipOffstage: false), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1), skipOffstage: false), findsOneWidget);
@@ -290,7 +288,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
-    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(0).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0), skipOffstage: false), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1), skipOffstage: false), findsOneWidget);
@@ -298,7 +296,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
-    const GlobalObjectKey<_LeafState>(1).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(1).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0), skipOffstage: false), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1), skipOffstage: false), findsNothing);
@@ -353,7 +351,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(3)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(4), skipOffstage: false), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(5), skipOffstage: false), findsNothing);
-    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(true);
+    const GlobalObjectKey<_LeafState>(0).currentState!.setKeepAlive(true);
     await tester.drag(find.byType(ListView), const Offset(0.0, -1000.0)); // move to bottom
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0), skipOffstage: false), findsOneWidget);
@@ -420,7 +418,7 @@ void main() {
     expect(find.byKey(const GlobalObjectKey<_LeafState>(4)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(5)), findsNothing);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(0)), findsNothing);
-    const GlobalObjectKey<_LeafState>(0).currentState.setKeepAlive(false);
+    const GlobalObjectKey<_LeafState>(0).currentState!.setKeepAlive(false);
     await tester.pump();
     expect(find.byKey(const GlobalObjectKey<_LeafState>(1)), findsOneWidget);
     expect(find.byKey(const GlobalObjectKey<_LeafState>(2)), findsOneWidget);
@@ -562,7 +560,7 @@ void main() {
 }
 
 class _AlwaysKeepAlive extends StatefulWidget {
-  const _AlwaysKeepAlive({Key key}) : super(key: key);
+  const _AlwaysKeepAlive({ required Key key }) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _AlwaysKeepAliveState();
@@ -614,16 +612,16 @@ class RenderSliverMultiBoxAdaptorAlt extends RenderSliver with
     RenderSliverWithKeepAliveMixin {
 
   RenderSliverMultiBoxAdaptorAlt({
-    RenderSliverBoxChildManager childManager,
+    RenderSliverBoxChildManager? childManager,
   }) : _childManager = childManager;
 
   @protected
-  RenderSliverBoxChildManager get childManager => _childManager;
-  final RenderSliverBoxChildManager _childManager;
+  RenderSliverBoxChildManager? get childManager => _childManager;
+  final RenderSliverBoxChildManager? _childManager;
 
   final List<RenderBox> children = <RenderBox>[];
 
-  void insert(RenderBox child, { RenderBox after }) {
+  void insert(RenderBox child, { RenderBox? after }) {
     children.add(child);
   }
 

--- a/packages/flutter/test/widgets/backdrop_filter_test.dart
+++ b/packages/flutter/test/widgets/backdrop_filter_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/widgets/baseline_test.dart
+++ b/packages/flutter/test/widgets/baseline_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
@@ -116,7 +114,7 @@ void main() {
 }
 
 class BaselineDetector extends LeafRenderObjectWidget {
-  const BaselineDetector(this.callback, { Key key }) : super(key: key);
+  const BaselineDetector(this.callback, { Key? key }) : super(key: key);
 
   final VoidCallback callback;
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:math' as math;
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -347,8 +345,8 @@ void main() {
   });
 
   group('ColoredBox', () {
-    _MockCanvas mockCanvas;
-    _MockPaintingContext mockContext;
+    late _MockCanvas mockCanvas;
+    late _MockPaintingContext mockContext;
     const Color colorToPaint = Color(0xFFABCDEF);
 
     setUp(() {
@@ -456,7 +454,7 @@ void main() {
 
   testWidgets('IgnorePointer ignores pointers', (WidgetTester tester) async {
     final List<String> logs = <String>[];
-    Widget target({bool ignoring}) => Align(
+    Widget target({required bool ignoring}) => Align(
       alignment: Alignment.topLeft,
       child: Directionality(
         textDirection: TextDirection.ltr,
@@ -534,7 +532,7 @@ void main() {
 
   testWidgets('AbsorbPointer absorbs pointers', (WidgetTester tester) async {
     final List<String> logs = <String>[];
-    Widget target({bool absorbing}) => Align(
+    Widget target({required bool absorbing}) => Align(
       alignment: Alignment.topLeft,
       child: Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/binding_attach_root_widget_test.dart
+++ b/packages/flutter/test/widgets/binding_attach_root_widget_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 
 import 'package:flutter/scheduler.dart';
@@ -14,12 +12,12 @@ import 'package:flutter/widgets.dart';
 void main() {
   test('attachRootWidget will schedule a frame', () async {
     final WidgetsFlutterBinding binding = WidgetsFlutterBinding.ensureInitialized() as WidgetsFlutterBinding;
-    expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
+    expect(SchedulerBinding.instance!.hasScheduledFrame, isFalse);
     // Framework starts with detached statue. Sends resumed signal to enable frame.
-    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
 
     binding.attachRootWidget(const Placeholder());
-    expect(SchedulerBinding.instance.hasScheduledFrame, isTrue);
+    expect(SchedulerBinding.instance!.hasScheduledFrame, isTrue);
   });
 }

--- a/packages/flutter/test/widgets/binding_cannot_schedule_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_cannot_schedule_frame_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 
 import 'package:flutter/scheduler.dart';
@@ -14,22 +12,22 @@ import 'package:flutter/widgets.dart';
 void main() {
   test('Can only schedule frames after widget binding attaches the root widget', () async {
     final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
-    expect(SchedulerBinding.instance.framesEnabled, isFalse);
-    expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
+    expect(SchedulerBinding.instance!.framesEnabled, isFalse);
+    expect(SchedulerBinding.instance!.hasScheduledFrame, isFalse);
     // Sends a message to notify that the engine is ready to accept frames.
-    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
 
     // Enables the semantics should not schedule any frames if the root widget
     // has not been attached.
     binding.setSemanticsEnabled(true);
-    expect(SchedulerBinding.instance.framesEnabled, isFalse);
-    expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
+    expect(SchedulerBinding.instance!.framesEnabled, isFalse);
+    expect(SchedulerBinding.instance!.hasScheduledFrame, isFalse);
 
     // The widget binding should be ready to produce frames after it attaches
     // the root widget.
     binding.attachRootWidget(const Placeholder());
-    expect(SchedulerBinding.instance.framesEnabled, isTrue);
-    expect(SchedulerBinding.instance.hasScheduledFrame, isTrue);
+    expect(SchedulerBinding.instance!.framesEnabled, isTrue);
+    expect(SchedulerBinding.instance!.hasScheduledFrame, isTrue);
   });
 }

--- a/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter/rendering.dart';
@@ -16,7 +14,7 @@ const String _loading = 'Loading...';
 
 void main() {
   testWidgets('deferFirstFrame/allowFirstFrame stops sending frames to engine', (WidgetTester tester) async {
-    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+    expect(RendererBinding.instance!.sendFramesToEngine, isTrue);
 
     final Completer<void> completer = Completer<void>();
     await tester.pumpWidget(
@@ -32,28 +30,28 @@ void main() {
 
     expect(find.text(_loading), findsOneWidget);
     expect(find.text(_actualContent), findsNothing);
-    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+    expect(RendererBinding.instance!.sendFramesToEngine, isFalse);
 
     await tester.pump();
     expect(find.text(_loading), findsOneWidget);
     expect(find.text(_actualContent), findsNothing);
-    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+    expect(RendererBinding.instance!.sendFramesToEngine, isFalse);
     expect(state.doneLoading, isFalse);
 
     // Complete the future to start sending frames.
     completer.complete();
     await tester.idle();
     expect(state.doneLoading, isTrue);
-    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+    expect(RendererBinding.instance!.sendFramesToEngine, isTrue);
 
     await tester.pump();
     expect(find.text(_loading), findsNothing);
     expect(find.text(_actualContent), findsOneWidget);
-    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+    expect(RendererBinding.instance!.sendFramesToEngine, isTrue);
   });
 
   testWidgets('Two widgets can defer frames', (WidgetTester tester) async {
-    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+    expect(RendererBinding.instance!.sendFramesToEngine, isTrue);
 
     final Completer<void> completer1 = Completer<void>();
     final Completer<void> completer2 = Completer<void>();
@@ -76,7 +74,7 @@ void main() {
     );
     expect(find.text(_loading), findsNWidgets(2));
     expect(find.text(_actualContent), findsNothing);
-    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+    expect(RendererBinding.instance!.sendFramesToEngine, isFalse);
 
     completer1.complete();
     completer2.complete();
@@ -85,12 +83,12 @@ void main() {
     await tester.pump();
     expect(find.text(_loading), findsNothing);
     expect(find.text(_actualContent), findsNWidgets(2));
-    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+    expect(RendererBinding.instance!.sendFramesToEngine, isTrue);
   });
 }
 
 class _DeferringWidget extends StatefulWidget {
-  const _DeferringWidget({Key key, this.loader}) : super(key: key);
+  const _DeferringWidget({required Key key, required this.loader}) : super(key: key);
 
   final Future<void> loader;
 
@@ -104,11 +102,11 @@ class _DeferringWidgetState extends State<_DeferringWidget> {
   @override
   void initState() {
     super.initState();
-    RendererBinding.instance.deferFirstFrame();
+    RendererBinding.instance!.deferFirstFrame();
     widget.loader.then((_) {
       setState(() {
         doneLoading = true;
-        RendererBinding.instance.allowFirstFrame();
+        RendererBinding.instance!.allowFirstFrame();
       });
     });
   }

--- a/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -21,14 +19,14 @@ void main() {
 
       // Simulates the engine completing a frame render to trigger the
       // appropriate callback setting [WidgetBinding.firstFrameRasterized].
-      binding.window.onReportTimings(<FrameTiming>[]);
+      binding.window.onReportTimings!(<FrameTiming>[]);
       expect(binding.firstFrameRasterized, isFalse);
 
       binding.allowFirstFrame();
       fakeAsync.flushTimers();
 
       // Simulates the engine again.
-      binding.window.onReportTimings(<FrameTiming>[]);
+      binding.window.onReportTimings!(<FrameTiming>[]);
       expect(binding.firstFrameRasterized, isTrue);
     });
   });

--- a/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
+++ b/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 import 'dart:ui' show window;
 
@@ -27,8 +25,8 @@ void main() {
     expect(window.onDrawFrame, isNull);
 
     // Framework starts with detached statue. Sends resumed signal to enable frame.
-    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
 
     // A frame can only be scheduled when there is a root widget.
     binding.attachRootWidget(const Placeholder());

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -21,7 +19,7 @@ class MemoryPressureObserver with WidgetsBindingObserver {
 }
 
 class AppLifecycleStateObserver with WidgetsBindingObserver {
-  AppLifecycleState lifecycleState;
+  late AppLifecycleState lifecycleState;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
@@ -30,7 +28,7 @@ class AppLifecycleStateObserver with WidgetsBindingObserver {
 }
 
 class PushRouteObserver with WidgetsBindingObserver {
-  String pushedRoute;
+  late String pushedRoute;
 
   @override
   Future<bool> didPushRoute(String route) async {
@@ -40,7 +38,7 @@ class PushRouteObserver with WidgetsBindingObserver {
 }
 
 class PushRouteInformationObserver with WidgetsBindingObserver {
-  RouteInformation pushedRouteInformation;
+  late RouteInformation pushedRouteInformation;
 
   @override
   Future<bool> didPushRouteInformation(RouteInformation routeInformation) async {
@@ -56,52 +54,52 @@ void main() {
 
   testWidgets('didHaveMemoryPressure callback', (WidgetTester tester) async {
     final MemoryPressureObserver observer = MemoryPressureObserver();
-    WidgetsBinding.instance.addObserver(observer);
+    WidgetsBinding.instance!.addObserver(observer);
     final ByteData message = const JSONMessageCodec().encodeMessage(
-      <String, dynamic>{'type': 'memoryPressure'});
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/system', message, (_) { });
+      <String, dynamic>{'type': 'memoryPressure'})!;
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/system', message, (_) { });
     expect(observer.sawMemoryPressure, true);
-    WidgetsBinding.instance.removeObserver(observer);
+    WidgetsBinding.instance!.removeObserver(observer);
   });
 
   testWidgets('handleLifecycleStateChanged callback', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance.defaultBinaryMessenger;
+    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance!.defaultBinaryMessenger;
     final AppLifecycleStateObserver observer = AppLifecycleStateObserver();
-    WidgetsBinding.instance.addObserver(observer);
+    WidgetsBinding.instance!.addObserver(observer);
 
-    ByteData message = const StringCodec().encodeMessage('AppLifecycleState.paused');
+    ByteData message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(observer.lifecycleState, AppLifecycleState.paused);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
+    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(observer.lifecycleState, AppLifecycleState.resumed);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive');
+    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(observer.lifecycleState, AppLifecycleState.inactive);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.detached');
+    message = const StringCodec().encodeMessage('AppLifecycleState.detached')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(observer.lifecycleState, AppLifecycleState.detached);
   });
 
   testWidgets('didPushRoute callback', (WidgetTester tester) async {
     final PushRouteObserver observer = PushRouteObserver();
-    WidgetsBinding.instance.addObserver(observer);
+    WidgetsBinding.instance!.addObserver(observer);
 
     const String testRouteName = 'testRouteName';
     final ByteData message = const JSONMethodCodec().encodeMethodCall(
       const MethodCall('pushRoute', testRouteName));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     expect(observer.pushedRoute, testRouteName);
 
-    WidgetsBinding.instance.removeObserver(observer);
+    WidgetsBinding.instance!.removeObserver(observer);
   });
 
   testWidgets('didPushRouteInformation calls didPushRoute by default', (WidgetTester tester) async {
     final PushRouteObserver observer = PushRouteObserver();
-    WidgetsBinding.instance.addObserver(observer);
+    WidgetsBinding.instance!.addObserver(observer);
 
     const Map<String, dynamic> testRouteInformation = <String, dynamic>{
       'location': 'testRouteName',
@@ -110,14 +108,14 @@ void main() {
     };
     final ByteData message = const JSONMethodCodec().encodeMethodCall(
       const MethodCall('pushRouteInformation', testRouteInformation));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     expect(observer.pushedRoute, 'testRouteName');
-    WidgetsBinding.instance.removeObserver(observer);
+    WidgetsBinding.instance!.removeObserver(observer);
   });
 
   testWidgets('didPushRouteInformation callback', (WidgetTester tester) async {
     final PushRouteInformationObserver observer = PushRouteInformationObserver();
-    WidgetsBinding.instance.addObserver(observer);
+    WidgetsBinding.instance!.addObserver(observer);
 
     const Map<String, dynamic> testRouteInformation = <String, dynamic>{
       'location': 'testRouteName',
@@ -125,42 +123,42 @@ void main() {
     };
     final ByteData message = const JSONMethodCodec().encodeMethodCall(
       const MethodCall('pushRouteInformation', testRouteInformation));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     expect(observer.pushedRouteInformation.location, 'testRouteName');
     expect(observer.pushedRouteInformation.state, 'state');
-    WidgetsBinding.instance.removeObserver(observer);
+    WidgetsBinding.instance!.removeObserver(observer);
   });
 
   testWidgets('Application lifecycle affects frame scheduling', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance.defaultBinaryMessenger;
+    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance!.defaultBinaryMessenger;
     ByteData message;
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.paused');
+    message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
-    expect(tester.binding.hasScheduledFrame, isTrue);
-    await tester.pump();
-    expect(tester.binding.hasScheduledFrame, isFalse);
-
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive');
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
-    expect(tester.binding.hasScheduledFrame, isFalse);
-
-    message = const StringCodec().encodeMessage('AppLifecycleState.detached');
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
-    expect(tester.binding.hasScheduledFrame, isFalse);
-
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive');
+    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(tester.binding.hasScheduledFrame, isTrue);
     await tester.pump();
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.paused');
+    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    message = const StringCodec().encodeMessage('AppLifecycleState.detached')!;
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    expect(tester.binding.hasScheduledFrame, isTrue);
+    await tester.pump();
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(tester.binding.hasScheduledFrame, isFalse);
 
@@ -184,14 +182,14 @@ void main() {
     expect(frameCount, 1);
 
     // Get the tester back to a resumed state for subsequent tests.
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed');
+    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(tester.binding.hasScheduledFrame, isTrue);
     await tester.pump();
   });
 
   testWidgets('scheduleFrameCallback error control test', (WidgetTester tester) async {
-    FlutterError error;
+    late FlutterError error;
     try {
       tester.binding.scheduleFrameCallback((Duration _) { }, rescheduling: true);
     } on FlutterError catch (e) {
@@ -223,12 +221,10 @@ void main() {
   });
 
   testWidgets('defaultStackFilter elides framework Element mounting stacks', (WidgetTester tester) async {
-    final FlutterExceptionHandler oldHandler = FlutterError.onError;
-    String filteredStack;
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    late FlutterErrorDetails errorDetails;
     FlutterError.onError = (FlutterErrorDetails details) {
-      expect(details.exception, isAssertionError);
-      expect(filteredStack, isNull);
-      filteredStack = details.toString();
+      errorDetails = details;
     };
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -238,7 +234,10 @@ void main() {
             return Opacity(
               opacity: .5,
               child: Builder(
-                builder: (BuildContext context) => Text(null),
+                builder: (BuildContext context) {
+                  assert(false);
+                  return const Text('');
+                },
               ),
             );
           },
@@ -246,13 +245,14 @@ void main() {
       ),
     ));
     FlutterError.onError = oldHandler;
+    expect(errorDetails.exception, isAssertionError);
     const String toMatch = '...     Normal element mounting (';
-    expect(toMatch.allMatches(filteredStack)?.length, 1);
+    expect(toMatch.allMatches(errorDetails.toString()).length, 1);
   });
 }
 
 class TestStatefulWidget extends StatefulWidget {
-  const TestStatefulWidget({this.child, Key key}) : super(key: key);
+  const TestStatefulWidget({required this.child, Key? key}) : super(key: key);
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
@@ -23,7 +21,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 
   final Future<void> future;
 
-  static ui.Image image;
+  static late ui.Image image;
 
   @override
   Future<TestImageProvider> obtainKey(ImageConfiguration configuration) {
@@ -270,7 +268,7 @@ Future<void> main() async {
 
   testWidgets('Can hit test on BoxDecoration', (WidgetTester tester) async {
 
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
 
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
@@ -307,7 +305,7 @@ Future<void> main() async {
 
   testWidgets('Can hit test on BoxDecoration circle', (WidgetTester tester) async {
 
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
 
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
@@ -346,7 +344,7 @@ Future<void> main() async {
   });
 
   testWidgets('Can hit test on BoxDecoration border', (WidgetTester tester) async {
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];
@@ -388,7 +386,7 @@ Future<void> main() async {
     const double width = 50.0;
     const double radius = 12.3;
 
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];
@@ -448,7 +446,7 @@ Future<void> main() async {
     const double width = 50.0;
     const double radius = 12.3;
 
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];
@@ -496,7 +494,7 @@ Future<void> main() async {
     const double width = 50.0;
     const double radius = 20;
 
-    List<int> itemsTapped;
+    late List<int> itemsTapped;
     const Key key = Key('Container with BoxDecoration');
     Widget buildFrame(Border border) {
       itemsTapped = <int>[];

--- a/packages/flutter/test/widgets/box_sliver_mismatch_test.dart
+++ b/packages/flutter/test/widgets/box_sliver_mismatch_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/build_fail_test.dart
+++ b/packages/flutter/test/widgets/build_fail_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/build_scope_test.dart
+++ b/packages/flutter/test/widgets/build_scope_test.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 import 'test_widgets.dart';
 
 class ProbeWidget extends StatefulWidget {
-  const ProbeWidget({ Key key }) : super(key: key);
+  const ProbeWidget({ Key? key }) : super(key: key);
   @override
   ProbeWidgetState createState() => ProbeWidgetState();
 }
@@ -39,7 +37,7 @@ class ProbeWidgetState extends State<ProbeWidget> {
 }
 
 class BadWidget extends StatelessWidget {
-  const BadWidget(this.parentState, { Key key }) : super(key: key);
+  const BadWidget(this.parentState, { Key? key }) : super(key: key);
 
   final BadWidgetParentState parentState;
 
@@ -51,7 +49,7 @@ class BadWidget extends StatelessWidget {
 }
 
 class BadWidgetParent extends StatefulWidget {
-  const BadWidgetParent({ Key key }) : super(key: key);
+  const BadWidgetParent({ Key? key }) : super(key: key);
   @override
   BadWidgetParentState createState() => BadWidgetParentState();
 }
@@ -71,7 +69,7 @@ class BadWidgetParentState extends State<BadWidgetParent> {
 }
 
 class BadDisposeWidget extends StatefulWidget {
-  const BadDisposeWidget({ Key key }) : super(key: key);
+  const BadDisposeWidget({ Key? key }) : super(key: key);
   @override
   BadDisposeWidgetState createState() => BadDisposeWidgetState();
 }
@@ -91,8 +89,8 @@ class BadDisposeWidgetState extends State<BadDisposeWidget> {
 
 class StatefulWrapper extends StatefulWidget {
   const StatefulWrapper({
-    Key key,
-    this.child,
+    Key? key,
+    required this.child,
   }) : super(key: key);
 
   final Widget child;
@@ -107,8 +105,8 @@ class StatefulWrapperState extends State<StatefulWrapper> {
     setState(() { built = null; });
   }
 
-  int built;
-  int oldBuilt;
+  int? built;
+  late int oldBuilt;
 
   static int buildId = 0;
 
@@ -122,8 +120,8 @@ class StatefulWrapperState extends State<StatefulWrapper> {
 
 class Wrapper extends StatelessWidget {
   const Wrapper({
-    Key key,
-    this.child,
+    Key? key,
+    required this.child,
   }) : super(key: key);
 
   final Widget child;
@@ -148,11 +146,11 @@ void main() {
       right: const ProbeWidget(key: Key('c')),
     ));
     expect(ProbeWidgetState.buildCount, equals(2));
-    final FlipWidgetState flipState1 = flipKey.currentState as FlipWidgetState;
+    final FlipWidgetState flipState1 = flipKey.currentState! as FlipWidgetState;
     flipState1.flip();
     await tester.pump();
     expect(ProbeWidgetState.buildCount, equals(3));
-    final FlipWidgetState flipState2 = flipKey.currentState as FlipWidgetState;
+    final FlipWidgetState flipState2 = flipKey.currentState! as FlipWidgetState;
     flipState2.flip();
     await tester.pump();
     expect(ProbeWidgetState.buildCount, equals(3));
@@ -178,7 +176,7 @@ void main() {
     final GlobalKey key2 = GlobalKey(debugLabel: 'key2');
 
     bool didMiddle = false;
-    Widget middle;
+    late Widget middle;
     final List<StateSetter> setStates = <StateSetter>[];
     Widget builder(BuildContext context, StateSetter setState) {
       setStates.add(setState);
@@ -214,7 +212,7 @@ void main() {
 
     for (final StatefulWrapperState state in tester.stateList<StatefulWrapperState>(find.byType(StatefulWrapper))) {
       expect(state.built, isNotNull);
-      state.oldBuilt = state.built;
+      state.oldBuilt = state.built!;
       state.trigger();
     }
     for (final StateSetter setState in setStates)

--- a/packages/flutter/test/widgets/center_test.dart
+++ b/packages/flutter/test/widgets/center_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -13,7 +11,7 @@ import 'package:flutter/widgets.dart';
 // The top of the bottom widget is at 550 (the top of the top widget
 // is at 0). The top of the bottom widget is 500 when it has been
 // scrolled completely into view.
-Widget buildFrame(ScrollPhysics physics, { ScrollController scrollController }) {
+Widget buildFrame(ScrollPhysics physics, { ScrollController? scrollController }) {
   return SingleChildScrollView(
     key: UniqueKey(),
     physics: physics,

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -43,7 +41,7 @@ class ValueClipper<T> extends CustomClipper<T> {
 }
 
 class NotifyClipper<T> extends CustomClipper<T> {
-  NotifyClipper({this.clip}) : super(reclip: clip);
+  NotifyClipper({required this.clip}) : super(reclip: clip);
 
   final ValueNotifier<T> clip;
 

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -73,7 +73,7 @@ void main() {
 
     await pumpWithColor(Colors.red);
     final RenderObject renderObject = tester.firstRenderObject(find.byType(ColorFiltered));
-    final ColorFilterLayer originalLayer = renderObject.debugLayer as ColorFilterLayer;
+    final ColorFilterLayer originalLayer = renderObject.debugLayer! as ColorFilterLayer;
     expect(originalLayer, isNotNull);
 
     // Change color to force a repaint.

--- a/packages/flutter/test/widgets/column_test.dart
+++ b/packages/flutter/test/widgets/column_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/column_test.dart
+++ b/packages/flutter/test/widgets/column_test.dart
@@ -39,19 +39,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(400.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(100.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
   });
 
@@ -85,19 +85,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(100.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(200.0));
   });
 
@@ -129,13 +129,13 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(200.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(300.0));
   });
 
@@ -169,19 +169,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(300.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(400.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
   });
 
@@ -215,19 +215,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(250.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
   });
 
@@ -263,25 +263,25 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(25.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(175.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(325.0));
 
     renderBox = tester.renderObject(find.byKey(child3Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(475.0));
   });
 
@@ -315,19 +315,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(135.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(290.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(445.0));
   });
 
@@ -423,19 +423,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(400.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(100.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
   });
 
@@ -470,19 +470,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(400.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(300.0));
   });
 
@@ -515,13 +515,13 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(300.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(200.0));
   });
 
@@ -556,19 +556,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(200.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(100.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
   });
 
@@ -603,19 +603,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(250.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(0.0));
   });
 
@@ -652,25 +652,25 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0 - 25.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0 - 175.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0 - 325.0));
 
     renderBox = tester.renderObject(find.byKey(child3Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(100.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(500.0 - 475.0));
   });
 
@@ -705,19 +705,19 @@ void main() {
     renderBox = tester.renderObject(find.byKey(child0Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(600.0 - 135.0 - 20.0));
 
     renderBox = tester.renderObject(find.byKey(child1Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(600.0 - 290.0 - 20.0));
 
     renderBox = tester.renderObject(find.byKey(child2Key));
     expect(renderBox.size.width, equals(100.0));
     expect(renderBox.size.height, equals(20.0));
-    boxParentData = renderBox.parentData as BoxParentData;
+    boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dy, equals(600.0 - 445.0 - 20.0));
   });
 

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -13,7 +11,7 @@ void main() {
 
   testWidgets('Change link during layout', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
-    Widget build({ LayerLink linkToUse }) {
+    Widget build({ LayerLink? linkToUse }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         // The LayoutBuilder forces the CompositedTransformTarget widget to
@@ -49,7 +47,7 @@ void main() {
     }
 
     await tester.pumpWidget(build());
-    final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+    final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
     expect(box.localToGlobal(Offset.zero), const Offset(118.0, 451.0));
 
     await tester.pumpWidget(build(linkToUse: LayerLink()));
@@ -59,7 +57,7 @@ void main() {
   group('Composited transforms - only offsets', () {
     final GlobalKey key = GlobalKey();
 
-    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+    Widget build({ required Alignment targetAlignment, required Alignment followerAlignment }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
@@ -89,19 +87,19 @@ void main() {
 
     testWidgets('topLeft', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
-      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
       expect(box.localToGlobal(Offset.zero), const Offset(123.0, 456.0));
     });
 
     testWidgets('center', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
-      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
       expect(box.localToGlobal(Offset.zero), const Offset(118.0, 451.0));
     });
 
     testWidgets('bottomRight - topRight', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
-      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
       expect(box.localToGlobal(Offset.zero), const Offset(113.0, 466.0));
     });
   });
@@ -110,7 +108,7 @@ void main() {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
 
-    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+    Widget build({ required Alignment targetAlignment, required Alignment followerAlignment }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
@@ -145,8 +143,8 @@ void main() {
     }
     testWidgets('topLeft', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(Offset.zero);
       final Offset position2 = box2.localToGlobal(Offset.zero);
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -154,8 +152,8 @@ void main() {
 
     testWidgets('center', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(const Offset(40, 5));
       final Offset position2 = box2.localToGlobal(const Offset(20, 10));
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -163,8 +161,8 @@ void main() {
 
     testWidgets('bottomRight - topRight', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(const Offset(80, 10));
       final Offset position2 = box2.localToGlobal(const Offset(40, 0));
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -175,7 +173,7 @@ void main() {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
 
-    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+    Widget build({ required Alignment targetAlignment, required Alignment followerAlignment }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
@@ -222,8 +220,8 @@ void main() {
     }
     testWidgets('topLeft', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(Offset.zero);
       final Offset position2 = box2.localToGlobal(Offset.zero);
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -231,8 +229,8 @@ void main() {
 
     testWidgets('center', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.center, followerAlignment: Alignment.center));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(Alignment.center.alongSize(const Size(80, 10)));
       final Offset position2 = box2.localToGlobal(Alignment.center.alongSize(const Size(40, 20)));
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -240,8 +238,8 @@ void main() {
 
     testWidgets('bottomRight - topRight', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.bottomRight, followerAlignment: Alignment.topRight));
-      final RenderBox box1 = key1.currentContext.findRenderObject() as RenderBox;
-      final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+      final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
+      final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
       final Offset position1 = box1.localToGlobal(Alignment.bottomRight.alongSize(const Size(80, 10)));
       final Offset position2 = box2.localToGlobal(Alignment.topRight.alongSize(const Size(40, 20)));
       expect(position1, offsetMoreOrLessEquals(position2));
@@ -255,7 +253,7 @@ void main() {
 
     bool tapped = false;
 
-    Widget build({ @required Alignment targetAlignment, @required Alignment followerAlignment }) {
+    Widget build({ required Alignment targetAlignment, required Alignment followerAlignment }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
@@ -294,7 +292,7 @@ void main() {
       for (final Alignment followerAlignment in alignments) {
         testWidgets('$targetAlignment - $followerAlignment', (WidgetTester tester) async{
           await tester.pumpWidget(build(targetAlignment: targetAlignment, followerAlignment: followerAlignment));
-          final RenderBox box2 = key2.currentContext.findRenderObject() as RenderBox;
+          final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
           expect(box2.size, const Size(2.0, 2.0));
           expect(tapped, isFalse);
           await tester.tap(find.byKey(key3));

--- a/packages/flutter/test/widgets/constrained_box_test.dart
+++ b/packages/flutter/test/widgets/constrained_box_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
@@ -440,7 +438,7 @@ void main() {
 
     final RenderBox decoratedBox = tester.renderObject(find.byType(DecoratedBox).last);
     final PaintingContext context = _MockPaintingContext();
-    FlutterError error;
+    late FlutterError error;
     try {
       decoratedBox.paint(context, const Offset(0, 0));
     } on FlutterError catch (e) {

--- a/packages/flutter/test/widgets/coordinates_test.dart
+++ b/packages/flutter/test/widgets/coordinates_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
-  BoxConstraints getSizeConstraints;
+  late BoxConstraints getSizeConstraints;
 
   @override
   Size getSize(BoxConstraints constraints) {
@@ -19,10 +17,10 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
     return const Size(200.0, 300.0);
   }
 
-  Size performLayoutSize;
-  Size performLayoutSize0;
-  Size performLayoutSize1;
-  bool performLayoutIsChild;
+  Size? performLayoutSize;
+  late Size performLayoutSize0;
+  late Size performLayoutSize1;
+  late bool performLayoutIsChild;
 
   @override
   void performLayout(Size size) {
@@ -60,7 +58,7 @@ Widget buildFrame(MultiChildLayoutDelegate delegate) {
 }
 
 class PreferredSizeDelegate extends MultiChildLayoutDelegate {
-  PreferredSizeDelegate({ this.preferredSize });
+  PreferredSizeDelegate({ required this.preferredSize });
 
   final Size preferredSize;
 
@@ -152,8 +150,8 @@ class InvalidConstraintsChildLayoutDelegate extends MultiChildLayoutDelegate {
 
 class LayoutWithMissingId extends ParentDataWidget<MultiChildLayoutParentData> {
   const LayoutWithMissingId({
-    Key key,
-    @required Widget child,
+    Key? key,
+    required Widget child,
   }) : assert(child != null),
        super(key: key, child: child);
 
@@ -174,8 +172,8 @@ void main() {
     expect(delegate.getSizeConstraints.minHeight, 0.0);
     expect(delegate.getSizeConstraints.maxHeight, 600.0);
 
-    expect(delegate.performLayoutSize.width, 200.0);
-    expect(delegate.performLayoutSize.height, 300.0);
+    expect(delegate.performLayoutSize!.width, 200.0);
+    expect(delegate.performLayoutSize!.height, 300.0);
     expect(delegate.performLayoutSize0.width, 150.0);
     expect(delegate.performLayoutSize0.height, 100.0);
     expect(delegate.performLayoutSize1.width, 100.0);
@@ -285,16 +283,16 @@ void main() {
     }
 
     Future<void> expectFlutterErrorMessage({
-      Widget widget,
-      MultiChildLayoutDelegate delegate,
-      @required WidgetTester tester,
-      @required String message,
+      Widget? widget,
+      MultiChildLayoutDelegate? delegate,
+      required WidgetTester tester,
+      required String message,
     }) async {
-      final FlutterExceptionHandler oldHandler = FlutterError.onError;
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
       final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
       FlutterError.onError = (FlutterErrorDetails error) => errors.add(error);
       try {
-        await tester.pumpWidget(widget ?? buildSingleChildFrame(delegate));
+        await tester.pumpWidget(widget ?? buildSingleChildFrame(delegate!));
       } finally {
         FlutterError.onError = oldHandler;
       }

--- a/packages/flutter/test/widgets/custom_paint_test.dart
+++ b/packages/flutter/test/widgets/custom_paint_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,10 +9,10 @@ import 'package:flutter_test/flutter_test.dart';
 import '../flutter_test_alternative.dart' show Fake;
 
 class TestCustomPainter extends CustomPainter {
-  TestCustomPainter({ this.log, this.name });
+  TestCustomPainter({ required this.log, this.name });
 
-  final List<String> log;
-  final String name;
+  final List<String?> log;
+  final String? name;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -90,12 +88,12 @@ void main() {
       isComplex: true,
       painter: TestCustomPainter(log: log),
     ));
-    final RenderCustomPaint renderCustom = target.currentContext.findRenderObject() as RenderCustomPaint;
+    final RenderCustomPaint renderCustom = target.currentContext!.findRenderObject()! as RenderCustomPaint;
     final MockPaintingContext paintingContext = MockPaintingContext();
     final MockCanvas canvas = paintingContext.canvas;
 
     FlutterError getError() {
-      FlutterError error;
+      late FlutterError error;
       try {
         renderCustom.paint(paintingContext, const Offset(0, 0));
       } on FlutterError catch (e) {
@@ -144,32 +142,32 @@ void main() {
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target),
     ));
-    expect(target.currentContext.size, Size.zero);
+    expect(target.currentContext!.size, Size.zero);
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, child: Container()),
     ));
-    expect(target.currentContext.size, const Size(800.0, 600.0));
+    expect(target.currentContext!.size, const Size(800.0, 600.0));
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, size: const Size(20.0, 20.0)),
     ));
-    expect(target.currentContext.size, const Size(20.0, 20.0));
+    expect(target.currentContext!.size, const Size(20.0, 20.0));
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, size: const Size(2000.0, 100.0)),
     ));
-    expect(target.currentContext.size, const Size(800.0, 100.0));
+    expect(target.currentContext!.size, const Size(800.0, 100.0));
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, size: Size.zero, child: Container()),
     ));
-    expect(target.currentContext.size, const Size(800.0, 600.0));
+    expect(target.currentContext!.size, const Size(800.0, 600.0));
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, child: const SizedBox(height: 0.0, width: 0.0)),
     ));
-    expect(target.currentContext.size, Size.zero);
+    expect(target.currentContext!.size, Size.zero);
 
   });
 
@@ -182,7 +180,7 @@ void main() {
       isComplex: true,
       painter: TestCustomPainter(log: log),
     ));
-    RenderCustomPaint renderCustom = target.currentContext.findRenderObject() as RenderCustomPaint;
+    RenderCustomPaint renderCustom = target.currentContext!.findRenderObject()! as RenderCustomPaint;
     expect(renderCustom.isComplex, true);
     expect(renderCustom.willChange, false);
 
@@ -191,7 +189,7 @@ void main() {
       willChange: true,
       foregroundPainter: TestCustomPainter(log: log),
     ));
-    renderCustom = target.currentContext.findRenderObject() as RenderCustomPaint;
+    renderCustom = target.currentContext!.findRenderObject()! as RenderCustomPaint;
     expect(renderCustom.isComplex, false);
     expect(renderCustom.willChange, true);
   });

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -373,7 +371,7 @@ void _defineTests() {
     expect(semantics, hasSemantics(expectedSemantics, ignoreRect: true, ignoreTransform: true));
 
     // Do the actions work?
-    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner;
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
     int expectedLength = 1;
     for (final SemanticsAction action in allActions) {
       switch (action) {
@@ -710,7 +708,7 @@ class _DiffTester {
   ///
   /// - checks that initial and final configurations are in the desired states.
   /// - checks that keyed nodes have stable IDs.
-  Future<void> diff({ List<String> from, List<String> to }) async {
+  Future<void> diff({ required List<String> from, required List<String> to }) async {
     final SemanticsTester semanticsTester = SemanticsTester(tester);
 
     TestSemantics createExpectations(List<String> labels) {
@@ -735,12 +733,12 @@ class _DiffTester {
     ));
     expect(semanticsTester, hasSemantics(createExpectations(from), ignoreId: true));
 
-    SemanticsNode root = RendererBinding.instance?.renderView?.debugSemantics;
+    SemanticsNode root = RendererBinding.instance!.renderView.debugSemantics!;
     final Map<Key, int> idAssignments = <Key, int>{};
     root.visitChildren((SemanticsNode firstChild) {
       firstChild.visitChildren((SemanticsNode node) {
         if (node.key != null) {
-          idAssignments[node.key] = node.id;
+          idAssignments[node.key!] = node.id;
         }
         return true;
       });
@@ -753,7 +751,7 @@ class _DiffTester {
     await tester.pumpAndSettle();
     expect(semanticsTester, hasSemantics(createExpectations(to), ignoreId: true));
 
-    root = RendererBinding.instance?.renderView?.debugSemantics;
+    root = RendererBinding.instance!.renderView.debugSemantics!;
     root.visitChildren((SemanticsNode firstChild) {
       firstChild.visitChildren((SemanticsNode node) {
         if (node.key != null && idAssignments[node.key] != null) {
@@ -787,7 +785,7 @@ class _SemanticsDiffTest extends CustomPainter {
   List<CustomPainterSemantics> buildSemantics(Size size) {
     final List<CustomPainterSemantics> semantics = <CustomPainterSemantics>[];
     for (final String label in data) {
-      Key key;
+      Key? key;
       if (label.endsWith('-k')) {
         key = ValueKey<String>(label);
       }
@@ -810,7 +808,7 @@ class _SemanticsDiffTest extends CustomPainter {
 }
 
 class _PainterWithSemantics extends CustomPainter {
-  _PainterWithSemantics({ this.semantics });
+  _PainterWithSemantics({ required this.semantics });
 
   final CustomPainterSemantics semantics;
 

--- a/packages/flutter/test/widgets/custom_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/custom_scroll_view_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/custom_single_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_single_child_layout_test.dart
@@ -2,17 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 class TestSingleChildLayoutDelegate extends SingleChildLayoutDelegate {
-  BoxConstraints constraintsFromGetSize;
-  BoxConstraints constraintsFromGetConstraintsForChild;
-  Size sizeFromGetPositionForChild;
-  Size childSizeFromGetPositionForChild;
+  late BoxConstraints constraintsFromGetSize;
+  BoxConstraints? constraintsFromGetConstraintsForChild;
+  late Size sizeFromGetPositionForChild;
+  late Size childSizeFromGetPositionForChild;
 
   @override
   Size getSize(BoxConstraints constraints) {
@@ -105,10 +103,10 @@ void main() {
     expect(delegate.constraintsFromGetSize.minHeight, 0.0);
     expect(delegate.constraintsFromGetSize.maxHeight, 600.0);
 
-    expect(delegate.constraintsFromGetConstraintsForChild.minWidth, 0.0);
-    expect(delegate.constraintsFromGetConstraintsForChild.maxWidth, 800.0);
-    expect(delegate.constraintsFromGetConstraintsForChild.minHeight, 0.0);
-    expect(delegate.constraintsFromGetConstraintsForChild.maxHeight, 600.0);
+    expect(delegate.constraintsFromGetConstraintsForChild!.minWidth, 0.0);
+    expect(delegate.constraintsFromGetConstraintsForChild!.maxWidth, 800.0);
+    expect(delegate.constraintsFromGetConstraintsForChild!.minHeight, 0.0);
+    expect(delegate.constraintsFromGetConstraintsForChild!.maxHeight, 600.0);
 
     expect(delegate.sizeFromGetPositionForChild.width, 200.0);
     expect(delegate.sizeFromGetPositionForChild.height, 300.0);

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,7 +17,7 @@ void main() {
       direction: Axis.vertical,
       children: children
     );
-    FlutterError error;
+    late FlutterError error;
     try {
       debugChildrenHaveDuplicateKeys(widget, children);
     } on FlutterError catch (e) {
@@ -47,7 +45,7 @@ void main() {
       Container(key: key),
       Container(key: key),
     ];
-    FlutterError error;
+    late FlutterError error;
     try {
       debugItemsHaveDuplicateKeys(items);
     } on FlutterError catch (e) {
@@ -68,7 +66,7 @@ void main() {
     await tester.pumpWidget(
       Builder(
         builder: (BuildContext context) {
-          FlutterError error;
+          late FlutterError error;
           try {
             debugCheckHasTable(context);
           } on FlutterError catch (e) {
@@ -100,7 +98,7 @@ void main() {
     await tester.pumpWidget(
       Builder(
         builder: (BuildContext context) {
-          FlutterError error;
+          late FlutterError error;
           try {
             debugCheckHasMediaQuery(context);
           } on FlutterError catch (e) {
@@ -141,14 +139,14 @@ void main() {
 
   test('debugWidgetBuilderValue control test', () {
     final Widget widget = Container();
-    FlutterError error;
+    FlutterError? error;
     try {
       debugWidgetBuilderValue(widget, null);
     } on FlutterError catch (e) {
       error = e;
     } finally {
       expect(error, isNotNull);
-      expect(error.diagnostics.length, 4);
+      expect(error!.diagnostics.length, 4);
       expect(error.diagnostics[1], isA<DiagnosticsProperty<Widget>>());
       expect(error.diagnostics[1].style, DiagnosticsTreeStyle.errorProperty);
       expect(
@@ -191,7 +189,7 @@ void main() {
       error = e;
     } finally {
       expect(error, isNotNull);
-      expect(error.diagnostics.length, 3);
+      expect(error!.diagnostics.length, 3);
       expect(error.diagnostics[1], isA<DiagnosticsProperty<Widget>>());
       expect(error.diagnostics[1].style, DiagnosticsTreeStyle.errorProperty);
       expect(
@@ -219,7 +217,7 @@ void main() {
 
   test('debugAssertAllWidgetVarsUnset', () {
     debugHighlightDeprecatedWidgets = true;
-    FlutterError error;
+    late FlutterError error;
     try {
       debugAssertAllWidgetVarsUnset('The value of a widget debug variable was changed by the test.');
     } on FlutterError catch (e) {

--- a/packages/flutter/test/widgets/default_text_height_behavior_test.dart
+++ b/packages/flutter/test/widgets/default_text_height_behavior_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' show TextHeightBehavior;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -117,7 +115,7 @@ void main() {
   testWidgets('DefaultTextHeightBehavior.of(context) returns null if no '
       'DefaultTextHeightBehavior widget in tree', (WidgetTester tester) async {
     const Text textWidget = Text('Hello', textDirection: TextDirection.ltr);
-    TextHeightBehavior textHeightBehavior;
+    TextHeightBehavior? textHeightBehavior;
 
     await tester.pumpWidget(Builder(
       builder: (BuildContext context) {

--- a/packages/flutter/test/widgets/default_text_style_test.dart
+++ b/packages/flutter/test/widgets/default_text_style_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui show TextHeightBehavior;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/directionality_test.dart
+++ b/packages/flutter/test/widgets/directionality_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -12,7 +10,7 @@ void main() {
     final List<TextDirection> log = <TextDirection>[];
     final Widget inner = Builder(
       builder: (BuildContext context) {
-        log.add(Directionality.of(context));
+        log.add(Directionality.of(context)!);
         return const Placeholder();
       }
     );
@@ -63,11 +61,5 @@ void main() {
       },
     ));
     expect(good, isTrue);
-  });
-
-  testWidgets("Directionality can't be null", (WidgetTester tester) async {
-    expect(() {
-      Directionality(textDirection: nonconst(null), child: const Placeholder());
-    }, throwsAssertionError);
   });
 }


### PR DESCRIPTION
## Description

This migrates several tests from the widgets library to NNBD.


## Related Issues

dart-lang/sdk#40146
#62886

## Tests

Pass!

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
