### PR TITLE
Add current version to the upgrade message of the Flutter tool

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -151,15 +151,15 @@ class UpgradeCommandRunner {
         'command with --force.'
       );
     }
-    recordState(flutterVersion, upstreamVersion);
+    recordState(flutterVersion);
+    globals.printStatus('Upgrading Flutter to ${upstreamVersion.frameworkVersion} from ${flutterVersion.frameworkVersion} in $workingDirectory...');
     await attemptReset(upstreamVersion.frameworkRevision);
     if (!testFlow) {
       await flutterUpgradeContinue();
     }
   }
 
-  void recordState(FlutterVersion flutterVersion, FlutterVersion upstreamVersion) {
-    globals.printStatus('Upgrading Flutter to ${upstreamVersion.frameworkVersion} from ${flutterVersion.frameworkVersion} in $workingDirectory...');
+  void recordState(FlutterVersion flutterVersion) {
     final Channel channel = getChannelForName(flutterVersion.channel);
     if (channel == null) {
       return;

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -151,14 +151,15 @@ class UpgradeCommandRunner {
         'command with --force.'
       );
     }
-    recordState(flutterVersion);
+    recordState(flutterVersion, upstreamVersion);
     await attemptReset(upstreamVersion.frameworkRevision);
     if (!testFlow) {
       await flutterUpgradeContinue();
     }
   }
 
-  void recordState(FlutterVersion flutterVersion) {
+  void recordState(FlutterVersion flutterVersion, FlutterVersion upstreamVersion) {
+    globals.printStatus('Upgrading Flutter to ${upstreamVersion.frameworkVersion} from ${flutterVersion.frameworkVersion} in $workingDirectory...');
     final Channel channel = getChannelForName(flutterVersion.channel);
     if (channel == null) {
       return;

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -352,25 +352,6 @@ void main() {
         Platform: () => fakePlatform,
       });
 
-      testUsingContext('Show current version to the upgrade message.', () async {
-        const String revision = 'abc123';
-        final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
-          force: false,
-          continueFlow: false,
-          testFlow: false,
-          gitTagVersion: gitTagVersion,
-          flutterVersion: flutterVersion,
-          verifyOnly: false,
-        );
-        expect(await result, FlutterCommandResult.success());
-        await realCommandRunner.upgradeChannel(flutterVersion, gitTagVersion.frameworkVersionFor(revision));
-        expect(testLogger.statusText, contains('Upgrading Flutter to ${gitTagVersion.frameworkVersionFor(revision)} from ${flutterVersion.frameworkVersion} in ${realCommandRunner.workingDirectory}'));
-        expect(processManager.hasRemainingExpectations, isFalse);
-      }, overrides: <Type, Generator>{
-        ProcessManager: () => processManager,
-        Platform: () => fakePlatform,
-      });
-
       testUsingContext("Doesn't throw on known tag, dev branch, no force", () async {
         final MockFlutterVersion latestVersion = MockFlutterVersion();
         fakeCommandRunner.remoteVersion = latestVersion;

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -298,30 +298,18 @@ void main() {
 
       fakeCommandRunner.alreadyUpToDate = false;
       fakeCommandRunner.remoteVersion = latestVersion;
+      fakeCommandRunner.workingDirectory = 'workingDirectory/aaa/bbb';
 
-      processManager.addCommands(<FakeCommand>[
-        const FakeCommand(command: <String>[
-          'git', 'fetch', '--tags'
-        ]),
-        const FakeCommand(command: <String>[
-          'git', 'rev-parse', '--verify', '@{u}',
-        ],
-            stdout: upstreamRevision),
-        const FakeCommand(command: <String>[
-          'git', 'tag', '--points-at', upstreamRevision,
-        ],
-            stdout: ''),
-        const FakeCommand(command: <String>[
-          'git', 'describe', '--match', '*.*.*', '--long', '--tags', upstreamRevision,
-        ],
-            stdout: upstreamVersion),
-        const FakeCommand(command: <String>[
-          'git', 'reset', '--hard', upstreamRevision
-        ]),
-      ]);
-
-      await realCommandRunner.runCommandFirstHalf(force: true, gitTagVersion: gitTagVersion, flutterVersion: flutterVersion, testFlow: true, verifyOnly: false);
-      expect(testLogger.statusText, contains('Upgrading Flutter to 4.5.6 from 1.2.3 in null'));
+      final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
+        force: true,
+        continueFlow: false,
+        testFlow: true,
+        gitTagVersion: gitTagVersion,
+        flutterVersion: flutterVersion,
+        verifyOnly: false,
+      );
+      expect(await result, FlutterCommandResult.success());
+      expect(testLogger.statusText, contains('Upgrading Flutter to 4.5.6 from 1.2.3 in workingDirectory/aaa/bbb...'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       Platform: () => fakePlatform,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -287,12 +287,10 @@ void main() {
       const String upstreamRevision = 'def456';
       const String version = '1.2.3';
       const String upstreamVersion = '4.5.6';
-      const String channel = "stable";
 
       when(flutterVersion.frameworkRevision).thenReturn(revision);
       when(flutterVersion.frameworkRevisionShort).thenReturn(revision);
       when(flutterVersion.frameworkVersion).thenReturn(version);
-      when(flutterVersion.channel).thenReturn(channel);
 
       final MockFlutterVersion latestVersion = MockFlutterVersion();
 

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -352,6 +352,25 @@ void main() {
         Platform: () => fakePlatform,
       });
 
+      testUsingContext('Show current version to the upgrade message.', () async {
+        const String revision = 'abc123';
+        final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
+          force: false,
+          continueFlow: false,
+          testFlow: false,
+          gitTagVersion: gitTagVersion,
+          flutterVersion: flutterVersion,
+          verifyOnly: false,
+        );
+        expect(await result, FlutterCommandResult.success());
+        await realCommandRunner.upgradeChannel(flutterVersion, revision);
+        expect(testLogger.statusText, contains('Upgrading Flutter to $revision from ${flutterVersion.frameworkRevision} in ${realCommandRunner.workingDirectory}'));
+        expect(processManager.hasRemainingExpectations, isFalse);
+      }, overrides: <Type, Generator>{
+        ProcessManager: () => processManager,
+        Platform: () => fakePlatform,
+      });
+
       testUsingContext("Doesn't throw on known tag, dev branch, no force", () async {
         final MockFlutterVersion latestVersion = MockFlutterVersion();
         fakeCommandRunner.remoteVersion = latestVersion;

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -363,8 +363,8 @@ void main() {
           verifyOnly: false,
         );
         expect(await result, FlutterCommandResult.success());
-        await realCommandRunner.upgradeChannel(flutterVersion, revision);
-        expect(testLogger.statusText, contains('Upgrading Flutter to $revision from ${flutterVersion.frameworkRevision} in ${realCommandRunner.workingDirectory}'));
+        await realCommandRunner.upgradeChannel(flutterVersion, gitTagVersion.frameworkVersionFor(revision));
+        expect(testLogger.statusText, contains('Upgrading Flutter to ${gitTagVersion.frameworkVersionFor(revision)} from ${flutterVersion.frameworkVersion} in ${realCommandRunner.workingDirectory}'));
         expect(processManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
         ProcessManager: () => processManager,


### PR DESCRIPTION
## Description

Add current version to the upgrade message of the Flutter tool. 

I'm a first-time contributor.
There are many things I don't understand, so please let me know.
Please point out any mistakes.
Thank you for reviewing it.

```
Upgrading Flutter to 1.22.1 from 1.22.0 in C:\Programming\Flutter\sdk\flutter...                                                            Checking Dart SDK version...                                                                                            Downloading Dart SDK from Flutter engine c8e3b9485386425213e2973126d6f57e7ed83c54...                                    Unzipping Dart SDK...
Building flutter tool...
Running pub upgrade...

Upgrading engine...
```

## Related Issues

Add current version to the upgrade message of the Flutter tool. #63023

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
