### PR TITLE
[SwitchListTile and CheckboxListTile] Adds selectedTileColor property

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -390,7 +390,7 @@ class CheckboxListTile extends StatelessWidget {
   final ShapeBorder? shape;
 
   /// The color of the tile if it's selected.
-  /// 
+  ///
   final Color? selectedTileColor;
 
   void _handleValueChange() {

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -274,6 +274,7 @@ class CheckboxListTile extends StatelessWidget {
     this.contentPadding,
     this.tristate = false,
     this.shape,
+    this.selectedTileColor,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(isThreeLine != null),
@@ -388,6 +389,10 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
+  /// The color of the tile if it's selected.
+  /// 
+  final Color? selectedTileColor;
+
   void _handleValueChange() {
     assert(onChanged != null);
     switch (value) {
@@ -442,6 +447,7 @@ class CheckboxListTile extends StatelessWidget {
           autofocus: autofocus,
           contentPadding: contentPadding,
           shape: shape,
+          selectedTileColor: selectedTileColor,
           tileColor: tileColor,
         ),
       ),

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -389,7 +389,7 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
-  /// The color of the tile if it's selected.
+  /// {@macro flutter.material.ListTile.selectedTileColor}
   final Color? selectedTileColor;
 
   void _handleValueChange() {

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -390,7 +390,6 @@ class CheckboxListTile extends StatelessWidget {
   final ShapeBorder? shape;
 
   /// The color of the tile if it's selected.
-  ///
   final Color? selectedTileColor;
 
   void _handleValueChange() {

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -389,7 +389,7 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.ListTile.selectedTileColor}
+  /// If non-null, defines the background color when [CheckboxListTile.selected] is true.
   final Color? selectedTileColor;
 
   void _handleValueChange() {

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -125,12 +125,10 @@ class ListTileTheme extends InheritedTheme {
   /// If [ListTile.tileColor] is provided, [tileColor] is ignored.
   final Color? tileColor;
 
-  /// {@template flutter.material.ListTile.selectedTileColor}
   /// If specified, defines the background color for `ListTile` when
   /// [ListTile.selected] is true.
   ///
   /// If [ListTile.selectedTileColor] is provided, [selectedTileColor] is ignored.
-  /// {@endtemplate}
   final Color? selectedTileColor;
 
   /// The closest instance of this class that encloses the given context.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -125,10 +125,12 @@ class ListTileTheme extends InheritedTheme {
   /// If [ListTile.tileColor] is provided, [tileColor] is ignored.
   final Color? tileColor;
 
+  /// {@template flutter.material.ListTile.selectedTileColor}
   /// If specified, defines the background color for `ListTile` when
   /// [ListTile.selected] is true.
   ///
   /// If [ListTile.selectedTileColor] is provided, [selectedTileColor] is ignored.
+  /// {@endtemplate}
   final Color? selectedTileColor;
 
   /// The closest instance of this class that encloses the given context.

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -448,7 +448,7 @@ class SwitchListTile extends StatelessWidget {
   final ShapeBorder? shape;
 
   /// The color of the tile if it's selected.
-  /// 
+  ///
   final Color? selectedTileColor;
 
   @override

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -275,6 +275,7 @@ class SwitchListTile extends StatelessWidget {
     this.autofocus = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.shape,
+    this.selectedTileColor,
   }) : _switchListTileType = _SwitchListTileType.material,
        assert(value != null),
        assert(isThreeLine != null),
@@ -312,6 +313,7 @@ class SwitchListTile extends StatelessWidget {
     this.autofocus = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.shape,
+    this.selectedTileColor,
   }) : _switchListTileType = _SwitchListTileType.adaptive,
        assert(value != null),
        assert(isThreeLine != null),
@@ -445,6 +447,10 @@ class SwitchListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
+  /// The color of the tile if it's selected.
+  /// 
+  final Color? selectedTileColor;
+
   @override
   Widget build(BuildContext context) {
     final Widget control;
@@ -506,6 +512,7 @@ class SwitchListTile extends StatelessWidget {
           enabled: onChanged != null,
           onTap: onChanged != null ? () { onChanged!(!value); } : null,
           selected: selected,
+          selectedTileColor: selectedTileColor,
           autofocus: autofocus,
           shape: shape,
           tileColor: tileColor,

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -448,7 +448,6 @@ class SwitchListTile extends StatelessWidget {
   final ShapeBorder? shape;
 
   /// The color of the tile if it's selected.
-  ///
   final Color? selectedTileColor;
 
   @override

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -447,7 +447,7 @@ class SwitchListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
-  /// {@macro flutter.material.ListTile.selectedTileColor}
+  /// If non-null, defines the background color when [SwitchListTile.selected] is true.
   final Color? selectedTileColor;
 
   @override

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -447,7 +447,7 @@ class SwitchListTile extends StatelessWidget {
   /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
-  /// The color of the tile if it's selected.
+  /// {@macro flutter.material.ListTile.selectedTileColor}
   final Color? selectedTileColor;
 
   @override

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -259,4 +259,25 @@ void main() {
     final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));
     expect(coloredBox.color, equals(tileColor));
   });
+
+  testWidgets('CheckboxListTile respects selectedTileColor', (WidgetTester tester) async {
+    const Color selectedTileColor = Colors.black;
+
+    await tester.pumpWidget(
+      wrap(
+        child: const Center(
+          child: CheckboxListTile(
+            value: false,
+            onChanged: null,
+            title: Text('Title'),
+            selected: true,
+            selectedTileColor: selectedTileColor,
+          ),
+        ),
+      )
+    );
+
+    final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));
+    expect(coloredBox.color, equals(selectedTileColor));
+  });
 }

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -274,7 +274,7 @@ void main() {
             selectedTileColor: selectedTileColor,
           ),
         ),
-      )
+      ),
     );
 
     final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -377,4 +377,26 @@ void main() {
     final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));
     expect(coloredBox.color, tileColor);
   });
+
+  testWidgets('SwitchListTile respects selectedTileColor', (WidgetTester tester) async {
+    const Color selectedTileColor = Colors.black;
+
+    await tester.pumpWidget(
+      wrap(
+        child: const Center(
+          child: SwitchListTile(
+            value: false,
+            onChanged: null,
+            title: Text('Title'),
+            selected: true,
+            selectedTileColor: selectedTileColor,
+          ),
+        ),
+      ),
+    );
+
+    final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));
+    expect(coloredBox.color, equals(selectedTileColor));
+  });
+
 }


### PR DESCRIPTION
## Description

Adds selectedTileColor property to SwitchListTile and CheckboxListTIle.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68304

## Tests

I added the following tests:

* Added tests in checkbox_list_tile_test.dart.
* Added tests in switch_list_tile.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
