### PR TITLE
ExpansionPanelList ExpandIcon color support

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/colors.dart';
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
@@ -231,6 +232,8 @@ class ExpansionPanelList extends StatefulWidget {
     this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
     this.dividerColor,
     this.elevation = 2,
+    this.expandedColor = Colors.black54,
+    this.expandColor = Colors.black54,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -322,6 +325,8 @@ class ExpansionPanelList extends StatefulWidget {
     this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
     this.dividerColor,
     this.elevation = 2,
+    this.expandedColor = Colors.black54,
+    this.expandColor = Colors.black54,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,
@@ -365,6 +370,16 @@ class ExpansionPanelList extends StatefulWidget {
   /// By default, 16px of space is added to the header vertically (above and below)
   /// during expansion.
   final EdgeInsets expandedHeaderPadding;
+
+  /// Defines color for the [ExpansionPanel]'s [ExpandIcon] when [ExpansionPanel.isExpanded] is true.
+  ///
+  /// If `expandedColor` is null, the default [Colors.black54] is used.
+  final Color? expandedColor;
+
+  /// Defines color for the [ExpansionPanel]'s [ExpandIcon] when [ExpansionPanel.isExpanded] is false.
+  ///
+  /// If `expandedColor` is null, the default [Colors.black54] is used.
+  final Color? expandColor;
 
   /// Defines color for the divider when [ExpansionPanel.isExpanded] is false.
   ///
@@ -489,6 +504,8 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         margin: const EdgeInsetsDirectional.only(end: 8.0),
         child: ExpandIcon(
           isExpanded: _isChildExpanded(index),
+          expandedColor: widget.expandedColor,
+          color: widget.expandColor,
           padding: const EdgeInsets.all(16.0),
           onPressed: !child.canTapOnHeader
               ? (bool isExpanded) => _handlePressed(isExpanded, index)

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -14,12 +14,16 @@ class SimpleExpansionPanelListTestWidget extends StatefulWidget {
     this.expandedHeaderPadding,
     this.dividerColor,
     this.elevation = 2,
+    this.expandedColor = Colors.black54,
+    this.expandColor = Colors.black54,
   }) : super(key: key);
 
   final Key? firstPanelKey;
   final Key? secondPanelKey;
   final bool canTapOnHeader;
   final Color? dividerColor;
+  final Color? expandedColor;
+  final Color? expandColor;
   final int elevation;
 
   /// If null, the default [ExpansionPanelList]'s expanded header padding value is applied via [defaultExpandedHeaderPadding]
@@ -48,6 +52,8 @@ class _SimpleExpansionPanelListTestWidgetState extends State<SimpleExpansionPane
         });
       },
       dividerColor: widget.dividerColor,
+      expandColor: widget.expandColor,
+      expandedColor: widget.expandedColor,
       elevation: widget.elevation,
       children: <ExpansionPanel>[
         ExpansionPanel(
@@ -1346,6 +1352,63 @@ void main() {
     box = tester.renderObject(find.ancestor(of: find.byKey(firstPanelKey), matching: find.byType(AnimatedContainer)).first);
     expect(box.size.height, equals(128.0)); // _kPanelHeaderCollapsedHeight + 80.0 (double padding)
     expect(box.size.width, equals(736.0));
+  });
+
+  testWidgets('ExpandIcon default expanded color', (WidgetTester tester) async {
+    const Color expandedColor = Colors.black54;
+    await tester.pumpWidget(const MaterialApp(
+      home: SingleChildScrollView(
+        child: SimpleExpansionPanelListTestWidget(),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).last);
+
+    expect(expandIcon.expandedColor, expandedColor);
+  });
+
+  testWidgets('ExpandIcon color respects expandedColor', (WidgetTester tester) async {
+    const Color expandedColor = Colors.red;
+    await tester.pumpWidget(const MaterialApp(
+      home: SingleChildScrollView(
+        child: SimpleExpansionPanelListTestWidget(
+          expandedColor: expandedColor,
+        ),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).last);
+
+    expect(expandIcon.expandedColor, expandedColor);
+  });
+
+  testWidgets('ExpandIcon default expand color', (WidgetTester tester) async {
+    const Color defaultColor = Colors.black54;
+    await tester.pumpWidget(const MaterialApp(
+      home: SingleChildScrollView(
+        child: SimpleExpansionPanelListTestWidget(),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
+
+    expect(expandIcon.color, defaultColor);
+  });
+
+
+  testWidgets('ExpandIcon color respects expandColor', (WidgetTester tester) async {
+    const Color expandColor = Colors.red;
+    await tester.pumpWidget(const MaterialApp(
+      home: SingleChildScrollView(
+        child: SimpleExpansionPanelListTestWidget(
+          expandColor: expandColor,
+        ),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
+
+    expect(expandIcon.color, expandColor);
   });
 
   testWidgets('ExpansionPanelList respects dividerColor', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

I have needed to change the ExpansionPanelList ExpandIcon color but no way to change this, that's way I have added the parameters.

## Related Issues

It is like a new feature

## Tests

I added the following tests

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
