### PR TITLE
Detach debugger when VM connection fails on iOS

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -468,10 +468,12 @@ class IOSDevice extends Device {
         packageName: FlutterProject.current().manifest.appName,
       );
       if (localUri == null) {
+        iosDeployDebugger?.detach();
         return LaunchResult.failed();
       }
       return LaunchResult.succeeded(observatoryUri: localUri);
     } on ProcessException catch (e) {
+      iosDeployDebugger?.detach();
       _logger.printError(e.message);
       return LaunchResult.failed();
     } finally {

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -25,6 +25,9 @@ const String noProvisioningProfileErrorTwo = 'Error 0xe8000067';
 const String deviceLockedError = 'e80000e2';
 const String unknownAppLaunchError = 'Error 0xe8000022';
 
+// Another debugger instance is already attached?
+const String processLaunchFailedError = 'error: process launch failed';
+
 class IOSDeploy {
   IOSDeploy({
     @required Artifacts artifacts,
@@ -412,6 +415,13 @@ Error launching app. Try launching from within Xcode via:
     open ios/Runner.xcworkspace
 
 Your Xcode version may be too old for your iOS version.
+═══════════════════════════════════════════════════════════════════════════════════''',
+        emphasis: true);
+  } else if (stdout.contains(processLaunchFailedError)) {
+    logger.printError('''
+═══════════════════════════════════════════════════════════════════════════════════
+Could not attach the debugger.
+Try uninstalling the app from your device and retrying.
 ═══════════════════════════════════════════════════════════════════════════════════''',
         emphasis: true);
   }

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -210,6 +210,21 @@ void main () {
         await iosDeployDebugger.launchAndAttach();
         expect(logger.errorText, contains('Try launching from within Xcode'));
       });
+
+      testWithoutContext('cannot attach', () async {
+        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['ios-deploy'],
+            stdout: 'error: process launch failed: timed out waiting for app to launch',
+          ),
+        ]);
+        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+          processManager: processManager,
+          logger: logger,
+        );
+        await iosDeployDebugger.launchAndAttach();
+        expect(logger.errorText, contains('Could not attach the debugger'));
+      });
     });
 
     testWithoutContext('detach', () async {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -431,7 +431,7 @@ void main() {
             bundlePath: anyNamed('bundlePath'),
             launchArguments: anyNamed('launchArguments'),
             interfaceType: anyNamed('interfaceType')))
-        .thenAnswer((_) => Future<int>.value(0));
+        .thenAnswer((_) async => 0);
 
     when(mockIOSDeployDebugger.launchAndAttach()).thenAnswer((_) async => true);
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -411,6 +411,62 @@ void main() {
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   });
+
+  // Still uses context for analytics.
+  testUsingContext(
+      'IOSDevice.startApp detaches lldb when VM service connection fails',
+      () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+
+    final MockIOSDeploy mockIOSDeploy = MockIOSDeploy();
+    final MockIOSDeployDebugger mockIOSDeployDebugger = MockIOSDeployDebugger();
+    when(mockIOSDeploy.prepareDebuggerForLaunch(
+            deviceId: anyNamed('deviceId'),
+            bundlePath: anyNamed('bundlePath'),
+            launchArguments: anyNamed('launchArguments'),
+            interfaceType: anyNamed('interfaceType')))
+        .thenReturn(mockIOSDeployDebugger);
+    when(mockIOSDeploy.installApp(
+            deviceId: anyNamed('deviceId'),
+            bundlePath: anyNamed('bundlePath'),
+            launchArguments: anyNamed('launchArguments'),
+            interfaceType: anyNamed('interfaceType')))
+        .thenAnswer((_) => Future<int>.value(0));
+
+    when(mockIOSDeployDebugger.launchAndAttach()).thenAnswer((_) async => true);
+
+    final IOSDevice device = setUpIOSDevice(
+      fileSystem: fileSystem,
+      iosDeploy: mockIOSDeploy,
+      vmServiceConnector: (String string, {Log log}) async {
+        throw const io.SocketException(
+          'OS Error: Connection refused, errno = 61, address = localhost, port '
+          '= 58943',
+        );
+      },
+    );
+    final IOSApp iosApp = PrebuiltIOSApp(
+      projectBundleId: 'app',
+      bundleName: 'Runner',
+      bundleDir: fileSystem.currentDirectory,
+    );
+    device.portForwarder = const NoOpDevicePortForwarder();
+    device.setLogReader(iosApp, FakeDeviceLogReader());
+
+    final LaunchResult launchResult = await device.startApp(
+      iosApp,
+      prebuiltApplication: true,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
+      fallbackThrottleTimeout: const Duration(milliseconds: 10),
+    );
+
+    expect(launchResult.started, false);
+    verify(mockIOSDeployDebugger.detach()).called(1);
+  }, overrides: <Type, Generator>{
+    Usage: () => MockUsage(),
+  });
 }
 
 IOSDevice setUpIOSDevice({
@@ -419,6 +475,7 @@ IOSDevice setUpIOSDevice({
   Logger logger,
   ProcessManager processManager,
   VmServiceConnector vmServiceConnector,
+  IOSDeploy iosDeploy,
 }) {
   final Artifacts artifacts = Artifacts.test();
   final FakePlatform macPlatform = FakePlatform(
@@ -441,13 +498,14 @@ IOSDevice setUpIOSDevice({
     platform: macPlatform,
     iProxy: IProxy.test(logger: logger, processManager: processManager ?? FakeProcessManager.any()),
     logger: logger ?? BufferLogger.test(),
-    iosDeploy: IOSDeploy(
-      logger: logger ?? BufferLogger.test(),
-      platform: macPlatform,
-      processManager: processManager ?? FakeProcessManager.any(),
-      artifacts: artifacts,
-      cache: cache,
-    ),
+    iosDeploy: iosDeploy ??
+        IOSDeploy(
+          logger: logger ?? BufferLogger.test(),
+          platform: macPlatform,
+          processManager: processManager ?? FakeProcessManager.any(),
+          artifacts: artifacts,
+          cache: cache,
+        ),
     iMobileDevice: IMobileDevice(
       logger: logger ?? BufferLogger.test(),
       processManager: processManager ?? FakeProcessManager.any(),
@@ -461,7 +519,9 @@ IOSDevice setUpIOSDevice({
 }
 
 class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
-class MockDeviceLogReader extends Mock implements DeviceLogReader  {}
+class MockDeviceLogReader extends Mock implements DeviceLogReader {}
 class MockUsage extends Mock implements Usage {}
 class MockVmService extends Mock implements VmService {}
 class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
+class MockIOSDeployDebugger extends Mock implements IOSDeployDebugger {}
+class MockIOSDeploy extends Mock implements IOSDeploy {}


### PR DESCRIPTION
## Description
When the debugger attaches but the tool cannot connect to the VM service (for any reason), detach the debugger before failing.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68035

## Tests

Added a detach test.  I know this is mock heavy but the code path is hard to test... We can reinvestigate with all our other mocks once we know what our limitations are in null safety land.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*