### PR TITLE
Solve Chinese Pinyin Composing status problem when textfield has inpu…

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2222,7 +2222,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // as the pre-formatting value of the previous pass (repeat call).
     final bool textChanged = _value.text != value.text || _value.composing != value.composing;
 
-    if (textChanged) {
+    // Composing text does not need be formate
+    final bool isComposing = value.composing.isValid;
+
+    if (textChanged && !isComposing) {
       // Only format when the text has changed and there are available formatters.
       // Pass through the formatter regardless of repeat status if the input value is
       // different than the stored value.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2222,7 +2222,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // as the pre-formatting value of the previous pass (repeat call).
     final bool textChanged = _value.text != value.text || _value.composing != value.composing;
 
-    // Composing text does not need be formate
+    // Composing text does not need be formate.
     final bool isComposing = value.composing.isValid;
 
     if (textChanged && !isComposing) {


### PR DESCRIPTION
…tFormatters

## Description
Solve the problem when a textField sets inputFormatters such as FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9]')), then user input word with Chinese Pinyin Keyboard, the composing letters will be formate.  The problem show in Rateted Issue, there is a gif.

## Related Issues
![edit_textField](https://user-images.githubusercontent.com/13768204/95935764-a07be980-0e06-11eb-8f21-7e85cbfd195a.gif)

## Tests

I added the following tests:
## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ]I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
