### PR TITLE
[flutter_tools] update metadata detection to account for invalid yaml

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_project_metadata.dart
+++ b/packages/flutter_tools/lib/src/flutter_project_metadata.dart
@@ -85,7 +85,12 @@ class FlutterProjectMetadata {
       if (!_metadataFile.existsSync()) {
         return null;
       }
-      final dynamic metadataYaml = loadYaml(_metadataFile.readAsStringSync());
+      dynamic metadataYaml;
+      try {
+        metadataYaml = loadYaml(_metadataFile.readAsStringSync());
+      } on YamlException {
+        // Handled in return below.
+      }
       if (metadataYaml is YamlMap) {
         _metadataYaml = metadataYaml;
       } else {

--- a/packages/flutter_tools/test/general.shard/flutter_project_metadata_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_project_metadata_test.dart
@@ -41,6 +41,17 @@ void main() {
     expect(logger.traceText, contains('.metadata version is malformed.'));
   });
 
+  testWithoutContext('project metadata fields are empty when file is not valid yaml', () {
+    metadataFile.writeAsStringSync(' channel: @something');
+    final FlutterProjectMetadata projectMetadata = FlutterProjectMetadata(metadataFile, logger);
+    expect(projectMetadata.projectType, isNull);
+    expect(projectMetadata.versionChannel, isNull);
+    expect(projectMetadata.versionRevision, isNull);
+
+    expect(logger.traceText, contains('.metadata project_type version is malformed.'));
+    expect(logger.traceText, contains('.metadata version is malformed.'));
+  });
+
   testWithoutContext('projectType is populated when version is malformed', () {
     metadataFile
       ..createSync()


### PR DESCRIPTION
## Description

Fixes crash on dev:

```
Error on line 8, column 12: Unexpected character.
  ╷
8 │   channel: @u
  │            ^
  ╵

  | at Parser.parse | (parser.dart:50)
-- | -- | --
  | at Loader._loadMapping | (loader.dart:163)
  | at Loader._loadNode | (loader.dart:86)
  | at Loader._loadMapping | (loader.dart:163)
  | at Loader._loadNode | (loader.dart:86)
  | at Loader._loadDocument | (loader.dart:62)
  | at Loader.load | (loader.dart:54)
  | at loadYamlDocument | (yaml.dart:51)
  | at loadYamlNode | (yaml.dart:42)
  | at loadYaml | (yaml.dart:34)
  | at FlutterProjectMetadata._metadataValue | (flutter_project_metadata.dart:88)
  | at FlutterProjectMetadata.projectType | (flutter_project_metadata.dart:56)
  | at CreateCommand._determineTemplateType | (create.dart:180)
  | at CreateCommand._getProjectType | (create.dart:261)
  | at CreateCommand.runCommand | (create.dart:359)
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:1005)
  | at _rootRunUnary | (zone.dart:1198)
  | at _CustomZone.runUnary | (zone.dart:1100)
  | at _FutureListener.handleValue | (future_impl.dart:143)
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:696)
  | at Future._propagateToListeners | (future_impl.dart:725)
  | at Future._completeWithValue | (future_impl.dart:529)
  | at Future._asyncCompleteWithValue.<anonymous closure> | (future_impl.dart:567)
  | at _rootRun | (zone.dart:1190)
  | at _CustomZone.run | (zone.dart:1093)
  | at _CustomZone.runGuarded | (zone.dart:997)
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:1037)
  | at _microtaskLoop | (schedule_microtask.dart:41)
  | at _startMicrotaskLoop | (schedule_microtask.dart:50)
  | at _runPendingImmediateCallback | (isolate_patch.dart:118)
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:169)


```