### PR TITLE
Revert noninteractive lldb debugging, timeout warning

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -48,7 +50,6 @@ void main () {
             '--bundle',
             '/',
             '--debug',
-            '--noninteractive',
             '--args',
             <String>[
               '--enable-dart-profiling',
@@ -86,7 +87,7 @@ void main () {
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>['ios-deploy'],
-            stdout: '(lldb)     run\r\nsuccess\r\n(lldb)     autoexit\r\nsuccess\r\nLog on attach1\r\n\r\nLog on attach2\r\n\r\n\r\n\r\nPROCESS_STOPPED\r\nLog after process exit',
+            stdout: '(lldb)     run\r\nsuccess\r\nsuccess\r\nLog on attach1\r\n\r\nLog on attach2\r\n\r\n\r\n\r\nPROCESS_STOPPED\r\nLog after process exit',
           ),
         ]);
         final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
@@ -110,7 +111,7 @@ void main () {
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>['ios-deploy'],
-            stdout: '(lldb)     run\r\nsuccess\r\n(lldb)     autoexit\r\nLog on attach\r\nProcess 100 exited with status = 0\r\nLog after process exit',
+            stdout: '(lldb)     run\r\nsuccess\r\nLog on attach\r\nProcess 100 exited with status = 0\r\nLog after process exit',
           ),
         ]);
         final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
@@ -209,21 +210,26 @@ void main () {
         await iosDeployDebugger.launchAndAttach();
         expect(logger.errorText, contains('Try launching from within Xcode'));
       });
+    });
 
-      testWithoutContext('cannot attach', () async {
-        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-          const FakeCommand(
-            command: <String>['ios-deploy'],
-            stdout: 'error: process launch failed: timed out waiting for app to launch',
-          ),
-        ]);
-        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
-          processManager: processManager,
-          logger: logger,
-        );
-        await iosDeployDebugger.launchAndAttach();
-        expect(logger.errorText, contains('Could not attach the debugger'));
-      });
+    testWithoutContext('detach', () async {
+      final StreamController<List<int>> stdin = StreamController<List<int>>();
+      final Stream<String> stdinStream = stdin.stream.transform<String>(const Utf8Decoder());
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: const <String>[
+            'ios-deploy',
+          ],
+          stdout: '(lldb)     run\nsuccess',
+          stdin: IOSink(stdin.sink),
+        ),
+      ]);
+      final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+        processManager: processManager,
+      );
+      await iosDeployDebugger.launchAndAttach();
+      iosDeployDebugger.detach();
+      expect(await stdinStream.first, 'process detach');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -239,6 +239,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
       ));
 
       final MockIOSDeployDebugger iosDeployDebugger = MockIOSDeployDebugger();
+      when(iosDeployDebugger.debuggerAttached).thenReturn(true);
 
       final Stream<String> debuggingLogs = Stream<String>.fromIterable(<String>[
         'Message from debugger'
@@ -302,6 +303,24 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
       logReader.debuggerStream = iosDeployDebugger;
 
       await streamComplete.future;
+    });
+
+    testWithoutContext('detaches debugger', () async {
+      final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
+        iMobileDevice: IMobileDevice(
+          artifacts: artifacts,
+          processManager: processManager,
+          cache: fakeCache,
+          logger: logger,
+        ),
+        useSyslog: false,
+      );
+      final MockIOSDeployDebugger iosDeployDebugger = MockIOSDeployDebugger();
+      when(iosDeployDebugger.logLines).thenAnswer((Invocation invocation) => const Stream<String>.empty());
+      logReader.debuggerStream = iosDeployDebugger;
+
+      logReader.dispose();
+      verify(iosDeployDebugger.detach());
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -92,7 +92,6 @@ const FakeCommand kAttachDebuggerCommand = FakeCommand(command: <String>[
   '--bundle',
   '/',
   '--debug',
-  '--noninteractive',
   '--no-wifi',
   '--args',
   '--enable-dart-profiling --enable-service-port-fallback --disable-service-auth-codes --observatory-port=60700 --enable-checked-mode --verify-entry-points'
@@ -100,7 +99,7 @@ const FakeCommand kAttachDebuggerCommand = FakeCommand(command: <String>[
   'PATH': '/usr/bin:null',
   'DYLD_LIBRARY_PATH': '/path/to/libraries',
 },
-stdout: '(lldb)     run\nsuccess\n(lldb)     autoexit',
+stdout: '(lldb)     run\nsuccess',
 );
 
 void main() {
@@ -167,6 +166,7 @@ void main() {
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, true);
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'log-success')).called(1);
+    expect(await device.stopApp(iosApp), false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   });
@@ -216,6 +216,7 @@ void main() {
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, true);
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'log-success')).called(1);
+    expect(await device.stopApp(iosApp), false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   });
@@ -301,6 +302,7 @@ void main() {
 
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, false);
+    expect(await device.stopApp(iosApp), false);
     expect(processManager.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
@@ -323,7 +325,6 @@ void main() {
           '--bundle',
           '/',
           '--debug',
-          '--noninteractive',
           '--no-wifi',
           // The arguments below are determined by what is passed into
           // the debugging options argument to startApp.
@@ -405,7 +406,64 @@ void main() {
     );
 
     expect(launchResult.started, true);
+    expect(await device.stopApp(iosApp), false);
     expect(processManager.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    Usage: () => MockUsage(),
+  });
+
+  // Still uses context for analytics.
+  testUsingContext(
+      'IOSDevice.startApp detaches lldb when VM service connection fails',
+      () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+
+    final MockIOSDeploy mockIOSDeploy = MockIOSDeploy();
+    final MockIOSDeployDebugger mockIOSDeployDebugger = MockIOSDeployDebugger();
+    when(mockIOSDeploy.prepareDebuggerForLaunch(
+            deviceId: anyNamed('deviceId'),
+            bundlePath: anyNamed('bundlePath'),
+            launchArguments: anyNamed('launchArguments'),
+            interfaceType: anyNamed('interfaceType')))
+        .thenReturn(mockIOSDeployDebugger);
+    when(mockIOSDeploy.installApp(
+            deviceId: anyNamed('deviceId'),
+            bundlePath: anyNamed('bundlePath'),
+            launchArguments: anyNamed('launchArguments'),
+            interfaceType: anyNamed('interfaceType')))
+        .thenAnswer((_) async => 0);
+
+    when(mockIOSDeployDebugger.launchAndAttach()).thenAnswer((_) async => true);
+
+    final IOSDevice device = setUpIOSDevice(
+      fileSystem: fileSystem,
+      iosDeploy: mockIOSDeploy,
+      vmServiceConnector: (String string, {Log log}) async {
+        throw const io.SocketException(
+          'OS Error: Connection refused, errno = 61, address = localhost, port '
+          '= 58943',
+        );
+      },
+    );
+    final IOSApp iosApp = PrebuiltIOSApp(
+      projectBundleId: 'app',
+      bundleName: 'Runner',
+      bundleDir: fileSystem.currentDirectory,
+    );
+    device.portForwarder = const NoOpDevicePortForwarder();
+    device.setLogReader(iosApp, FakeDeviceLogReader());
+
+    final LaunchResult launchResult = await device.startApp(
+      iosApp,
+      prebuiltApplication: true,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
+      fallbackThrottleTimeout: const Duration(milliseconds: 10),
+    );
+
+    expect(launchResult.started, false);
+    verify(mockIOSDeployDebugger.detach()).called(1);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   });


### PR DESCRIPTION
## Description

#68145 was a failed experiment to autoexit ios-deploy on device app exit. Revert it.
Revert the part of #68046 that emitted a confusing warning which says to delete the app.  The previous "try running in Xcode" warning was more helpful.