### PR TITLE
Generate only requested platform directories on create

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -546,7 +546,10 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         generateSyntheticPackage: false,
       );
       final FlutterProject project = FlutterProject.fromDirectory(directory);
-      await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
+      await project.ensureReadyForPlatformSpecificTooling(
+        androidPlatform: true,
+        iosPlatform: true,
+      );
     }
     return generatedCount;
   }
@@ -641,7 +644,6 @@ https://flutter.dev/docs/development/packages-and-plugins/developing-packages#pl
       }
     }
 
-
     final FlutterProject project = FlutterProject.fromDirectory(directory);
     final bool generateAndroid = templateContext['android'] == true;
     if (generateAndroid) {
@@ -680,7 +682,15 @@ https://flutter.dev/docs/development/packages-and-plugins/developing-packages#pl
         offline: boolArg('offline'),
         generateSyntheticPackage: false,
       );
-      await project.ensureReadyForPlatformSpecificTooling(checkProjects: pluginExampleApp);
+
+      await project.ensureReadyForPlatformSpecificTooling(
+        androidPlatform: templateContext['android'] as bool ?? false,
+        iosPlatform: templateContext['ios'] as bool ?? false,
+        linuxPlatform: templateContext['linux'] as bool ?? false,
+        macOSPlatform: templateContext['macos'] as bool ?? false,
+        windowsPlatform: templateContext['windows'] as bool ?? false,
+        webPlatform: templateContext['web'] as bool ?? false,
+      );
     }
     if (templateContext['android'] == true) {
       gradle.updateLocalProperties(project: project, requireAndroidSdk: false);

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -147,13 +147,13 @@ class PackagesGetCommand extends FlutterCommand {
     final FlutterProject rootProject = FlutterProject.fromPath(target);
 
     await _runPubGet(target, rootProject);
-    await rootProject.ensureReadyForPlatformSpecificTooling(checkProjects: true);
+    await rootProject.regeneratePlatformSpecificTooling();
 
     // Get/upgrade packages in example app as well
     if (rootProject.hasExampleApp) {
       final FlutterProject exampleProject = rootProject.example;
       await _runPubGet(exampleProject.directory.path, exampleProject);
-      await exampleProject.ensureReadyForPlatformSpecificTooling(checkProjects: true);
+      await exampleProject.regeneratePlatformSpecificTooling();
     }
 
     return FlutterCommandResult.success();

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -657,7 +657,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
 
       final bool hasWebPlugins = (await findPlugins(flutterProject))
         .any((Plugin p) => p.platforms.containsKey(WebPlugin.kConfigKey));
-      await injectPlugins(flutterProject, checkProjects: true);
+      await injectPlugins(flutterProject, webPlatform: true);
 
       final Uri generatedUri = globals.fs.currentDirectory
         .childDirectory('lib')

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -18,7 +18,7 @@ Future<void> processPodsIfNeeded(
 ) async {
   final FlutterProject project = xcodeProject.parent;
   // Ensure that the plugin list is up to date, since hasPlugins relies on it.
-  await refreshPluginsList(project);
+  await refreshPluginsList(project, macOSPlatform: project.macos.existsSync());
   if (!(hasPlugins(project) || (project.isModule && xcodeProject.podfile.existsSync()))) {
     return;
   }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -229,38 +229,64 @@ class FlutterProject {
     return manifest;
   }
 
+  /// Re-generates project files necessary to make Gradle builds work on Android
+  /// and CocoaPods+Xcode work on iOS, for app and module projects only.
+  ///
+  /// Will not create project platform directories if they do not already exist.
+  Future<void> regeneratePlatformSpecificTooling() async {
+    return ensureReadyForPlatformSpecificTooling(
+      androidPlatform: android.existsSync(),
+      iosPlatform: ios.existsSync(),
+      // TODO(stuartmorgan): Revisit the conditions here once the plans for handling
+      // desktop in existing projects are in place.
+      linuxPlatform: featureFlags.isLinuxEnabled && linux.existsSync(),
+      macOSPlatform: featureFlags.isMacOSEnabled && macos.existsSync(),
+      windowsPlatform: featureFlags.isWindowsEnabled && windows.existsSync(),
+      webPlatform: featureFlags.isWebEnabled && web.existsSync(),
+    );
+  }
+
   /// Generates project files necessary to make Gradle builds work on Android
   /// and CocoaPods+Xcode work on iOS, for app and module projects only.
-  // TODO(cyanglaz): The param `checkProjects` is confusing. We should give it a better name
-  // or add some documentation explaining what it does, or both.
-  // https://github.com/flutter/flutter/issues/60023
-  Future<void> ensureReadyForPlatformSpecificTooling({bool checkProjects = false}) async {
+  Future<void> ensureReadyForPlatformSpecificTooling({
+    bool androidPlatform = false,
+    bool iosPlatform = false,
+    bool linuxPlatform = false,
+    bool macOSPlatform = false,
+    bool windowsPlatform = false,
+    bool webPlatform = false,
+  }) async {
     if (!directory.existsSync() || hasExampleApp) {
       return;
     }
-    await refreshPluginsList(this);
-    if ((android.existsSync() && checkProjects) || !checkProjects) {
+    await refreshPluginsList(this, iosPlatform: iosPlatform, macOSPlatform: macOSPlatform);
+    if (androidPlatform) {
       await android.ensureReadyForPlatformSpecificTooling();
     }
-    if ((ios.existsSync() && checkProjects) || !checkProjects) {
+    if (iosPlatform) {
       await ios.ensureReadyForPlatformSpecificTooling();
     }
-    // TODO(stuartmorgan): Revisit conditions once there is a plan for handling
-    // non-default platform projects. For now, always treat checkProjects as
-    // true for desktop.
-    if (featureFlags.isLinuxEnabled && linux.existsSync()) {
+    if (linuxPlatform) {
       await linux.ensureReadyForPlatformSpecificTooling();
     }
-    if (featureFlags.isMacOSEnabled && macos.existsSync()) {
+    if (macOSPlatform) {
       await macos.ensureReadyForPlatformSpecificTooling();
     }
-    if (featureFlags.isWindowsEnabled && windows.existsSync()) {
+    if (windowsPlatform) {
       await windows.ensureReadyForPlatformSpecificTooling();
     }
-    if (featureFlags.isWebEnabled && web.existsSync()) {
+    if (webPlatform) {
       await web.ensureReadyForPlatformSpecificTooling();
     }
-    await injectPlugins(this, checkProjects: checkProjects);
+    await injectPlugins(
+      this,
+      androidPlatform: androidPlatform,
+      iosPlatform: iosPlatform,
+      linuxPlatform: linuxPlatform,
+      macOSPlatform: macOSPlatform,
+      windowsPlatform: windowsPlatform,
+      webPlatform: webPlatform,
+    );
   }
 
   /// Returns a json encoded string containing the [appName], [version], and [buildNumber] that is used to generate version.json

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -229,8 +229,8 @@ class FlutterProject {
     return manifest;
   }
 
-  /// Re-generates project files necessary to make Gradle builds work on Android
-  /// and CocoaPods+Xcode work on iOS, for app and module projects only.
+  /// Reapplies template files and regenerates project files and plugin
+  /// registrants for app and module projects only.
   ///
   /// Will not create project platform directories if they do not already exist.
   Future<void> regeneratePlatformSpecificTooling() async {
@@ -246,8 +246,8 @@ class FlutterProject {
     );
   }
 
-  /// Generates project files necessary to make Gradle builds work on Android
-  /// and CocoaPods+Xcode work on iOS, for app and module projects only.
+  /// Applies template files and generates project files and plugin
+  /// registrants for app and module projects only for the specified platforms.
   Future<void> ensureReadyForPlatformSpecificTooling({
     bool androidPlatform = false,
     bool iosPlatform = false,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -996,7 +996,7 @@ abstract class FlutterCommand extends Command<void> {
       );
       // All done updating dependencies. Release the cache lock.
       Cache.releaseLock();
-      await project.ensureReadyForPlatformSpecificTooling(checkProjects: true);
+      await project.regeneratePlatformSpecificTooling();
     } else {
       Cache.releaseLock();
     }

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -41,7 +41,7 @@ Future<void> buildWeb(
     outputDirectory.deleteSync(recursive: true);
     outputDirectory.createSync(recursive: true);
   }
-  await injectPlugins(flutterProject, checkProjects: true);
+  await injectPlugins(flutterProject, webPlatform: true);
   final Status status = globals.logger.startProgress('Compiling $target for the Web...');
   final Stopwatch sw = Stopwatch()..start();
   try {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -662,6 +662,65 @@ void main() {
     expect(testLogger.statusText, isNot(contains('https://flutter.dev/go/android-project-migration')));
   });
 
+  testUsingContext('app does not include desktop or web by default', () async {
+    Cache.flutterRoot = '../..';
+    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
+    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>['create', '--no-pub', projectDir.path]);
+
+    expect(projectDir.childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('windows').existsSync(), false);
+    expect(projectDir.childDirectory('web').existsSync(), false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(),
+  });
+
+  testUsingContext('plugin does not include desktop or web by default',
+      () async {
+    Cache.flutterRoot = '../..';
+    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
+    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(
+        <String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+
+    expect(projectDir.childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('windows').existsSync(), false);
+    expect(projectDir.childDirectory('web').existsSync(), false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('linux')
+            .existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('macos')
+            .existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('windows')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('web').existsSync(),
+        false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(),
+  });
+
   testUsingContext('app supports Linux if requested', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
@@ -670,26 +729,26 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', projectDir.path]);
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--platforms=linux',
+      projectDir.path,
+    ]);
 
-    expect(projectDir.childDirectory('linux').childFile('CMakeLists.txt').existsSync(), true);
+    expect(
+        projectDir
+            .childDirectory('linux')
+            .childFile('CMakeLists.txt')
+            .existsSync(),
+        true);
+    expect(projectDir.childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('windows').existsSync(), false);
+    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('web').existsSync(), false);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
-  });
-
-  testUsingContext('app does not include Linux by default', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', projectDir.path]);
-
-    expect(projectDir.childDirectory('linux').childFile('CMakeLists.txt').existsSync(), false);
-  }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
   testUsingContext('plugin supports Linux if requested', () async {
@@ -704,7 +763,31 @@ void main() {
 
     expect(projectDir.childDirectory('linux').childFile('CMakeLists.txt').existsSync(), true);
     expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), true);
-        validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('android')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('windows')
+            .existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('macos')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('web').existsSync(),
+        false);
+    validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'linux',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
@@ -712,7 +795,7 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
-  testUsingContext('plugin does not include Linux by default', () async {
+  testUsingContext('app supports macOS if requested', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -720,27 +803,26 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--platforms=macos',
+      projectDir.path,
+    ]);
 
-    expect(projectDir.childDirectory('linux').childFile('CMakeLists.txt').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), false);
+    expect(
+        projectDir
+            .childDirectory('macos')
+            .childDirectory('Runner.xcworkspace')
+            .existsSync(),
+        true);
+    expect(projectDir.childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('windows').existsSync(), false);
+    expect(projectDir.childDirectory('web').existsSync(), false);
   }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
-  });
-
-  testUsingContext('app does not include macOS by default', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', projectDir.path]);
-
-    expect(projectDir.childDirectory('macos').childDirectory('Runner.xcworkspace').existsSync(), false);
-  }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('plugin supports macOS if requested', () async {
@@ -755,28 +837,36 @@ void main() {
 
     expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), true);
     expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), true);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('linux')
+            .existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('android')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('windows')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('web').existsSync(),
+        false);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'macos',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
-  });
-
-  testUsingContext('plugin does not include macOS by default', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-
-    expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), false);
-  }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
   testUsingContext('app supports Windows if requested', () async {
@@ -787,9 +877,21 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', projectDir.path]);
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--platforms=windows',
+      projectDir.path,
+    ]);
 
-    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt').existsSync(), true);
+    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt')
+            .existsSync(),
+        true);
+    expect(projectDir.childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('web').existsSync(), false);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -813,21 +915,6 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
 
-  testUsingContext('app does not include Windows by default', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', projectDir.path]);
-
-    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt').existsSync(), false);
-  }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
-  });
-
   testUsingContext('plugin supports Windows if requested', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
@@ -840,6 +927,30 @@ void main() {
 
     expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt').existsSync(), true);
     expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), true);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('android')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('linux')
+            .existsSync(),
+        false);
+    expect(
+        projectDir
+            .childDirectory('example')
+            .childDirectory('macos')
+            .existsSync(),
+        false);
+    expect(
+        projectDir.childDirectory('example').childDirectory('web').existsSync(),
+        false);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'windows'
     ], pluginClass: 'FlutterProjectPlugin',
@@ -848,7 +959,7 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
 
-  testUsingContext('plugin does not include Windows by default', () async {
+  testUsingContext('app supports web if requested', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -856,12 +967,23 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--platforms=web',
+      projectDir.path,
+    ]);
 
-    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), false);
+    expect(
+        projectDir.childDirectory('web').childFile('index.html').existsSync(),
+        true);
+    expect(projectDir.childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('ios').existsSync(), false);
+    expect(projectDir.childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('windows').existsSync(), false);
   }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
 
   testUsingContext('plugin uses new platform schema', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:args/command_runner.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -672,10 +673,10 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
 
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(),
   });
@@ -692,31 +693,18 @@ void main() {
     await runner.run(
         <String>['create', '--no-pub', '--template=plugin', projectDir.path]);
 
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('linux')
-            .existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('macos')
-            .existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('windows')
-            .existsSync(),
-        false);
-    expect(
-        projectDir.childDirectory('example').childDirectory('web').existsSync(),
-        false);
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('linux'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('macos'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('windows'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('web'),
+        isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(),
   });
@@ -737,16 +725,12 @@ void main() {
     ]);
 
     expect(
-        projectDir
-            .childDirectory('linux')
-            .childFile('CMakeLists.txt')
-            .existsSync(),
-        true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
+        projectDir.childDirectory('linux').childFile('CMakeLists.txt'), exists);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('ios'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -761,35 +745,26 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
 
-    expect(projectDir.childDirectory('linux').childFile('CMakeLists.txt').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), true);
     expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('android')
-            .existsSync(),
-        false);
+        projectDir.childDirectory('linux').childFile('CMakeLists.txt'), exists);
     expect(
-        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('windows')
-            .existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('macos')
-            .existsSync(),
-        false);
-    expect(
-        projectDir.childDirectory('example').childDirectory('web').existsSync(),
-        false);
-    validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
-      'linux',
-    ], pluginClass: 'FlutterProjectPlugin',
+        projectDir.childDirectory('example').childDirectory('linux'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('android'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('ios'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('windows'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('macos'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('web'),
+        isNot(exists));
+    validatePubspecForPlugin(
+        projectDir: projectDir.absolute.path,
+        expectedPlatforms: const <String>[
+          'linux',
+        ],
+        pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
@@ -811,16 +786,13 @@ void main() {
     ]);
 
     expect(
-        projectDir
-            .childDirectory('macos')
-            .childDirectory('Runner.xcworkspace')
-            .existsSync(),
-        true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
+        projectDir.childDirectory('macos').childDirectory('Runner.xcworkspace'),
+        exists);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('ios'), isNot(exists));
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -835,32 +807,20 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
 
-    expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), true);
+    expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec'),
+        exists);
     expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('linux')
-            .existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('android')
-            .existsSync(),
-        false);
-    expect(
-        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('windows')
-            .existsSync(),
-        false);
-    expect(
-        projectDir.childDirectory('example').childDirectory('web').existsSync(),
-        false);
+        projectDir.childDirectory('example').childDirectory('macos'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('linux'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('android'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('ios'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('windows'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('web'),
+        isNot(exists));
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'macos',
     ], pluginClass: 'FlutterProjectPlugin',
@@ -884,14 +844,13 @@ void main() {
       projectDir.path,
     ]);
 
-    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt')
-            .existsSync(),
-        true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
+    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt'),
+        exists);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('ios'), isNot(exists));
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -907,7 +866,7 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--org', 'com.foo.bar', projectDir.path]);
 
     final File resourceFile = projectDir.childDirectory('windows').childDirectory('runner').childFile('Runner.rc');
-    expect(resourceFile.existsSync(), true);
+    expect(resourceFile, exists);
     final String contents = resourceFile.readAsStringSync();
     expect(contents, contains('"CompanyName", "com.foo.bar"'));
     expect(contents, contains('"ProductName", "flutter_project"'));
@@ -925,32 +884,31 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
 
-    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), true);
+    expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt'),
+        exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('windows'), exists);
     expect(
         projectDir
             .childDirectory('example')
-            .childDirectory('android')
-            .existsSync(),
-        false);
+            .childDirectory('android'),
+        isNot(exists));
     expect(
-        projectDir.childDirectory('example').childDirectory('ios').existsSync(),
-        false);
-    expect(
-        projectDir
-            .childDirectory('example')
-            .childDirectory('linux')
-            .existsSync(),
-        false);
+        projectDir.childDirectory('example').childDirectory('ios'),
+        isNot(exists));
     expect(
         projectDir
             .childDirectory('example')
-            .childDirectory('macos')
-            .existsSync(),
-        false);
+            .childDirectory('linux'),
+        isNot(exists));
     expect(
-        projectDir.childDirectory('example').childDirectory('web').existsSync(),
-        false);
+        projectDir
+            .childDirectory('example')
+            .childDirectory('macos'),
+        isNot(exists));
+    expect(
+        projectDir.childDirectory('example').childDirectory('web'),
+        isNot(exists));
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'windows'
     ], pluginClass: 'FlutterProjectPlugin',
@@ -975,13 +933,13 @@ void main() {
     ]);
 
     expect(
-        projectDir.childDirectory('web').childFile('index.html').existsSync(),
-        true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
+        projectDir.childDirectory('web').childFile('index.html'),
+        exists);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('ios'), isNot(exists));
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
@@ -1638,7 +1596,7 @@ void main() {
 
     await runner.run(args);
     final File expectedFile = globals.fs.file(outputFile);
-    expect(expectedFile.existsSync(), isTrue);
+    expect(expectedFile, exists);
     expect(expectedFile.readAsStringSync(), equals(samplesIndexJson));
   }, overrides: <Type, Generator>{
     HttpClientFactory: () =>
@@ -1677,7 +1635,7 @@ void main() {
     ];
 
     await expectLater(runner.run(args), throwsToolExit(exitCode: 2, message: 'Failed to write samples'));
-    expect(globals.fs.file(outputFile).existsSync(), isFalse);
+    expect(globals.fs.file(outputFile), isNot(exists));
   }, overrides: <Type, Generator>{
     HttpClientFactory: () =>
         () => MockHttpClient(404, result: 'not found'),
@@ -1695,21 +1653,27 @@ void main() {
 
     // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
     // https://github.com/flutter/flutter/issues/59787
-    expect(projectDir.childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('web').existsSync(), false);
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('ios'), isNot(exists));
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('web'), isNot(exists));
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('macos'), isNot(exists));
 
     // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
     // https://github.com/flutter/flutter/issues/59787
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('web').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('example').childDirectory('ios'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('android'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('web'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('linux'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('windows'),
+        isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('macos'),
+        isNot(exists));
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: <String>[
       'some_platform'
     ], pluginClass: 'somePluginClass',
@@ -1729,8 +1693,8 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
 
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: <String>[
       'ios',
     ], pluginClass: 'FlutterProjectPlugin',
@@ -1749,8 +1713,9 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'android'
     ], pluginClass: 'FlutterProjectPlugin',
@@ -1769,7 +1734,9 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
-    expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart').existsSync(), true);
+    expect(
+        projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
+        exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'web'
     ], pluginClass: 'FlutterProjectWeb',
@@ -1789,7 +1756,9 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
-    expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart').existsSync(), false);
+    expect(
+        projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
+        isNot(exists));
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'some_platform'
     ], pluginClass: 'somePluginClass',
@@ -1808,8 +1777,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
 
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
@@ -1824,8 +1793,9 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
@@ -1840,8 +1810,9 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
 
-    expect(projectDir.childDirectory('linux').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), true);
+    expect(projectDir.childDirectory('linux'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('linux'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -1856,8 +1827,9 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
 
-    expect(projectDir.childDirectory('macos').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), true);
+    expect(projectDir.childDirectory('macos'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('macos'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -1872,8 +1844,9 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
 
-    expect(projectDir.childDirectory('windows').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), true);
+    expect(projectDir.childDirectory('windows'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('windows'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -1888,7 +1861,9 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
 
-    expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart').existsSync(), true);
+    expect(
+        projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
+        exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
@@ -1901,18 +1876,19 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'ios',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
-    expect(projectDir.childDirectory('macos').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), true);
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('macos'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('macos'), exists);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -1925,13 +1901,14 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios,android', projectDir.path]);
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
 
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('ios').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('ios').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
+    expect(projectDir.childDirectory('ios'), exists);
+    expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
       'ios', 'android'
     ], pluginClass: 'FlutterProjectPlugin',
@@ -1971,18 +1948,21 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
 
     globals.fs.file(globals.fs.path.join(projectDir.path, 'android')).deleteSync(recursive: true);
     globals.fs.file(globals.fs.path.join(projectDir.path, 'example/android')).deleteSync(recursive: true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('android'),
+        isNot(exists));
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
 
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
   });
 
   testUsingContext('create a plugin with android, delete then re-create folders while also adding windows', () async {
@@ -1993,20 +1973,24 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
 
     globals.fs.file(globals.fs.path.join(projectDir.path, 'android')).deleteSync(recursive: true);
     globals.fs.file(globals.fs.path.join(projectDir.path, 'example/android')).deleteSync(recursive: true);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('android'),
+        isNot(exists));
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
 
-    expect(projectDir.childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), true);
-    expect(projectDir.childDirectory('windows').existsSync(), true);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), true);
+    expect(projectDir.childDirectory('android'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('android'), exists);
+    expect(projectDir.childDirectory('windows'), exists);
+    expect(
+        projectDir.childDirectory('example').childDirectory('windows'), exists);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -2021,8 +2005,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
-    expect(projectDir.childDirectory('android').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('android').existsSync(), false);
+    expect(projectDir.childDirectory('android'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('android'), isNot(exists));
   });
 
   testUsingContext('flutter create . on and existing plugin does not add windows folder even feature is enabled', () async {
@@ -2035,8 +2019,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
-    expect(projectDir.childDirectory('windows').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('windows').existsSync(), false);
+    expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('windows'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -2051,8 +2035,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
-    expect(projectDir.childDirectory('linux').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('linux').existsSync(), false);
+    expect(projectDir.childDirectory('linux'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('linux'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -2067,7 +2051,7 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
-    expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart').existsSync(), false);
+    expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
@@ -2082,8 +2066,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
-    expect(projectDir.childDirectory('macos').existsSync(), false);
-    expect(projectDir.childDirectory('example').childDirectory('macos').existsSync(), false);
+    expect(projectDir.childDirectory('macos'), isNot(exists));
+    expect(projectDir.childDirectory('example').childDirectory('macos'), isNot(exists));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -2170,8 +2154,8 @@ void main() {
         .childFile(headerName);
     final File implFile = platformDir.childFile('$classFilenameBase.cc');
     // Ensure that the files have the right names.
-    expect(headerFile.existsSync(), true);
-    expect(implFile.existsSync(), true);
+    expect(headerFile, exists);
+    expect(implFile, exists);
     // Ensure that the include is correct.
     expect(implFile.readAsStringSync(), contains(headerName));
     // Ensure that the CMake file has the right target and source values.
@@ -2203,8 +2187,8 @@ void main() {
         .childFile(headerName);
     final File implFile = platformDir.childFile('$classFilenameBase.cpp');
     // Ensure that the files have the right names.
-    expect(headerFile.existsSync(), true);
-    expect(implFile.existsSync(), true);
+    expect(headerFile, exists);
+    expect(implFile, exists);
     // Ensure that the include is correct.
     expect(implFile.readAsStringSync(), contains(headerName));
     // Ensure that the plugin target name matches the post-processed version.
@@ -2238,8 +2222,8 @@ void main() {
         .childFile(headerName);
     final File implFile = platformDir.childFile('$classFilenameBase.cc');
     // Ensure that the files have the right names.
-    expect(headerFile.existsSync(), true);
-    expect(implFile.existsSync(), true);
+    expect(headerFile, exists);
+    expect(implFile, exists);
     // Ensure that the include is correct.
     expect(implFile.readAsStringSync(), contains(headerName));
     // Ensure that the CMake file has the right target and source values.
@@ -2276,8 +2260,8 @@ void main() {
         .childFile(headerName);
     final File implFile = platformDir.childFile('$classFilenameBase.cpp');
     // Ensure that the files have the right names.
-    expect(headerFile.existsSync(), true);
-    expect(implFile.existsSync(), true);
+    expect(headerFile, exists);
+    expect(implFile, exists);
     // Ensure that the include is correct.
     expect(implFile.readAsStringSync(), contains(headerName));
     // Ensure that the CMake file has the right target and source values.

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -301,7 +301,7 @@ void main() {
         ..writeAsStringSync('Existing release config');
 
       final FlutterProject project = FlutterProject.fromPath('project');
-      await injectPlugins(project, checkProjects: true);
+      await injectPlugins(project, iosPlatform: true);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
       expect(debugContents, contains(

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -514,7 +514,7 @@ dependencies:
         when(iosProject.existsSync()).thenReturn(true);
         when(macosProject.existsSync()).thenReturn(true);
 
-        await refreshPluginsList(flutterProject);
+        await refreshPluginsList(flutterProject, iosPlatform: true, macOSPlatform: true);
         expect(iosProject.podManifestLock.existsSync(), false);
         expect(macosProject.podManifestLock.existsSync(), false);
       }, overrides: <Type, Generator>{
@@ -533,7 +533,7 @@ dependencies:
         // Since there was no plugins list, the lock files will be invalidated.
         // The second call is where the plugins list is compared to the existing one, and if there is no change,
         // the podfiles shouldn't be invalidated.
-        await refreshPluginsList(flutterProject);
+        await refreshPluginsList(flutterProject, iosPlatform: true, macOSPlatform: true);
         simulatePodInstallRun(iosProject);
         simulatePodInstallRun(macosProject);
 
@@ -549,16 +549,9 @@ dependencies:
     });
 
     group('injectPlugins', () {
-      MockFeatureFlags featureFlags;
       MockXcodeProjectInterpreter xcodeProjectInterpreter;
 
       setUp(() {
-        featureFlags = MockFeatureFlags();
-        when(featureFlags.isLinuxEnabled).thenReturn(false);
-        when(featureFlags.isMacOSEnabled).thenReturn(false);
-        when(featureFlags.isWindowsEnabled).thenReturn(false);
-        when(featureFlags.isWebEnabled).thenReturn(false);
-
         xcodeProjectInterpreter = MockXcodeProjectInterpreter();
         when(xcodeProjectInterpreter.isInstalled).thenReturn(false);
       });
@@ -567,7 +560,7 @@ dependencies:
         when(flutterProject.isModule).thenReturn(false);
         when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -580,14 +573,13 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Registrant uses new embedding if app uses new embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
         when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v2);
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -600,7 +592,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Registrant uses shim for plugins using old embedding if app uses new embedding', () async {
@@ -611,7 +602,7 @@ dependencies:
         createNewKotlinPlugin2();
         createOldJavaPlugin('plugin3');
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -629,7 +620,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -641,7 +631,7 @@ dependencies:
 
         await expectLater(
           () async {
-            await injectPlugins(flutterProject);
+            await injectPlugins(flutterProject, androidPlatform: true);
           },
           throwsToolExit(
             message: 'The plugin `plugin1` requires your app to be migrated to the Android embedding v2. '
@@ -651,7 +641,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -664,7 +653,7 @@ dependencies:
 
         await expectLater(
           () async {
-            await injectPlugins(flutterProject);
+            await injectPlugins(flutterProject, androidPlatform: true);
           },
           throwsToolExit(
             message: "The plugin `plugin1` doesn't have a main class defined in "
@@ -678,7 +667,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -688,7 +676,7 @@ dependencies:
 
         createDualSupportJavaPlugin4();
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -702,7 +690,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -712,7 +699,7 @@ dependencies:
 
         createDualSupportJavaPlugin4();
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -726,7 +713,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -734,7 +720,7 @@ dependencies:
         when(flutterProject.isModule).thenReturn(true);
         when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v2);
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -747,7 +733,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Module using old plugin shows warning', () async {
@@ -756,7 +741,7 @@ dependencies:
 
         createOldJavaPlugin('plugin3');
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -767,7 +752,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -777,7 +761,7 @@ dependencies:
 
         createNewJavaPlugin1();
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -789,7 +773,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -799,7 +782,7 @@ dependencies:
 
         createDualSupportJavaPlugin4();
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -811,7 +794,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -822,7 +804,7 @@ dependencies:
         createOldJavaPlugin('plugin3');
         createOldJavaPlugin('plugin4');
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
         final File registrant = flutterProject.directory
           .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
@@ -836,7 +818,6 @@ dependencies:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
@@ -846,7 +827,7 @@ dependencies:
         final File manifest = fs.file('AndroidManifest.xml');
         when(androidProject.appManifestFile).thenReturn(manifest);
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, androidPlatform: true);
 
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -855,9 +836,6 @@ dependencies:
 
       testUsingContext("Registrant for web doesn't escape slashes in imports", () async {
         when(flutterProject.isModule).thenReturn(true);
-        when(featureFlags.isWebEnabled).thenReturn(true);
-        when(webProject.existsSync()).thenReturn(true);
-
         final Directory webPluginWithNestedFile =
             fs.systemTempDirectory.createTempSync('web_plugin_with_nested');
         webPluginWithNestedFile.childFile('pubspec.yaml').writeAsStringSync('''
@@ -880,7 +858,7 @@ dependencies:
 web_plugin_with_nested:${webPluginWithNestedFile.childDirectory('lib').uri.toString()}
 ''');
 
-        await injectPlugins(flutterProject);
+        await injectPlugins(flutterProject, webPlatform: true);
 
         final File registrant = flutterProject.directory
             .childDirectory('lib')
@@ -891,12 +869,9 @@ web_plugin_with_nested:${webPluginWithNestedFile.childDirectory('lib').uri.toStr
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated macos registrant, but does not include Dart-only plugins', () async {
-        when(macosProject.existsSync()).thenReturn(true);
-        when(featureFlags.isMacOSEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(true);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -908,7 +883,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, macOSPlatform: true);
 
         final File registrantFile = macosProject.managedDirectory.childFile('GeneratedPluginRegistrant.swift');
 
@@ -917,12 +892,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('pluginClass: none doesn\'t trigger registrant entry on macOS', () async {
-        when(macosProject.existsSync()).thenReturn(true);
-        when(featureFlags.isMacOSEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(true);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -935,7 +907,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, macOSPlatform: true);
 
         final File registrantFile = macosProject.managedDirectory.childFile('GeneratedPluginRegistrant.swift');
 
@@ -945,12 +917,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Invalid yaml does not crash plugin lookup.', () async {
-        when(macosProject.existsSync()).thenReturn(true);
-        when(featureFlags.isMacOSEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(true);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -958,7 +927,7 @@ flutter:
 "aws ... \"Branch\": $BITBUCKET_BRANCH, \"Date\": $(date +"%m-%d-%y"), \"Time\": $(date +"%T")}\"
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, macOSPlatform: true);
 
         final File registrantFile = macosProject.managedDirectory.childFile('GeneratedPluginRegistrant.swift');
 
@@ -966,16 +935,13 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated Linux registrant', () async {
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         createFakePlugin(fs);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true);
 
         final File registrantHeader = linuxProject.managedDirectory.childFile('generated_plugin_registrant.h');
         final File registrantImpl = linuxProject.managedDirectory.childFile('generated_plugin_registrant.cc');
@@ -986,12 +952,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated Linux registrant, but does not include Dart-only plugins', () async {
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -1003,7 +966,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true);
 
         final File registrantImpl = linuxProject.managedDirectory.childFile('generated_plugin_registrant.cc');
 
@@ -1013,12 +976,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('pluginClass: none doesn\'t trigger registrant entry on Linux', () async {
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -1031,7 +991,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true);
 
         final File registrantImpl = linuxProject.managedDirectory.childFile('generated_plugin_registrant.cc');
 
@@ -1041,16 +1001,13 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated Linux plugin Cmake file', () async {
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         createFakePlugin(fs);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true);
 
         final File pluginMakefile = linuxProject.generatedPluginCmakeFile;
 
@@ -1063,12 +1020,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Generated Linux plugin files sorts by plugin name', () async {
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         createFakePlugins(fs, <String>[
           'plugin_d',
@@ -1077,7 +1031,7 @@ flutter:
           '/local_plugins/plugin_b'
         ]);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true);
 
         final File pluginCmakeFile = linuxProject.generatedPluginCmakeFile;
         final File pluginRegistrant = linuxProject.managedDirectory.childFile('generated_plugin_registrant.cc');
@@ -1090,16 +1044,13 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated Windows registrant', () async {
-        when(windowsProject.existsSync()).thenReturn(true);
-        when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         createFakePlugin(fs);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, windowsPlatform: true);
 
         final File registrantHeader = windowsProject.managedDirectory.childFile('generated_plugin_registrant.h');
         final File registrantImpl = windowsProject.managedDirectory.childFile('generated_plugin_registrant.cc');
@@ -1110,12 +1061,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Injecting creates generated Windows registrant, but does not include Dart-only plugins', () async {
-        when(windowsProject.existsSync()).thenReturn(true);
-        when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -1127,7 +1075,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, windowsPlatform: true);
 
         final File registrantImpl = windowsProject.managedDirectory.childFile('generated_plugin_registrant.cc');
 
@@ -1136,12 +1084,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('pluginClass: none doesn\'t trigger registrant entry on Windows', () async {
-        when(windowsProject.existsSync()).thenReturn(true);
-        when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         // Create a plugin without a pluginClass.
         final Directory pluginDirectory = createFakePlugin(fs);
@@ -1154,7 +1099,7 @@ flutter:
         dartPluginClass: SomePlugin
     ''');
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, windowsPlatform: true);
 
         final File registrantImpl = windowsProject.managedDirectory.childFile('generated_plugin_registrant.cc');
 
@@ -1164,12 +1109,9 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Generated Windows plugin files sorts by plugin name', () async {
-        when(windowsProject.existsSync()).thenReturn(true);
-        when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
         createFakePlugins(fs, <String>[
           'plugin_d',
@@ -1178,7 +1120,7 @@ flutter:
           '/local_plugins/plugin_b'
         ]);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, windowsPlatform: true);
 
         final File pluginCmakeFile = windowsProject.generatedPluginCmakeFile;
         final File pluginRegistrant = windowsProject.managedDirectory.childFile('generated_plugin_registrant.cc');
@@ -1191,7 +1133,6 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
 
       testUsingContext('Generated plugin CMake files always use posix-style paths', () async {
@@ -1199,13 +1140,9 @@ flutter:
         setUpProject(fsWindows);
         createFakePlugin(fsWindows);
 
-        when(linuxProject.existsSync()).thenReturn(true);
-        when(windowsProject.existsSync()).thenReturn(true);
-        when(featureFlags.isLinuxEnabled).thenReturn(true);
-        when(featureFlags.isWindowsEnabled).thenReturn(true);
         when(flutterProject.isModule).thenReturn(false);
 
-        await injectPlugins(flutterProject, checkProjects: true);
+        await injectPlugins(flutterProject, linuxPlatform: true, windowsPlatform: true);
 
         for (final CmakeBasedProject project in <CmakeBasedProject>[linuxProject, windowsProject]) {
           final File pluginCmakefile = project.generatedPluginCmakeFile;
@@ -1217,7 +1154,6 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fsWindows,
         ProcessManager: () => FakeProcessManager.any(),
-        FeatureFlags: () => featureFlags,
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -116,12 +116,12 @@ void main() {
           FlutterManifest.empty(logger: logger),
           FlutterManifest.empty(logger: logger),
         );
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectNotExists(project.directory);
       });
       _testInMemory('does nothing in plugin or package root project', () async {
         final FlutterProject project = await aPluginProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectNotExists(project.ios.hostAppRoot.childDirectory('Runner').childFile('GeneratedPluginRegistrant.h'));
         expectNotExists(androidPluginRegistrant(project.android.hostAppGradleRoot.childDirectory('app')));
         expectNotExists(project.ios.hostAppRoot.childDirectory('Flutter').childFile('Generated.xcconfig'));
@@ -129,22 +129,22 @@ void main() {
       });
       _testInMemory('injects plugins for iOS', () async {
         final FlutterProject project = await someProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.ios.hostAppRoot.childDirectory('Runner').childFile('GeneratedPluginRegistrant.h'));
       });
       _testInMemory('generates Xcode configuration for iOS', () async {
         final FlutterProject project = await someProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.ios.hostAppRoot.childDirectory('Flutter').childFile('Generated.xcconfig'));
       });
       _testInMemory('injects plugins for Android', () async {
         final FlutterProject project = await someProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(androidPluginRegistrant(project.android.hostAppGradleRoot.childDirectory('app')));
       });
       _testInMemory('updates local properties for Android', () async {
         final FlutterProject project = await someProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.android.hostAppGradleRoot.childFile('local.properties'));
       });
       _testInMemory('Android project not on v2 embedding shows a warning', () async {
@@ -153,18 +153,18 @@ void main() {
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
 
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expect(testLogger.statusText, contains('https://flutter.dev/go/android-project-migration'));
       });
       _testInMemory('updates local properties for Android', () async {
         final FlutterProject project = await someProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.android.hostAppGradleRoot.childFile('local.properties'));
       });
       testUsingContext('injects plugins for macOS', () async {
         final FlutterProject project = await someProject();
         project.macos.managedDirectory.createSync(recursive: true);
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.macos.managedDirectory.childFile('GeneratedPluginRegistrant.swift'));
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem.test(),
@@ -178,7 +178,7 @@ void main() {
       testUsingContext('generates Xcode configuration for macOS', () async {
         final FlutterProject project = await someProject();
         project.macos.managedDirectory.createSync(recursive: true);
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.macos.generatedXcodePropertiesFile);
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem.test(),
@@ -192,7 +192,7 @@ void main() {
       testUsingContext('injects plugins for Linux', () async {
         final FlutterProject project = await someProject();
         project.linux.cmakeFile.createSync(recursive: true);
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.linux.managedDirectory.childFile('generated_plugin_registrant.h'));
         expectExists(project.linux.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
@@ -207,7 +207,7 @@ void main() {
       testUsingContext('injects plugins for Windows', () async {
         final FlutterProject project = await someProject();
         project.windows.cmakeFile.createSync(recursive: true);
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.windows.managedDirectory.childFile('generated_plugin_registrant.h'));
         expectExists(project.windows.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
@@ -221,14 +221,14 @@ void main() {
       });
       _testInMemory('creates Android library in module', () async {
         final FlutterProject project = await aModuleProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         expectExists(project.android.hostAppGradleRoot.childFile('settings.gradle'));
         expectExists(project.android.hostAppGradleRoot.childFile('local.properties'));
         expectExists(androidPluginRegistrant(project.android.hostAppGradleRoot.childDirectory('Flutter')));
       });
       _testInMemory('creates iOS pod in module', () async {
         final FlutterProject project = await aModuleProject();
-        await project.ensureReadyForPlatformSpecificTooling();
+        await project.regeneratePlatformSpecificTooling();
         final Directory flutter = project.ios.hostAppRoot.childDirectory('Flutter');
         expectExists(flutter.childFile('podhelper.rb'));
         expectExists(flutter.childFile('flutter_export_environment.sh'));


### PR DESCRIPTION
## Description

The `android` (and `ios`) directories are incorrectly created during the plugin registrant generation step.  After a `flutter create` the only thing in `android` is `GeneratedPluginRegistrant.java` and the only thing in `ios` is `GeneratedPluginRegistrant.{h,m}`.
https://github.com/flutter/flutter/blob/345188d40e576ffb6c97fee60446af58b8c9965a/packages/flutter_tools/lib/src/project.dart#L860-L862
is guarded by a check if the `android` directory exists (it did, but only contained `GeneratedPluginRegistrant.java`) and returned `v1` because the app manifest didn't exist, and caused a confusing warning.

Avoid creating platform directories during the plugin registrant generation step, which bypasses the Android embedding version warning.

- For `flutter create -t app`, generate the directories/plugins only for the requested platforms.  
- For other commands that regenerate various files (plugins, create missing template files, etc), only do so in existing platform directories.
- Replace the `checkProject` concept by explicitly requesting platforms based on user flags, existing directories, and whether features are on, as appropriate.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67346
Fixes https://github.com/flutter/flutter/issues/60023

Related:
https://github.com/flutter/flutter/pull/31342
https://github.com/flutter/flutter/pull/59507

## Tests

Added `--platform` app create tests.  Update existing plugin, project, cocoapods tests which already exercise these code paths.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*