### PR TITLE
Improve the date and time input pickers (#68047)

### DIFF
--- a/packages/flutter/lib/src/material/pickers/input_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_picker.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../material.dart';
 import '../input_border.dart';
 import '../input_decorator.dart';
 import '../material_localizations.dart';
@@ -14,7 +15,7 @@ import '../theme.dart';
 import 'date_picker_common.dart';
 import 'date_utils.dart' as utils;
 
-/// A [TextFormField] configured to accept and validate a date entered by a user.
+/// A [TextFormField] configured to accept and validate a date entered by the user.
 ///
 /// When the field is saved or submitted, the text will be parsed into a
 /// [DateTime] according to the ambient locale's compact date format. If the
@@ -37,7 +38,7 @@ class InputDatePickerFormField extends StatefulWidget {
   /// Creates a [TextFormField] configured to accept and validate a date.
   ///
   /// If the optional [initialDate] is provided, then it will be used to populate
-  /// the text field. If the [fieldHintText] is provided, it will be shown.
+  /// the text field. If the [fieldHintText] is provided, it will be shown instead.
   ///
   /// If [initialDate] is provided, it must not be before [firstDate] or after
   /// [lastDate]. If [selectableDayPredicate] is provided, it must return `true`
@@ -50,22 +51,27 @@ class InputDatePickerFormField extends StatefulWidget {
   InputDatePickerFormField({
     Key? key,
     DateTime? initialDate,
-    required DateTime firstDate,
-    required DateTime lastDate,
+    DateTime? currentDate,
+    DateTime? firstDate,
+    DateTime? lastDate,
     this.onDateSubmitted,
     this.onDateSaved,
     this.selectableDayPredicate,
     this.errorFormatText,
     this.errorInvalidText,
+    this.errorEmptyText,
     this.fieldHintText,
     this.fieldLabelText,
+    this.helperText,
+    this.controller,
     this.autofocus = false,
-  }) : assert(firstDate != null),
-       assert(lastDate != null),
-       assert(autofocus != null),
+    this.allowEmptyDate = false,
+    this.textInputAction,
+  }) : assert(autofocus != null),
        initialDate = initialDate != null ? utils.dateOnly(initialDate) : null,
-       firstDate = utils.dateOnly(firstDate),
-       lastDate = utils.dateOnly(lastDate),
+       currentDate = currentDate != null ? utils.dateOnly(currentDate) : null,
+       firstDate = firstDate != null ? utils.dateOnly(firstDate) : DateTime(0),
+       lastDate = lastDate != null ? utils.dateOnly(lastDate) : DateTime(2100),
        super(key: key) {
     assert(
       !this.lastDate.isBefore(this.firstDate),
@@ -85,9 +91,13 @@ class InputDatePickerFormField extends StatefulWidget {
     );
   }
 
-  /// If provided, it will be used as the default value of the field.
+  /// If provided, it will be used as the default value for the field.
   final DateTime? initialDate;
 
+  /// The [currentDate] represents the current day (i.e. today). This
+  /// date will be highlighted in the day grid. If null, the date of
+  /// `DateTime.now()` will be used.
+  final DateTime? currentDate;
   /// The earliest allowable [DateTime] that the user can input.
   final DateTime firstDate;
 
@@ -116,6 +126,8 @@ class InputDatePickerFormField extends StatefulWidget {
   /// [lastDate], or doesn't pass the [selectableDayPredicate].
   final String? errorInvalidText;
 
+  /// The error text displayed if the text is empty.
+  final String? errorEmptyText;
   /// The hint text displayed in the [TextField].
   ///
   /// If this is null, it will default to the date format string. For example,
@@ -128,15 +140,37 @@ class InputDatePickerFormField extends StatefulWidget {
   /// string. For example, 'Month, Day, Year' for en_US.
   final String? fieldLabelText;
 
+  /// Text that provides context about the [InputDecorator.child]'s value, such
+  /// as how the value will be used.
+  ///
+  /// If non-null, the text is displayed below the [InputDecorator.child], in
+  /// the same location as [errorText]. If a non-null [errorText] value is
+  /// specified then the helper text is not shown.
+  final String? helperText;
+  /// The [TextEditingController] to be passed to the [TextField].
+  final TextEditingController? controller;
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
 
+  /// If set to `true` allows the return of a `null` [DateTime].
+  ///
+  /// If set to `false` the validators will show an error if the field is left
+  /// empty.
+  ///
+  /// This is useful for cases where a form needs a date, but it's not a
+  /// required field and can be left empty.
+  final bool allowEmptyDate;
+  /// The type of action button to use for the keyboard.
+  ///
+  /// Defaults to [TextInputAction.newline] if [keyboardType] is
+  /// [TextInputType.multiline] and [TextInputAction.done] otherwise.
+  final TextInputAction? textInputAction;
   @override
   _InputDatePickerFormFieldState createState() => _InputDatePickerFormFieldState();
 }
 
 class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
-  final TextEditingController _controller = TextEditingController();
+  TextEditingController? _controller;
   DateTime? _selectedDate;
   String? _inputText;
   bool _autoSelected = false;
@@ -144,12 +178,13 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   @override
   void initState() {
     super.initState();
+    _controller = widget.controller ?? TextEditingController();
     _selectedDate = widget.initialDate;
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller?.dispose();
     super.dispose();
   }
 
@@ -157,9 +192,8 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_selectedDate != null) {
-      final MaterialLocalizations localizations = MaterialLocalizations.of(context)!;
-      _inputText = localizations.formatCompactDate(_selectedDate!);
-      TextEditingValue textEditingValue = _controller.value.copyWith(text: _inputText);
+      _inputText = _formatCompactDate(_selectedDate);
+      TextEditingValue textEditingValue = _controller!.value.copyWith(text: _inputText);
       // Select the new text if we are auto focused and haven't selected the text before.
       if (widget.autofocus && !_autoSelected) {
         textEditingValue = textEditingValue.copyWith(selection: TextSelection(
@@ -168,10 +202,16 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         ));
         _autoSelected = true;
       }
-      _controller.value = textEditingValue;
+      _controller!.value = textEditingValue;
     }
   }
 
+  bool _isBlank(String? s) => s == null || s.trim().isEmpty;
+
+  String _formatCompactDate(DateTime? date) {
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context)!;
+    return date != null ? localizations.formatCompactDate(date) : '';
+  }
   DateTime? _parseDate(String? text) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context)!;
     return localizations.parseCompactDate(text);
@@ -186,8 +226,14 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   }
 
   String? _validateDate(String? text) {
+    if (_isBlank(text) && !widget.allowEmptyDate) {
+      return widget.errorEmptyText;
+    }
     final DateTime? date = _parseDate(text);
     if (date == null) {
+      if (widget.allowEmptyDate) {
+        return null;
+      }
       return widget.errorFormatText ?? MaterialLocalizations.of(context)!.invalidDateFormatLabel;
     } else if (!_isValidAcceptableDate(date)) {
       return widget.errorInvalidText ?? MaterialLocalizations.of(context)!.dateOutOfRangeLabel;
@@ -227,9 +273,33 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         filled: inputTheme.filled,
         hintText: widget.fieldHintText ?? localizations.dateHelpText,
         labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
+        helperText: widget.helperText,
+        suffixIcon: Padding(
+          padding: const EdgeInsetsDirectional.only(end: 12.0),
+          child: IconButton(
+            focusNode: FocusNode(skipTraversal: true),
+            icon: const Icon(Icons.date_range),
+            onPressed: () async {
+              final DateTime selectedDate = await showDatePicker(
+                context: context,
+                initialDate: widget.initialDate ?? DateTime.now(),
+                firstDate: widget.firstDate,
+                lastDate: widget.lastDate,
+                currentDate: widget.currentDate,
+                fieldHintText: widget.fieldHintText,
+                fieldLabelText: widget.fieldLabelText,
+                errorFormatText: widget.errorFormatText,
+                errorInvalidText: widget.errorInvalidText,
+                locale: Localizations.localeOf(context),
+              );
+              _controller!.text = _formatCompactDate(selectedDate);
+            },
+          ),
+        ),
       ),
       validator: _validateDate,
       keyboardType: TextInputType.datetime,
+      textInputAction: widget.textInputAction,
       onSaved: _handleSaved,
       onFieldSubmitted: _handleSubmitted,
       autofocus: widget.autofocus,

--- a/packages/flutter/lib/src/material/pickers/input_time_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_time_picker.dart
@@ -1,0 +1,222 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../../material.dart';
+
+/// A [TextFormField] configured to accept and validate a time entered by the user.
+///
+/// When the field is saved or submitted, the text will be parsed into a
+/// [TimeOfDay]. If the input text doesn't parse into a time, the
+/// [errorFormatText] message will be displayed under the field.
+///
+/// See also:
+///
+///  * [showTimePicker], which shows a dialog that contains a material design
+///    time picker which includes support for text entry as well.
+///
+class InputTimePickerFormField extends StatefulWidget {
+  /// Creates a [TextFormField] configured to accept and validate time.
+  ///
+  /// If the optional [initialTime] is provided, then it will be used to populate
+  /// the text field. If the [fieldHintText] is provided, it will be shown instead.
+  ///
+  /// [autofocus] must be non-null.
+  ///
+  const InputTimePickerFormField({
+    Key? key,
+    this.initialTime,
+    this.onTimeSubmitted,
+    this.onTimeSaved,
+    this.errorFormatText,
+    this.errorEmptyText,
+    this.fieldHintText,
+    this.fieldLabelText,
+    this.helperText,
+    this.controller,
+    this.autofocus = false,
+    this.allowEmptyTime = false,
+    this.textInputAction,
+  })  : assert(autofocus != null),
+        assert(allowEmptyTime != null),
+        super(key: key);
+
+  /// If provided, it will be used as the default value for the field.
+  final TimeOfDay? initialTime;
+
+  /// An optional method to call when the user indicates they are done editing
+  /// the text in the field. Will only be called if the input represents a valid
+  /// [TimeOfDay].
+  final ValueChanged<TimeOfDay?>? onTimeSubmitted;
+
+  /// An optional method to call with the final time when the form is
+  /// saved via [FormState.save]. Will only be called if the input represents
+  /// a valid [TimeOfDay].
+  final ValueChanged<TimeOfDay?>? onTimeSaved;
+
+  /// The error text displayed if the entered time is not in the correct format.
+  final String? errorFormatText;
+
+  /// The error text displayed if the text is empty.
+  final String? errorEmptyText;
+
+  /// The hint text displayed in the [TextField].
+  ///
+  /// If this is null, it will default to the time format string. For example,
+  /// 'HH:mm' for en_US.
+  // TODO(anyone): Add a helper text for the time format string. This isn't currently working
+  final String? fieldHintText;
+
+  /// The label text displayed in the [TextField].
+  ///
+  /// If this is null, it will default to the words representing the time format
+  /// string. For example, 'Hour, Minute' for en_US.
+  // TODO(anyone): Add a helper text for the time format string. This isn't currently working
+  final String? fieldLabelText;
+
+  /// Text that provides context about the [InputDecorator.child]'s value, such
+  /// as how the value will be used.
+  ///
+  /// If non-null, the text is displayed below the [InputDecorator.child], in
+  /// the same location as [errorText]. If a non-null [errorText] value is
+  /// specified then the helper text is not shown.
+  final String? helperText;
+
+  /// The [TextEditingController] to be passed to the [TextField].
+  final TextEditingController? controller;
+
+  /// {@macro flutter.widgets.editableText.autofocus}
+  final bool autofocus;
+
+  /// If set to `true` allows the return of a `null` [TimeOfDay].
+  ///
+  /// If set to `false` the validators will show an error if the field is left
+  /// empty.
+  ///
+  /// This is useful for cases where a form needs a time, but it's not a
+  /// required field and can be left empty.
+  final bool allowEmptyTime;
+
+  /// The type of action button to use for the keyboard.
+  ///
+  /// Defaults to [TextInputAction.newline] if [keyboardType] is
+  /// [TextInputType.multiline] and [TextInputAction.done] otherwise.
+  final TextInputAction? textInputAction;
+
+  @override
+  _InputTimePickerFormFieldState createState() => _InputTimePickerFormFieldState();
+}
+
+class _InputTimePickerFormFieldState extends State<InputTimePickerFormField> {
+  TextEditingController? _controller;
+  bool isInit = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // Only runs once. We can't place this on initState as TimeOfDay.format
+    // needs to access the context, in order to get the localizations for the
+    // time format.
+    if (isInit) {
+      isInit = false;
+      _controller = widget.controller ??
+          TextEditingController(text: widget.initialTime?.format(context));
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  bool _isBlank(String? s) => s == null || s.trim().isEmpty;
+
+  String _formatCompactTime(TimeOfDay? time) => time?.format(context) ?? '';
+
+  TimeOfDay? _parseTime(String? text) {
+    final String languageTag = Localizations.localeOf(context)!.toLanguageTag();
+    DateTime? dateTime;
+    try {
+      // TODO(anyone): Create an equivalent parser: https://github.com/flutter/flutter/issues/68238
+      // dateTime = DateFormat.Hm(languageTag).parseStrict(text);
+      // Adding this just so there won't be any compilation errors, this line should be removed:
+      dateTime = DateTime.now();
+    } on FormatException catch (_) {
+      return null;
+    }
+    return TimeOfDay.fromDateTime(dateTime);
+  }
+
+  String? _validateTime(String? text) {
+    if (_isBlank(text) && !widget.allowEmptyTime) {
+      return widget.errorEmptyText;
+    }
+
+    final TimeOfDay? time = _parseTime(text);
+
+    if (time != null || widget.allowEmptyTime) {
+      return null;
+    }
+    return widget.errorFormatText ??
+        MaterialLocalizations.of(context)!.invalidTimeLabel;
+  }
+
+  void _handleSaved(String? text) {
+    if (widget.onTimeSaved != null) {
+      final TimeOfDay? time = _parseTime(text);
+      widget.onTimeSaved!(time);
+    }
+  }
+
+  void _handleSubmitted(String text) {
+    if (widget.onTimeSubmitted != null) {
+      final TimeOfDay? time = _parseTime(text);
+      widget.onTimeSubmitted!(time);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context)!;
+    final InputDecorationTheme inputTheme = Theme.of(context)!.inputDecorationTheme;
+    return TextFormField(
+      decoration: InputDecoration(
+        border: inputTheme.border ?? const UnderlineInputBorder(),
+        filled: inputTheme.filled,
+        // TODO(anyone): Make localizations for these time texts, the same there are for dates:
+        hintText: widget.fieldHintText ?? localizations.timePickerInputHelpText,
+        labelText: widget.fieldLabelText ?? localizations.timePickerInputHelpText,
+        helperText: widget.helperText,
+        suffixIcon: Padding(
+          padding: const EdgeInsetsDirectional.only(end: 12.0),
+          child: IconButton(
+            focusNode: FocusNode(skipTraversal: true),
+            icon: const Icon(Icons.access_time),
+            onPressed: () async {
+              // showTimePicker returns null if the dialog was canceled. I
+              // believe it wasn't converted yet to non nullable.
+              final TimeOfDay? selectedTime = await showTimePicker(
+                context: context,
+                initialTime: widget.initialTime ??
+                    _parseTime(_controller?.text) ??
+                    TimeOfDay.now(),
+                initialEntryMode: TimePickerEntryMode.input,
+              );
+
+              _controller?.text = _formatCompactTime(selectedTime);
+            },
+          ),
+        ),
+      ),
+      validator: _validateTime,
+      keyboardType: TextInputType.datetime,
+      textInputAction: widget.textInputAction,
+      onSaved: _handleSaved,
+      onFieldSubmitted: _handleSubmitted,
+      autofocus: widget.autofocus,
+      controller: _controller,
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/pickers/pickers.dart
+++ b/packages/flutter/lib/src/material/pickers/pickers.dart
@@ -13,6 +13,7 @@ export 'date_picker_deprecated.dart';
 export 'date_picker_dialog.dart' show showDatePicker;
 export 'date_range_picker_dialog.dart' show showDateRangePicker;
 export 'input_date_picker.dart' show InputDatePickerFormField;
+export 'input_time_picker.dart' show InputTimePickerFormField;
 
 // TODO(ianh): Not exporting everything is unusual and we should
 // probably change to just exporting everything and making sure it's


### PR DESCRIPTION
## Description

This PR addresses several issues, linked below. It doesn't fully address them all, but its a good start IMO.

I need this functionality in my app, that's why I opened those issues, but since I couldn't wait for the fixes to arrive, I made my own version that suits my needs. I decided to share my code here so those fixes could arrive sooner.

There are some very few things that are opinionated changes, like the inclusion of an `IconButton` for opening pickers. While I think that should be optional and even exposed through a `trailing` widget, I decided to include it here so you guys can evaluate if this is worthy or not.

This code is not complete, there are some `TODO`s spread around the code, pointing out things that aren't fully functioning because flutter still doesn't provide them (in my code I use external libraries like `Intl` for that).

## Related Issues

Fixes #68057
Fixes #68042
#68047
#68048

There are other issues realted to this same subject, but they aren't fixed or partially addressed here, so I didn't include them.

## Tests

I added the following tests:

No tests were included as I couldn't find any previous tests for these classes.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
