### PR TITLE
Add CocoaPods sudo installation note

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -165,23 +165,19 @@ class UserMessages {
   String cocoaPodsMissing(String consequence, String installInstructions) =>
       'CocoaPods not installed.\n'
       '$consequence\n'
-      'To install:\n'
-      '$installInstructions';
+      'To install $installInstructions';
   String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
       'Unknown CocoaPods version installed.\n'
       '$consequence\n'
-      'To upgrade:\n'
-      '$upgradeInstructions';
+      'To upgrade $upgradeInstructions';
   String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
       'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
       '$consequence\n'
-      'To upgrade:\n'
-      '$upgradeInstructions';
+      'To upgrade $upgradeInstructions';
   String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
       'CocoaPods installed but not working.\n'
       '$consequence\n'
-      'To re-install CocoaPods, run:\n'
-      '$reinstallInstructions';
+      'To re-install $reinstallInstructions';
 
   // Messages used in VsCodeValidator
   String vsCodeVersion(String version) => 'version $version';

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -42,10 +42,8 @@ const String outOfDatePluginsPodfileConsequence = '''
   If you have local Podfile edits you would like to keep, see https://github.com/flutter/flutter/issues/45197 for instructions.''';
 
 const String cocoaPodsInstallInstructions = '''
-  sudo gem install cocoapods''';
-
-const String cocoaPodsUpgradeInstructions = '''
-  sudo gem install cocoapods''';
+  sudo gem install cocoapods
+If you are using a Ruby version manager, you may need to run without sudo.''';
 
 const String podfileMigrationInstructions = '''
   rm ios/Podfile''';
@@ -205,7 +203,7 @@ class CocoaPods {
           'Warning: CocoaPods is installed but broken. Skipping pod install.\n'
           '$brokenCocoaPodsConsequence\n'
           'To re-install:\n'
-          '$cocoaPodsUpgradeInstructions\n',
+          '$cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -214,7 +212,7 @@ class CocoaPods {
           'Warning: Unknown CocoaPods version installed.\n'
           '$unknownCocoaPodsConsequence\n'
           'To upgrade:\n'
-          '$cocoaPodsUpgradeInstructions\n',
+          '$cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         break;
@@ -223,7 +221,7 @@ class CocoaPods {
           'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'
           '$noCocoaPodsConsequence\n'
           'To upgrade:\n'
-          '$cocoaPodsUpgradeInstructions\n',
+          '$cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -232,7 +230,7 @@ class CocoaPods {
           'Warning: CocoaPods recommended version $cocoaPodsRecommendedVersion or greater not installed.\n'
           'Pods handling may fail on some projects involving plugins.\n'
           'To upgrade:\n'
-          '$cocoaPodsUpgradeInstructions\n',
+          '$cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         break;

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -30,7 +30,7 @@ const String unknownCocoaPodsConsequence = '''
 const String brokenCocoaPodsConsequence = '''
   You appear to have CocoaPods installed but it is not working.
   This can happen if the version of Ruby that CocoaPods was installed with is different from the one being used to invoke it.
-  This can usually be fixed by re-installing CocoaPods. For more info, see https://github.com/flutter/flutter/issues/14293.''';
+  This can usually be fixed by re-installing CocoaPods.''';
 
 const String outOfDateFrameworksPodfileConsequence = '''
   This can cause a mismatched version of Flutter to be embedded in your app, which may result in App Store submission rejection or crashes.
@@ -41,9 +41,7 @@ const String outOfDatePluginsPodfileConsequence = '''
   See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms for details.
   If you have local Podfile edits you would like to keep, see https://github.com/flutter/flutter/issues/45197 for instructions.''';
 
-const String cocoaPodsInstallInstructions = '''
-  sudo gem install cocoapods
-If you are using a Ruby version manager, you may need to run without sudo.''';
+const String cocoaPodsInstallInstructions = 'see https://guides.cocoapods.org/using/getting-started.html#installation for instructions.';
 
 const String podfileMigrationInstructions = '''
   rm ios/Podfile''';
@@ -193,8 +191,7 @@ class CocoaPods {
         _logger.printError(
           'Warning: CocoaPods not installed. Skipping pod install.\n'
           '$noCocoaPodsConsequence\n'
-          'To install:\n'
-          '$cocoaPodsInstallInstructions\n',
+          'To install $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -202,8 +199,7 @@ class CocoaPods {
         _logger.printError(
           'Warning: CocoaPods is installed but broken. Skipping pod install.\n'
           '$brokenCocoaPodsConsequence\n'
-          'To re-install:\n'
-          '$cocoaPodsInstallInstructions\n',
+          'To re-install $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -211,8 +207,7 @@ class CocoaPods {
         _logger.printError(
           'Warning: Unknown CocoaPods version installed.\n'
           '$unknownCocoaPodsConsequence\n'
-          'To upgrade:\n'
-          '$cocoaPodsInstallInstructions\n',
+          'To upgrade $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         break;
@@ -220,8 +215,7 @@ class CocoaPods {
         _logger.printError(
           'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'
           '$noCocoaPodsConsequence\n'
-          'To upgrade:\n'
-          '$cocoaPodsInstallInstructions\n',
+          'To upgrade $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -229,8 +223,7 @@ class CocoaPods {
         _logger.printError(
           'Warning: CocoaPods recommended version $cocoaPodsRecommendedVersion or greater not installed.\n'
           'Pods handling may fail on some projects involving plugins.\n'
-          'To upgrade:\n'
-          '$cocoaPodsInstallInstructions\n',
+          'To upgrade $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         break;

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -50,12 +50,12 @@ class CocoaPodsValidator extends DoctorValidator {
       } else if (cocoaPodsStatus == CocoaPodsStatus.unknownVersion) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.hint(
-          _userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          _userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsInstallInstructions)));
       } else {
         status = ValidationType.partial;
         final String currentVersionText = await _cocoaPods.cocoaPodsVersionText;
         messages.add(ValidationMessage.hint(
-          _userMessages.cocoaPodsOutdated(currentVersionText, _cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          _userMessages.cocoaPodsOutdated(currentVersionText, _cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
       }
     }
 


### PR DESCRIPTION
## Description

Instead of suggesting a possibly incorrect installation command, refer users to CocoaPod's own instructions.
<img width="1124" alt="Screen Shot 2020-10-20 at 1 36 48 PM" src="https://user-images.githubusercontent.com/682784/96641307-5fd61180-12d9-11eb-8730-ed55c48b1435.png">


## Related Issues

Fixes https://github.com/flutter/flutter/issues/10122, specifically @InMatrix's request at https://github.com/flutter/flutter/issues/10122#issuecomment-699034668.
Website update at https://github.com/flutter/website/pull/4662
