### PR TITLE
[devicelab] reduce iterations, uninstall at end, and use  --application-binary in all startup tests

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -455,11 +455,9 @@ class StartupTest {
   Future<TaskResult> run() async {
     return await inDirectory<TaskResult>(testDirectory, () async {
       final String deviceId = (await devices.workingDevice).deviceId;
-      await flutter('packages', options: <String>['get']);
-
-      const int iterations = 15;
+      const int iterations = 5;
       final List<Map<String, dynamic>> results = <Map<String, dynamic>>[];
-      for (int i = 0; i < iterations; ++i) {
+      for (int i = 0; i < iterations; i += 1) {
         await flutter('run', options: <String>[
           '--no-android-gradle-daemon',
           '--verbose',
@@ -472,6 +470,12 @@ class StartupTest {
           file('$testDirectory/build/start_up_info.json').readAsStringSync(),
         ) as Map<String, dynamic>;
         results.add(data);
+
+        await flutter('install', options: <String>[
+          '--uninstall-only',
+          '-d',
+          deviceId,
+        ]);
       }
 
       final Map<String, dynamic> averageResults = _average(results, iterations);


### PR DESCRIPTION
## Description

These devicelab tests are incredibly flaky. Currently they will build & install the same application 15 times. This causes the temp storage to fill up on android, and has a good chance of flaking on iOS due to install issues.

The change from 3 to 15 increased total test time for 2 -> 12 minutes on iOS, or roughly 5 more test equivalents for every single iOS test. Reduce the iteration count back to 5

Uninstall the app after each run so temp storage does not fill up.