### PR TITLE
request.mainUri should be fileUri

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -600,7 +600,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
         message = fileUri.toString();
       } else {
         message = request.packageConfig.toPackageUri(fileUri)?.toString() ??
-          toMultiRootPath(request.mainUri, fileSystemScheme, fileSystemRoots, _platform.isWindows);
+          toMultiRootPath(fileUri, fileSystemScheme, fileSystemRoots, _platform.isWindows);
       }
       _server.stdin.writeln(message);
       _logger.printTrace(message.toString());


### PR DESCRIPTION
When filesystem scheme is used and when files other than entrypoint is updated, it couldn't be hot reloaded because the uri passed was incorrect.