### PR TITLE
Refactor command utilities for tests

### DIFF
--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -37,10 +37,13 @@ Stream<String> runAndGetStdout(String executable, List<String> arguments, {
     },
   );
 
-  yield* output.stream;
+  // Close the stream controller after the command is complete. Otherwise,
+  // the yield* will never finish.
+  command.whenComplete(() {
+    output.close();
+  });
 
-  // Don't check the exit code because `runCommand` already does that.
-  await command;
+  yield* output.stream;
 }
 
 /// Represents a running process launched using [startCommand].

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:core' hide print;
 import 'dart:io' hide exit;
@@ -10,80 +11,99 @@ import 'package:path/path.dart' as path;
 
 import 'utils.dart';
 
-// TODO(ianh): These two functions should be refactored into something that avoids all this code duplication.
-
+/// Runs the `executable` and returns standard output as a stream of lines.
+///
+/// The returned stream reaches its end immediately after the command exits.
+///
+/// If `expectNonZeroExit` is false and the process exits with a non-zero exit
+/// code fails the test immediately by exiting the test process with exit code
+/// 1.
 Stream<String> runAndGetStdout(String executable, List<String> arguments, {
   String workingDirectory,
   Map<String, String> environment,
   bool expectNonZeroExit = false,
-  int expectedExitCode,
-  String failureMessage,
-  bool skip = false,
 }) async* {
-  final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
-  final String relativeWorkingDir = path.relative(workingDirectory);
-  if (skip) {
-    printProgress('SKIPPING', relativeWorkingDir, commandDescription);
-    return;
-  }
-  printProgress('RUNNING', relativeWorkingDir, commandDescription);
-
-  final Stopwatch time = Stopwatch()..start();
-  final Process process = await Process.start(executable, arguments,
+  final StreamController<String> output = StreamController<String>();
+  final Future<CommandResult> command = runCommand(
+    executable,
+    arguments,
     workingDirectory: workingDirectory,
     environment: environment,
+    expectNonZeroExit: expectNonZeroExit,
+    // Capture the output so it's not printed to the console by default.
+    outputMode: OutputMode.capture,
+    outputListener: (String line, Process process) {
+      output.add(line);
+    },
   );
 
-  stderr.addStream(process.stderr);
-  final Stream<String> lines = process.stdout.transform(utf8.decoder).transform(const LineSplitter());
-  yield* lines;
+  yield* output.stream;
 
-  final int exitCode = await process.exitCode;
-  if ((exitCode == 0) == expectNonZeroExit || (expectedExitCode != null && exitCode != expectedExitCode)) {
-    exitWithError(<String>[
-      if (failureMessage != null)
-        failureMessage
-      else
-        '${bold}ERROR: ${red}Last command exited with $exitCode (expected: ${expectNonZeroExit ? (expectedExitCode ?? 'non-zero') : 'zero'}).$reset',
-      '${bold}Command: $green$commandDescription$reset',
-      '${bold}Relative working directory: $cyan$relativeWorkingDir$reset',
-    ]);
-  }
-  print('$clock ELAPSED TIME: ${prettyPrintDuration(time.elapsed)} for $green$commandDescription$reset in $cyan$relativeWorkingDir$reset');
+  // Don't check the exit code because `runCommand` already does that.
+  await command;
 }
 
-/// Runs the `executable` and waits until the process exits.
-///
-/// If the process exits with a non-zero exit code, exits this process with
-/// exit code 1, unless `expectNonZeroExit` is set to true.
+/// Represents a running process launched using [startCommand].
+class Command {
+  Command._(this.process, this._time, this._savedStdout, this._savedStderr);
+
+  /// The raw process that was launched for this command.
+  final Process process;
+
+  final Stopwatch _time;
+  final Future<List<List<int>>> _savedStdout;
+  final Future<List<List<int>>> _savedStderr;
+
+  /// Evaluates when the [process] exits.
+  ///
+  /// Returns the result of running the command.
+  Future<CommandResult> get onExit async {
+    final int exitCode = await process.exitCode;
+    _time.stop();
+
+    // Saved output is null when OutputMode.print is used.
+    final String flattenedStdout = _savedStdout != null ? _flattenToString(await _savedStdout) : null;
+    final String flattenedStderr = _savedStderr != null ? _flattenToString(await _savedStderr) : null;
+    return CommandResult._(exitCode, _time.elapsed, flattenedStdout, flattenedStderr);
+  }
+}
+
+/// The result of running a command using [startCommand] and [runCommand];
+class CommandResult {
+  CommandResult._(this.exitCode, this.elapsedTime, this.flattenedStdout, this.flattenedStderr);
+
+  /// The exit code of the process.
+  final int exitCode;
+
+  /// The amount of time it took the process to complete.
+  final Duration elapsedTime;
+
+  /// Standard output decoded as a string using UTF8 decoder.
+  final String flattenedStdout;
+
+  /// Standard error output decoded as a string using UTF8 decoder.
+  final String flattenedStderr;
+}
+
+/// Starts the `executable` and returns a command object representing the
+/// running process.
 ///
 /// `outputListener` is called for every line of standard output from the
 /// process, and is given the [Process] object. This can be used to interrupt
 /// an indefinitely running process, for example, by waiting until the process
 /// emits certain output.
-Future<void> runCommand(String executable, List<String> arguments, {
+///
+/// `outputMode` controls where the standard output from the command process
+/// goes. See [OutputMode].
+Future<Command> startCommand(String executable, List<String> arguments, {
   String workingDirectory,
   Map<String, String> environment,
-  bool expectNonZeroExit = false,
-  int expectedExitCode,
-  String failureMessage,
   OutputMode outputMode = OutputMode.print,
-  CapturedOutput output,
-  bool skip = false,
   bool Function(String) removeLine,
   void Function(String, Process) outputListener,
 }) async {
-  assert(
-    (outputMode == OutputMode.capture) == (output != null),
-    'The output parameter must be non-null with and only with OutputMode.capture',
-  );
-
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
   final String relativeWorkingDir = path.relative(workingDirectory ?? Directory.current.path);
-  if (skip) {
-    printProgress('SKIPPING', relativeWorkingDir, commandDescription);
-    return;
-  }
   printProgress('RUNNING', relativeWorkingDir, commandDescription);
 
   final Stopwatch time = Stopwatch()..start();
@@ -113,17 +133,55 @@ Future<void> runCommand(String executable, List<String> arguments, {
       ]);
       break;
     case OutputMode.capture:
-    case OutputMode.discard:
       savedStdout = stdoutSource.toList();
       savedStderr = process.stderr.toList();
       break;
   }
 
-  final int exitCode = await process.exitCode;
-  if (output != null) {
-    output.stdout = _flattenToString(await savedStdout);
-    output.stderr = _flattenToString(await savedStderr);
+  return Command._(process, time, savedStdout, savedStderr);
+}
+
+/// Runs the `executable` and waits until the process exits.
+///
+/// If the process exits with a non-zero exit code, exits this process with
+/// exit code 1, unless `expectNonZeroExit` is set to true.
+///
+/// `outputListener` is called for every line of standard output from the
+/// process, and is given the [Process] object. This can be used to interrupt
+/// an indefinitely running process, for example, by waiting until the process
+/// emits certain output.
+///
+/// Returns the result of the finished process, or null if `skip` is true.
+///
+/// `outputMode` controls where the standard output from the command process
+/// goes. See [OutputMode].
+Future<CommandResult> runCommand(String executable, List<String> arguments, {
+  String workingDirectory,
+  Map<String, String> environment,
+  bool expectNonZeroExit = false,
+  int expectedExitCode,
+  String failureMessage,
+  OutputMode outputMode = OutputMode.print,
+  bool skip = false,
+  bool Function(String) removeLine,
+  void Function(String, Process) outputListener,
+}) async {
+  final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
+  final String relativeWorkingDir = path.relative(workingDirectory ?? Directory.current.path);
+  if (skip) {
+    printProgress('SKIPPING', relativeWorkingDir, commandDescription);
+    return null;
   }
+
+  final Command command = await startCommand(executable, arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    outputMode: outputMode,
+    removeLine: removeLine,
+    outputListener: outputListener,
+  );
+
+  final CommandResult result = await command.onExit;
 
   if ((exitCode == 0) == expectNonZeroExit || (expectedExitCode != null && exitCode != expectedExitCode)) {
     // Print the output when we get unexpected results (unless output was
@@ -132,9 +190,8 @@ Future<void> runCommand(String executable, List<String> arguments, {
       case OutputMode.print:
         break;
       case OutputMode.capture:
-      case OutputMode.discard:
-        stdout.writeln(_flattenToString(await savedStdout));
-        stderr.writeln(_flattenToString(await savedStderr));
+        stdout.writeln(result.flattenedStdout);
+        stderr.writeln(result.flattenedStderr);
         break;
     }
     exitWithError(<String>[
@@ -146,15 +203,31 @@ Future<void> runCommand(String executable, List<String> arguments, {
       '${bold}Relative working directory: $cyan$relativeWorkingDir$reset',
     ]);
   }
-  print('$clock ELAPSED TIME: ${prettyPrintDuration(time.elapsed)} for $green$commandDescription$reset in $cyan$relativeWorkingDir$reset');
+  print('$clock ELAPSED TIME: ${prettyPrintDuration(result.elapsedTime)} for $green$commandDescription$reset in $cyan$relativeWorkingDir$reset');
+  return result;
 }
 
 /// Flattens a nested list of UTF-8 code units into a single string.
 String _flattenToString(List<List<int>> chunks) =>
   utf8.decode(chunks.expand<int>((List<int> ints) => ints).toList());
 
-/// Specifies what to do with command output from [runCommand].
-enum OutputMode { print, capture, discard }
+/// Specifies what to do with command output from [runCommand] and [startCommand].
+enum OutputMode {
+  /// Forwards standard output and standard error streams to the test process'
+  /// respective standard streams.
+  ///
+  /// Use this mode if all you want is print the output of the command to the
+  /// console. The output is no longer available after the process exits.
+  print,
+
+  /// Saves standard output and standard error streams in memory.
+  ///
+  /// Captured output can be retrieved from the [CommandResult] object.
+  ///
+  /// Use this mode in tests that need to inspect the output of a command, or
+  /// when the output should not be printed to console.
+  capture,
+}
 
 /// Stores command output from [runCommand] when used with [OutputMode.capture].
 class CapturedOutput {

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -211,7 +211,7 @@ Future<CommandResult> runCommand(String executable, List<String> arguments, {
 String _flattenToString(List<List<int>> chunks) =>
   utf8.decode(chunks.expand<int>((List<int> ints) => ints).toList());
 
-/// Specifies what to do with command output from [runCommand] and [startCommand].
+/// Specifies what to do with the command output from [runCommand] and [startCommand].
 enum OutputMode {
   /// Forwards standard output and standard error streams to the test process'
   /// respective standard streams.

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -39,9 +39,7 @@ Stream<String> runAndGetStdout(String executable, List<String> arguments, {
 
   // Close the stream controller after the command is complete. Otherwise,
   // the yield* will never finish.
-  command.whenComplete(() {
-    output.close();
-  });
+  command.whenComplete(output.close);
 
   yield* output.stream;
 }


### PR DESCRIPTION
## Description

Refactor command utilities for tests:

- Split `runCommand` into `startCommand` and `runCommand`. (`startCommand` will be used in https://github.com/flutter/flutter/pull/67324).
- Introduce:
  - `Command` represents a running command.
  - `CommandResult` represents the result of a finished command.
- Remove unused parameters from `runAndGetStdout` and reimplement it in terms of `runCommand`.
- Remove `CapturedOutput`. Reimplement existing usages in terms of `CommandResult`.
- Remove the no longer necessary `OutputMode.discard` (you "discard" by ignoring the `CommandResult`).

## Tests

Refactoring existing tests.