### PR TITLE
[devicelab] mark catalina not flaky and list iproxy processes before test

### DIFF
--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -87,6 +87,11 @@ class _TaskRunner {
       ).toSet();
       final Set<RunningProcessInfo> allProcesses = await getRunningProcesses().toSet();
       beforeRunningDartInstances.forEach(print);
+      for (final RunningProcessInfo info in allProcesses) {
+        if (info.commandLine.contains('iproxy')) {
+          print('[LEAK]: ${info.commandLine} ${info.creationDate} ${info.pid} ');
+        }
+      }
 
       print('enabling configs for macOS, Linux, Windows, and Web...');
       final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -643,7 +643,6 @@ tasks:
       A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
-    flaky: true
 
   smoke_catalina_hot_mode_dev_cycle_ios__benchmark:
     description: >


### PR DESCRIPTION
## Description

We think the failures might be related to iproxy, list out any iproxy processes running before the test. Also mark catalina test as non-flaky