### PR TITLE
[flutter_tool] support --use-application-binary in flutter drive

### DIFF
--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -62,21 +62,40 @@ class GalleryTransitionTest {
     final Device device = await devices.workingDevice;
     await device.unlock();
     final String deviceId = device.deviceId;
-    final Directory galleryDirectory =
-        dir('${flutterDirectory.path}/dev/integration_tests/flutter_gallery');
+    final Directory galleryDirectory = dir('${flutterDirectory.path}/dev/integration_tests/flutter_gallery');
     await inDirectory<void>(galleryDirectory, () async {
-      await flutter('packages', options: <String>['get']);
+      String applicationBinaryPath;
+      if (deviceOperatingSystem == DeviceOperatingSystem.android) {
+        section('BUILDING APPLICATION');
+        await flutter(
+          'build',
+          options: <String>[
+            'apk',
+            '--profile',
+            '-t',
+            'test_driver/$testFile.dart',
+            '--target-platform',
+            'android-arm,android-arm64',
+          ],
+        );
+        applicationBinaryPath = 'build/app/outputs/flutter-apk/app-profile.apk';
+      }
 
       final String testDriver = driverFile ?? (semanticsEnabled
           ? '${testFile}_with_semantics_test'
           : '${testFile}_test');
-
+      section('DRIVE START');
       await flutter('drive', options: <String>[
         '--profile',
         if (needFullTimeline)
           '--trace-startup',
-        '-t',
-        'test_driver/$testFile.dart',
+        if (applicationBinaryPath != null)
+          '--use-application-binary=$applicationBinaryPath'
+        else
+          ...<String>[
+            '-t',
+            'test_driver/$testFile.dart',
+          ],
         '--driver',
         'test_driver/$testDriver.dart',
         '-d',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -572,7 +572,6 @@ class PerfTest {
   @protected
   Future<TaskResult> internalRun({
       bool cacheSkSL = false,
-      bool noBuild = false,
       String existingApp,
       String writeSkslFileName,
   }) {
@@ -589,7 +588,6 @@ class PerfTest {
         if (needsFullTimeline)
           '--trace-startup', // Enables "endless" timeline event buffering.
         '-t', testTarget,
-        if (noBuild) '--no-build',
         if (testDriver != null)
           ...<String>['--driver', testDriver],
         if (existingApp != null)
@@ -730,7 +728,6 @@ class PerfTestWithSkSL extends PerfTest {
     // that we won't remove the SkSLs generated earlier.
     await super.internalRun(
       cacheSkSL: true,
-      noBuild: true,
       writeSkslFileName: _skslJsonFileName,
     );
   }

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -468,7 +468,7 @@ Future<LaunchResult> _startApp(
 
   final File applicationBinary = command.stringArg('use-application-binary') == null
     ? null
-    : globals.fs.file( command.stringArg('use-application-binary'));
+    : globals.fs.file(command.stringArg('use-application-binary'));
   final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(
     await command.device.targetPlatform,
     buildInfo: command.getBuildInfo(),

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -466,8 +466,14 @@ Future<LaunchResult> _startApp(
   globals.printTrace('Stopping previously running application, if any.');
   await appStopper(command);
 
-  final ApplicationPackage package = await command.applicationPackages
-    .getPackageForPlatform(await command.device.targetPlatform, buildInfo: command.getBuildInfo());
+  final File applicationBinary = command.stringArg('use-application-binary') == null
+    ? null
+    : globals.fs.file( command.stringArg('use-application-binary'));
+  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(
+    await command.device.targetPlatform,
+    buildInfo: command.getBuildInfo(),
+    applicationBinary: applicationBinary,
+  );
 
   final Map<String, dynamic> platformArgs = <String, dynamic>{};
   if (command.traceStartup) {
@@ -508,6 +514,7 @@ Future<LaunchResult> _startApp(
     ),
     platformArgs: platformArgs,
     userIdentifier: userIdentifier,
+    prebuiltApplication: applicationBinary != null,
   );
 
   if (!result.started) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -70,7 +70,14 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         negatable: false,
         hide: !verboseHelp,
         help: 'No longer require an authentication code to connect to the VM '
-              'service (not recommended).');
+              'service (not recommended).'
+      )
+      ..addOption('use-application-binary',
+        help: 'Specify a pre-built application binary to use when running. For android applications, '
+        'this must be the path to an APK. For iOS applications, the path to an IPA. Other device types '
+        'do not yet support prebuilt application binaries',
+        valueHelp: 'path/to/app.apk',
+      );
     usesWebOptions(hide: !verboseHelp);
     usesTargetOption();
     usesPortOptions();
@@ -178,10 +185,6 @@ class RunCommand extends RunCommandBase {
               'This flag is not available on the stable channel and is only '
               'applied in debug and profile modes. This option should only '
               'be used for experiments and should not be used by typical users.')
-      ..addOption('use-application-binary',
-        hide: !verboseHelp,
-        help: 'Specify a pre-built application binary to use when running.',
-      )
       ..addOption('project-root',
         hide: !verboseHelp,
         help: 'Specify the project root directory.',


### PR DESCRIPTION
## Description

--use-application-binary allows running with an already built APK. This can be useful for speeding up CI test cases, or in our case eventually supporting some sort of build server.

Demonstrate that this works by updating the old gallery test to use it

Fixes https://github.com/flutter/flutter/issues/56604