### PR TITLE
Fix links to GitHub bug template

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -675,7 +675,7 @@ class FlutterErrorDetails with Diagnosticable {
             'provide substantially more information in this error message to help you determine '
             'and fix the underlying cause.\n'
             'In either case, please report this assertion by filing a bug on GitHub:\n'
-            '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+            '  https://github.com/flutter/flutter/issues/new?template=2_bug.md'
           ));
         }
       }
@@ -808,7 +808,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
           '\nThis error should still help you solve your problem, '
           'however please also report this malformed error in the '
           'framework by filing a bug on GitHub:\n'
-          '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+          '  https://github.com/flutter/flutter/issues/new?template=2_bug.md'
         ),
       ],
     ));
@@ -834,7 +834,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
           '\nThis error should still help you solve your problem, '
           'however please also report this malformed error in the '
           'framework by filing a bug on GitHub:\n'
-          '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+          '  https://github.com/flutter/flutter/issues/new?template=2_bug.md'
         ));
         throw FlutterError.fromParts(message);
       }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2072,7 +2072,7 @@ abstract class RenderBox extends RenderObject {
           DiagnosticsProperty<Size>('Size', _size, style: DiagnosticsTreeStyle.errorProperty),
           ErrorHint(
             'If you are not writing your own RenderBox subclass, then this is not '
-            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+            'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=2_bug.md'
           ),
         ]);
       }
@@ -2119,7 +2119,7 @@ abstract class RenderBox extends RenderObject {
             ...failures,
             ErrorHint(
               'If you are not writing your own RenderBox subclass, then this is not\n'
-              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=BUG.md'
+              'your fault. Contact support: https://github.com/flutter/flutter/issues/new?template=2_bug.md'
             ),
           ]);
         }

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -739,7 +739,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
             ...addendum,
             ErrorDescription(
               "If none of the above helps enough to fix this problem, please don't hesitate to file a bug:\n"
-              '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+              '  https://github.com/flutter/flutter/issues/new?template=2_bug.md'
             ),
           ]);
         }());

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2605,7 +2605,7 @@ class BuildOwner {
           ErrorHint(
             'If you did not attempt to call scheduleBuildFor() yourself, then this probably '
             'indicates a bug in the widgets framework. Please report it:\n'
-            '  https://github.com/flutter/flutter/issues/new?template=BUG.md'
+            '  https://github.com/flutter/flutter/issues/new?template=2_bug.md'
           ),
         ]);
       }

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -255,7 +255,7 @@ void main() {
         'This error should still help you solve your problem, however\n'
         'please also report this malformed error in the framework by\n'
         'filing a bug on GitHub:\n'
-        '  https://github.com/flutter/flutter/issues/new?template=BUG.md\n'
+        '  https://github.com/flutter/flutter/issues/new?template=2_bug.md\n'
         '═════════════════════════════════════════════════════════════════\n',
       );
     }
@@ -292,7 +292,7 @@ void main() {
         'This error should still help you solve your problem, however\n'
         'please also report this malformed error in the framework by\n'
         'filing a bug on GitHub:\n'
-        '  https://github.com/flutter/flutter/issues/new?template=BUG.md\n'
+        '  https://github.com/flutter/flutter/issues/new?template=2_bug.md\n'
         '═════════════════════════════════════════════════════════════════\n',
       );
     }
@@ -321,7 +321,7 @@ void main() {
         'This error should still help you solve your problem, however\n'
         'please also report this malformed error in the framework by\n'
         'filing a bug on GitHub:\n'
-        '  https://github.com/flutter/flutter/issues/new?template=BUG.md\n'
+        '  https://github.com/flutter/flutter/issues/new?template=2_bug.md\n'
         '═════════════════════════════════════════════════════════════════\n',
       );
     }
@@ -421,7 +421,7 @@ void main() {
       'provide substantially more information in this error message to help you determine '
       'and fix the underlying cause.\n'
       'In either case, please report this assertion by filing a bug on GitHub:\n'
-      '  https://github.com/flutter/flutter/issues/new?template=BUG.md',
+      '  https://github.com/flutter/flutter/issues/new?template=2_bug.md',
     );
     expect(builder.properties[4] is ErrorSpacer, true);
     final DiagnosticsStackTrace trace = builder.properties[5] as DiagnosticsStackTrace;

--- a/packages/flutter_localizations/lib/src/l10n/README.md
+++ b/packages/flutter_localizations/lib/src/l10n/README.md
@@ -220,7 +220,7 @@ Google contributes translations for all the languages supported by
 this package. (Googlers, for more details see <go/flutter-l10n>.)
 
 If you have feedback about the translations please
-[file an issue on the Flutter github repo](https://github.com/flutter/flutter/issues/new?template=BUG.md).
+[file an issue on the Flutter github repo](https://github.com/flutter/flutter/issues/new?template=2_bug.md).
 
 
 ### See Also


### PR DESCRIPTION

## Description

The name of the bug issue template has changed, thus breaking the links printed by the engine when a core assertion fails. Update the template name to make sure developers who see the log messages are filling out the correct template.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

