### PR TITLE
[flutter_tools] add support for determinate progress bars in cli

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -315,7 +315,7 @@ class Doctor {
     }
     final List<_DoctorValidationResult> results = await Future.wait(startValidatorTasks().map(finishValidator));
     progress.finish();
-    
+
     for (final _DoctorValidationResult validationResult in results) {
       final ValidationResult result = validationResult.result;
       final DoctorValidator validator = validationResult.task.validator;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -707,6 +707,12 @@ class StreamLogger extends Logger {
 
   @override
   void clear() => _log('[stdout] ${globals.terminal.clearScreen()}\n');
+
+  @override
+  Progress createDeterminateProgress() {
+    _log('[progress]');
+    return SilentProgress();
+  }
 }
 
 class LoggerInterrupted implements Exception {


### PR DESCRIPTION
## Description

Add support for a determinate progress bar in logger.dart. Uses either unicode blocks or extended ascii, based on whether emoji support is detected. Use this new progress bar in the doctor checks.

This is intended to be a replacement for the status spinner for cases where we know some unit of completion (i.e. validators, downloaded bytes, et cetera)


![ezgif-7-9dbe8a92dd6e](https://user-images.githubusercontent.com/8975114/96009455-871e7180-0df5-11eb-9759-767c42e6c511.gif)


