### PR TITLE
[NNBD] Migrate some Widgets tests

### DIFF
--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -412,7 +412,7 @@ class MethodChannel {
   /// return value of the call. The value will be encoded using
   /// [MethodCodec.encodeSuccessEnvelope], to act as if platform plugin had
   /// returned that value.
-  void setMockMethodCallHandler(Future<dynamic> Function(MethodCall call)? handler) {
+  void setMockMethodCallHandler(Future<dynamic>? Function(MethodCall call)? handler) {
     _methodChannelMockHandlers[this] = handler;
     binaryMessenger.setMockMessageHandler(
       name,
@@ -430,7 +430,7 @@ class MethodChannel {
   /// is not set.
   bool checkMockMethodCallHandler(Future<dynamic> Function(MethodCall call)? handler) => _methodChannelMockHandlers[this] == handler;
 
-  Future<ByteData?> _handleAsMethodCall(ByteData? message, Future<dynamic> handler(MethodCall call)) async {
+  Future<ByteData?> _handleAsMethodCall(ByteData? message, Future<dynamic>? handler(MethodCall call)) async {
     final MethodCall call = codec.decodeMethodCall(message);
     try {
       return codec.encodeSuccessEnvelope(await handler(call));

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -195,7 +195,7 @@ class FakeTextChannel implements MethodChannel {
   bool checkMethodCallHandler(Future<void> Function(MethodCall call)? handler) => throw UnimplementedError();
 
   @override
-  void setMockMethodCallHandler(Future<void> Function(MethodCall call)? handler)  => throw UnimplementedError();
+  void setMockMethodCallHandler(Future<void>? Function(MethodCall call)? handler)  => throw UnimplementedError();
 
   @override
   bool checkMockMethodCallHandler(Future<void> Function(MethodCall call)? handler) => throw UnimplementedError();

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -460,7 +460,7 @@ class FakeTextChannel implements MethodChannel {
 
 
   @override
-  void setMockMethodCallHandler(Future<void> Function(MethodCall call)? handler)  => throw UnimplementedError();
+  void setMockMethodCallHandler(Future<void>? Function(MethodCall call)? handler)  => throw UnimplementedError();
 
   @override
   bool checkMockMethodCallHandler(Future<void> Function(MethodCall call)? handler) => throw UnimplementedError();

--- a/packages/flutter/test/widgets/overflow_box_test.dart
+++ b/packages/flutter/test/widgets/overflow_box_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -27,7 +25,7 @@ void main() {
         ),
       ),
     ));
-    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    final RenderBox box = inner.currentContext!.findRenderObject()! as RenderBox;
     expect(box.localToGlobal(Offset.zero), equals(const Offset(745.0, 565.0)));
     expect(box.size, equals(const Size(100.0, 50.0)));
   });
@@ -64,7 +62,7 @@ void main() {
         ),
       ),
     ));
-    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    final RenderBox box = inner.currentContext!.findRenderObject()! as RenderBox;
     expect(box.size, equals(const Size(50.0, 50.0)));
     expect(
       box.localToGlobal(box.size.center(Offset.zero)),
@@ -87,7 +85,7 @@ void main() {
         ),
       ),
     ));
-    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    final RenderBox box = inner.currentContext!.findRenderObject()! as RenderBox;
     expect(box.size, equals(const Size(50.0, 50.0)));
     expect(
       box.localToGlobal(box.size.center(Offset.zero)),

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
@@ -23,8 +21,7 @@ void main() {
             OverlayEntry(
               builder: (BuildContext context) {
                 didBuild = true;
-                final Overlay overlay = context.findAncestorWidgetOfExactType<Overlay>();
-                expect(overlay, isNotNull);
+                final Overlay overlay = context.findAncestorWidgetOfExactType<Overlay>()!;
                 expect(overlay.key, equals(overlayKey));
                 return Container();
               },
@@ -37,7 +34,7 @@ void main() {
       ),
     );
     expect(didBuild, isTrue);
-    final RenderObject theater = overlayKey.currentContext.findRenderObject();
+    final RenderObject theater = overlayKey.currentContext!.findRenderObject()!;
 
     expect(theater, hasAGoodToStringDeep);
     expect(
@@ -110,7 +107,7 @@ void main() {
         ),
       ),
     );
-    final RenderObject theater = overlayKey.currentContext.findRenderObject();
+    final RenderObject theater = overlayKey.currentContext!.findRenderObject()!;
 
     expect(theater, hasAGoodToStringDeep);
     expect(
@@ -189,7 +186,7 @@ void main() {
     expect(buildOrder, <String>['Base']);
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insert(
       OverlayEntry(
         builder: (BuildContext context) {
@@ -227,7 +224,7 @@ void main() {
     expect(buildOrder, <String>['Base']);
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insert(
       OverlayEntry(
           builder: (BuildContext context) {
@@ -272,7 +269,7 @@ void main() {
     expect(buildOrder, <String>['Base', 'Top']);
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insert(
       OverlayEntry(
           builder: (BuildContext context) {
@@ -325,7 +322,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insertAll(entries);
     await tester.pump();
 
@@ -371,7 +368,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insertAll(entries, below: base);
     await tester.pump();
 
@@ -423,7 +420,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.insertAll(entries, above: base);
     await tester.pump();
 
@@ -486,7 +483,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.rearrange(rearranged);
     await tester.pump();
 
@@ -549,7 +546,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.rearrange(rearranged, above: initialEntries[2]);
     await tester.pump();
 
@@ -612,7 +609,7 @@ void main() {
     ];
 
     buildOrder.clear();
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
     overlay.rearrange(rearranged, below: initialEntries[2]);
     await tester.pump();
 
@@ -639,7 +636,7 @@ void main() {
       ),
     );
 
-    final OverlayState overlay = overlayKey.currentState as OverlayState;
+    final OverlayState overlay = overlayKey.currentState! as OverlayState;
 
     try {
       overlay.insert(
@@ -657,8 +654,7 @@ void main() {
           },
         ),
       );
-    } catch (e) {
-      expect(e, isAssertionError);
+    } on AssertionError catch (e) {
       expect(e.message, 'Only one of `above` and `below` may be specified.');
     }
 
@@ -680,8 +676,7 @@ void main() {
           },
         ),
       );
-    } catch (e) {
-      expect(e, isAssertionError);
+    } on AssertionError catch (e) {
       expect(e.message, 'The provided entry used for `above` must be present in the Overlay.');
     }
 
@@ -692,8 +687,7 @@ void main() {
         },
       ));
 
-    } catch (e) {
-      expect(e, isAssertionError);
+    } on AssertionError catch (e) {
       expect(e.message, 'The provided entry used for `above` must be present in the Overlay and in the `newEntriesList`.');
     }
 
@@ -706,7 +700,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Builder(
           builder: (BuildContext context) {
-            FlutterError error;
+            late FlutterError error;
             final Widget debugRequiredFor = Container();
             try {
               Overlay.of(context, debugRequiredFor: debugRequiredFor);
@@ -778,7 +772,7 @@ void main() {
     expect(newEntry.opaque, isTrue);
 
     // The new opaqueness is honored when inserted into an overlay.
-    overlayKey.currentState.insert(newEntry);
+    overlayKey.currentState!.insert(newEntry);
     await tester.pumpAndSettle();
 
     expect(find.byKey(root), findsNothing);
@@ -892,7 +886,7 @@ void main() {
     expect(tester.state<StatefulTestState>(find.byKey(bottom)).rebuildCount, 1);
     expect(tester.state<StatefulTestState>(find.byKey(top)).rebuildCount, 1);
 
-    overlayKey.currentState.rearrange(<OverlayEntry>[
+    overlayKey.currentState!.rearrange(<OverlayEntry>[
       bottomEntry, middleEntry, topEntry,
     ]);
     await tester.pump();
@@ -932,7 +926,7 @@ void main() {
     await tester.tap(find.byKey(overlayKey));
     expect(bottomTapCount, 1);
 
-    overlayKey.currentState.insert(OverlayEntry(
+    overlayKey.currentState!.insert(OverlayEntry(
       maintainState: true,
       opaque: true,
       builder: (BuildContext context) {
@@ -948,7 +942,7 @@ void main() {
     expect(bottomTapCount, 1);
 
     int topTapCount = 0;
-    overlayKey.currentState.insert(OverlayEntry(
+    overlayKey.currentState!.insert(OverlayEntry(
       maintainState: true,
       opaque: true,
       builder: (BuildContext context) {
@@ -1026,6 +1020,7 @@ void main() {
   });
 
   testWidgets('Overlay can set and update clipBehavior', (WidgetTester tester) async {
+
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -1040,7 +1035,8 @@ void main() {
     );
 
     // By default, clipBehavior should be Clip.hardEdge
-    final dynamic renderObject = tester.renderObject(find.byType(Overlay));
+    late dynamic renderObject;
+    renderObject = tester.renderObject(find.byType(Overlay));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     for(final Clip clip in Clip.values) {
@@ -1063,7 +1059,7 @@ void main() {
 }
 
 class StatefulTestWidget extends StatefulWidget {
-  const StatefulTestWidget({Key key}) : super(key: key);
+  const StatefulTestWidget({Key? key}) : super(key: key);
 
   @override
   State<StatefulTestWidget> createState() => StatefulTestState();

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1035,8 +1035,8 @@ void main() {
     );
 
     // By default, clipBehavior should be Clip.hardEdge
-    late dynamic renderObject;
-    renderObject = tester.renderObject(find.byType(Overlay));
+    // ignore: unnecessary_nullable_for_final_variable_declarations
+    final dynamic renderObject = tester.renderObject(find.byType(Overlay));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     for(final Clip clip in Clip.values) {

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -2,18 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 class TestTransition extends AnimatedWidget {
   const TestTransition({
-    Key key,
-    this.childFirstHalf,
-    this.childSecondHalf,
-    Animation<double> animation,
+    Key? key,
+    required this.childFirstHalf,
+    required this.childSecondHalf,
+    required Animation<double> animation,
   }) : super(key: key, listenable: animation);
 
   final Widget childFirstHalf;
@@ -29,7 +27,11 @@ class TestTransition extends AnimatedWidget {
 }
 
 class TestRoute<T> extends PageRoute<T> {
-  TestRoute({ this.child, RouteSettings settings, this.barrierColor }) : super(settings: settings);
+  TestRoute({
+    required this.child,
+    required RouteSettings settings,
+    this.barrierColor,
+  }) : super(settings: settings);
 
   final Widget child;
 
@@ -37,10 +39,10 @@ class TestRoute<T> extends PageRoute<T> {
   Duration get transitionDuration => const Duration(milliseconds: 150);
 
   @override
-  final Color barrierColor;
+  final Color? barrierColor;
 
   @override
-  String get barrierLabel => null;
+  String? get barrierLabel => null;
 
   @override
   bool get maintainState => false;
@@ -88,18 +90,18 @@ void main() {
                 child: Builder(
                   key: insideKey,
                   builder: (BuildContext context) {
-                    final PageRoute<void> route = ModalRoute.of(context) as PageRoute<void>;
+                    final PageRoute<void> route = ModalRoute.of(context)! as PageRoute<void>;
                     return Column(
                       children: <Widget>[
                         TestTransition(
                           childFirstHalf: const Text('A'),
                           childSecondHalf: const Text('B'),
-                          animation: route.animation,
+                          animation: route.animation!,
                         ),
                         TestTransition(
                           childFirstHalf: const Text('C'),
                           childSecondHalf: const Text('D'),
-                          animation: route.secondaryAnimation,
+                          animation: route.secondaryAnimation!,
                         ),
                       ],
                     );
@@ -115,7 +117,7 @@ void main() {
       )
     );
 
-    final NavigatorState navigator = insideKey.currentContext.findAncestorStateOfType<NavigatorState>();
+    final NavigatorState navigator = insideKey.currentContext!.findAncestorStateOfType<NavigatorState>()!;
 
     expect(state(), equals('BC')); // transition ->1 is at 1.0
 

--- a/packages/flutter/test/widgets/page_route_builder_test.dart
+++ b/packages/flutter/test/widgets/page_route_builder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,7 +26,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   void _presentModalPage() {
-    Navigator.of(context).push(PageRouteBuilder<void>(
+    Navigator.of(context)!.push(PageRouteBuilder<void>(
       transitionDuration: const Duration(milliseconds: 300),
       barrierColor: Colors.black54,
       opaque: false,
@@ -64,7 +62,7 @@ class ModalPage extends StatelessWidget {
               highlightColor: Colors.transparent,
               splashColor: Colors.transparent,
               onTap: () {
-                Navigator.of(context).pop();
+                Navigator.of(context)!.pop();
               },
               child: const SizedBox.expand(),
             ),

--- a/packages/flutter/test/widgets/page_storage_test.dart
+++ b/packages/flutter/test/widgets/page_storage_test.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
   testWidgets('PageStorage read and write', (WidgetTester tester) async {
     const Key builderKey = PageStorageKey<String>('builderKey');
-    StateSetter setState;
+    late StateSetter setState;
     int storedValue = 0;
 
     await tester.pumpWidget(
@@ -18,7 +16,7 @@ void main() {
         home: StatefulBuilder(
           key: builderKey,
           builder: (BuildContext context, StateSetter setter) {
-            PageStorage.of(context).writeState(context, storedValue);
+            PageStorage.of(context)!.writeState(context, storedValue);
             setState = setter;
             return Center(
               child: Text('storedValue: $storedValue'),
@@ -30,17 +28,17 @@ void main() {
 
     final Element builderElement = tester.element(find.byKey(builderKey));
     expect(PageStorage.of(builderElement), isNotNull);
-    expect(PageStorage.of(builderElement).readState(builderElement), equals(storedValue));
+    expect(PageStorage.of(builderElement)!.readState(builderElement), equals(storedValue));
 
     setState(() {
       storedValue = 1;
     });
     await tester.pump();
-    expect(PageStorage.of(builderElement).readState(builderElement), equals(storedValue));
+    expect(PageStorage.of(builderElement)!.readState(builderElement), equals(storedValue));
   });
 
   testWidgets('PageStorage read and write by identifier', (WidgetTester tester) async {
-    StateSetter setState;
+    late StateSetter setState;
     int storedValue = 0;
 
     Widget buildWidthKey(Key key) {
@@ -48,7 +46,7 @@ void main() {
         home: StatefulBuilder(
           key: key,
           builder: (BuildContext context, StateSetter setter) {
-            PageStorage.of(context).writeState(context, storedValue, identifier: 123);
+            PageStorage.of(context)!.writeState(context, storedValue, identifier: 123);
             setState = setter;
             return Center(
               child: Text('storedValue: $storedValue'),
@@ -62,8 +60,8 @@ void main() {
     await tester.pumpWidget(buildWidthKey(key));
     Element builderElement = tester.element(find.byKey(key));
     expect(PageStorage.of(builderElement), isNotNull);
-    expect(PageStorage.of(builderElement).readState(builderElement), isNull);
-    expect(PageStorage.of(builderElement).readState(builderElement, identifier: 123), equals(storedValue));
+    expect(PageStorage.of(builderElement)!.readState(builderElement), isNull);
+    expect(PageStorage.of(builderElement)!.readState(builderElement, identifier: 123), equals(storedValue));
 
     // New StatefulBuilder widget - different key - but the same PageStorage identifier.
 
@@ -71,14 +69,14 @@ void main() {
     await tester.pumpWidget(buildWidthKey(key));
     builderElement = tester.element(find.byKey(key));
     expect(PageStorage.of(builderElement), isNotNull);
-    expect(PageStorage.of(builderElement).readState(builderElement), isNull);
-    expect(PageStorage.of(builderElement).readState(builderElement, identifier: 123), equals(storedValue));
+    expect(PageStorage.of(builderElement)!.readState(builderElement), isNull);
+    expect(PageStorage.of(builderElement)!.readState(builderElement, identifier: 123), equals(storedValue));
 
     setState(() {
       storedValue = 1;
     });
     await tester.pump();
-    expect(PageStorage.of(builderElement).readState(builderElement, identifier: 123), equals(storedValue));
+    expect(PageStorage.of(builderElement)!.readState(builderElement, identifier: 123), equals(storedValue));
   });
 
 }

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 class TestOverlayRoute extends OverlayRoute<void> {
-  TestOverlayRoute({ RouteSettings settings }) : super(settings: settings);
+  TestOverlayRoute({ RouteSettings? settings }) : super(settings: settings);
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {
     yield OverlayEntry(builder: _build);
@@ -17,7 +15,7 @@ class TestOverlayRoute extends OverlayRoute<void> {
 }
 
 class PersistentBottomSheetTest extends StatefulWidget {
-  const PersistentBottomSheetTest({ Key key }) : super(key: key);
+  const PersistentBottomSheetTest({ Key? key }) : super(key: key);
 
   @override
   PersistentBottomSheetTestState createState() => PersistentBottomSheetTestState();
@@ -29,7 +27,7 @@ class PersistentBottomSheetTestState extends State<PersistentBottomSheetTest> {
   bool setStateCalled = false;
 
   void showBottomSheet() {
-    _scaffoldKey.currentState.showBottomSheet<void>((BuildContext context) {
+    _scaffoldKey.currentState!.showBottomSheet<void>((BuildContext context) {
       return const Text('bottomSheet');
     })
     .closed.whenComplete(() {
@@ -63,9 +61,9 @@ void main() {
     expect(find.text('Settings'), findsNothing);
     expect(find.text('Overlay'), findsNothing);
 
-    expect(Navigator.canPop(containerKey1.currentContext), isFalse);
-    Navigator.pushNamed(containerKey1.currentContext, '/settings');
-    expect(Navigator.canPop(containerKey1.currentContext), isTrue);
+    expect(Navigator.canPop(containerKey1.currentContext!), isFalse);
+    Navigator.pushNamed(containerKey1.currentContext!, '/settings');
+    expect(Navigator.canPop(containerKey1.currentContext!), isTrue);
 
     await tester.pump();
 
@@ -85,7 +83,7 @@ void main() {
     expect(find.text('Settings'), isOnstage);
     expect(find.text('Overlay'), findsNothing);
 
-    Navigator.push(containerKey2.currentContext, TestOverlayRoute());
+    Navigator.push(containerKey2.currentContext!, TestOverlayRoute());
 
     await tester.pump();
 
@@ -99,8 +97,8 @@ void main() {
     expect(find.text('Settings'), isOnstage);
     expect(find.text('Overlay'), isOnstage);
 
-    expect(Navigator.canPop(containerKey2.currentContext), isTrue);
-    Navigator.pop(containerKey2.currentContext);
+    expect(Navigator.canPop(containerKey2.currentContext!), isTrue);
+    Navigator.pop(containerKey2.currentContext!);
     await tester.pump();
 
     expect(find.text('Home'), findsNothing);
@@ -113,8 +111,8 @@ void main() {
     expect(find.text('Settings'), isOnstage);
     expect(find.text('Overlay'), findsNothing);
 
-    expect(Navigator.canPop(containerKey2.currentContext), isTrue);
-    Navigator.pop(containerKey2.currentContext);
+    expect(Navigator.canPop(containerKey2.currentContext!), isTrue);
+    Navigator.pop(containerKey2.currentContext!);
     await tester.pump();
     await tester.pump();
 
@@ -128,7 +126,7 @@ void main() {
     expect(find.text('Settings'), findsNothing);
     expect(find.text('Overlay'), findsNothing);
 
-    expect(Navigator.canPop(containerKey1.currentContext), isFalse);
+    expect(Navigator.canPop(containerKey1.currentContext!), isFalse);
   });
 
   testWidgets('Check back gesture disables Heroes', (WidgetTester tester) async {
@@ -161,7 +159,7 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(routes: routes));
 
-    Navigator.pushNamed(containerKey1.currentContext, '/settings');
+    Navigator.pushNamed(containerKey1.currentContext!, '/settings');
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 16));
@@ -210,7 +208,7 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(routes: routes));
 
-    Navigator.pushNamed(containerKey1.currentContext, '/settings');
+    Navigator.pushNamed(containerKey1.currentContext!, '/settings');
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
@@ -254,7 +252,7 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(routes: routes));
 
-    Navigator.pushNamed(containerKey1.currentContext, '/sheet');
+    Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -269,7 +267,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
-    Navigator.pushNamed(containerKey1.currentContext, '/sheet');
+    Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -278,7 +276,7 @@ void main() {
     expect(find.text('Sheet'), isOnstage);
 
     // Show the bottom sheet.
-    final PersistentBottomSheetTestState sheet = containerKey2.currentState as PersistentBottomSheetTestState;
+    final PersistentBottomSheetTestState sheet = containerKey2.currentState! as PersistentBottomSheetTestState;
     sheet.showBottomSheet();
 
     await tester.pump(const Duration(seconds: 1));

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -333,7 +331,7 @@ void main() {
     final List<int> log = <int>[];
     final PageController controller = PageController(viewportFraction: 0.9);
 
-    Widget build(PageController controller, { Size size }) {
+    Widget build(PageController controller, { Size? size }) {
       final Widget pageView = Directionality(
         textDirection: TextDirection.ltr,
         child: PageView(
@@ -429,7 +427,7 @@ void main() {
   testWidgets('Page snapping disable and reenable', (WidgetTester tester) async {
     final List<int> log = <int>[];
 
-    Widget build({ bool pageSnapping }) {
+    Widget build({ required bool pageSnapping }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: PageView(
@@ -643,7 +641,7 @@ void main() {
     (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/23873.
       final PageController controller = PageController(viewportFraction: 1/4, initialPage: 0);
-      int tappedIndex;
+      late int tappedIndex;
 
       Widget build() {
         return Directionality(

--- a/packages/flutter/test/widgets/pageable_list_test.dart
+++ b/packages/flutter/test/widgets/pageable_list_test.dart
@@ -2,17 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 
 Size pageSize = const Size(600.0, 300.0);
 const List<int> defaultPages = <int>[0, 1, 2, 3, 4, 5];
 final List<GlobalKey> globalKeys = defaultPages.map<GlobalKey>((_) => GlobalKey()).toList();
-int currentPage;
+int? currentPage;
 
 Widget buildPage(int page) {
   return Container(
@@ -26,7 +23,7 @@ Widget buildPage(int page) {
 Widget buildFrame({
   bool reverse = false,
   List<int> pages = defaultPages,
-  @required TextDirection textDirection,
+  required TextDirection textDirection,
 }) {
   final PageView child = PageView(
     scrollDirection: Axis.horizontal,

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -13,10 +11,10 @@ import 'test_widgets.dart';
 class TestParentData {
   TestParentData({ this.top, this.right, this.bottom, this.left });
 
-  final double top;
-  final double right;
-  final double bottom;
-  final double left;
+  final double? top;
+  final double? right;
+  final double? bottom;
+  final double? left;
 }
 
 void checkTree(WidgetTester tester, List<TestParentData> expectedParentData) {
@@ -27,18 +25,18 @@ void checkTree(WidgetTester tester, List<TestParentData> expectedParentData) {
   expect(element.renderObject, isA<RenderStack>());
   final RenderStack renderObject = element.renderObject as RenderStack;
   try {
-    RenderObject child = renderObject.firstChild;
+    RenderObject? child = renderObject.firstChild;
     for (final TestParentData expected in expectedParentData) {
       expect(child, isA<RenderDecoratedBox>());
-      final RenderDecoratedBox decoratedBox = child as RenderDecoratedBox;
+      final RenderDecoratedBox decoratedBox = child! as RenderDecoratedBox;
       expect(decoratedBox.parentData, isA<StackParentData>());
-      final StackParentData parentData = decoratedBox.parentData as StackParentData;
+      final StackParentData parentData = decoratedBox.parentData! as StackParentData;
       expect(parentData.top, equals(expected.top));
       expect(parentData.right, equals(expected.right));
       expect(parentData.bottom, equals(expected.bottom));
       expect(parentData.left, equals(expected.left));
-      final StackParentData decoratedBoxParentData = decoratedBox.parentData as StackParentData;
-      child = decoratedBoxParentData.nextSibling;
+      final StackParentData? decoratedBoxParentData = decoratedBox.parentData as StackParentData?;
+      child = decoratedBoxParentData?.nextSibling;
     }
     expect(child, isNull);
   } catch (e) {
@@ -431,7 +429,7 @@ void main() {
         child: Container(),
       ),
     );
-    DummyParentData parentData = tester.renderObject(find.byType(Container)).parentData as DummyParentData;
+    DummyParentData parentData = tester.renderObject(find.byType(Container)).parentData! as DummyParentData;
     expect(parentData.string, isNull);
 
     await tester.pumpWidget(
@@ -442,7 +440,7 @@ void main() {
         ),
       ),
     );
-    parentData = tester.renderObject(find.byType(Container)).parentData as DummyParentData;
+    parentData = tester.renderObject(find.byType(Container)).parentData! as DummyParentData;
     expect(parentData.string, 'Foo');
 
     await tester.pumpWidget(
@@ -453,16 +451,16 @@ void main() {
         ),
       ),
     );
-    parentData = tester.renderObject(find.byType(Container)).parentData as DummyParentData;
+    parentData = tester.renderObject(find.byType(Container)).parentData! as DummyParentData;
     expect(parentData.string, 'Bar');
   });
 }
 
 class TestParentDataWidget extends ParentDataWidget<DummyParentData> {
   const TestParentDataWidget({
-    Key key,
-    this.string,
-    Widget child,
+    Key? key,
+    required this.string,
+    required Widget child,
   }) : super(key: key, child: child);
 
   final String string;
@@ -470,7 +468,7 @@ class TestParentDataWidget extends ParentDataWidget<DummyParentData> {
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is DummyParentData);
-    final DummyParentData parentData = renderObject.parentData as DummyParentData;
+    final DummyParentData parentData = renderObject.parentData! as DummyParentData;
     parentData.string = string;
   }
 
@@ -479,13 +477,13 @@ class TestParentDataWidget extends ParentDataWidget<DummyParentData> {
 }
 
 class DummyParentData extends ParentData {
-  String string;
+  String? string;
 }
 
 class OneAncestorWidget extends SingleChildRenderObjectWidget {
   const OneAncestorWidget({
-    Key key,
-    Widget child,
+    Key? key,
+    required Widget child,
   }) : super(key: key, child: child);
 
   @override
@@ -494,8 +492,8 @@ class OneAncestorWidget extends SingleChildRenderObjectWidget {
 
 class AnotherAncestorWidget extends SingleChildRenderObjectWidget {
   const AnotherAncestorWidget({
-    Key key,
-    Widget child,
+    Key? key,
+    required Widget child,
   }) : super(key: key, child: child);
 
   @override

--- a/packages/flutter/test/widgets/performance_overlay_test.dart
+++ b/packages/flutter/test/widgets/performance_overlay_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:math' as math show pi;
 
 import 'package:flutter/material.dart';
@@ -106,7 +104,7 @@ void main() {
     Future<void> _testStackChildren(
       WidgetTester tester,
       List<Widget> children, {
-      @required int expectedErrorCount,
+      required int expectedErrorCount,
       bool enableCheck = true,
     }) async {
       assert(expectedErrorCount != null);
@@ -117,7 +115,7 @@ void main() {
       }
       debugDisableShadows = false;
       int count = 0;
-      final void Function(FlutterErrorDetails) oldOnError = FlutterError.onError;
+      final void Function(FlutterErrorDetails)? oldOnError = FlutterError.onError;
       FlutterError.onError = (FlutterErrorDetails details) {
         count++;
       };

--- a/packages/flutter/test/widgets/placeholder_test.dart
+++ b/packages/flutter/test/widgets/placeholder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 @TestOn('!chrome')
 import 'dart:async';
 import 'dart:typed_data';
@@ -65,7 +63,7 @@ void main() {
       );
 
       final FakeAndroidPlatformView fakeView = viewsController.views.first;
-      final Uint8List rawCreationParams = fakeView.creationParams;
+      final Uint8List rawCreationParams = fakeView.creationParams!;
       final ByteData byteData = ByteData.view(
           rawCreationParams.buffer,
           rawCreationParams.offsetInBytes,
@@ -141,7 +139,7 @@ void main() {
         ]),
       );
 
-      viewsController.resizeCompleter.complete();
+      viewsController.resizeCompleter!.complete();
       await tester.pump();
 
       expect(
@@ -946,7 +944,7 @@ void main() {
       expect(semantics.transform, Matrix4.translationValues(600, 500, 0));
       expect(semantics.childrenCount, 0);
 
-      viewsController.createCompleter.complete();
+      viewsController.createCompleter!.complete();
       await tester.pumpAndSettle();
 
       expect(semantics.platformViewId, currentViewId + 1);
@@ -992,8 +990,8 @@ void main() {
           ),
       );
       final Element containerElement = tester.element(find.byKey(containerKey));
-      final FocusNode androidViewFocusNode = androidViewFocusWidget.focusNode;
-      final FocusNode containerFocusNode = Focus.of(containerElement);
+      final FocusNode androidViewFocusNode = androidViewFocusWidget.focusNode!;
+      final FocusNode containerFocusNode = Focus.of(containerElement)!;
 
       containerFocusNode.requestFocus();
 
@@ -1036,16 +1034,16 @@ void main() {
         ),
       );
 
-      viewsController.createCompleter.complete();
+      viewsController.createCompleter!.complete();
 
 
       final Element containerElement = tester.element(find.byKey(containerKey));
-      final FocusNode containerFocusNode = Focus.of(containerElement);
+      final FocusNode containerFocusNode = Focus.of(containerElement)!;
 
       containerFocusNode.requestFocus();
       await tester.pump();
 
-      int lastPlatformViewTextClient;
+      late int lastPlatformViewTextClient;
       SystemChannels.textInput.setMockMethodCallHandler((MethodCall call) {
         if (call.method == 'TextInput.setPlatformViewClient') {
           lastPlatformViewTextClient = call.arguments as int;
@@ -1085,10 +1083,10 @@ void main() {
         ),
       );
 
-      viewsController.createCompleter.complete();
+      viewsController.createCompleter!.complete();
 
       final Element containerElement = tester.element(find.byKey(containerKey));
-      final FocusNode containerFocusNode = Focus.of(containerElement);
+      final FocusNode containerFocusNode = Focus.of(containerElement)!;
 
       containerFocusNode.requestFocus();
       await tester.pump();
@@ -1152,7 +1150,7 @@ void main() {
   });
 
   group('AndroidViewSurface', () {
-    FakeAndroidViewController controller;
+    late FakeAndroidViewController controller;
 
     setUp(() {
       controller = FakeAndroidViewController(0);
@@ -1276,7 +1274,7 @@ void main() {
         ),
       );
 
-      viewsController.creationDelay.complete();
+      viewsController.creationDelay!.complete();
 
       expect(
         viewsController.views,
@@ -1340,7 +1338,7 @@ void main() {
       );
 
       final FakeUiKitView fakeView = viewsController.views.first;
-      final Uint8List rawCreationParams = fakeView.creationParams;
+      final Uint8List rawCreationParams = fakeView.creationParams!;
       final ByteData byteData = ByteData.view(
           rawCreationParams.buffer,
           rawCreationParams.offsetInBytes,
@@ -1956,7 +1954,7 @@ void main() {
   });
 
   group('Common PlatformView', () {
-    FakePlatformViewController controller;
+    late FakePlatformViewController controller;
 
     setUp((){
       controller = FakePlatformViewController(0);
@@ -2219,9 +2217,9 @@ void main() {
 
     testWidgets('PlatformViewLink Widget init, should create a SizedBox widget before onPlatformViewCreated and a PlatformViewSurface after', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      int createdPlatformViewId;
+      late int createdPlatformViewId;
 
-      PlatformViewCreatedCallback onPlatformViewCreatedCallBack;
+      late PlatformViewCreatedCallback onPlatformViewCreatedCallBack;
 
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'webview',
@@ -2251,7 +2249,7 @@ void main() {
     });
 
     testWidgets('PlatformViewLink Widget dispose', (WidgetTester tester) async {
-      FakePlatformViewController disposedController;
+      late FakePlatformViewController disposedController;
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'webview',
         onCreatePlatformView: (PlatformViewCreationParams params){
@@ -2416,8 +2414,8 @@ void main() {
 
     testWidgets('PlatformViewLink manages the focus properly', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
-      FakePlatformViewController controller;
-      ValueChanged<bool> focusChanged;
+      late FakePlatformViewController controller;
+      late ValueChanged<bool> focusChanged;
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'webview',
         onCreatePlatformView: (PlatformViewCreationParams params){
@@ -2453,9 +2451,9 @@ void main() {
               matching: find.byType(Focus),
           ),
       );
-      final FocusNode platformViewFocusNode = platformViewFocusWidget.focusNode;
+      final FocusNode platformViewFocusNode = platformViewFocusWidget.focusNode!;
       final Element containerElement = tester.element(find.byKey(containerKey));
-      final FocusNode containerFocusNode = Focus.of(containerElement);
+      final FocusNode containerFocusNode = Focus.of(containerElement)!;
 
       containerFocusNode.requestFocus();
       await tester.pump();

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -1,8 +1,5 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-// @dart = 2.8
+// Use of this source code is governed
 
 import 'dart:async';
 
@@ -78,8 +75,8 @@ void main() {
     final GlobalKey key = GlobalKey();
 
     void recordMetrics() {
-      final RenderBox box = key.currentContext.findRenderObject() as RenderBox;
-      final BoxParentData boxParentData = box.parentData as BoxParentData;
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
+      final BoxParentData boxParentData = box.parentData! as BoxParentData;
       sizes.add(box.size);
       positions.add(boxParentData.offset);
     }

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -1,5 +1,6 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'dart:async';
 

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class ExpandingBox extends StatefulWidget {
-  const ExpandingBox({this.collapsedSize, this.expandedSize});
+  const ExpandingBox({ required this.collapsedSize, required this.expandedSize });
 
   final double collapsedSize;
   final double expandedSize;
@@ -19,7 +17,7 @@ class ExpandingBox extends StatefulWidget {
 }
 
 class _ExpandingBoxState extends State<ExpandingBox> with AutomaticKeepAliveClientMixin<ExpandingBox>{
-  double _height;
+  late double _height;
 
   @override
   void initState() {

--- a/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
+++ b/packages/flutter/test/widgets/raw_keyboard_listener_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/reassemble_test.dart
+++ b/packages/flutter/test/widgets/reassemble_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/render_object_element_test.dart
+++ b/packages/flutter/test/widgets/render_object_element_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -12,7 +10,7 @@ import 'package:flutter/widgets.dart';
 @immutable
 class Pair<T> {
   const Pair(this.first, this.second);
-  final T first;
+  final T? first;
   final T second;
 
   @override
@@ -31,10 +29,10 @@ class Pair<T> {
 /// and the other child in the bottom half. It will swap which child is on top
 /// and which is on bottom every time the widget is rendered.
 abstract class Swapper extends RenderObjectWidget {
-  const Swapper({this.stable, this.swapper});
+  const Swapper({ this.stable, this.swapper });
 
-  final Widget stable;
-  final Widget swapper;
+  final Widget? stable;
+  final Widget? swapper;
 
   @override
   SwapperElement createElement();
@@ -45,8 +43,8 @@ abstract class Swapper extends RenderObjectWidget {
 
 class SwapperWithProperOverrides extends Swapper {
   const SwapperWithProperOverrides({
-    Widget stable,
-    Widget swapper,
+    Widget? stable,
+    Widget? swapper,
   }) : super(stable: stable, swapper: swapper);
 
   @override
@@ -55,8 +53,8 @@ class SwapperWithProperOverrides extends Swapper {
 
 class SwapperWithNoOverrides extends Swapper {
   const SwapperWithNoOverrides({
-    Widget stable,
-    Widget swapper,
+    Widget? stable,
+    Widget? swapper,
   }) : super(stable: stable, swapper: swapper);
 
   @override
@@ -65,8 +63,8 @@ class SwapperWithNoOverrides extends Swapper {
 
 class SwapperWithDeprecatedOverrides extends Swapper {
   const SwapperWithDeprecatedOverrides({
-    Widget stable,
-    Widget swapper,
+    Widget? stable,
+    Widget? swapper,
   }) : super(stable: stable, swapper: swapper);
 
   @override
@@ -76,8 +74,8 @@ class SwapperWithDeprecatedOverrides extends Swapper {
 abstract class SwapperElement extends RenderObjectElement {
   SwapperElement(Swapper widget) : super(widget);
 
-  Element stable;
-  Element swapper;
+  Element? stable;
+  Element? swapper;
   bool swapperIsOnTop = true;
   List<dynamic> insertSlots = <dynamic>[];
   List<Pair<dynamic>> moveSlots = <Pair<dynamic>>[];
@@ -92,9 +90,9 @@ abstract class SwapperElement extends RenderObjectElement {
   @override
   void visitChildren(ElementVisitor visitor) {
     if (stable != null)
-      visitor(stable);
+      visitor(stable!);
     if (swapper != null)
-      visitor(swapper);
+      visitor(swapper!);
   }
 
   @override
@@ -104,7 +102,7 @@ abstract class SwapperElement extends RenderObjectElement {
   }
 
   @override
-  void mount(Element parent, dynamic newSlot) {
+  void mount(Element? parent, dynamic newSlot) {
     super.mount(parent, newSlot);
     _updateChildren(widget);
   }
@@ -183,22 +181,22 @@ class SwapperElementWithDeprecatedOverrides extends SwapperElement {
 }
 
 class RenderSwapper extends RenderBox {
-  RenderBox _stable;
-  RenderBox get stable => _stable;
-  set stable(RenderBox child) {
+  RenderBox? _stable;
+  RenderBox? get stable => _stable;
+  set stable(RenderBox? child) {
     if (child == _stable)
       return;
     if (_stable != null)
-      dropChild(_stable);
+      dropChild(_stable!);
     _stable = child;
     if (child != null)
       adoptChild(child);
   }
 
-  bool _swapperIsOnTop;
-  RenderBox _swapper;
-  RenderBox get swapper => _swapper;
-  void setSwapper(RenderBox child, bool isOnTop) {
+  bool? _swapperIsOnTop;
+  RenderBox? _swapper;
+  RenderBox? get swapper => _swapper;
+  void setSwapper(RenderBox? child, bool isOnTop) {
     if (isOnTop != _swapperIsOnTop) {
       _swapperIsOnTop = isOnTop;
       markNeedsLayout();
@@ -206,7 +204,7 @@ class RenderSwapper extends RenderBox {
     if (child == _swapper)
       return;
     if (_swapper != null)
-      dropChild(_swapper);
+      dropChild(_swapper!);
     _swapper = child;
     if (child != null)
       adoptChild(child);
@@ -215,9 +213,9 @@ class RenderSwapper extends RenderBox {
   @override
   void visitChildren(RenderObjectVisitor visitor) {
     if (_stable != null)
-      visitor(_stable);
+      visitor(_stable!);
     if (_swapper != null)
-      visitor(_swapper);
+      visitor(_swapper!);
   }
 
   @override
@@ -244,21 +242,21 @@ class RenderSwapper extends RenderBox {
       maxHeight: constraints.maxHeight / 2,
     );
     if (_stable != null) {
-      final BoxParentData stableParentData = _stable.parentData as BoxParentData;
-      _stable.layout(childConstraints);
-      stableParentData.offset = _swapperIsOnTop ? bottomOffset : topOffset;
+      final BoxParentData stableParentData = _stable!.parentData! as BoxParentData;
+      _stable!.layout(childConstraints);
+      stableParentData.offset = _swapperIsOnTop! ? bottomOffset : topOffset;
     }
     if (_swapper != null) {
-      final BoxParentData swapperParentData = _swapper.parentData as BoxParentData;
-      _swapper.layout(childConstraints);
-      swapperParentData.offset = _swapperIsOnTop ? topOffset : bottomOffset;
+      final BoxParentData swapperParentData = _swapper!.parentData! as BoxParentData;
+      _swapper!.layout(childConstraints);
+      swapperParentData.offset = _swapperIsOnTop! ? topOffset : bottomOffset;
     }
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
     visitChildren((RenderObject child) {
-      final BoxParentData childParentData = child.parentData as BoxParentData;
+      final BoxParentData childParentData = child.parentData! as BoxParentData;
       context.paintChild(child, offset + childParentData.offset);
     });
   }
@@ -269,7 +267,7 @@ class RenderSwapper extends RenderBox {
   }
 }
 
-BoxParentData parentDataFor(RenderObject renderObject) => renderObject.parentData as BoxParentData;
+BoxParentData parentDataFor(RenderObject renderObject) => renderObject.parentData! as BoxParentData;
 
 void main() {
   testWidgets('RenderObjectElement *RenderObjectChild methods get called with correct arguments', (WidgetTester tester) async {
@@ -356,7 +354,7 @@ void main() {
     expect(swapper.insertSlots.length, 2);
     expect(swapper.moveSlots.length, 1);
     expect(swapper.removeSlots.length, 2);
-    expect(swapper.removeSlots, <bool>[null,null]);
+    expect(swapper.removeSlots, <bool?>[null,null]);
   });
 
   testWidgets('RenderObjectElement *ChildRenderObject methods fail with deprecation message', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/render_object_widget_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -16,8 +14,8 @@ final BoxDecoration kBoxDecorationC = BoxDecoration(border: nonconst(null));
 
 class TestWidget extends StatelessWidget {
   const TestWidget({
-    Key key,
-    this.child,
+    Key? key,
+    required this.child,
   }) : super(key: key);
 
   final Widget child;
@@ -27,18 +25,16 @@ class TestWidget extends StatelessWidget {
 }
 
 class TestOrientedBox extends SingleChildRenderObjectWidget {
-  const TestOrientedBox({ Key key, Widget child }) : super(key: key, child: child);
+  const TestOrientedBox({ Key? key, Widget? child }) : super(key: key, child: child);
 
   Decoration _getDecoration(BuildContext context) {
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.of(context)!.orientation;
     switch (orientation) {
       case Orientation.landscape:
         return const BoxDecoration(color: Color(0xFF00FF00));
       case Orientation.portrait:
         return const BoxDecoration(color: Color(0xFF0000FF));
     }
-    assert(orientation != null);
-    return null;
   }
 
   @override
@@ -51,7 +47,7 @@ class TestOrientedBox extends SingleChildRenderObjectWidget {
 }
 
 class TestNonVisitingWidget extends SingleChildRenderObjectWidget {
-  const TestNonVisitingWidget({ Key key, Widget child }) : super(key: key, child: child);
+  const TestNonVisitingWidget({ Key? key, required Widget child }) : super(key: key, child: child);
 
   @override
   RenderObject createRenderObject(BuildContext context) => TestNonVisitingRenderObject();
@@ -60,13 +56,13 @@ class TestNonVisitingWidget extends SingleChildRenderObjectWidget {
 class TestNonVisitingRenderObject extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
   @override
   void performLayout() {
-    child.layout(constraints, parentUsesSize: true);
-    size = child.size;
+    child!.layout(constraints, parentUsesSize: true);
+    size = child!.size;
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    context.paintChild(child, offset);
+    context.paintChild(child!, offset);
   }
 
   @override
@@ -107,7 +103,7 @@ void main() {
       expect(renderObject.position, equals(DecorationPosition.background));
       expect(renderObject.child, isNotNull);
       expect(renderObject.child, isA<RenderDecoratedBox>());
-      final RenderDecoratedBox child = renderObject.child as RenderDecoratedBox;
+      final RenderDecoratedBox child = renderObject.child! as RenderDecoratedBox;
       expect(child.decoration, equals(kBoxDecorationB));
       expect(child.position, equals(DecorationPosition.background));
       expect(child.child, isNull);
@@ -196,10 +192,10 @@ void main() {
     expect(element.renderObject, isA<RenderDecoratedBox>());
     final RenderDecoratedBox parent = element.renderObject as RenderDecoratedBox;
     expect(parent.child, isA<RenderDecoratedBox>());
-    final RenderDecoratedBox child = parent.child as RenderDecoratedBox;
+    final RenderDecoratedBox child = parent.child! as RenderDecoratedBox;
     expect(child.decoration, equals(kBoxDecorationB));
     expect(child.child, isA<RenderDecoratedBox>());
-    final RenderDecoratedBox grandChild = child.child as RenderDecoratedBox;
+    final RenderDecoratedBox grandChild = child.child! as RenderDecoratedBox;
     expect(grandChild.decoration, equals(kBoxDecorationC));
     expect(grandChild.child, isNull);
 

--- a/packages/flutter/test/widgets/reparent_state_harder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_harder_test.dart
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // This is a regression test for https://github.com/flutter/flutter/issues/5588.
 
 class OrderSwitcher extends StatefulWidget {
-  const OrderSwitcher({ Key key, this.a, this.b }) : super(key: key);
+  const OrderSwitcher({
+    Key? key,
+    required this.a,
+    required this.b,
+  }) : super(key: key);
 
   final Widget a;
   final Widget b;
@@ -47,7 +49,7 @@ class OrderSwitcherState extends State<OrderSwitcher> {
 }
 
 class DummyStatefulWidget extends StatefulWidget {
-  const DummyStatefulWidget(Key key) : super(key: key);
+  const DummyStatefulWidget(Key? key) : super(key: key);
 
   @override
   DummyStatefulWidgetState createState() => DummyStatefulWidgetState();
@@ -60,18 +62,18 @@ class DummyStatefulWidgetState extends State<DummyStatefulWidget> {
 
 class RekeyableDummyStatefulWidgetWrapper extends StatefulWidget {
   const RekeyableDummyStatefulWidgetWrapper({
-    Key key,
+    Key? key,
     this.child,
-    this.initialKey,
+    required this.initialKey,
   }) : super(key: key);
-  final Widget child;
+  final Widget? child;
   final GlobalKey initialKey;
   @override
   RekeyableDummyStatefulWidgetWrapperState createState() => RekeyableDummyStatefulWidgetWrapperState();
 }
 
 class RekeyableDummyStatefulWidgetWrapperState extends State<RekeyableDummyStatefulWidgetWrapper> {
-  GlobalKey _key;
+  GlobalKey? _key;
 
   @override
   void initState() {
@@ -79,7 +81,7 @@ class RekeyableDummyStatefulWidgetWrapperState extends State<RekeyableDummyState
     _key = widget.initialKey;
   }
 
-  void _setChild(GlobalKey value) {
+  void _setChild(GlobalKey? value) {
     setState(() {
       _key = value;
     });
@@ -160,7 +162,7 @@ void main() {
     expect(find.byType(RekeyableDummyStatefulWidgetWrapper), findsNWidgets(2));
     expect(find.byType(DummyStatefulWidget), findsNWidgets(2));
 
-    keyRoot.currentState.switchChildren();
+    keyRoot.currentState!.switchChildren();
     final List<State> states = tester.stateList(find.byType(RekeyableDummyStatefulWidgetWrapper)).toList();
     final RekeyableDummyStatefulWidgetWrapperState a = states[0] as RekeyableDummyStatefulWidgetWrapperState;
     a._setChild(null);

--- a/packages/flutter/test/widgets/reparent_state_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_test.dart
@@ -2,33 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
 class StateMarker extends StatefulWidget {
-  const StateMarker({ Key key, this.child }) : super(key: key);
+  const StateMarker({ Key? key, this.child }) : super(key: key);
 
-  final Widget child;
+  final Widget? child;
 
   @override
   StateMarkerState createState() => StateMarkerState();
 }
 
 class StateMarkerState extends State<StateMarker> {
-  String marker;
+  String? marker;
 
   @override
   Widget build(BuildContext context) {
     if (widget.child != null)
-      return widget.child;
+      return widget.child!;
     return Container();
   }
 }
 
 class DeactivateLogger extends StatefulWidget {
-  const DeactivateLogger({ Key key, this.log }) : super(key: key);
+  const DeactivateLogger({ required Key key, required this.log }) : super(key: key);
 
   final List<String> log;
 
@@ -73,9 +71,9 @@ void main() {
       ),
     );
 
-    final StateMarkerState leftState = left.currentState as StateMarkerState;
+    final StateMarkerState leftState = left.currentState! as StateMarkerState;
     leftState.marker = 'left';
-    final StateMarkerState rightState = right.currentState as StateMarkerState;
+    final StateMarkerState rightState = right.currentState! as StateMarkerState;
     rightState.marker = 'right';
 
     final StateMarkerState grandchildState = tester.state(find.byWidget(grandchild));
@@ -144,9 +142,9 @@ void main() {
       ),
     );
 
-    final StateMarkerState leftState = left.currentState as StateMarkerState;
+    final StateMarkerState leftState = left.currentState! as StateMarkerState;
     leftState.marker = 'left';
-    final StateMarkerState rightState = right.currentState as StateMarkerState;
+    final StateMarkerState rightState = right.currentState! as StateMarkerState;
     rightState.marker = 'right';
 
     final StateMarkerState grandchildState = tester.state(find.byWidget(grandchild));
@@ -198,7 +196,7 @@ void main() {
 
     await tester.pumpWidget(StateMarker(key: key));
 
-    final StateMarkerState keyState = key.currentState as StateMarkerState;
+    final StateMarkerState keyState = key.currentState! as StateMarkerState;
     keyState.marker = 'marked';
 
     await tester.pumpWidget(
@@ -237,7 +235,7 @@ void main() {
       ],
     ));
 
-    final StateMarkerState keyState = key.currentState as StateMarkerState;
+    final StateMarkerState keyState = key.currentState!as StateMarkerState;
     keyState.marker = 'marked';
 
     await tester.pumpWidget(Stack(
@@ -275,7 +273,7 @@ void main() {
       ],
     ));
 
-    final StateMarkerState keyState = key.currentState as StateMarkerState;
+    final StateMarkerState keyState = key.currentState! as StateMarkerState;
     keyState.marker = 'marked';
 
     await tester.pumpWidget(Stack(

--- a/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui show window;
 
 import 'package:flutter/material.dart';
@@ -12,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 // This is a regression test for https://github.com/flutter/flutter/issues/5840.
 
 class Bar extends StatefulWidget {
-  const Bar({ Key key }) : super(key: key);
+  const Bar({ Key? key }) : super(key: key);
   @override
   BarState createState() => BarState();
 }
@@ -49,7 +47,7 @@ class BarState extends State<Bar> {
 }
 
 class StatefulCreationCounter extends StatefulWidget {
-  const StatefulCreationCounter({ Key key }) : super(key: key);
+  const StatefulCreationCounter({ Key? key }) : super(key: key);
 
   @override
   StatefulCreationCounterState createState() => StatefulCreationCounterState();
@@ -82,9 +80,9 @@ void main() {
   testWidgets('Clean then reparent with dependencies', (WidgetTester tester) async {
     int layoutBuilderBuildCount = 0;
 
-    StateSetter keyedSetState;
-    StateSetter layoutBuilderSetState;
-    StateSetter childSetState;
+    late StateSetter keyedSetState;
+    late StateSetter layoutBuilderSetState;
+    late StateSetter childSetState;
 
     final GlobalKey key = GlobalKey();
     final Widget keyedWidget = StatefulBuilder(

--- a/packages/flutter/test/widgets/restorable_property_test.dart
+++ b/packages/flutter/test/widgets/restorable_property_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,14 +15,6 @@ void main() {
     expect(() => RestorableBool(true).value, throwsAssertionError);
     expect(() => RestorableTextEditingController().value, throwsAssertionError);
     expect(() => _TestRestorableValue().value, throwsAssertionError);
-  });
-
-  testWidgets('cannot initialize with null', (WidgetTester tester) async {
-    expect(() => RestorableNum<num>(null), throwsAssertionError);
-    expect(() => RestorableDouble(null), throwsAssertionError);
-    expect(() => RestorableInt(null), throwsAssertionError);
-    expect(() => RestorableString(null).value, throwsAssertionError);
-    expect(() => RestorableBool(null).value, throwsAssertionError);
   });
 
   testWidgets('work when not in restoration scope', (WidgetTester tester) async {
@@ -117,22 +107,6 @@ void main() {
     expect(state.controllerValue.value.text, 'blabla');
     expect(state.objectValue.value, 53);
     expect(find.text('guten tag'), findsOneWidget);
-  });
-
-  testWidgets('cannot set to null', (WidgetTester tester) async {
-    await tester.pumpWidget(const RootRestorationScope(
-      restorationId: 'root-child',
-      child: _RestorableWidget(),
-    ));
-
-    expect(find.text('hello world'), findsOneWidget);
-    final _RestorableWidgetState state = tester.state(find.byType(_RestorableWidget));
-
-    expect(() => state.numValue.value = null, throwsAssertionError);
-    expect(() => state.doubleValue.value = null, throwsAssertionError);
-    expect(() => state.intValue.value = null, throwsAssertionError);
-    expect(() => state.stringValue.value = null, throwsAssertionError);
-    expect(() => state.boolValue.value = null, throwsAssertionError);
   });
 
   testWidgets('restore to older state', (WidgetTester tester) async {
@@ -320,7 +294,7 @@ class _TestRestorableValue extends RestorableValue<Object> {
   int didUpdateValueCallCount = 0;
 
   @override
-  void didUpdateValue(Object oldValue) {
+  void didUpdateValue(Object? oldValue) {
     didUpdateValueCallCount++;
     notifyListeners();
   }
@@ -337,7 +311,7 @@ class _TestRestorableValue extends RestorableValue<Object> {
 }
 
 class _RestorableWidget extends StatefulWidget {
-  const _RestorableWidget({Key key}) : super(key: key);
+  const _RestorableWidget({Key? key}) : super(key: key);
 
   @override
   State<_RestorableWidget> createState() => _RestorableWidgetState();
@@ -353,7 +327,7 @@ class _RestorableWidgetState extends State<_RestorableWidget> with RestorationMi
   final _TestRestorableValue objectValue = _TestRestorableValue();
 
   @override
-  void restoreState(RestorationBucket oldBucket, bool initialRestore) {
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
     registerForRestoration(numValue, 'num');
     registerForRestoration(doubleValue, 'double');
     registerForRestoration(intValue, 'int');
@@ -369,7 +343,7 @@ class _RestorableWidgetState extends State<_RestorableWidget> with RestorationMi
 
   @override
   Widget build(BuildContext context) {
-    return Text(stringValue.value ?? 'null', textDirection: TextDirection.ltr,);
+    return Text(stringValue.value, textDirection: TextDirection.ltr,);
   }
 
   @override


### PR DESCRIPTION
## Description

This migrates several tests from the widgets library to NNBD.

## Related Issues

dart-lang/sdk#40146
#62886

## Tests

Pass!

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
