### PR TITLE
InteractiveViewer constrained docs

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -140,6 +140,15 @@ class InteractiveViewer extends StatefulWidget {
   /// If set to false, then the child will be given infinite constraints. This
   /// is often useful when a child should be bigger than the InteractiveViewer.
   ///
+  /// For example, for a child which is bigger than the viewport but can be
+  /// panned to reveal parts that were initially offscreen, constrained must be
+  /// set to false to allow it to size itself properly. If constrained is true
+  /// and the child can only size itself to the viewport, then areas initially
+  /// outside of the viewport will not be able to receive user interaction
+  /// events. If experiencing regions of the child that are not receptive to
+  /// user gestures, make sure constrained is false and the child is sized
+  /// properly.
+  ///
   /// Defaults to true.
   ///
   /// {@tool dartpad --template=stateless_widget_scaffold}

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -141,13 +141,13 @@ class InteractiveViewer extends StatefulWidget {
   /// is often useful when a child should be bigger than the InteractiveViewer.
   ///
   /// For example, for a child which is bigger than the viewport but can be
-  /// panned to reveal parts that were initially offscreen, constrained must be
-  /// set to false to allow it to size itself properly. If constrained is true
-  /// and the child can only size itself to the viewport, then areas initially
-  /// outside of the viewport will not be able to receive user interaction
-  /// events. If experiencing regions of the child that are not receptive to
-  /// user gestures, make sure constrained is false and the child is sized
-  /// properly.
+  /// panned to reveal parts that were initially offscreen, [constrained] must
+  /// be set to false to allow it to size itself properly. If [constrained] is
+  /// true and the child can only size itself to the viewport, then areas
+  /// initially outside of the viewport will not be able to receive user
+  /// interaction events. If experiencing regions of the child that are not
+  /// receptive to user gestures, make sure [constrained] is false and the child
+  /// is sized properly.
   ///
   /// Defaults to true.
   ///


### PR DESCRIPTION
## Description

Multiple users, and myself, have been confused when using InteractiveViewer with a child that's larger than its viewport.  The child gets sized to the viewport, but because Flutter doesn't clip widgets to their size by default, the child appears to be larger.  However, taps on the overflowing part of the child are not received.

This PR updates the docs for `constrained` to explain this problem and how to solve it.

## Related Issues

Closes https://github.com/flutter/flutter/issues/68187

## Tests

None, docs only.