### PR TITLE
Fix a multiple pointers bug

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -386,12 +386,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   void _giveUpPointer(int pointer, {bool reject = true}) {
     stopTrackingPointer(pointer);
-    if (reject) {
-      if (_velocityTrackers.containsKey(pointer)) {
-        _velocityTrackers.remove(pointer);
-        resolvePointer(pointer, GestureDisposition.rejected);
-      }
-    }
+    if (reject)
+      resolvePointer(pointer, GestureDisposition.rejected);
   }
 
   void _checkDown() {

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -266,10 +266,11 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   @protected
   @mustCallSuper
   void resolvePointer(int pointer, GestureDisposition disposition) {
-    final GestureArenaEntry? entry = _entries[pointer];
+    final Map<int, GestureArenaEntry> localEntries = Map<int, GestureArenaEntry>.from(_entries);
+    final GestureArenaEntry? entry = localEntries[pointer];
     if (entry != null) {
-      entry.resolve(disposition);
       _entries.remove(pointer);
+      entry.resolve(disposition);
     }
   }
 

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -266,8 +266,7 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   @protected
   @mustCallSuper
   void resolvePointer(int pointer, GestureDisposition disposition) {
-    final Map<int, GestureArenaEntry> localEntries = Map<int, GestureArenaEntry>.from(_entries);
-    final GestureArenaEntry? entry = localEntries[pointer];
+    final GestureArenaEntry? entry = _entries[pointer];
     if (entry != null) {
       _entries.remove(pointer);
       entry.resolve(disposition);


### PR DESCRIPTION
## Description

This bug can be reproduced with a high probability by #68373 

The scenario where the bug occurs is:

1. Pointer 1 down and add two Recognize(`TapGestureRecognizer` & `VerticalDragGestureRecognizer#5efda`)
2. Pointer 2 down and add two Recognize(`TapGestureRecognizer` & `VerticalDragGestureRecognizer#5efda`)
3. Pointer 3 down and add two Recognize(`TapGestureRecognizer` & `VerticalDragGestureRecognizer#5efda`)
4. Pointer 4 down and add only one Recognize(`VerticalDragGestureRecognizer#5efda`)

Because there is only one gesture in Arena 4, the `VerticalDragGestureRecognizer#5efda` will win by default, and `acceptGesture`. Therefore, this gesture can no longer be accepted by another arena, otherwise, there will be the assertion information mentioned in the #68373.

5. Then release one of the fingers slightly before release all at the other fingers.

## Why the issue happen?
From the log we can catch that:
1. When process the last finger event `_TransformedPointerCancelEvent`，What we expect is `stopTrackingPointer` and then reject this gesture, as the following code show:
```dart
  void _giveUpPointer(int pointer, {bool reject = true}) {
    stopTrackingPointer(pointer);
    if (reject) {
      if (_velocityTrackers.containsKey(pointer)) {
        _velocityTrackers.remove(pointer);
        resolvePointer(pointer, GestureDisposition.rejected);
      }
    }
  }
```
2. But when stop tracking the last pointer will call `didStopTrackingLastPointer` and clear the `_velocityTrackers`, This leads to the `resolvePointer` method cannot be called.  This gesture becomes the last member and wins via sweeping incorrectly.

## Related PR
**This change is an improvement of #39017, @dkwingsmt Please review, thanks. :)**


## Log
```dart
Launching lib\main.dart on PDCM00 in debug mode...
Running Gradle task 'assembleDebug'...
Parameter format not correct -
√ Built build\app\outputs\flutter-apk\app-debug.apk.
Installing build\app\outputs\flutter-apk\app.apk...
Waiting for PDCM00 to report its views...
Debug service listening on ws://127.0.0.1:59993/0X88-HsbOEM=/ws
Syncing files to device PDCM00...
I/flutter ( 5750): Gesture arena 1    ❙ ★ Opening new gesture arena.
I/flutter ( 5750): Gesture arena 1    ❙ Adding: TapGestureRecognizer#93267(debugOwner: GestureDetector, state: ready, button: 1)
I/flutter ( 5750): addAllowedPointer this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.ready]
I/flutter ( 5750): Gesture arena 1    ❙ Adding: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]event[_TransformedPointerDownEvent#da02f(position: Offset(37.7, 134.0))][1]
I/flutter ( 5750): Gesture arena 1    ❙ Closing with 2 members.
I/flutter ( 5750): Gesture arena 2    ❙ ★ Opening new gesture arena.
I/flutter ( 5750): Gesture arena 2    ❙ Adding: TapGestureRecognizer#d4edf(debugOwner: GestureDetector, state: ready, button: 1)
I/flutter ( 5750): addAllowedPointer this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]
I/flutter ( 5750): Gesture arena 2    ❙ Adding: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]event[_TransformedPointerDownEvent#ed1ae(position: Offset(48.7, 335.3))][2]
I/flutter ( 5750): Gesture arena 2    ❙ Closing with 2 members.
I/flutter ( 5750): Gesture arena 3    ❙ ★ Opening new gesture arena.
I/flutter ( 5750): Gesture arena 3    ❙ Adding: TapGestureRecognizer#3379a(debugOwner: GestureDetector, state: ready, button: 1)
I/flutter ( 5750): addAllowedPointer this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]
I/flutter ( 5750): Gesture arena 3    ❙ Adding: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]event[_TransformedPointerDownEvent#68437(position: Offset(65.0, 192.3))][3]
I/flutter ( 5750): Gesture arena 3    ❙ Closing with 2 members.
I/flutter ( 5750): addAllowedPointer this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]
I/flutter ( 5750): Gesture arena 4    ❙ ★ Opening new gesture arena.
I/flutter ( 5750): Gesture arena 4    ❙ Adding: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.possible]event[_TransformedPointerDownEvent#1675a(position: Offset(63.7, 263.7))][4]
I/flutter ( 5750): Gesture arena 4    ❙ Closing with 1 member.
I/flutter ( 5750): Gesture arena 4    ❙ Default winner: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): acceptGesture pointer[4][VerticalDragGestureRecognizer#aac43(start behavior: start)]state[_DragState.possible]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#f3c66(position: Offset(37.7, 134.0))][1]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.504000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#778c6(position: Offset(48.7, 335.3))][2]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.504000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#6c668(position: Offset(65.0, 192.3))][3]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.504000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#2ca47(position: Offset(63.7, 263.7))][4]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.504000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#a0143(position: Offset(37.7, 134.0))][1]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.538000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#355eb(position: Offset(48.7, 335.3))][2]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.538000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#660c6(position: Offset(65.0, 192.3))][3]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.538000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#09744(position: Offset(63.7, 263.7))][4]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:53.538000]
...
start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#aeb42(position: Offset(36.0, 131.0))][1]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.442000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#e482e(position: Offset(48.7, 335.3))][2]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.442000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#059bd(position: Offset(64.0, 193.3))][3]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.442000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#91b4a(position: Offset(62.0, 267.0))][4]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.442000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#64629(position: Offset(35.7, 131.0))][1]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.449000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#cc7c2(position: Offset(64.0, 193.0))][3]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.449000]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerMoveEvent#4e474(position: Offset(62.0, 267.0))][4]
I/flutter ( 5750): handleEvent 2 this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]ts[745:29:54.449000]
I/flutter ( 5750): stopTrackingPointer pointer[2]_trackedPointers[{2}]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerUpEvent#42107(position: Offset(48.7, 335.3))][2]
I/flutter ( 5750): _giveUpPointer [0] [2]reject[false]_velocityTrackers[{1: Instance of 'VelocityTracker', 2: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[2]_trackedPointers[{1, 2, 3, 4}]
I/flutter ( 5750): _giveUpPointer [1] [2]reject[false]_velocityTrackers[{1: Instance of 'VelocityTracker', 2: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): Gesture arena 2    ❙ Sweeping with 2 members.
I/flutter ( 5750): Gesture arena 2    ❙ Winner: TapGestureRecognizer#d4edf(debugOwner: GestureDetector, state: ready, finalPosition: Offset(48.7, 335.3), finalLocalPosition: Offset(48.7, 15.3), button: 1, sent tap down)
I/flutter ( 5750): _giveUpPointer [0] [2]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 2: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[2]_trackedPointers[{1, 3, 4}]
I/flutter ( 5750): _giveUpPointer [1] [2]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 2: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): resolvePointer [2]disposition[GestureDisposition.rejected]_entries[{1: Instance of 'GestureArenaEntry', 2: Instance of 'GestureArenaEntry', 3: Instance of 'GestureArenaEntry', 4: Instance of 'GestureArenaEntry'}]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerCancelEvent#8b921(position: Offset(0.0, 0.0))][4]
I/flutter ( 5750): _giveUpPointer [0] [4]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[4]_trackedPointers[{1, 3, 4}]
I/flutter ( 5750): _giveUpPointer [1] [4]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker', 4: Instance of 'VelocityTracker'}]
I/flutter ( 5750): resolvePointer [4]disposition[GestureDisposition.rejected]_entries[{1: Instance of 'GestureArenaEntry', 3: Instance of 'GestureArenaEntry', 4: Instance of 'GestureArenaEntry'}]
I/flutter ( 5750): Gesture arena 3    ❙ Rejecting: TapGestureRecognizer#3379a(debugOwner: GestureDetector, state: possible, button: 1, sent tap down)
I/flutter ( 5750): stopTrackingPointer pointer[3]_trackedPointers[{3}]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerCancelEvent#cb079(position: Offset(0.0, 0.0))][3]
I/flutter ( 5750): _giveUpPointer [0] [3]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[3]_trackedPointers[{1, 3}]
I/flutter ( 5750): _giveUpPointer [1] [3]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker', 3: Instance of 'VelocityTracker'}]
I/flutter ( 5750): resolvePointer [3]disposition[GestureDisposition.rejected]_entries[{1: Instance of 'GestureArenaEntry', 3: Instance of 'GestureArenaEntry'}]
I/flutter ( 5750): Gesture arena 3    ❙ Rejecting: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): _giveUpPointer [0] [3]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[3]_trackedPointers[{1}]
I/flutter ( 5750): _giveUpPointer [1] [3]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker'}]
I/flutter ( 5750): Gesture arena 3    ❙ Arena empty.
I/flutter ( 5750): Gesture arena 1    ❙ Rejecting: TapGestureRecognizer#93267(debugOwner: GestureDetector, state: possible, button: 1, sent tap down)
I/flutter ( 5750): stopTrackingPointer pointer[1]_trackedPointers[{1}]
I/flutter ( 5750): handleEvent this[VerticalDragGestureRecognizer#aac43(start behavior: start)]_state[_DragState.accepted]event[_TransformedPointerCancelEvent#7e63e(position: Offset(0.0, 0.0))][1]
I/flutter ( 5750): _giveUpPointer [0] [1]reject[true]_velocityTrackers[{1: Instance of 'VelocityTracker'}]
I/flutter ( 5750): stopTrackingPointer pointer[1]_trackedPointers[{1}]
I/flutter ( 5750): _giveUpPointer [1] [1]reject[true]_velocityTrackers[{}]
I/flutter ( 5750): Gesture arena 1    ❙ Default winner: VerticalDragGestureRecognizer#aac43(start behavior: start)
I/flutter ( 5750): acceptGesture pointer[1][VerticalDragGestureRecognizer#aac43(start behavior: start)]state[_DragState.ready]
E/flutter ( 5750): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: Null check operator used on a null value
E/flutter ( 5750): #0      DragGestureRecognizer.acceptGesture (package:flutter/src/gestures/monodrag.dart:328:60)
E/flutter ( 5750): #1      GestureArenaManager._resolveByDefault (package:flutter/src/gestures/arena.dart:251:25)
E/flutter ( 5750): #2      GestureArenaManager._tryToResolveArena.<anonymous closure> (package:flutter/src/gestures/arena.dart:232:31)
E/flutter ( 5750): #3      _rootRun (dart:async/zone.dart:1182:47)
E/flutter ( 5750): #4      _CustomZone.run (dart:async/zone.dart:1093:19)
E/flutter ( 5750): #5      _CustomZone.runGuarded (dart:async/zone.dart:997:7)
E/flutter ( 5750): #6      _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1037:23)
E/flutter ( 5750): #7      _rootRun (dart:async/zone.dart:1190:13)
E/flutter ( 5750): #8      _CustomZone.run (dart:async/zone.dart:1093:19)
E/flutter ( 5750): #9      _CustomZone.runGuarded (dart:async/zone.dart:997:7)
E/flutter ( 5750): #10     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1037:23)
E/flutter ( 5750): #11     _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
E/flutter ( 5750): #12     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
E/flutter ( 5750): 
```


## Related Issues

Fixes #68373 

## Tests

See files.
