### PR TITLE
Respond to HTTP POST requests with 404 in WebAssetServer

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -333,7 +333,7 @@ class WebAssetServer implements AssetReader {
   // handle requests for JavaScript source, dart sources maps, or asset files.
   @visibleForTesting
   Future<shelf.Response> handleRequest(shelf.Request request) async {
-    if (request.method == 'POST') {
+    if (request.method != 'GET') {
       // Assets are served via GET only.
       return shelf.Response.notFound('');
     }
@@ -974,6 +974,11 @@ class ReleaseAssetServer {
   ];
 
   Future<shelf.Response> handle(shelf.Request request) async {
+    if (request.method != 'GET') {
+      // Assets are served via GET only.
+      return shelf.Response.notFound('');
+    }
+
     Uri fileUri;
     final String requestPath = _stripBasePath(request.url.path, basePath);
 

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -333,6 +333,11 @@ class WebAssetServer implements AssetReader {
   // handle requests for JavaScript source, dart sources maps, or asset files.
   @visibleForTesting
   Future<shelf.Response> handleRequest(shelf.Request request) async {
+    if (request.method == 'POST') {
+      // Assets are served via GET only.
+      return shelf.Response.notFound('');
+    }
+
     final String requestPath = _stripBasePath(request.url.path, basePath);
 
     if (requestPath == null) {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -924,6 +924,13 @@ void main() {
     expect(webAssetServer.defaultResponseHeaders['x-frame-options'], null);
     await webAssetServer.dispose();
   });
+
+  test('responds to POST requests with 404 not found', () => testbed.run(() async {
+    final Response response = await webAssetServer.handleRequest(
+      Request('POST', Uri.parse('http://foobar/something')),
+    );
+    expect(response.statusCode, 404);
+  }));
 }
 
 class MockHttpServer extends Mock implements HttpServer {}

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -32,6 +32,7 @@ const List<int> kTransparentImage = <int>[
 void main() {
   Testbed testbed;
   WebAssetServer webAssetServer;
+  ReleaseAssetServer releaseAssetServer;
   Platform linux;
   PackageConfig packages;
   Platform windows;
@@ -55,6 +56,14 @@ void main() {
         null,
         null,
         null,
+      );
+      releaseAssetServer = ReleaseAssetServer(
+        globals.fs.file('main.dart').uri,
+        fileSystem: null,
+        flutterRoot: null,
+        platform: null,
+        webBuildDirectory: null,
+        basePath: null,
       );
     });
   });
@@ -925,8 +934,15 @@ void main() {
     await webAssetServer.dispose();
   });
 
-  test('responds to POST requests with 404 not found', () => testbed.run(() async {
+  test('WebAssetServer responds to POST requests with 404 not found', () => testbed.run(() async {
     final Response response = await webAssetServer.handleRequest(
+      Request('POST', Uri.parse('http://foobar/something')),
+    );
+    expect(response.statusCode, 404);
+  }));
+
+  test('ReleaseAssetServer responds to POST requests with 404 not found', () => testbed.run(() async {
+    final Response response = await releaseAssetServer.handle(
       Request('POST', Uri.parse('http://foobar/something')),
     );
     expect(response.statusCode, 404);


### PR DESCRIPTION
## Description

Respond to HTTP POST requests with 404 in `WebAssetServer`. The issue seems to have been introduced with custom URL strategies, when the server started responding with HTTP 200 and serving `index.html` to all requests.