### PR TITLE
Make TabBar indicator color automatic adjustment optional

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -690,7 +690,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// If [automaticIndicatorColorAdjustment] is true,
   /// then the [indicatorColor] will be automatically adjusted to [Colors.white]
-  /// when the [indicatorColor] is same as [Material.color].
+  /// when the [indicatorColor] is same as [Material.color] of the [Material] parent widget.
   final bool automaticIndicatorColorAdjustment;
 
   /// Defines how the selected tab indicator's size is computed.
@@ -822,6 +822,8 @@ class _TabBarState extends State<TabBar> {
     //
     // The material's color might be null (if it's a transparency). In that case
     // there's no good way for us to find out what the color is so we don't.
+    // TODO(xu-baolin): Remove this code without breaking something.
+    // https://github.com/flutter/flutter/pull/68171#pullrequestreview-517753917
     if (widget.automaticIndicatorColorAdjustment && color.value == Material.of(context)?.color?.value)
       color = Colors.white;
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -822,7 +822,9 @@ class _TabBarState extends State<TabBar> {
     //
     // The material's color might be null (if it's a transparency). In that case
     // there's no good way for us to find out what the color is so we don't.
-    // TODO(xu-baolin): Remove this code without breaking something.
+    //
+    // TODO(xu-baolin): Remove automatic adjustment to white color indicator
+    // with a better long-term solution.
     // https://github.com/flutter/flutter/pull/68171#pullrequestreview-517753917
     if (widget.automaticIndicatorColorAdjustment && color.value == Material.of(context)?.color?.value)
       color = Colors.white;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -597,6 +597,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.controller,
     this.isScrollable = false,
     this.indicatorColor,
+    this.automaticIndicatorColorAdjustment = true,
     this.indicatorWeight = 2.0,
     this.indicatorPadding = EdgeInsets.zero,
     this.indicator,
@@ -684,6 +685,13 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// [TabBarIndicatorSize.label], then the tab's bounds are only as wide as
   /// the tab widget itself.
   final Decoration? indicator;
+
+  /// Whether this tab bar should automatically adjust the [indicatorColor].
+  ///
+  /// If [automaticIndicatorColorAdjustment] is true,
+  /// then the [indicatorColor] will be automatically adjusted to [Colors.white]
+  /// when the [indicatorColor] is same as [Material.color].
+  final bool automaticIndicatorColorAdjustment;
 
   /// Defines how the selected tab indicator's size is computed.
   ///
@@ -814,7 +822,7 @@ class _TabBarState extends State<TabBar> {
     //
     // The material's color might be null (if it's a transparency). In that case
     // there's no good way for us to find out what the color is so we don't.
-    if (color.value == Material.of(context)?.color?.value)
+    if (widget.automaticIndicatorColorAdjustment && color.value == Material.of(context)?.color?.value)
       color = Colors.white;
 
     return UnderlineTabIndicator(

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -345,7 +345,7 @@ class ThemeData with Diagnosticable {
     textSelectionHandleColor ??= isDark ? Colors.tealAccent[400]! : primarySwatch[300]!;
     backgroundColor ??= isDark ? Colors.grey[700]! : primarySwatch[200]!;
     dialogBackgroundColor ??= isDark ? Colors.grey[800]! : Colors.white;
-    indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
+    indicatorColor ??= accentColor;
     hintColor ??= isDark ? Colors.white60 : Colors.black.withOpacity(0.6);
     errorColor ??= Colors.red[700]!;
     inputDecorationTheme ??= const InputDecorationTheme();

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -345,7 +345,7 @@ class ThemeData with Diagnosticable {
     textSelectionHandleColor ??= isDark ? Colors.tealAccent[400]! : primarySwatch[300]!;
     backgroundColor ??= isDark ? Colors.grey[700]! : primarySwatch[200]!;
     dialogBackgroundColor ??= isDark ? Colors.grey[800]! : Colors.white;
-    indicatorColor ??= accentColor;
+    indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
     hintColor ??= isDark ? Colors.white60 : Colors.black.withOpacity(0.6);
     errorColor ??= Colors.red[700]!;
     inputDecorationTheme ??= const InputDecorationTheme();

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -169,7 +169,7 @@ class TabControllerFrameState extends State<TabControllerFrame> with SingleTicke
   }
 }
 
-Widget buildLeftRightApp({ required List<String> tabs, required String value }) {
+Widget buildLeftRightApp({required List<String> tabs, required String value, bool automaticIndicatorColorAdjustment = true}) {
   return MaterialApp(
     theme: ThemeData(platform: TargetPlatform.android),
     home: DefaultTabController(
@@ -180,6 +180,7 @@ Widget buildLeftRightApp({ required List<String> tabs, required String value }) 
           title: const Text('tabs'),
           bottom: TabBar(
             tabs: tabs.map<Widget>((String tab) => Tab(text: tab)).toList(),
+            automaticIndicatorColorAdjustment: automaticIndicatorColorAdjustment,
           ),
         ),
         body: const TabBarView(
@@ -2213,7 +2214,16 @@ void main() {
     expect(tabBarBox, paints..line(
       color: Colors.white,
     ));
+  });
 
+  testWidgets('Tab indicator color should not be adjusted when disable [automaticIndicatorColorAdjustment]', (WidgetTester tester) async {
+     // Regression test for https://github.com/flutter/flutter/issues/68077
+     final List<String> tabs = <String>['LEFT', 'RIGHT'];
+     await tester.pumpWidget(buildLeftRightApp(tabs: tabs, value: 'LEFT', automaticIndicatorColorAdjustment: false));
+     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+     expect(tabBarBox, paints..line(
+       color: const Color(0xff2196f3),
+     ));
   });
 
   testWidgets('Skipping tabs with global key does not crash', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

The automatic adjustment behavior of the tab bar indicator color is not documented in the API doc, I think we should document that.
https://github.com/flutter/flutter/blob/ed2a4809dae2c8faa643a55897d824c2006627fd/packages/flutter/lib/src/material/tabs.dart#L814-L825

At the same time, there are several reasons that let developers have the opportunity to not apply this behavior:

1、This automatic adjustment solution is not perfect as the discussion at https://github.com/flutter/flutter/pull/14741#discussion_r169478150

2、Sometimes developer wants the same color such as #68077 

3、Even if they are the same color, it does not necessarily cause the indicator to be invisible such as #68077 

In summary, considering backward compatibility, I set the `automaticIndicatorColorAdjustment` default value to true. Of course, I would love to hear that you have a better solution.

https://github.com/flutter/flutter/blob/ed2a4809dae2c8faa643a55897d824c2006627fd/packages/flutter/lib/src/material/theme_data.dart#L348
I believe this should be a typo instead of `accentColor.value == primaryColor.value`.
Most of the time, `primaryColor` is `MaterialColor` type and `accentColor` is `Color` type. They cannot be compared directly with `==`, otherwise it will not be the expected result.
 Considering backward compatibility and do not want to break something, I make this change to avoid future undesired behaviors.

## Related Issues

Fixes #68077 

## Tests

I added the following tests:

See files.