### PR TITLE
InteractiveViewer minScale docs improvement

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -218,6 +218,11 @@ class InteractiveViewer extends StatefulWidget {
   ///
   /// The scale will be clamped between this and [maxScale] inclusively.
   ///
+  /// Scale is also affected by [boundaryMargin]. If the scale would result in
+  /// viewing beyond the boundary, then it will not be allowed. By default,
+  /// boundaryMargin is EdgeInsets.zero, so scaling below 1.0 will not be
+  /// allowed in most cases without first increasing the boundaryMargin.
+  ///
   /// Defaults to 0.8.
   ///
   /// Cannot be null, and must be a finite number greater than zero and less


### PR DESCRIPTION
## Description

Currently, EdgeInsets tightly wraps the child by default, and so it prevents scaling down below 1.0 for a typical viewport.  It was brought to my attention in https://github.com/flutter/flutter/issues/68448 that this is confusing for users are just trying to get minScale to work, so I've updated minScale's docs with some information about this.

## Related Issues

Closes https://github.com/flutter/flutter/issues/68448

## Tests

Non, docs-only change.