### PR TITLE
Correctly handle centerSlice with resoultion-aware assets.

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -448,12 +448,9 @@ void paintImage({
   Size inputSize = Size(image.width.toDouble(), image.height.toDouble());
   Offset? sliceBorder;
   if (centerSlice != null) {
-    sliceBorder = Offset(
-      centerSlice.left + inputSize.width - centerSlice.right,
-      centerSlice.top + inputSize.height - centerSlice.bottom,
-    );
+    sliceBorder = inputSize / scale - centerSlice.size as Offset;
     outputSize = outputSize - sliceBorder as Size;
-    inputSize = inputSize - sliceBorder as Size;
+    inputSize = inputSize - sliceBorder * scale as Size;
   }
   fit ??= centerSlice == null ? BoxFit.scaleDown : BoxFit.fill;
   assert(centerSlice == null || (fit != BoxFit.none && fit != BoxFit.cover));
@@ -559,7 +556,7 @@ void paintImage({
     }
   }
 
-  final bool needSave = repeat != ImageRepeat.noRepeat || flipHorizontally;
+  final bool needSave = centerSlice != null || repeat != ImageRepeat.noRepeat || flipHorizontally;
   if (needSave)
     canvas.save();
   if (repeat != ImageRepeat.noRepeat)
@@ -581,11 +578,12 @@ void paintImage({
         canvas.drawImageRect(image, sourceRect, tileRect, paint);
     }
   } else {
+    canvas.scale(1 / scale);
     if (repeat == ImageRepeat.noRepeat) {
-      canvas.drawImageNine(image, centerSlice, destinationRect, paint);
+      canvas.drawImageNine(image, _scaleRect(centerSlice, scale), _scaleRect(destinationRect, scale), paint);
     } else {
       for (final Rect tileRect in _generateImageTileRects(rect, destinationRect, repeat))
-        canvas.drawImageNine(image, centerSlice, tileRect, paint);
+        canvas.drawImageNine(image, _scaleRect(centerSlice, scale), _scaleRect(tileRect, scale), paint);
     }
   }
   if (needSave)
@@ -619,3 +617,5 @@ Iterable<Rect> _generateImageTileRects(Rect outputRect, Rect fundamentalRect, Im
       yield fundamentalRect.shift(Offset(i * strideX, j * strideY));
   }
 }
+
+Rect _scaleRect(Rect rect, double scale) => Rect.fromLTRB(rect.left * scale, rect.top * scale, rect.right * scale, rect.bottom * scale);

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -108,6 +108,26 @@ void main() {
     FlutterError.onError = oldFlutterError;
   });
 
+  test('centerSlice with scale ≠ 1', () async {
+    final TestCanvas canvas = TestCanvas();
+    paintImage(
+      canvas: canvas,
+      rect: const Rect.fromLTRB(10, 20, 430, 420),
+      image: image300x300,
+      scale: 2.0,
+      centerSlice: const Rect.fromLTRB(50, 40, 250, 260),
+    );
+
+    final Invocation command = canvas.invocations.firstWhere((Invocation invocation) {
+      return invocation.memberName == #drawImageNine;
+    });
+
+    expect(command, isNotNull);
+    expect(command.positionalArguments[0], equals(image300x300));
+    expect(command.positionalArguments[1], equals(const Rect.fromLTRB(100.0, 80.0, 500.0, 520.0)));
+    expect(command.positionalArguments[2], equals(const Rect.fromLTRB(20.0, 40.0, 860.0, 840.0)));
+  });
+
   testWidgets('Reports Image painting', (WidgetTester tester) async {
     late ImageSizeInfo imageSizeInfo;
     int count = 0;


### PR DESCRIPTION
## Description

This fixes both the `centerSlice` `Rect` being misinterpreted and the image being rendered too big.

## Related Issues

Fixes #20013.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
-  `448540 issues found. (ran in 97.9s; 6488 public members lack documentation)`
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
