### PR TITLE
[flutter_tools] ensure android log reader works in flutter drive

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -683,6 +683,7 @@ class AndroidDevice extends Device {
           return LaunchResult.failed();
         }
       }
+      resetLogReaders();
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } on Exception catch (error) {
       _logger.printError('Error waiting for a debug connection: $error');
@@ -740,6 +741,14 @@ class AndroidDevice extends Device {
   @override
   void clearLogs() {
     _processUtils.runSync(adbCommandForDevice(<String>['logcat', '-c']));
+  }
+
+  /// Android device log readers are singletons. if they are closed by the
+  /// protocol discovery, the same kind of reader cannot be recreated.
+  @visibleForTesting
+  void resetLogReaders() {
+    _pastLogReader = null;
+    _logReader = null;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -491,12 +491,6 @@ Future<LaunchResult> _startApp(
 
   globals.printTrace('Starting application.');
 
-  // Forward device log messages to the terminal window running the "drive" command.
-  final DeviceLogReader logReader = await command.device.getLogReader(app: package);
-  command._deviceLogSubscription = logReader
-    .logLines
-    .listen(globals.printStatus);
-
   final LaunchResult result = await command.device.startApp(
     package,
     mainPath: mainPath,
@@ -518,9 +512,14 @@ Future<LaunchResult> _startApp(
   );
 
   if (!result.started) {
-    await command._deviceLogSubscription.cancel();
     return null;
   }
+
+  // Forward device log messages to the terminal window running the "drive" command.
+  final DeviceLogReader logReader = await command.device.getLogReader(app: package);
+  command._deviceLogSubscription = logReader
+    .logLines
+    .listen(globals.printStatus);
 
   return result;
 }

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -30,6 +30,20 @@ void main() {
     expect(device.id, '1234');
   });
 
+  testWithoutContext('Can reset log reader singletons', () async {
+    final AndroidDevice device = setUpAndroidDevice();
+    final DeviceLogReader logReader = await device.getLogReader();
+    final DeviceLogReader logReader2 = await device.getLogReader();
+
+    expect(logReader, logReader2);
+
+    device.resetLogReaders();
+
+    final DeviceLogReader logReader3 = await device.getLogReader();
+
+    expect(logReader, isNot(logReader3));
+  });
+
   testWithoutContext('parseAdbDeviceProperties parses adb shell output', () {
     final Map<String, String> properties = parseAdbDeviceProperties(kAdbShellGetprop);
 


### PR DESCRIPTION
## Description

The android log reader is a singleton, and is disposed by the protocol discovery process. Ensure this can be recreated so that logging works for flutter drive on Android.