### PR TITLE
Updated Builder API doc

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7160,7 +7160,7 @@ class KeyedSubtree extends StatelessWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=xXNOkIuSYuA}
 ///
-/// This widget is a simple inline alternative to defining a StatelessWidget
+/// This widget is a simple inline alternative to defining a [StatelessWidget]
 /// subclass. For example a widget defined and used like this:
 ///
 /// ```dart
@@ -7174,6 +7174,7 @@ class KeyedSubtree extends StatelessWidget {
 ///
 /// Could equally well be defined and used like this, without
 /// definining a new widget class:
+///
 /// ```dart
 /// Center(
 ///   child: Builder(
@@ -7184,7 +7185,7 @@ class KeyedSubtree extends StatelessWidget {
 ///
 /// The difference between either of the previous examples and simply
 /// creating a child directly, without an intervening widget, is the
-/// extra BuildContext element that the additional widget adds. This
+/// extra [BuildContext] element that the additional widget adds. This
 /// is particularly noticeable when the tree contains an inherited
 /// widget that is referred to by a method like [ScaffoldState.of],
 /// which visits the child widget's BuildContext ancestors.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7187,11 +7187,11 @@ class KeyedSubtree extends StatelessWidget {
 /// creating a child directly, without an intervening widget, is the
 /// extra [BuildContext] element that the additional widget adds. This
 /// is particularly noticeable when the tree contains an inherited
-/// widget that is referred to by a method like [ScaffoldState.of],
+/// widget that is referred to by a method like [Scaffold.of],
 /// which visits the child widget's BuildContext ancestors.
 ///
 /// In the following example the button's `onPressed` callback is unable
-/// to find the enclosing [Scaffold] with [ScaffoldState.of]:
+/// to find the enclosing [ScaffoldState] with [Scaffold.of]:
 ///
 /// ```dart
 /// Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7155,13 +7155,86 @@ class KeyedSubtree extends StatelessWidget {
   Widget build(BuildContext context) => child;
 }
 
-/// A platonic widget that calls a closure to obtain its child widget.
+/// A stateless utility widget whose [build] method uses its
+/// [builder] callback to create the widget's child.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=xXNOkIuSYuA}
 ///
+/// This widget is a simple inline alternative to defining a StatelessWidget
+/// subclass. For example a widget defined and used like this:
+///
+/// ```dart
+/// class Foo extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) => Text('foo');
+/// }
+///
+/// Center(child: Foo())
+/// ```
+///
+/// Could equally well be defined and used like this, without
+/// definining a new widget class:
+/// ```dart
+/// Center(
+///   child: Builder(
+///     builder: (BuildContext context) => Text('foo');
+///   ),
+/// )
+/// ```
+///
+/// The difference between either of the previous examples and simply
+/// creating a child directly, without an intervening widget, is the
+/// extra BuildContext element that the additional widget adds. This
+/// is particularly noticeable when the tree contains an inherited
+/// widget that is referred to by a method like [ScaffoldState.of],
+/// which visits the child widget's BuildContext ancestors.
+///
+/// In the following example the button's `onPressed` callback is unable
+/// to find the enclosing [Scaffold] with [ScaffoldState.of]:
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     body: Center(
+///       child: TextButton(
+///         onPressed: () {
+///           // Fails because Scaffold.of() doesn't find anything
+///           // above this widget's context.
+///           print(Scaffold.of(context).hasAppBar);
+///         },
+///         child: Text('hasAppBar'),
+///       )
+///     ),
+///   );
+/// }
+/// ```
+///
+/// A [Builder] widget introduces an additional [BuildContext] element
+/// and so the [Scaffold.of] method succeeds.
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     body: Builder(
+///       builder: (BuildContext context) {
+///         return Center(
+///           child: TextButton(
+///             onPressed: () {
+///               print(Scaffold.of(context).hasAppBar);
+///             },
+///             child: Text('hasAppBar'),
+///           ),
+///         );
+///       },
+///     ),
+///   );
+/// }
+/// ```
+///
 /// See also:
 ///
-///  * [StatefulBuilder], a platonic widget which also has state.
+///  * [StatefulBuilder], A stateful utility widget whose [build] method uses its
+///    [builder] callback to create the widget's child.
 class Builder extends StatelessWidget {
   /// Creates a widget that delegates its build to a callback.
   ///


### PR DESCRIPTION
Removes ["platonic"](https://github.com/flutter/flutter/issues/48137#issuecomment-570680498) from the widget class's API doc and includes a `ScaffoldState.of()` example.

Fixes #48137.

Thanks to  Reuben Turner for taking a shot at improving this doc - https://github.com/flutter/flutter/pull/63584.