### PR TITLE
Card padding

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -109,12 +109,13 @@ class Card extends StatelessWidget {
     this.shape,
     this.borderOnForeground = true,
     this.margin,
+    this.padding,
     this.clipBehavior,
     this.child,
     this.semanticContainer = true,
-  }) : assert(elevation == null || elevation >= 0.0),
-       assert(borderOnForeground != null),
-       super(key: key);
+  })  : assert(elevation == null || elevation >= 0.0),
+        assert(borderOnForeground != null),
+        super(key: key);
 
   /// The card's background color.
   ///
@@ -170,6 +171,15 @@ class Card extends StatelessWidget {
   /// logical pixels on all sides: `EdgeInsets.all(4.0)`.
   final EdgeInsetsGeometry? margin;
 
+  /// The empty space that surrounds the child.
+  /// 
+  /// Defines the child's outer [Padding.padding]
+  /// 
+  /// If this property is null then [CardTheme.padding] of
+  /// [ThemeData.cardTheme] is used. If that's null, the default padding is 8.0
+  /// logical pixels on all sides: `EdgeInsets.all(8.0)`.
+  final EdgeInsetsGeometry? padding;
+
   /// Whether this widget represents a single semantic container, or if false
   /// a collection of individual semantic nodes.
   ///
@@ -204,14 +214,19 @@ class Card extends StatelessWidget {
           shadowColor: shadowColor ?? cardTheme.shadowColor ?? theme.shadowColor,
           color: color ?? cardTheme.color ?? theme.cardColor,
           elevation: elevation ?? cardTheme.elevation ?? _defaultElevation,
-          shape: shape ?? cardTheme.shape ?? const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(4.0)),
-          ),
+          shape: shape ??
+              cardTheme.shape ??
+              const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(4.0)),
+              ),
           borderOnForeground: borderOnForeground,
           clipBehavior: clipBehavior ?? cardTheme.clipBehavior ?? Clip.none,
           child: Semantics(
             explicitChildNodes: !semanticContainer,
-            child: child,
+            child: Padding(
+              padding: padding ?? cardTheme.padding ?? const EdgeInsets.all(8.0),
+              child: child,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -38,6 +38,7 @@ class CardTheme with Diagnosticable {
     this.shadowColor,
     this.elevation,
     this.margin,
+    this.padding,
     this.shape,
   }) : assert(elevation == null || elevation >= 0.0);
 
@@ -67,6 +68,12 @@ class CardTheme with Diagnosticable {
   /// `EdgeInsets.all(4.0)`.
   final EdgeInsetsGeometry? margin;
 
+  /// Default value for [Card.padding].
+  ///
+  /// If null, [Card] uses a default padding of 8.0 logical pixels on all sides:
+  /// `EdgeInsets.all(8.0)`.
+  final EdgeInsetsGeometry? padding;
+
   /// Default value for [Card.shape].
   ///
   /// If null, [Card] then uses a [RoundedRectangleBorder] with a circular
@@ -81,6 +88,7 @@ class CardTheme with Diagnosticable {
     Color? shadowColor,
     double? elevation,
     EdgeInsetsGeometry? margin,
+    EdgeInsetsGeometry? padding,
     ShapeBorder? shape,
   }) {
     return CardTheme(
@@ -89,6 +97,7 @@ class CardTheme with Diagnosticable {
       shadowColor: shadowColor ?? this.shadowColor,
       elevation: elevation ?? this.elevation,
       margin: margin ?? this.margin,
+      padding: padding ?? this.padding,
       shape: shape ?? this.shape,
     );
   }
@@ -111,6 +120,7 @@ class CardTheme with Diagnosticable {
       shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       margin: EdgeInsetsGeometry.lerp(a?.margin, b?.margin, t),
+      padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
     );
   }
@@ -123,6 +133,7 @@ class CardTheme with Diagnosticable {
       shadowColor,
       elevation,
       margin,
+      padding,
       shape,
     );
   }
@@ -139,6 +150,7 @@ class CardTheme with Diagnosticable {
         && other.shadowColor == shadowColor
         && other.elevation == elevation
         && other.margin == margin
+        && other.padding == padding
         && other.shape == shape;
   }
 
@@ -150,6 +162,7 @@ class CardTheme with Diagnosticable {
     properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -140,9 +140,9 @@ void main() {
 
     // Default margin is 4
     expect(tester.getTopLeft(find.byType(Card)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byType(Card)), const Size(108.0, 108.0));
+    expect(tester.getSize(find.byType(Card)), const Size(124.0, 124.0)); // 2 * 4.0 margin + 2 * 8.0 padding
 
-    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(4.0, 4.0));
+    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(12.0, 12.0)); // 4.0 margin + 8.0 padding
     expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
 
     await tester.pumpWidget(
@@ -162,10 +162,10 @@ void main() {
 
     // Specified margin is zero
     expect(tester.getTopLeft(find.byType(Card)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byType(Card)), const Size(100.0, 100.0));
+    expect(tester.getSize(find.byType(Card)), const Size(116.0, 116.0)); // 2 * 8.0 padding (default)
 
-    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
+    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(8.0, 8.0));
+    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0)); // 2 * 8.0 padding (default)
   });
 
 testWidgets('Card padding', (WidgetTester tester) async {

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -168,6 +168,51 @@ void main() {
     expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
   });
 
+testWidgets('Card padding', (WidgetTester tester) async {
+    const Key contentsKey = ValueKey<String>('contents');
+
+    await tester.pumpWidget(
+      Align(
+        alignment: Alignment.topLeft,
+          child: Card(
+          child: Container(
+            key: contentsKey,
+            color: const Color(0xFF00FF00),
+            width: 100.0,
+            height: 100.0,
+          ),
+        ),
+      ),
+    );
+
+    // Default padding is 8 and default margin is 4
+    expect(tester.getSize(find.byType(Card)), const Size(124.0, 124.0)); // 2 * 4.0 margin + 2 * 8.0 padding
+
+    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(12.0, 12.0)); // 4.0 margin + 8.0 padding
+    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
+
+    await tester.pumpWidget(
+      Align(
+        alignment: Alignment.topLeft,
+          child: Card(
+          padding: EdgeInsets.zero,
+          child: Container(
+            key: contentsKey,
+            color: const Color(0xFF00FF00),
+            width: 100.0,
+            height: 100.0,
+          ),
+        ),
+      ),
+    );
+
+    // Specified padding is zero
+    expect(tester.getSize(find.byType(Card)), const Size(108.0, 108.0)); // 2 * 4.0 margin (default)
+
+    expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(4.0, 4.0)); // 4.0 margin (default)
+    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
+  });
+
   testWidgets('Card clipBehavior property passes through to the Material', (WidgetTester tester) async {
     await tester.pumpWidget(const Card());
     expect(tester.widget<Material>(find.byType(Material)).clipBehavior, Clip.none);


### PR DESCRIPTION
## Description

Add padding around card's child.

## Related Issues

Fixes #68029 

## Tests

I added the following test:

Card padding

I modified the following test:

Card margin

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
