### PR TITLE
null safety in ElevatedButton.icon

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -82,11 +82,11 @@ class ElevatedButton extends ButtonStyleButton {
   ///
   /// The [icon] and [label] arguments must not be null.
   factory ElevatedButton.icon({
-    Key key,
-    required VoidCallback onPressed,
-    VoidCallback onLongPress,
-    ButtonStyle style,
-    FocusNode focusNode,
+    Key? key,
+    required VoidCallback? onPressed,
+    VoidCallback? onLongPress,
+    ButtonStyle? style,
+    FocusNode? focusNode,
     bool autofocus,
     Clip clipBehavior,
     required Widget icon,

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -106,6 +106,28 @@ void main() {
     expect(material.type, MaterialType.button);
   });
 
+  testWidgets('ElevatedButton.icon defaults', (WidgetTester tester) async {
+    const ColorScheme colorScheme = ColorScheme.light();
+
+    // Enabled ElevatedButton
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.from(colorScheme: colorScheme),
+        home: Center(
+          child: ElevatedButton.icon(
+            onPressed: null,
+            key: null,
+            onLongPress: null,
+            style: null,
+            focusNode: null,
+            icon: const Icon(Icons.add),
+            label: const Text('buton'),
+          ),
+        ),
+      ),
+    );
+  });
+
   testWidgets('Default ElevatedButton meets a11y contrast guidelines', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
 
@@ -359,82 +381,6 @@ void main() {
             didLongPressButton = true;
           },
           child: const Text('button'),
-        ),
-      ),
-    );
-
-    final Finder elevatedButton = find.byType(ElevatedButton);
-    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
-
-    expect(didPressButton, isFalse);
-    await tester.tap(elevatedButton);
-    expect(didPressButton, isTrue);
-
-    expect(didLongPressButton, isFalse);
-    await tester.longPress(elevatedButton);
-    expect(didLongPressButton, isTrue);
-  });
-
-   testWidgets('ElevatedButton.icon onPressed and onLongPress callbacks are correctly called when non-null', (WidgetTester tester) async {
-    bool wasPressed;
-    Finder elevatedButton;
-
-    Widget buildFrame({ VoidCallback? onPressed, VoidCallback? onLongPress }) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: ElevatedButton.icon(
-          label: const Text('button'),
-          icon: const Icon(Icons.add),
-          onPressed: onPressed,
-          onLongPress: onLongPress,
-        ),
-      );
-    }
-
-    // onPressed not null, onLongPress null.
-    wasPressed = false;
-    await tester.pumpWidget(
-      buildFrame(onPressed: () { wasPressed = true; }, onLongPress: null),
-    );
-    elevatedButton = find.byType(ElevatedButton);
-    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
-    await tester.tap(elevatedButton);
-    expect(wasPressed, true);
-
-    // onPressed null, onLongPress not null.
-    wasPressed = false;
-    await tester.pumpWidget(
-      buildFrame(onPressed: null, onLongPress: () { wasPressed = true; }),
-    );
-    elevatedButton = find.byType(ElevatedButton);
-    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
-    await tester.longPress(elevatedButton);
-    expect(wasPressed, true);
-
-    // onPressed null, onLongPress null.
-    await tester.pumpWidget(
-      buildFrame(onPressed: null, onLongPress: null),
-    );
-    elevatedButton = find.byType(ElevatedButton);
-    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, false);
-  });
-
-  testWidgets('ElevatedButton.icon onPressed and onLongPress callbacks are distinctly recognized', (WidgetTester tester) async {
-    bool didPressButton = false;
-    bool didLongPressButton = false;
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: ElevatedButton.icon(
-          onPressed: () {
-            didPressButton = true;
-          },
-          onLongPress: () {
-            didLongPressButton = true;
-          },
-          label: const Text('button'),
-          icon: const Icon(Icons.add),
         ),
       ),
     );

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -375,6 +375,82 @@ void main() {
     expect(didLongPressButton, isTrue);
   });
 
+   testWidgets('ElevatedButton.icon onPressed and onLongPress callbacks are correctly called when non-null', (WidgetTester tester) async {
+    bool wasPressed;
+    Finder elevatedButton;
+
+    Widget buildFrame({ VoidCallback? onPressed, VoidCallback? onLongPress }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton.icon(
+          label: const Text('button'),
+          icon:const Icon(Icons.ac_unit),
+          onPressed: onPressed,
+          onLongPress: onLongPress,
+        ),
+      );
+    }
+
+    // onPressed not null, onLongPress null.
+    wasPressed = false;
+    await tester.pumpWidget(
+      buildFrame(onPressed: () { wasPressed = true; }, onLongPress: null),
+    );
+    elevatedButton = find.byType(ElevatedButton);
+    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
+    await tester.tap(elevatedButton);
+    expect(wasPressed, true);
+
+    // onPressed null, onLongPress not null.
+    wasPressed = false;
+    await tester.pumpWidget(
+      buildFrame(onPressed: null, onLongPress: () { wasPressed = true; }),
+    );
+    elevatedButton = find.byType(ElevatedButton);
+    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
+    await tester.longPress(elevatedButton);
+    expect(wasPressed, true);
+
+    // onPressed null, onLongPress null.
+    await tester.pumpWidget(
+      buildFrame(onPressed: null, onLongPress: null),
+    );
+    elevatedButton = find.byType(ElevatedButton);
+    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, false);
+  });
+
+  testWidgets('ElevatedButton.icon onPressed and onLongPress callbacks are distinctly recognized', (WidgetTester tester) async {
+    bool didPressButton = false;
+    bool didLongPressButton = false;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton.icon(
+          onPressed: () {
+            didPressButton = true;
+          },
+          onLongPress: () {
+            didLongPressButton = true;
+          },
+          label: const Text('button'),
+          icon:const Icon(Icons.ac_unit),
+        ),
+      ),
+    );
+
+    final Finder elevatedButton = find.byType(ElevatedButton);
+    expect(tester.widget<ElevatedButton>(elevatedButton).enabled, true);
+
+    expect(didPressButton, isFalse);
+    await tester.tap(elevatedButton);
+    expect(didPressButton, isTrue);
+
+    expect(didLongPressButton, isFalse);
+    await tester.longPress(elevatedButton);
+    expect(didLongPressButton, isTrue);
+  });
+
   testWidgets('Does ElevatedButton work with hover', (WidgetTester tester) async {
     const Color hoverColor = Color(0xff001122);
 

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -384,7 +384,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: ElevatedButton.icon(
           label: const Text('button'),
-          icon:const Icon(Icons.add),
+          icon: const Icon(Icons.add),
           onPressed: onPressed,
           onLongPress: onLongPress,
         ),
@@ -434,7 +434,7 @@ void main() {
             didLongPressButton = true;
           },
           label: const Text('button'),
-          icon:const Icon(Icons.add),
+          icon: const Icon(Icons.add),
         ),
       ),
     );

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -384,7 +384,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: ElevatedButton.icon(
           label: const Text('button'),
-          icon:const Icon(Icons.ac_unit),
+          icon:const Icon(Icons.add),
           onPressed: onPressed,
           onLongPress: onLongPress,
         ),
@@ -434,7 +434,7 @@ void main() {
             didLongPressButton = true;
           },
           label: const Text('button'),
-          icon:const Icon(Icons.ac_unit),
+          icon:const Icon(Icons.add),
         ),
       ),
     );


### PR DESCRIPTION
## Description

Null safety label is there but it is not present in the constructor.
https://master-api.flutter.dev/flutter/material/ElevatedButton/ElevatedButton.icon.html

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
