### PR TITLE
[Flutter] Use the correct place for the system navigation bar color adjustment

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -244,9 +244,47 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   }
 
   void _updateSystemChrome() {
+    // Take overlay style from the place where a system status bar and system
+    // navigation bar are placed to update system style overlay.
+    // The center of the system navigation bar and the center of the status bar
+    // are used to get SystemUiOverlayStyle's to update system overlay appearance.
+    //
+    //         Horizontal center of the screen
+    //                 V
+    //    ++++++++++++++++++++++++++
+    //    |                        |
+    //    |    System status bar   |  <- Vertical center of the status bar
+    //    |                        |
+    //    ++++++++++++++++++++++++++
+    //    |                        |
+    //    |        Content         |
+    //    ~                        ~
+    //    |                        |
+    //    ++++++++++++++++++++++++++
+    //    |                        |
+    //    |  System navigation bar | <- Vertical center of the navigation bar
+    //    |                        |
+    //    ++++++++++++++++++++++++++ <- bounds.bottom
     final Rect bounds = paintBounds;
-    final Offset top = Offset(bounds.center.dx, _window.padding.top / _window.devicePixelRatio);
-    final Offset bottom = Offset(bounds.center.dx, bounds.center.dy - _window.padding.bottom / _window.devicePixelRatio);
+    // Center of the status bar
+    final Offset top = Offset(
+      // Horizontal center of the screen
+      bounds.center.dx,
+      // The vertical center of the system status bar. The system status bar
+      // height is kept as top window padding.
+      _window.padding.top / 2.0,
+    );
+    // Center of the navigation bar
+    final Offset bottom = Offset(
+      // Horizontal center of the screen
+      bounds.center.dx,
+      // Vertical center of the system navigation bar. The system navigation bar
+      // height is kept as bottom window padding. The "1" needs to be subtracted
+      // from the bottom because available pixels are in (0..bottom) range.
+      // I.e. for a device with 1920 height, bound.bottom is 1920, but the most
+      // bottom drawn pixel is at 1919 position.
+      bounds.bottom - 1.0 - _window.padding.bottom / 2.0,
+    );
     final SystemUiOverlayStyle? upperOverlayStyle = layer!.find<SystemUiOverlayStyle>(top);
     // Only android has a customizable system navigation bar.
     SystemUiOverlayStyle? lowerOverlayStyle;

--- a/packages/flutter/test/rendering/view_chrome_style_test.dart
+++ b/packages/flutter/test/rendering/view_chrome_style_test.dart
@@ -1,0 +1,253 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SystemChrome - style', () {
+    const double statusBarHeight = 25.0;
+    const double navigationBarHeight = 54.0;
+    const double deviceHeight = 960.0;
+    const double deviceWidth = 480.0;
+    const double devicePixelRatio = 2.0;
+
+    void setupTestDevice() {
+      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
+      const FakeWindowPadding padding = FakeWindowPadding(
+        top: statusBarHeight * devicePixelRatio,
+        bottom: navigationBarHeight * devicePixelRatio,
+      );
+
+      binding.window
+        ..viewPaddingTestValue = padding
+        ..paddingTestValue = padding
+        ..devicePixelRatioTestValue = devicePixelRatio
+        ..physicalSizeTestValue = const Size(
+          deviceWidth * devicePixelRatio,
+          deviceHeight * devicePixelRatio,
+        );
+    }
+
+    tearDown(() async {
+      SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle());
+      await pumpEventQueue();
+    });
+
+    group('status bar', () {
+      testWidgets(
+        'statusBarColor isn\'t set for unannotated view',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(const SizedBox.expand());
+          await tester.pumpAndSettle();
+
+          expect(SystemChrome.latestStyle?.statusBarColor, isNull);
+        },
+      );
+
+      testWidgets(
+        'statusBarColor is set for annotated view',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              statusBarColor: Colors.blue,
+            ),
+            child: SizedBox.expand(),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(
+            SystemChrome.latestStyle?.statusBarColor,
+            Colors.blue,
+          );
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+
+      testWidgets(
+        'statusBarColor isn\'t set when view covers less than half of the system status bar',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          const double lessThanHalfOfTheStatusBarHeight =
+              statusBarHeight / 2.0 - 1;
+          await tester.pumpWidget(const Align(
+            alignment: Alignment.topCenter,
+            child: AnnotatedRegion<SystemUiOverlayStyle>(
+              value: SystemUiOverlayStyle(
+                statusBarColor: Colors.blue,
+              ),
+              child: SizedBox(
+                width: 100,
+                height: lessThanHalfOfTheStatusBarHeight,
+              ),
+            ),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(SystemChrome.latestStyle?.statusBarColor, isNull);
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+
+      testWidgets(
+        'statusBarColor is set when view covers more than half of tye system status bar',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          const double moreThanHalfOfTheStatusBarHeight =
+              statusBarHeight / 2.0 + 1;
+          await tester.pumpWidget(const Align(
+            alignment: Alignment.topCenter,
+            child: AnnotatedRegion<SystemUiOverlayStyle>(
+              value: SystemUiOverlayStyle(
+                statusBarColor: Colors.blue,
+              ),
+              child: SizedBox(
+                width: 100,
+                height: moreThanHalfOfTheStatusBarHeight,
+              ),
+            ),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(
+            SystemChrome.latestStyle?.statusBarColor,
+            Colors.blue,
+          );
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+    });
+
+    group('navigation color (Android only)', () {
+      testWidgets(
+        'systemNavigationBarColor isn\'t set for non Android device',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.blue,
+            ),
+            child: SizedBox.expand(),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(
+            SystemChrome.latestStyle?.systemNavigationBarColor,
+            isNull,
+          );
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      );
+
+      testWidgets(
+        'systemNavigationBarColor isn\'t set for unannotated view',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(const SizedBox.expand());
+          await tester.pumpAndSettle();
+
+          expect(SystemChrome.latestStyle?.systemNavigationBarColor, isNull);
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
+
+      testWidgets(
+        'systemNavigationBarColor is set for annotated view',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.blue,
+            ),
+            child: SizedBox.expand(),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(
+            SystemChrome.latestStyle?.systemNavigationBarColor,
+            Colors.blue,
+          );
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
+
+      testWidgets(
+        'systemNavigationBarColor isn\'t set when view covers less than half of navigation bar',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          const double lessThanHalfOfTheNavigationBarHeight =
+              navigationBarHeight / 2.0 - 1;
+          await tester.pumpWidget(const Align(
+            alignment: Alignment.bottomCenter,
+            child: AnnotatedRegion<SystemUiOverlayStyle>(
+              value: SystemUiOverlayStyle(
+                systemNavigationBarColor: Colors.blue,
+              ),
+              child: SizedBox(
+                width: 100,
+                height: lessThanHalfOfTheNavigationBarHeight,
+              ),
+            ),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(SystemChrome.latestStyle?.systemNavigationBarColor, isNull);
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
+
+      testWidgets(
+        'systemNavigationBarColor is set when view covers more than half of navigation bar',
+        (WidgetTester tester) async {
+          setupTestDevice();
+          const double moreThanHalfOfTheNavigationBarHeight =
+              navigationBarHeight / 2.0 + 1;
+          await tester.pumpWidget(const Align(
+            alignment: Alignment.bottomCenter,
+            child: AnnotatedRegion<SystemUiOverlayStyle>(
+              value: SystemUiOverlayStyle(
+                systemNavigationBarColor: Colors.blue,
+              ),
+              child: SizedBox(
+                width: 100,
+                height: moreThanHalfOfTheNavigationBarHeight,
+              ),
+            ),
+          ));
+          await tester.pumpAndSettle();
+
+          expect(
+            SystemChrome.latestStyle?.systemNavigationBarColor,
+            Colors.blue,
+          );
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
+    });
+  });
+}
+
+class FakeWindowPadding implements WindowPadding {
+  const FakeWindowPadding({
+    this.left = 0.0,
+    this.top = 0.0,
+    this.right = 0.0,
+    this.bottom = 0.0,
+  });
+
+  @override
+  final double left;
+  @override
+  final double top;
+  @override
+  final double right;
+  @override
+  final double bottom;
+}


### PR DESCRIPTION
## Description
Use the correct place for the system navigation bar color adjustment 

Before the fix: the center of the screen were used to adjust navigation bar color.
After the fix: the center of the bottom navigation bar is used to adjust navigation bar color.

| Before | After the fix |
|---|---|
| ![incorrect](https://user-images.githubusercontent.com/689211/95991062-97057800-0e2c-11eb-8614-6e4e75366458.gif) | ![correct](https://user-images.githubusercontent.com/689211/95991064-9836a500-0e2c-11eb-9944-94ea83abe18e.gif) |

For more you can read the following issue: https://github.com/flutter/flutter/issues/66429

For example code that shows differences before and after the change you can use https://github.com/jacek-marchwicki/flutter-insets-bug2

Keep in mind, that `window.padding` isn't calculated correctly for translucent navigation bar on Android (issue: https://github.com/flutter/flutter/issues/63761) and this is not fixed by the PR.

If you have further questions related to this PR, I'm happy to try answering all of them.

## Related Issues

* Closes: https://github.com/flutter/flutter/issues/66429
* Closes: https://github.com/flutter/flutter/issues/65626

## Tests

I added the following tests:
* 'statusBarColor isn\'t set for unannotated view',
* 'statusBarColor is set for annotated view',
* 'statusBarColor isn\'t set when view covers less than half of the system status bar',
* 'statusBarColor is set when view covers more than half of tye system status bar',
* 'systemNavigationBarColor isn\'t set for non Android device',
* 'systemNavigationBarColor isn\'t set for unannotated view',
* 'systemNavigationBarColor is set for annotated view',
* 'systemNavigationBarColor isn\'t set when view covers less than half of navigation bar',
* 'systemNavigationBarColor is set when view covers more than half of navigation bar'

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`). *NOT NEED*
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR. (**I'll wait for the CI build to pass, because unchanged master branch analyze execution is failing on my computer. But I got success on stable branch**)
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
