### PR TITLE
[devicelab] uninstall during memory test

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1094,6 +1094,7 @@ class MemoryTest {
       }
 
       await adb.cancel();
+      await flutter('install', options: <String>['--uninstall-only', '-d', device.deviceId]);
 
       final ListStatistics startMemoryStatistics = ListStatistics(_startMemory);
       final ListStatistics endMemoryStatistics = ListStatistics(_endMemory);


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/issues/68537

Since we can't delete or remove this test.