### PR TITLE
[NNBD] Migrate more widget tests to NNBD

### DIFF
--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -75,8 +73,8 @@ void main() {
 
     expect(scrollController.offset, kItemHeight / 2);
 
-    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics!.id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
 
@@ -137,8 +135,8 @@ void main() {
 
     expect(scrollController.offset, kItemHeight / 2);
 
-    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics!.id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
     expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
@@ -205,8 +203,8 @@ void main() {
 
     expect(scrollController.offset, 2.5 * kItemHeight);
 
-    final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(id0, SemanticsAction.showOnScreen);
+    final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
     expect(tester.getTopLeft(find.byWidget(children[0])).dy, kToolbarHeight);
@@ -405,9 +403,9 @@ void main() {
 
     const double kItemHeight = 100.0;
 
-    List<Widget> children;
-    ScrollController scrollController;
-    Widget widgetUnderTest;
+    late List<Widget> children;
+    late ScrollController scrollController;
+    late Widget widgetUnderTest;
 
     setUp(() {
       children = List<Widget>.generate(10, (int i) {
@@ -445,8 +443,8 @@ void main() {
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children.first)).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byWidget(children.first)).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, 0.0);
@@ -461,8 +459,8 @@ void main() {
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children[2])).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byWidget(children[2])).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, kItemHeight);
@@ -477,8 +475,8 @@ void main() {
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children[1])).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byWidget(children[1])).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, kItemHeight / 2);
@@ -490,9 +488,9 @@ void main() {
   group('showOnScreen with negative children', () {
     const double kItemHeight = 100.0;
 
-    List<Widget> children;
-    ScrollController scrollController;
-    Widget widgetUnderTest;
+    late List<Widget> children;
+    late ScrollController scrollController;
+    late Widget widgetUnderTest;
 
     setUp(() {
       final Key center = GlobalKey();
@@ -550,8 +548,8 @@ void main() {
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(2))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(2))).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -300.0);
@@ -566,8 +564,8 @@ void main() {
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(4))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(4))).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -200.0);
@@ -582,8 +580,8 @@ void main() {
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(3))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(3))).debugSemantics!.id;
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -250.0);
@@ -614,7 +612,7 @@ void main() {
 
     final SemanticsNode rootScrollNode = semantics.nodesWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]).single;
     final SemanticsNode innerListPane = semantics.nodesWith(ancestor: rootScrollNode, scrollExtentMax: 0).single;
-    final SemanticsNode outerListPane = innerListPane.parent;
+    final SemanticsNode outerListPane = innerListPane.parent!;
     final List<SemanticsNode> hiddenNodes = semantics.nodesWith(flags: <SemanticsFlag>[SemanticsFlag.isHidden]).toList();
 
     // This test is only valid if some children are offscreen.
@@ -631,7 +629,7 @@ void main() {
     expect(nodeGlobalRect(innerListPane), nodeGlobalRect(outerListPane));
 
     for (final SemanticsNode node in targetNodes) {
-      tester.binding.pipelineOwner.semanticsOwner.performAction(node.id, SemanticsAction.showOnScreen);
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(node.id, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(nodeGlobalRect(innerListPane), nodeGlobalRect(outerListPane));
@@ -659,9 +657,9 @@ Future<void> fling(WidgetTester tester, Offset offset, int repetitions) async {
 
 Rect nodeGlobalRect(SemanticsNode node) {
   Matrix4 globalTransform = node.transform ?? Matrix4.identity();
-  for (SemanticsNode parent = node.parent; parent != null; parent = parent.parent) {
+  for (SemanticsNode? parent = node.parent; parent != null; parent = parent.parent) {
     if (parent.transform != null) {
-      globalTransform = parent.transform.multiplied(globalTransform);
+      globalTransform = parent.transform!.multiplied(globalTransform);
     }
   }
   return MatrixUtils.transformRect(globalTransform, node.rect);

--- a/packages/flutter/test/widgets/scrollable_semantics_traversal_order_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_traversal_order_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -16,11 +14,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 Future<void> pumpTest(
   WidgetTester tester,
-  TargetPlatform platform, {
+  TargetPlatform? platform, {
   bool scrollable = true,
   bool reverse = false,
-  ScrollController controller,
-  Widget Function(Widget) wrapper,
+  ScrollController? controller,
 }) async {
   await tester.pumpWidget(MaterialApp(
     theme: ThemeData(
@@ -84,7 +81,7 @@ double getScrollOffset(WidgetTester tester, {bool last = true}) {
 double getScrollVelocity(WidgetTester tester) {
   final RenderViewport viewport = tester.renderObject(find.byType(Viewport));
   final ScrollPosition position = viewport.offset as ScrollPosition;
-  return position.activity.velocity;
+  return position.activity!.velocity;
 }
 
 void resetScrollOffset(WidgetTester tester) {
@@ -742,7 +739,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    Scrollable.of(find.byType(SizedBox).evaluate().first).position.activity.delegate.goBallistic(4000);
+    Scrollable.of(find.byType(SizedBox).evaluate().first)!.position.activity!.delegate.goBallistic(4000);
 
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey<String>('Box 0')), findsNothing);
@@ -771,7 +768,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    final ScrollPosition position = Scrollable.of(find.byType(SizedBox).evaluate().first).position;
+    final ScrollPosition position = Scrollable.of(find.byType(SizedBox).evaluate().first)!.position;
     final SuperPessimisticScrollPhysics physics = position.physics as SuperPessimisticScrollPhysics;
 
     expect(find.byKey(const ValueKey<String>('Box 0')), findsOneWidget);
@@ -784,7 +781,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    position.activity.delegate.goBallistic(4000);
+    position.activity!.delegate.goBallistic(4000);
 
     await tester.pumpAndSettle();
 
@@ -815,7 +812,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    final ScrollPosition position = Scrollable.of(find.byType(SizedBox).evaluate().first).position;
+    final ScrollPosition position = Scrollable.of(find.byType(SizedBox).evaluate().first)!.position;
 
     expect(find.byKey(const ValueKey<String>('Cheap box 0')), findsOneWidget);
     expect(find.byKey(const ValueKey<String>('Cheap box 52')), findsNothing);
@@ -826,7 +823,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    position.activity.delegate.goBallistic(4000);
+    position.activity!.delegate.goBallistic(4000);
 
     await tester.pumpAndSettle();
 
@@ -1010,7 +1007,7 @@ void main() {
 
 // ignore: must_be_immutable
 class SuperPessimisticScrollPhysics extends ScrollPhysics {
-  SuperPessimisticScrollPhysics({ScrollPhysics parent}) : super(parent: parent);
+  SuperPessimisticScrollPhysics({ScrollPhysics? parent}) : super(parent: parent);
 
   int count = 0;
 
@@ -1021,13 +1018,13 @@ class SuperPessimisticScrollPhysics extends ScrollPhysics {
   }
 
   @override
-  ScrollPhysics applyTo(ScrollPhysics ancestor) {
+  ScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return SuperPessimisticScrollPhysics(parent: buildParent(ancestor));
   }
 }
 
 class ExtraSuperPessimisticScrollPhysics extends ScrollPhysics {
-  const ExtraSuperPessimisticScrollPhysics({ScrollPhysics parent}) : super(parent: parent);
+  const ExtraSuperPessimisticScrollPhysics({ScrollPhysics? parent}) : super(parent: parent);
 
   @override
   bool recommendDeferredLoading(double velocity, ScrollMetrics metrics, BuildContext context) {
@@ -1035,7 +1032,7 @@ class ExtraSuperPessimisticScrollPhysics extends ScrollPhysics {
   }
 
   @override
-  ScrollPhysics applyTo(ScrollPhysics ancestor) {
+  ScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return ExtraSuperPessimisticScrollPhysics(parent: buildParent(ancestor));
   }
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/src/physics/utils.dart' show nearEqual;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,10 +19,10 @@ ScrollbarPainter _buildPainter({
   double thickness = _kThickness,
   double mainAxisMargin = 0.0,
   double crossAxisMargin = 0.0,
-  Radius radius,
+  Radius? radius,
   double minLength = _kMinThumbExtent,
-  double minOverscrollLength,
-  ScrollMetrics scrollMetrics,
+  double? minOverscrollLength,
+  required ScrollMetrics scrollMetrics,
 }) {
   return ScrollbarPainter(
     color: color,
@@ -56,7 +54,6 @@ void main() {
   Rect captureRect() => testCanvas.rects.removeLast();
 
   tearDown(() {
-    painter = null;
     testCanvas.rects.clear();
   });
 
@@ -136,14 +133,14 @@ void main() {
         startingMetrics.copyWith(pixels: maxExtent - 0.01),
       ];
 
-      double lastCoefficient;
+      late double lastCoefficient;
       for (final ScrollMetrics metrics in metricsList) {
         painter.update(metrics, metrics.axisDirection);
         painter.paint(testCanvas, size);
 
         final Rect rect = captureRect();
         final double newCoefficient = metrics.pixels/rect.top;
-        lastCoefficient ??= newCoefficient;
+        lastCoefficient = newCoefficient;
 
         expect(rect.top >= 0, true);
         expect(rect.bottom <= maxExtent, true);
@@ -483,13 +480,12 @@ void main() {
         )
         .takeWhile((ScrollMetrics metrics) => !metrics.outOfRange);
 
-        Rect previousRect;
+        Rect? previousRect;
 
         for (final ScrollMetrics metrics in metricsList) {
           painter.update(metrics, metrics.axisDirection);
           painter.paint(testCanvas, size);
           final Rect rect = captureRect();
-
           if (previousRect != null) {
             if (rect.height == size.height) {
               // Size of the scrollbar is too large for the view port

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,7 +13,7 @@ import 'package:flutter/gestures.dart';
 import '../widgets/semantics_tester.dart';
 
 class MockClipboard {
-  Object _clipboardData = <String, dynamic>{
+  dynamic _clipboardData = <String, dynamic>{
     'text': null,
   };
 
@@ -24,7 +22,7 @@ class MockClipboard {
       case 'Clipboard.getData':
         return _clipboardData;
       case 'Clipboard.setData':
-        _clipboardData = methodCall.arguments;
+        _clipboardData = methodCall.arguments as dynamic;
         break;
     }
   }
@@ -52,7 +50,7 @@ class WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliza
   bool shouldReload(WidgetsLocalizationsDelegate old) => false;
 }
 
-Widget overlay({ Widget child }) {
+Widget overlay({ Widget? child }) {
   final OverlayEntry entry = OverlayEntry(
     builder: (BuildContext context) {
       return Center(
@@ -86,7 +84,7 @@ Widget overlayWithEntry(OverlayEntry entry) {
   );
 }
 
-Widget boilerplate({ Widget child }) {
+Widget boilerplate({ Widget? child }) {
   return Localizations(
     locale: const Locale('en', 'US'),
     delegates: <LocalizationsDelegate<dynamic>>[
@@ -139,7 +137,7 @@ void main() {
     final RenderObject root = tester.renderObject(find.byType(EditableText));
     expect(root, isNotNull);
 
-    RenderEditable renderEditable;
+    late RenderEditable renderEditable;
     void recursiveFinder(RenderObject child) {
       if (child is RenderEditable) {
         renderEditable = child;
@@ -179,8 +177,8 @@ void main() {
 
   Widget selectableTextBuilder({
     String text = '',
-    int maxLines = 1,
-    int minLines,
+    int? maxLines = 1,
+    int? minLines,
   }) {
     return boilerplate(
       child: SelectableText(
@@ -625,7 +623,7 @@ void main() {
 
     final EditableTextState editableText = tester.state(find.byType(EditableText));
     // Collapse selection should not paint.
-    expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+    expect(editableText.selectionOverlay!.handlesAreVisible, isFalse);
     // Long press on the 't' character of text 'selectable' to show context menu.
     const int dIndex = 5;
     final Offset dPos = textOffsetToPosition(tester, dIndex);
@@ -1328,7 +1326,7 @@ void main() {
   });
 
   group('Keyboard Tests', () {
-    TextEditingController controller;
+    late TextEditingController controller;
 
     Future<void> setupWidget(WidgetTester tester, String text) async {
       final FocusNode focusNode = FocusNode();
@@ -2099,7 +2097,7 @@ void main() {
 
   testWidgets('SelectableText change selection with semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
-    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner;
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
     final Key key = UniqueKey();
 
     await tester.pumpWidget(
@@ -2204,7 +2202,7 @@ void main() {
     const String testValue = 'Hello';
 
     final SemanticsTester semantics = SemanticsTester(tester);
-    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner;
+    final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;
     final Key key = UniqueKey();
 
     await tester.pumpWidget(
@@ -3694,8 +3692,8 @@ void main() {
     await tester.pumpAndSettle();
 
     final EditableTextState editableText = tester.state(find.byType(EditableText));
-    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
-    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    expect(editableText.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay!.toolbarIsVisible, isTrue);
   });
 
   testWidgets('Double tap shows handles and toolbar', (WidgetTester tester) async {
@@ -3715,8 +3713,8 @@ void main() {
     await tester.pump();
 
     final EditableTextState editableText = tester.state(find.byType(EditableText));
-    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
-    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    expect(editableText.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay!.toolbarIsVisible, isTrue);
   });
 
   testWidgets(
@@ -3743,8 +3741,8 @@ void main() {
       await tester.pump();
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay!.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay!.handlesAreVisible, isFalse);
     },
   );
 
@@ -3772,8 +3770,8 @@ void main() {
       await tester.pump();
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay!.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay!.handlesAreVisible, isFalse);
     },
   );
 
@@ -3805,8 +3803,8 @@ void main() {
       await tester.pump();
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay!.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay!.handlesAreVisible, isFalse);
     },
   );
 
@@ -3928,7 +3926,7 @@ void main() {
 
     await tester.pump();
 
-    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+    expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
   });
 
   testWidgets('The handles show after pressing Select All', (WidgetTester tester) async {
@@ -3950,8 +3948,8 @@ void main() {
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Cut'), findsNothing);
     EditableTextState editableText = tester.state(find.byType(EditableText));
-    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
-    expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+    expect(editableText.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay!.toolbarIsVisible, isTrue);
 
     await tester.tap(find.text('Select all'));
     await tester.pump();
@@ -3960,7 +3958,7 @@ void main() {
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Cut'), findsNothing);
     editableText = tester.state(find.byType(EditableText));
-    expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+    expect(editableText.selectionOverlay!.handlesAreVisible, isTrue);
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{
       TargetPlatform.android,
@@ -3991,7 +3989,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final EditableTextState state = tester.state(find.byType(EditableText));
-    expect(state.selectionOverlay.handlesAreVisible, isFalse);
+    expect(state.selectionOverlay!.handlesAreVisible, isFalse);
     expect(
       state.currentTextEditingValue.selection,
       const TextSelection.collapsed(offset: 0),
@@ -4007,7 +4005,7 @@ void main() {
         state.currentTextEditingValue.selection,
         const TextSelection(baseOffset: 2, extentOffset: 7),
       );
-      expect(state.selectionOverlay.handlesAreVisible, isFalse);
+      expect(state.selectionOverlay!.handlesAreVisible, isFalse);
     }
   });
 
@@ -4019,7 +4017,7 @@ void main() {
         home: Material(
           child: SelectableText(
             'abc def ghi',
-            onSelectionChanged: (TextSelection selection, SelectionChangedCause cause) {
+            onSelectionChanged: (TextSelection selection, SelectionChangedCause? cause) {
               onSelectionChangedCallCount += 1;
             },
           ),

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -22,7 +22,7 @@ class MockClipboard {
       case 'Clipboard.getData':
         return _clipboardData;
       case 'Clipboard.setData':
-        _clipboardData = methodCall.arguments as dynamic;
+        _clipboardData = methodCall.arguments;
         break;
     }
   }

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
@@ -36,7 +34,11 @@ void main() {
   });
 }
 
-Widget buildTestWidgets({ bool excludeSemantics, String label, bool isSemanticsBoundary }) {
+Widget buildTestWidgets({
+  required bool excludeSemantics,
+  required String label,
+  required bool isSemanticsBoundary,
+}) {
   return Directionality(
     textDirection: TextDirection.ltr,
     child: Semantics(
@@ -65,10 +67,10 @@ Widget buildTestWidgets({ bool excludeSemantics, String label, bool isSemanticsB
 
 class TestWidget extends SingleChildRenderObjectWidget {
   const TestWidget({
-    Key key,
-    Widget child,
-    this.label,
-    this.isSemanticBoundary,
+    Key? key,
+    Widget? child,
+    required this.label,
+    required this.isSemanticBoundary,
   }) : super(key: key, child: child);
 
   final String label;

--- a/packages/flutter/test/widgets/semantics_10_test.dart
+++ b/packages/flutter/test/widgets/semantics_10_test.dart
@@ -68,7 +68,7 @@ Widget buildTestWidgets({
 class TestWidget extends SingleChildRenderObjectWidget {
   const TestWidget({
     Key? key,
-    Widget? child,
+    required Widget child,
     required this.label,
     required this.isSemanticBoundary,
   }) : super(key: key, child: child);

--- a/packages/flutter/test/widgets/semantics_11_test.dart
+++ b/packages/flutter/test/widgets/semantics_11_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/semantics_1_test.dart
+++ b/packages/flutter/test/widgets/semantics_1_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_2_test.dart
+++ b/packages/flutter/test/widgets/semantics_2_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_3_test.dart
+++ b/packages/flutter/test/widgets/semantics_3_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -125,7 +123,7 @@ void main() {
     ));
 
     int changeCount = 0;
-    tester.binding.pipelineOwner.semanticsOwner.addListener(() {
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
       changeCount += 1;
     });
 

--- a/packages/flutter/test/widgets/semantics_4_test.dart
+++ b/packages/flutter/test/widgets/semantics_4_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/semantics_5_test.dart
+++ b/packages/flutter/test/widgets/semantics_5_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_6_test.dart
+++ b/packages/flutter/test/widgets/semantics_6_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -51,7 +49,7 @@ void main() {
   });
 }
 
-Widget buildWidget({ @required String blockedText, bool blocking = true }) {
+Widget buildWidget({ required String blockedText, bool blocking = true }) {
   assert(blockedText != null);
   return Directionality(
     textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/semantics_6_test.dart
+++ b/packages/flutter/test/widgets/semantics_6_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 
 import 'semantics_tester.dart';
 

--- a/packages/flutter/test/widgets/semantics_7_test.dart
+++ b/packages/flutter/test/widgets/semantics_7_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_8_test.dart
+++ b/packages/flutter/test/widgets/semantics_8_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/semantics_9_test.dart
+++ b/packages/flutter/test/widgets/semantics_9_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
@@ -139,14 +137,14 @@ void main() {
 }
 
 class BoundaryBlockSemantics extends SingleChildRenderObjectWidget {
-  const BoundaryBlockSemantics({ Key key, Widget child }) : super(key: key, child: child);
+  const BoundaryBlockSemantics({ Key? key, Widget? child }) : super(key: key, child: child);
 
   @override
   RenderBoundaryBlockSemantics createRenderObject(BuildContext context) => RenderBoundaryBlockSemantics();
 }
 
 class RenderBoundaryBlockSemantics extends RenderProxyBox {
-  RenderBoundaryBlockSemantics({ RenderBox child }) : super(child);
+  RenderBoundaryBlockSemantics({ RenderBox? child }) : super(child);
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {

--- a/packages/flutter/test/widgets/semantics_9_test.dart
+++ b/packages/flutter/test/widgets/semantics_9_test.dart
@@ -137,14 +137,14 @@ void main() {
 }
 
 class BoundaryBlockSemantics extends SingleChildRenderObjectWidget {
-  const BoundaryBlockSemantics({ Key? key, Widget? child }) : super(key: key, child: child);
+  const BoundaryBlockSemantics({ Key? key, required Widget child }) : super(key: key, child: child);
 
   @override
   RenderBoundaryBlockSemantics createRenderObject(BuildContext context) => RenderBoundaryBlockSemantics();
 }
 
 class RenderBoundaryBlockSemantics extends RenderProxyBox {
-  RenderBoundaryBlockSemantics({ RenderBox? child }) : super(child);
+  RenderBoundaryBlockSemantics();
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {

--- a/packages/flutter/test/widgets/semantics_clipping_test.dart
+++ b/packages/flutter/test/widgets/semantics_clipping_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:ui' show window;
 
 import 'package:flutter/material.dart';
@@ -334,7 +332,7 @@ void main() {
     final Key keyTop = UniqueKey();
     final Key keyBottom = UniqueKey();
 
-    bool valueTop = false;
+    bool? valueTop = false;
     const bool valueBottom = true;
 
     await tester.pumpWidget(
@@ -347,7 +345,7 @@ void main() {
                 Checkbox(
                   key: keyTop,
                   value: valueTop,
-                  onChanged: (bool newValue) {
+                  onChanged: (bool? newValue) {
                     valueTop = newValue;
                   },
                 ),
@@ -395,7 +393,7 @@ void main() {
                   key: checkbox,
                   child: Checkbox(
                     value: true,
-                    onChanged: (bool _) { },
+                    onChanged: (bool? _) { },
                   ),
                 ),
                 Semantics(
@@ -403,7 +401,7 @@ void main() {
                   key: checkboxUnchecked,
                   child: Checkbox(
                     value: false,
-                    onChanged: (bool _) { },
+                    onChanged: (bool? _) { },
                   ),
                 ),
                 Semantics(
@@ -495,17 +493,17 @@ void main() {
 }
 
 String _getMessageShownInSemanticsDebugger({
-  @required Key widgetKey,
-  @required Key debuggerKey,
-  @required WidgetTester tester,
+  required Key widgetKey,
+  required Key debuggerKey,
+  required WidgetTester tester,
 }) {
   final dynamic semanticsDebuggerPainter = _getSemanticsDebuggerPainter(debuggerKey: debuggerKey, tester: tester);
   return semanticsDebuggerPainter.getMessage(tester.renderObject(find.byKey(widgetKey)).debugSemantics) as String;
 }
 
 dynamic _getSemanticsDebuggerPainter({
-  @required Key debuggerKey,
-  @required WidgetTester tester,
+  required Key debuggerKey,
+  required WidgetTester tester,
 }) {
   final CustomPaint customPaint = tester.widgetList(find.descendant(
     of: find.byKey(debuggerKey),

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -333,7 +333,6 @@ void main() {
     final Key keyBottom = UniqueKey();
 
     bool? valueTop = false;
-    const bool valueBottom = true;
 
     await tester.pumpWidget(
       Directionality(
@@ -351,7 +350,7 @@ void main() {
                 ),
                 Checkbox(
                   key: keyBottom,
-                  value: valueBottom,
+                  value: false,
                   onChanged: null,
                 ),
               ],
@@ -362,14 +361,11 @@ void main() {
     );
 
     await tester.tap(find.byKey(keyTop));
-
     expect(valueTop, isTrue);
     valueTop = false;
     expect(valueTop, isFalse);
 
     await tester.tap(find.byKey(keyBottom));
-
-    expect(valueTop, isFalse);
     expect(valueTop, isFalse);
   });
 

--- a/packages/flutter/test/widgets/semantics_event_test.dart
+++ b/packages/flutter/test/widgets/semantics_event_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -54,8 +52,8 @@ void main() {
 class TestSemanticsEvent extends SemanticsEvent {
   TestSemanticsEvent({ this.text, this.number }) : super('TestEvent');
 
-  final String text;
-  final int number;
+  final String? text;
+  final int? number;
 
   @override
   Map<String, dynamic> getDataMap() {

--- a/packages/flutter/test/widgets/semantics_keep_alive_offstage_test.dart
+++ b/packages/flutter/test/widgets/semantics_keep_alive_offstage_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -83,7 +81,11 @@ void main() {
 
 final Key paddingWidget = GlobalKey();
 
-Widget _buildTestWidget({ bool extraPadding, String text, ScrollController controller }) {
+Widget _buildTestWidget({
+  required bool extraPadding,
+  required String text,
+  required ScrollController controller,
+}) {
   return MaterialApp(
     home: Scaffold(
       body: Column(
@@ -117,7 +119,11 @@ Widget _buildTestWidget({ bool extraPadding, String text, ScrollController contr
 }
 
 class ProblemWidget extends StatefulWidget {
-  const ProblemWidget({Key key, this.extraPadding, this.text}) : super(key: key);
+  const ProblemWidget({
+    Key? key,
+    required this.extraPadding,
+    required this.text,
+  }) : super(key: key);
 
   final bool extraPadding;
   final String text;

--- a/packages/flutter/test/widgets/semantics_merge_test.dart
+++ b/packages/flutter/test/widgets/semantics_merge_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';


### PR DESCRIPTION
## Description

Covers the following:
```
./widgets/scrollable_semantics_test.dart	668
./widgets/scrollable_semantics_traversal_order_test.dart	870
./widgets/scrollable_test.dart	1048
./widgets/scrollbar_test.dart	510
./widgets/selectable_text_test.dart	4042
./widgets/semantics_10_test.dart	124
./widgets/semantics_11_test.dart	99
./widgets/semantics_1_test.dart	238
./widgets/semantics_2_test.dart	174
./widgets/semantics_3_test.dart	152
./widgets/semantics_4_test.dart	172
./widgets/semantics_5_test.dart	55
./widgets/semantics_6_test.dart	79
./widgets/semantics_7_test.dart	133
./widgets/semantics_8_test.dart	94
./widgets/semantics_9_test.dart	159
./widgets/semantics_clipping_test.dart	130
./widgets/semantics_debugger_test.dart	517
./widgets/semantics_event_test.dart	69
./widgets/semantics_keep_alive_offstage_test.dart	152
./widgets/semantics_merge_test.dart	169
```

## Related Issues

dart-lang/sdk#40146
#62886
