### PR TITLE
Revert "[flutter_tools] listen to the nice ios-deploy tool"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -268,33 +268,6 @@ class IOSDevice extends Device {
       _logger.printError(e.message);
       return false;
     }
-
-    if (installationResult == 0) {
-      return true;
-    }
-    _logger.printTrace('application failed to install: $installationResult');
-    // If the initial installation fails, attempt to uninstall the app if
-    // it was already installed. Regardless of whether or not this is successful,
-    // try once more to install.
-    if (await isAppInstalled(app, userIdentifier: userIdentifier)) {
-      _logger.printTrace('Uninstalling previously installed application...');
-      if (!await uninstallApp(app, userIdentifier: userIdentifier)) {
-        _logger.printTrace('Failed to uninstall');
-      }
-    }
-
-    try {
-      installationResult = await _iosDeploy.installApp(
-        deviceId: id,
-        bundlePath: bundle.path,
-        launchArguments: <String>[],
-        interfaceType: interfaceType,
-      );
-    } on ProcessException catch (e) {
-      _logger.printError(e.message);
-      return false;
-    }
-
     if (installationResult != 0) {
       _logger.printError('Could not install ${bundle.path} on $id.');
       _logger.printError('Try launching Xcode and selecting "Product > Run" to fix the problem:');

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -252,61 +252,6 @@ void main() {
     expect(wasAppInstalled, false);
   });
 
-   testWithoutContext('IOSDevice.installApp retries installation if it fails once', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    final IOSApp iosApp = PrebuiltIOSApp(
-      projectBundleId: 'app',
-      bundleDir: fileSystem.currentDirectory,
-    );
-    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      FakeCommand(command: <String>[
-        iosDeployPath,
-        '--id',
-        '1234',
-        '--bundle',
-        '/',
-        '--no-wifi',
-      ], environment: const <String, String>{
-        'PATH': '/usr/bin:null',
-        ...kDyLdLibEntry,
-      }, exitCode: 1),
-      FakeCommand(command: <String>[
-        iosDeployPath,
-        '--id',
-        '1234',
-        '--exists',
-        '--timeout',
-        '10',
-        '--bundle_id',
-        'app',
-      ]),
-      FakeCommand(command: <String>[
-        iosDeployPath,
-        '--id',
-        '1234',
-        '--uninstall_only',
-        '--bundle_id',
-        'app',
-      ]),
-      FakeCommand(command: <String>[
-        iosDeployPath,
-        '--id',
-        '1234',
-        '--bundle',
-        '/',
-        '--no-wifi',
-      ], environment: const <String, String>{
-        'PATH': '/usr/bin:null',
-        ...kDyLdLibEntry,
-      }),
-    ]);
-    final IOSDevice device = setUpIOSDevice(processManager: processManager, artifacts: artifacts);
-    final bool wasAppInstalled = await device.installApp(iosApp);
-
-    expect(wasAppInstalled, true);
-    expect(processManager.hasRemainingExpectations, false);
-  });
-
   testWithoutContext('IOSDevice.uninstallApp catches ProcessException from ios-deploy', () async {
     final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
Reverts flutter/flutter#68078

1. We shouldn't uninstall iOS apps out from the user. If it's the last app on the phone using the development cert, users have to go back in and approve on the next install.

2. That message is from https://github.com/flutter/flutter/pull/68046 not the ios-deploy.  That message should probably be "try quitting the app and try again" not uninstall.  I'll open a PR for that.

3. There's something Bad happening in the devicelab that isn't caused by this, it's just manifesting this way.  If we uninstall the app and retry we will be hiding flakes because it really took 2 tries but we would count it as working on the first go.