### PR TITLE
[flutter_tools] drive uses correct application package for prebuilt

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -181,6 +181,14 @@ class DriveCommand extends RunCommandBase {
     ResidentRunner residentRunner;
     final BuildInfo buildInfo = getBuildInfo();
     final bool isWebPlatform = await device.targetPlatform == TargetPlatform.web_javascript;
+    final File applicationBinary = stringArg('use-application-binary') == null
+      ? null
+      : globals.fs.file(stringArg('use-application-binary'));
+    final ApplicationPackage package = await applicationPackages.getPackageForPlatform(
+      await device.targetPlatform,
+      buildInfo: buildInfo,
+      applicationBinary: applicationBinary,
+    );
     if (argResults['use-existing-app'] == null) {
       globals.printStatus('Starting application: $targetFile');
 
@@ -238,7 +246,7 @@ class DriveCommand extends RunCommandBase {
         webUri = residentRunner.uri;
       }
 
-      final LaunchResult result = await appStarter(this, webUri);
+      final LaunchResult result = await appStarter(this, webUri, package, applicationBinary != null);
       if (result == null) {
         throwToolExit('Application failed to start. Will not run test. Quitting.', exitCode: 1);
       }
@@ -364,7 +372,7 @@ $ex
         globals.printStatus('Leaving the application running.');
       } else {
         globals.printStatus('Stopping application instance.');
-        await appStopper(this);
+        await appStopper(this, package);
       }
     }
 
@@ -417,7 +425,7 @@ $ex
 
 Future<Device> findTargetDevice({ @required Duration timeout }) async {
   final DeviceManager deviceManager = globals.deviceManager;
-  final List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current(), timeout: timeout);
+  final List<Device> devices = await deviceManager.findTargetDevices(null, timeout: timeout);
 
   if (deviceManager.hasSpecifiedDeviceId) {
     if (devices.isEmpty) {
@@ -444,7 +452,7 @@ Future<Device> findTargetDevice({ @required Duration timeout }) async {
 }
 
 /// Starts the application on the device given command configuration.
-typedef AppStarter = Future<LaunchResult> Function(DriveCommand command, Uri webUri);
+typedef AppStarter = Future<LaunchResult> Function(DriveCommand command, Uri webUri, ApplicationPackage applicationPackage, bool prebuiltApplication);
 
 AppStarter appStarter = _startApp; // (mutable for testing)
 void restoreAppStarter() {
@@ -453,9 +461,10 @@ void restoreAppStarter() {
 
 Future<LaunchResult> _startApp(
   DriveCommand command,
-  Uri webUri, {
-  String userIdentifier,
-}) async {
+  Uri webUri,
+  ApplicationPackage applicationPackage,
+  bool prebuiltApplication,
+) async {
   final String mainPath = findMainDartFile(command.targetFile);
   if (await globals.fs.type(mainPath) != FileSystemEntityType.file) {
     globals.printError('Tried to run $mainPath, but that file does not exist.');
@@ -463,16 +472,8 @@ Future<LaunchResult> _startApp(
   }
 
   globals.printTrace('Stopping previously running application, if any.');
-  await appStopper(command);
+  await appStopper(command, applicationPackage);
 
-  final File applicationBinary = command.stringArg('use-application-binary') == null
-    ? null
-    : globals.fs.file(command.stringArg('use-application-binary'));
-  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(
-    await command.device.targetPlatform,
-    buildInfo: command.getBuildInfo(),
-    applicationBinary: applicationBinary,
-  );
 
   final Map<String, dynamic> platformArgs = <String, dynamic>{};
   if (command.traceStartup) {
@@ -491,13 +492,13 @@ Future<LaunchResult> _startApp(
   globals.printTrace('Starting application.');
 
   // Forward device log messages to the terminal window running the "drive" command.
-  final DeviceLogReader logReader = await command.device.getLogReader(app: package);
+  final DeviceLogReader logReader = await command.device.getLogReader(app: applicationPackage);
   command._deviceLogSubscription = logReader
     .logLines
     .listen(globals.printStatus);
 
   final LaunchResult result = await command.device.startApp(
-    package,
+    applicationPackage,
     mainPath: mainPath,
     route: command.route,
     debuggingOptions: DebuggingOptions.enabled(
@@ -512,8 +513,8 @@ Future<LaunchResult> _startApp(
       purgePersistentCache: command.purgePersistentCache,
     ),
     platformArgs: platformArgs,
-    userIdentifier: userIdentifier,
-    prebuiltApplication: applicationBinary != null,
+    userIdentifier: command.userIdentifier,
+    prebuiltApplication: prebuiltApplication,
   );
 
   if (!result.started) {
@@ -551,18 +552,14 @@ Future<void> _runTests(List<String> testArgs, Map<String, String> environment) a
 
 
 /// Stops the application.
-typedef AppStopper = Future<bool> Function(DriveCommand command);
+typedef AppStopper = Future<bool> Function(DriveCommand command, ApplicationPackage applicationPackage);
 AppStopper appStopper = _stopApp;
 void restoreAppStopper() {
   appStopper = _stopApp;
 }
 
-Future<bool> _stopApp(DriveCommand command) async {
+Future<bool> _stopApp(DriveCommand command, ApplicationPackage package) async {
   globals.printTrace('Stopping application.');
-  final ApplicationPackage package = await command.applicationPackages.getPackageForPlatform(
-    await command.device.targetPlatform,
-    buildInfo: command.getBuildInfo(),
-  );
   final bool stopped = await command.device.stopApp(package, userIdentifier: command.userIdentifier);
   await command.device.uninstallApp(package);
   await command._deviceLogSubscription?.cancel();

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -45,13 +45,13 @@ void main() {
       fs.file('pubspec.yaml').createSync();
       fs.file('.packages').createSync();
       setExitFunctionForTests();
-      appStarter = (DriveCommand command, Uri webUri) {
+      appStarter = (DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) {
         throw 'Unexpected call to appStarter';
       };
       testRunner = (List<String> testArgs, Map<String, String> environment) {
         throw 'Unexpected call to testRunner';
       };
-      appStopper = (DriveCommand command) {
+      appStopper = (DriveCommand command, ApplicationPackage package) {
         throw 'Unexpected call to appStopper';
       };
       command.applicationPackages = FakeApplicationPackageFactory();
@@ -99,7 +99,7 @@ void main() {
 
     testUsingContext('returns 1 when app fails to run', () async {
       testDeviceManager.addDevice(MockDevice());
-      appStarter = expectAsync2((DriveCommand command, Uri webUri) async => null);
+      appStarter = expectAsync4((DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) async => null);
 
       final String testApp = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e.dart');
       final String testFile = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e_test.dart');
@@ -201,7 +201,7 @@ void main() {
       final String testApp = globals.fs.path.join(tempDir.path, 'test', 'e2e.dart');
       final String testFile = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e_test.dart');
 
-      appStarter = expectAsync2((DriveCommand command, Uri webUri) async {
+      appStarter = expectAsync4((DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) async {
         return LaunchResult.succeeded();
       });
       testRunner = expectAsync2((List<String> testArgs, Map<String, String> environment) async {
@@ -211,7 +211,7 @@ void main() {
           'VM_SERVICE_URL': 'null',
         });
       });
-      appStopper = expectAsync1((DriveCommand command) async {
+      appStopper = expectAsync2((DriveCommand command, ApplicationPackage package) async {
         return true;
       });
 
@@ -242,13 +242,13 @@ void main() {
       final String testApp = globals.fs.path.join(tempDir.path, 'test', 'e2e.dart');
       final String testFile = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e_test.dart');
 
-      appStarter = expectAsync2((DriveCommand command, Uri webUri) async {
+      appStarter = expectAsync4((DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) async {
         return LaunchResult.succeeded();
       });
       testRunner = (List<String> testArgs, Map<String, String> environment) async {
         throwToolExit(null, exitCode: 123);
       };
-      appStopper = expectAsync1((DriveCommand command) async {
+      appStopper = expectAsync2((DriveCommand command, ApplicationPackage package) async {
         return true;
       });
 
@@ -281,7 +281,7 @@ void main() {
       final String testApp = globals.fs.path.join(tempDir.path, 'test', 'e2e.dart');
       final String testFile = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e_test.dart');
 
-      appStarter = expectAsync2((DriveCommand command, Uri webUri) async {
+      appStarter = expectAsync4((DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) async {
         return LaunchResult.succeeded();
       });
       testRunner = expectAsync2((List<String> testArgs, Map<String, String> environment) async {
@@ -294,7 +294,7 @@ void main() {
           ]
         );
       });
-      appStopper = expectAsync1((DriveCommand command) async {
+      appStopper = expectAsync2((DriveCommand command, ApplicationPackage package) async {
         return true;
       });
 
@@ -324,7 +324,7 @@ void main() {
       final String testApp = globals.fs.path.join(tempDir.path, 'test', 'e2e.dart');
       final String testFile = globals.fs.path.join(tempDir.path, 'test_driver', 'e2e_test.dart');
 
-      appStarter = expectAsync2((DriveCommand command, Uri webUri) async {
+      appStarter = expectAsync4((DriveCommand command, Uri webUri, ApplicationPackage package, bool prebuiltApplication) async {
         return LaunchResult.succeeded();
       });
       testRunner = expectAsync2((List<String> testArgs, Map<String, String> environment) async {
@@ -336,7 +336,7 @@ void main() {
           ]
         );
       });
-      appStopper = expectAsync1((DriveCommand command) async {
+      appStopper = expectAsync2((DriveCommand command, ApplicationPackage package) async {
         return true;
       });
 
@@ -493,8 +493,8 @@ void main() {
         testRunner = (List<String> testArgs, Map<String, String> environment) async {
           throwToolExit(null, exitCode: 123);
         };
-        appStopper = expectAsync1(
-            (DriveCommand command) async {
+        appStopper = expectAsync2(
+            (DriveCommand command, ApplicationPackage package) async {
               return true;
             },
             count: 2,
@@ -603,8 +603,8 @@ void main() {
         testRunner = (List<String> testArgs, Map<String, String> environment) async {
           throwToolExit(null, exitCode: 123);
         };
-        appStopper = expectAsync1(
-          (DriveCommand command) async {
+        appStopper = expectAsync2(
+          (DriveCommand command, ApplicationPackage package) async {
             return true;
           },
           count: 2,


### PR DESCRIPTION
## Description

Both start and stop app create an application package, but only start app used the application binary. Create the application package once and pass it to both start and stop app.
