### PR TITLE
Use multiroot scheme for initial compilation in ResidentRunner recompile

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -584,15 +584,13 @@ class DefaultResidentCompiler implements ResidentCompiler {
     _compileRequestNeedsConfirmation = true;
     _stdoutHandler._suppressCompilerMessages = request.suppressErrors;
 
-    if (_server == null) {
-      return _compile(
-        request.packageConfig.toPackageUri(request.mainUri)?.toString() ?? request.mainUri.toString(),
-        request.outputPath,
-      );
-    }
-    final String inputKey = Uuid().generateV4();
     final String mainUri = request.packageConfig.toPackageUri(request.mainUri)?.toString() ??
       toMultiRootPath(request.mainUri, fileSystemScheme, fileSystemRoots, _platform.isWindows);
+
+    if (_server == null) {
+      return _compile(mainUri, request.outputPath);
+    }
+    final String inputKey = Uuid().generateV4();
 
     _server.stdin.writeln('recompile $mainUri $inputKey');
     _logger.printTrace('<- recompile $mainUri $inputKey');

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -240,7 +240,7 @@ void main() {
     expect(latestCommand, containsAllInOrder(<String>['-DFOO=bar', '-DBAZ=qux']));
   });
 
-  testWithoutContext('maps a file to a multiroot scheme if providfed', () async {
+  testWithoutContext('maps a file to a multiroot scheme if provided', () async {
     // Use unsuccessful result because it's easier to setup in test. We only care about arguments passed to the compiler.
     when(mockFrontendServer.exitCode).thenAnswer((_) async => 255);
     when(mockFrontendServer.stdout).thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(


### PR DESCRIPTION
This PR fixes the issue in #66405, where we didn't use the multiroot scheme for the initial compilation when recompile is used.