### PR TITLE
[flutter_tools] increase devFS sync timeout to 60 seconds

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -296,16 +296,11 @@ class _DevFSHttpWriter implements DevFSWriter {
           _osUtils,
         );
         await request.addStream(contents);
-        // The contents has already been streamed, closing the request should
-        // not take long but we are experiencing hangs with it, see #63869.
-        //
         // Once the bug in Dart is solved we can remove the timeout
-        // (https://github.com/dart-lang/sdk/issues/43525).  The timeout was
-        // chosen to be inflated based on the max observed time when running the
-        // tests in "Google Tests".
+        // (https://github.com/dart-lang/sdk/issues/43525).
         try {
           final HttpClientResponse response = await request.close().timeout(
-            const Duration(milliseconds: 10000));
+            const Duration(seconds: 60));
           response.listen((_) {},
             onError: (dynamic error) {
               _logger.printTrace('error: $error');

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -93,7 +93,7 @@ void main() {
     expect(content.isModified, isFalse);
   });
 
-  testWithoutContext('DevFS retries uploads when connection resert by peer', () async {
+  testWithoutContext('DevFS retries uploads when connection reset by peer', () async {
     final HttpClient httpClient = MockHttpClient();
     final FileSystem fileSystem = MemoryFileSystem.test();
     final OperatingSystemUtils osUtils = MockOperatingSystemUtils();
@@ -356,7 +356,7 @@ void main() {
     expect(writer.written, true);
   });
 
-  testWithoutContext('Local DevFSwriter can copy and write files', () async {
+  testWithoutContext('Local DevFSWriter can copy and write files', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final File file = fileSystem.file('foo_bar')
       ..writeAsStringSync('goodbye');
@@ -373,7 +373,7 @@ void main() {
     expect(fileSystem.file('/foo/bar/devfs/goodbye').readAsStringSync(), 'goodbye');
   });
 
-  testWithoutContext('Local DevFSwriter turns FileSystemException into DevFSException', () async {
+  testWithoutContext('Local DevFSWriter turns FileSystemException into DevFSException', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final LocalDevFSWriter writer = LocalDevFSWriter(fileSystem: fileSystem);
     final File file = MockFile();
@@ -382,84 +382,6 @@ void main() {
     await expectLater(() async => await writer.write(<Uri, DevFSContent>{
       Uri.parse('goodbye'): DevFSFileContent(file),
     }, Uri.parse('/foo/bar/devfs/')), throwsA(isA<DevFSException>()));
-  });
-
-  testWithoutContext('test handles request closure hangs', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[createDevFSRequest],
-    );
-    final HttpClient httpClient = MockHttpClient();
-    final MockHttpClientRequest httpRequest = MockHttpClientRequest();
-    when(httpRequest.headers).thenReturn(MockHttpHeaders());
-    when(httpClient.putUrl(any)).thenAnswer((Invocation invocation) {
-      return Future<HttpClientRequest>.value(httpRequest);
-    });
-    int closeCount = 0;
-    final Completer<MockHttpClientResponse> hanger = Completer<MockHttpClientResponse>();
-    final Completer<MockHttpClientResponse> succeeder = Completer<MockHttpClientResponse>();
-    final List<Completer<MockHttpClientResponse>> closeCompleters =
-      <Completer<MockHttpClientResponse>>[hanger, succeeder];
-    succeeder.complete(MockHttpClientResponse());
-
-    when(httpRequest.close()).thenAnswer((Invocation invocation) {
-      final Completer<MockHttpClientResponse> completer = closeCompleters[closeCount];
-      closeCount += 1;
-      return completer.future;
-    });
-    when(httpRequest.abort()).thenAnswer((_) {
-      hanger.completeError(const HttpException('aborted'));
-    });
-    when(httpRequest.done).thenAnswer((_) {
-      if (closeCount == 1) {
-        return hanger.future;
-      } else if (closeCount == 2) {
-        return succeeder.future;
-      } else {
-        // This branch shouldn't happen.
-        fail('This branch should not happen');
-      }
-    });
-
-    final BufferLogger logger = BufferLogger.test();
-    final DevFS devFS = DevFS(
-      fakeVmServiceHost.vmService,
-      'test',
-      fileSystem.currentDirectory,
-      fileSystem: fileSystem,
-      logger: logger,
-      osUtils: FakeOperatingSystemUtils(),
-      httpClient: httpClient,
-    );
-
-    await devFS.create();
-    final DateTime previousCompile = devFS.lastCompiled;
-
-    final MockResidentCompiler residentCompiler = MockResidentCompiler();
-    when(residentCompiler.recompile(
-      any,
-      any,
-      outputPath: anyNamed('outputPath'),
-      packageConfig: anyNamed('packageConfig'),
-    )).thenAnswer((Invocation invocation) async {
-      fileSystem.file('example').createSync();
-      return const CompilerOutput('lib/foo.txt.dill', 0, <Uri>[]);
-    });
-
-    final UpdateFSReport report = await devFS.update(
-      mainUri: Uri.parse('lib/main.dart'),
-      generator: residentCompiler,
-      dillOutputPath: 'lib/foo.dill',
-      pathToReload: 'lib/foo.txt.dill',
-      trackWidgetCreation: false,
-      invalidatedFiles: <Uri>[],
-      packageConfig: PackageConfig.empty,
-    );
-
-    expect(report.success, true);
-    expect(devFS.lastCompiled, isNot(previousCompile));
-    expect(closeCount, 2);
-    expect(logger.errorText, '');
   });
 }
 


### PR DESCRIPTION
## Description

The current timeout is too short for some remote workflows. The existing unit test require hitting a real timeout so I've removed it.

See b/171005910