### PR TITLE
[flutter_tools] make android deps no longer required for flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -26,13 +26,6 @@ class DoctorCommand extends FlutterCommand {
   final String name = 'doctor';
 
   @override
-  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
-    // This is required because the gradle host-only tests do not correctly specify
-    // their dependencies.
-    DevelopmentArtifact.androidGenSnapshot,
-  };
-
-  @override
   final String description = 'Show information about the installed tooling.';
 
   @override


### PR DESCRIPTION
## Description

Since https://github.com/flutter/flutter/commit/e8dc7a2e172d8a6eac23fb47716fc2142d4e388b landed this dependency can be removed now.