### PR TITLE
Allow OverlayEntry to lock route disposal

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -534,15 +534,7 @@ class _HeroFlight {
     );
   }
 
-  void _handleAnimationUpdate(AnimationStatus status) {
-    // The animation will not finish until the user lifts their finger, so we
-    // should ignore the status update if the gesture is in progress.
-    //
-    // This also relies on the animation to update its status at the end of the
-    // gesture. See the _CupertinoBackGestureController.dragEnd for how
-    // cupertino page route achieves that.
-    if (manifest!.fromRoute.navigator?.userGestureInProgress == true)
-      return;
+  void _performAnimationUpdate(AnimationStatus status) {
     if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
       _proxyAnimation.parent = null;
 
@@ -558,6 +550,33 @@ class _HeroFlight {
       manifest!.toHero.endFlight(keepPlaceholder: status == AnimationStatus.dismissed);
       onFlightEnded(this);
     }
+  }
+
+  bool _scheduledPerformAnimtationUpdate = false;
+  void _handleAnimationUpdate(AnimationStatus status) {
+    // The animation will not finish until the user lifts their finger, so we
+    // should suppress the status update if the gesture is in progress, and
+    // delay it until the finger is lifted.
+    if (manifest!.fromRoute.navigator?.userGestureInProgress != true) {
+      _performAnimationUpdate(status);
+      return;
+    }
+
+    // The `navigator` must be null, or the first if clause would have returned.
+    final NavigatorState navigator = manifest!.fromRoute.navigator!;
+    if (_scheduledPerformAnimtationUpdate)
+      return;
+
+    void delayedPerformAnimtationUpdate() {
+      assert(!navigator.userGestureInProgress);
+      assert(_scheduledPerformAnimtationUpdate);
+      _scheduledPerformAnimtationUpdate = false;
+      navigator.userGestureInProgressNotifier.removeListener(delayedPerformAnimtationUpdate);
+      _performAnimationUpdate(_proxyAnimation.status);
+    }
+    assert(navigator.userGestureInProgress);
+    _scheduledPerformAnimtationUpdate = true;
+    navigator.userGestureInProgressNotifier.addListener(delayedPerformAnimtationUpdate);
   }
 
   // The simple case: we're either starting a push or a pop animation.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3069,12 +3069,6 @@ class _RouteEntry extends RouteTransitionRecord {
 
   void dispose() {
     assert(currentState.index < _RouteLifecycle.disposed.index);
-    route.dispose();
-    currentState = _RouteLifecycle.disposed;
-  }
-
-  void gracefullyDispose() {
-    assert(currentState.index < _RouteLifecycle.disposed.index);
     route.gracefullyDispose();
     currentState = _RouteLifecycle.disposed;
   }
@@ -3888,7 +3882,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     for (final _RouteEntry entry in toBeDisposed) {
       for (final OverlayEntry overlayEntry in entry.route.overlayEntries)
         overlayEntry.remove();
-      entry.gracefullyDispose();
+      entry.dispose();
     }
     if (rearrangeOverlay) {
       overlay?.rearrange(_allRouteOverlayEntries);

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -479,6 +479,7 @@ abstract class Route<T> {
 
   /// Discards any resources used by the object.
   ///
+  /// Overwrite this method to customize how subclasses should discard resources.
   /// This method should not remove its [overlayEntries] from the [Overlay]. The
   /// object's owner is in charge of doing that.
   ///
@@ -3096,7 +3097,7 @@ class _RouteEntry extends RouteTransitionRecord {
 
   void dispose() {
     assert(currentState.index < _RouteLifecycle.disposed.index);
-    route.gracefullyDispose();
+    route.proposeToDispose();
     currentState = _RouteLifecycle.disposed;
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -427,7 +427,7 @@ abstract class Route<T> {
   ///
   /// This method increases the lock count by 1, and returns a callback that
   /// reduces the lock count by 1 and potentially calls [dispose] if the count
-  /// reduces to 0. Having a non-zero lock count prevents [proposeDispose] from
+  /// reduces to 0. Having a non-zero lock count prevents [proposeToDispose] from
   /// calling [dispose] immediately. The returned callback must be called exactly
   /// once.
   ///

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -187,11 +187,11 @@ class _OverlayEntryWidget extends StatefulWidget {
 }
 
 class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
-  VoidCallback? releaseDisposal;
+  VoidCallback? onUnmount;
 
   @override
   void initState() {
-    releaseDisposal = widget.entry.lockDisposal?.call();
+    onUnmount = widget.entry.onWidgetStatusChanged?.call();
     super.initState();
   }
 
@@ -206,7 +206,7 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
   @protected
   @override
   void dispose() {
-    releaseDisposal?.call();
+    onUnmount?.call();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -116,7 +116,7 @@ class OverlayEntry {
 
   /// A function that indicates the mounting and unmounting of the overlay widget.
   ///
-  /// If [lockDisposal] is not null, it will be called when the widget returned
+  /// If [onWidgetStatusChanged] is not null, it will be called when the widget returned
   /// by [builder] is mounted ([State.initState]), and the callback that it
   /// returns will be called when the widget is unmounted ([State.dispose]).
   ///

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -61,7 +61,7 @@ class OverlayEntry {
     required this.builder,
     bool opaque = false,
     bool maintainState = false,
-    this.lockDisposal,
+    this.onWidgetStatusChanged,
   }) : assert(builder != null),
        assert(opaque != null),
        assert(maintainState != null),
@@ -114,7 +114,19 @@ class OverlayEntry {
     _overlay!._didChangeEntryOpacity();
   }
 
-  final ValueGetter<VoidCallback>? lockDisposal;
+  /// A function that indicates the mounting and unmounting of the overlay widget.
+  ///
+  /// If [lockDisposal] is not null, it will be called when the widget returned
+  /// by [builder] is mounted ([State.initState]), and the callback that it
+  /// returns will be called when the widget is unmounted ([State.dispose]).
+  ///
+  /// This is usually used by [Route] to ensure that its resources are not
+  /// disposed until its children widgets are no longer alive.
+  ///
+  /// See also:
+  ///
+  ///  * [Route.lockDisposal], which is typically provided to this parameter.
+  final ValueGetter<VoidCallback>? onWidgetStatusChanged;
 
   OverlayState? _overlay;
   final GlobalKey<_OverlayEntryWidgetState> _key = GlobalKey<_OverlayEntryWidgetState>();

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -61,6 +61,7 @@ class OverlayEntry {
     required this.builder,
     bool opaque = false,
     bool maintainState = false,
+    this.lockDisposal,
   }) : assert(builder != null),
        assert(opaque != null),
        assert(maintainState != null),
@@ -112,6 +113,8 @@ class OverlayEntry {
     assert(_overlay != null);
     _overlay!._didChangeEntryOpacity();
   }
+
+  final ValueGetter<VoidCallback>? lockDisposal;
 
   OverlayState? _overlay;
   final GlobalKey<_OverlayEntryWidgetState> _key = GlobalKey<_OverlayEntryWidgetState>();
@@ -172,12 +175,27 @@ class _OverlayEntryWidget extends StatefulWidget {
 }
 
 class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
+  VoidCallback? releaseDisposal;
+
+  @override
+  void initState() {
+    releaseDisposal = widget.entry.lockDisposal?.call();
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return TickerMode(
       enabled: widget.tickerEnabled,
       child: widget.entry.builder(context),
     );
+  }
+
+  @protected
+  @override
+  void dispose() {
+    releaseDisposal?.call();
+    super.dispose();
   }
 
   void _markNeedsBuild() {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -189,7 +189,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         // removing the route and disposing it.
         if (!isActive) {
           navigator!.finalizeRoute(this);
-          assert(overlayEntries.isEmpty);
         }
         break;
     }
@@ -1520,8 +1519,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {
-    yield _modalBarrier = OverlayEntry(builder: _buildModalBarrier);
-    yield _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState);
+    yield _modalBarrier = OverlayEntry(builder: _buildModalBarrier, lockDisposal: lockDisposal);
+    yield _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState, lockDisposal: lockDisposal);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1519,8 +1519,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {
-    yield _modalBarrier = OverlayEntry(builder: _buildModalBarrier, lockDisposal: lockDisposal);
-    yield _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState, lockDisposal: lockDisposal);
+    yield _modalBarrier = OverlayEntry(builder: _buildModalBarrier, onWidgetStatusChanged: lockDisposal);
+    yield _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState, onWidgetStatusChanged: lockDisposal);
   }
 
   @override


### PR DESCRIPTION
## Description


This PR changes `ModalRoute` so that when it's popped, it postpones the disposal of resources until the child widget is unmounted after the next frame.

This fixes https://github.com/flutter/flutter/issues/63984. The issue is caused by programmatically popping a route while the back swipe is in progress (fingers held), which leads to the following series of event: 
- A route is popped and disposed. During the disposal,
  - Its animation controller is disposed.
  - A `PointerCancelEvent` is synthesized for the active pointer.
- The disposal of the route _should_ trigger the navigator to rebuild, removing all dependents of the controller, but this does not come until the widget tree is rebuilt in the _next_ frame.
- _Before_ the next frame, the cancel event is dispatched.
  - The drag gesture recognizer (which is not disposed until the next frame) receives the cancel event and starts to dispatch ending callbacks. The callback starts some animation, only to find the controller disposed, triggering assertion error.

To fix this issue, a route that is popped from a navigator might no longer release all of its resources immediately, but instead until all of its overlay widgets are unmounted (`State.dispose`). This is achieved by the following changes:
- `Route.dispose` is changed to a protected method. Instead, owners should call `Route.proposeToDispose`, which is controlled by `Route.lockDisposal`. `Route.lockDisposal` increases a lock count that is reduced by the callback it returns.
- `OverlayEntry` has a new property, `onWidgetStatusChanged`, which notifies owners when its widget is mounted and unmounted. Typically this property should be `route.lockDisposal`.

Some logic of `_HeroFlight` is also tweaked to fix a few test breakages. This is caused by a condition which _skips_ `Hero`'s end-flight operations when there are any on-going gestures, introduced by https://github.com/flutter/flutter/pull/58024. This was not an issue because the `fromRoute.navigator` had been `null` at that point, passing the condition unintentionally, which is exposed now that the lifecycle of `fromRoute` is extended. The  `_HeroFlight` now _postpones_ the operations until the gestures are cleared.


## Related Issues

- Fixes https://github.com/flutter/flutter/issues/63984

## Tests

I added the following tests:

- Popping routes during back swipe should not crash

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
