### PR TITLE
[devicelab] update hostonly tests to use flutter directly or precache deps

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -20,7 +18,12 @@ Future<void> main() async {
     try {
       await runProjectTest((FlutterProject project) async {
         section('App bundle content for task bundleRelease without explicit target platform');
-        await project.runGradleTask('bundleRelease');
+
+        await inDirectory(project.rootPath, () {
+          return flutter('build', options: <String>[
+            'appbundle',
+          ]);
+        });
 
         final String releaseBundle = path.join(
           project.rootPath,
@@ -42,10 +45,6 @@ Future<void> main() async {
       });
 
       await runProjectTest((FlutterProject project) async {
-        if (Platform.isWindows) {
-          // https://github.com/flutter/flutter/issues/42985
-          return;
-        }
         section('App bundle content using flavors without explicit target platform');
         // Add a few flavors.
         await project.addProductFlavors(<String> [
@@ -55,7 +54,13 @@ Future<void> main() async {
           'flavor_underscore', // https://github.com/flutter/flutter/issues/36067
         ]);
         // Build the production flavor in release mode.
-        await project.runGradleTask('bundleProductionRelease');
+        await inDirectory(project.rootPath, () {
+          return flutter('build', options: <String>[
+            'appbundle',
+            '--flavor',
+            'production',
+          ]);
+        });
 
         final String bundleFromGradlePath = path.join(
           project.rootPath,
@@ -77,9 +82,8 @@ Future<void> main() async {
 
         section('Build app bundle using the flutter tool - flavor: flavor_underscore');
 
-        int exitCode;
-        await inDirectory(project.rootPath, () async {
-          exitCode = await flutter(
+        int exitCode = await inDirectory(project.rootPath, ()  {
+          return flutter(
             'build',
             options: <String>[
               'appbundle',
@@ -113,8 +117,8 @@ Future<void> main() async {
 
         section('Build app bundle using the flutter tool - flavor: production');
 
-        await inDirectory(project.rootPath, () async {
-          exitCode = await flutter(
+        exitCode = await inDirectory(project.rootPath, () {
+          return flutter(
             'build',
             options: <String>[
               'appbundle',
@@ -149,8 +153,16 @@ Future<void> main() async {
 
       await runProjectTest((FlutterProject project) async {
         section('App bundle content for task bundleRelease with target platform = android-arm');
-        await project.runGradleTask('bundleRelease',
-            options: <String>['-Ptarget-platform=android-arm']);
+
+        await inDirectory(project.rootPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'appbundle',
+              '--target-platform=android-arm',
+            ],
+          );
+        });
 
         final String releaseBundle = path.join(
           project.rootPath,

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -15,7 +15,15 @@ Future<void> main() async {
     try {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug without explicit target platform');
-        await pluginProject.runGradleTask('assembleDebug');
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
@@ -40,7 +48,16 @@ Future<void> main() async {
 
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease without explicit target platform');
-        await pluginProject.runGradleTask('assembleRelease');
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
@@ -60,8 +77,17 @@ Future<void> main() async {
 
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm, android-arm64');
-        await pluginProject.runGradleTask('assembleRelease',
-            options: <String>['-Ptarget-platform=android-arm,android-arm64']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+              '--target-platform=android-arm,android-arm64'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
@@ -80,8 +106,18 @@ Future<void> main() async {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with '
                 'target platform = android-arm, android-arm64 and split per ABI');
-        await pluginProject.runGradleTask('assembleRelease',
-            options: <String>['-Ptarget-platform=android-arm,android-arm64', '-Psplit-per-abi=true']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+              '--split-per-abi',
+              '--target-platform=android-arm,android-arm64',
+            ],
+          );
+        });
 
         final Iterable<String> armApkFiles = await getFilesInApk(pluginProject.releaseArmApkPath);
 
@@ -108,7 +144,16 @@ Future<void> main() async {
 
       await runProjectTest((FlutterProject project) async {
         section('gradlew assembleRelease');
-        await project.runGradleTask('assembleRelease');
+
+        await inDirectory(project.rootPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+            ],
+          );
+        });
 
         // When the platform-target isn't specified, we generate the snapshots
         // for arm and arm64.

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -14,8 +14,17 @@ Future<void> main() async {
     try {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug with target platform = android-arm');
-        await pluginProject.runGradleTask('assembleDebug',
-            options: <String>['-Ptarget-platform=android-arm']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+              '--target-platform=android-arm'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
@@ -40,8 +49,16 @@ Future<void> main() async {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug with target platform = android-x86');
         // This is used by `flutter run`
-        await pluginProject.runGradleTask('assembleDebug',
-            options: <String>['-Ptarget-platform=android-x86']);
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+              '--target-platform=android-x86'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
@@ -64,8 +81,17 @@ Future<void> main() async {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug with target platform = android-x64');
         // This is used by `flutter run`
-        await pluginProject.runGradleTask('assembleDebug',
-            options: <String>['-Ptarget-platform=android-x64']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+              '--target-platform=android-x64'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
@@ -87,8 +113,17 @@ Future<void> main() async {
 
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm');
-        await pluginProject.runGradleTask('assembleRelease',
-            options: <String>['-Ptarget-platform=android-arm']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+              '--target-platform=android-arm'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
@@ -108,8 +143,17 @@ Future<void> main() async {
 
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm64');
-        await pluginProject.runGradleTask('assembleRelease',
-            options: <String>['-Ptarget-platform=android-arm64']);
+
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--release',
+              '--target-platform=android-arm64'
+            ],
+          );
+        });
 
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
@@ -129,7 +173,15 @@ Future<void> main() async {
 
       await runProjectTest((FlutterProject project) async {
         section('gradlew assembleDebug');
-        await project.runGradleTask('assembleDebug');
+        await inDirectory(project.rootPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+            ],
+          );
+        });
         final String errorMessage = validateSnapshotDependency(project, 'kernel_blob.bin');
         if (errorMessage != null) {
           throw TaskResult.failure(errorMessage);
@@ -138,7 +190,15 @@ Future<void> main() async {
 
       await runProjectTest((FlutterProject project) async {
         section('gradlew assembleProfile');
-        await project.runGradleTask('assembleProfile');
+        await inDirectory(project.rootPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--profile',
+            ],
+          );
+        });
       });
 
       await runProjectTest((FlutterProject project) async {
@@ -173,8 +233,13 @@ Future<void> main() async {
       await runProjectTest((FlutterProject project) async {
         section('gradlew on build script with error');
         await project.introduceError();
-        final ProcessResult result =
-            await project.resultOfGradleTask('assembleRelease');
+        final ProcessResult result = await inDirectory(project.rootPath, () {
+          return executeFlutter('build', options: <String>[
+            'apk',
+            '--release',
+          ]);
+        });
+
         if (result.exitCode == 0)
           throw failure(
               'Gradle did not exit with error as expected', result);
@@ -193,8 +258,12 @@ Future<void> main() async {
       await runProjectTest((FlutterProject project) async {
         section('gradlew assembleDebug forwards stderr');
         await project.introducePubspecError();
-                final ProcessResult result =
-            await project.resultOfGradleTask('assembleRelease');
+        final ProcessResult result = await inDirectory(project.rootPath, () {
+          return executeFlutter('build', options: <String>[
+            'apk',
+            '--release',
+          ]);
+        });
         if (result.exitCode == 0)
           throw failure(
               'Gradle did not exit with error as expected', result);
@@ -206,7 +275,12 @@ Future<void> main() async {
       await runProjectTest((FlutterProject project) async {
         section('flutter build apk on build script with error');
         await project.introduceError();
-        final ProcessResult result = await project.resultOfFlutterCommand('build', <String>['apk']);
+        final ProcessResult result = await inDirectory(project.rootPath, () {
+          return executeFlutter('build', options: <String>[
+            'apk',
+            '--release',
+          ]);
+        });
         if (result.exitCode == 0)
           throw failure(
               'flutter build apk should fail when Gradle does', result);
@@ -223,7 +297,15 @@ Future<void> main() async {
 
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('gradlew assembleDebug on plugin example');
-        await pluginProject.runGradleTask('assembleDebug');
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+            ],
+          );
+        });
         if (!File(pluginProject.debugApkPath).existsSync())
           throw TaskResult.failure(
               'Gradle did not produce an apk file at the expected place');

--- a/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
+++ b/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
@@ -29,6 +29,11 @@ Future<void> main() async {
 
     section('Create Flutter module project');
 
+    await flutter(
+      'precache',
+      options: <String>['--android', '--no-ios'],
+    );
+    
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_module_test.');
     final Directory projectDir = Directory(path.join(tempDir.path, 'hello'));
     try {

--- a/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
+++ b/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
@@ -33,7 +33,7 @@ Future<void> main() async {
       'precache',
       options: <String>['--android', '--no-ios'],
     );
-    
+
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_module_test.');
     final Directory projectDir = Directory(path.join(tempDir.path, 'hello'));
     try {

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -119,9 +119,23 @@ Future<String> _evalApkAnalyzer(
   String workingDirectory,
 }) async {
   final String javaHome = await findJavaHome();
+
+   final String apkAnalyzer = path
+     .join(_androidHome, 'cmdline-tools', 'latest', 'bin', Platform.isWindows ? 'apkanalyzer.bat' : 'apkanalyzer');
+   if (canRun(apkAnalyzer)) {
+     return eval(
+       apkAnalyzer,
+       args,
+       printStdout: printStdout,
+       workingDirectory: workingDirectory,
+       environment: <String, String>{
+         'JAVA_HOME': javaHome,
+       },
+     );
+   }
+
   final String javaBinary = path.join(javaHome, 'bin', 'java');
   assert(canRun(javaBinary));
-
   final String androidTools = path.join(_androidHome, 'tools');
   final String libs = path.join(androidTools, 'lib');
   assert(Directory(libs).existsSync());
@@ -366,9 +380,9 @@ class FlutterPluginProject {
   String get releaseArm64ApkPath => path.join(examplePath, 'build', 'app', 'outputs', 'flutter-apk', 'app-arm64-v8a-release.apk');
   String get releaseBundlePath => path.join(examplePath, 'build', 'app', 'outputs', 'bundle', 'release', 'app.aab');
 
-  Future<void> runGradleTask(String task, {List<String> options}) async {
-    return _runGradleTask(workingDirectory: exampleAndroidPath, task: task, options: options);
-  }
+  // Future<void> runGradleTask(String task, {List<String> options}) async {
+  //   return _runGradleTask(workingDirectory: exampleAndroidPath, task: task, options: options);
+  // }
 }
 
 class FlutterModuleProject {

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -379,10 +379,6 @@ class FlutterPluginProject {
   String get releaseArmApkPath => path.join(examplePath, 'build', 'app', 'outputs', 'flutter-apk','app-armeabi-v7a-release.apk');
   String get releaseArm64ApkPath => path.join(examplePath, 'build', 'app', 'outputs', 'flutter-apk', 'app-arm64-v8a-release.apk');
   String get releaseBundlePath => path.join(examplePath, 'build', 'app', 'outputs', 'bundle', 'release', 'app.aab');
-
-  // Future<void> runGradleTask(String task, {List<String> options}) async {
-  //   return _runGradleTask(workingDirectory: exampleAndroidPath, task: task, options: options);
-  // }
 }
 
 class FlutterModuleProject {

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -463,6 +463,15 @@ Future<String> evalFlutter(String command, {
       canFail: canFail, environment: environment, stderr: stderr);
 }
 
+Future<ProcessResult> executeFlutter(String command, {
+  List<String> options = const <String>[],
+}) async {
+   final List<String> args = flutterCommandArgs(command, options);
+  return _processManager.run(
+    <String>[path.join(flutterDirectory.path, 'bin', 'flutter'), ...args],
+  );
+}
+
 String get dartBin =>
     path.join(flutterDirectory.path, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -466,9 +466,10 @@ Future<String> evalFlutter(String command, {
 Future<ProcessResult> executeFlutter(String command, {
   List<String> options = const <String>[],
 }) async {
-   final List<String> args = flutterCommandArgs(command, options);
+  final List<String> args = flutterCommandArgs(command, options);
   return _processManager.run(
     <String>[path.join(flutterDirectory.path, 'bin', 'flutter'), ...args],
+    workingDirectory: cwd,
   );
 }
 


### PR DESCRIPTION

## Description

Fixes https://github.com/flutter/flutter/issues/67370

By running most of these executions through flutter, we get the benefit of the flutter error handling and precaching. IN the test where this is not feasible, call pre-cache directly.