### PR TITLE
Updated dartdoc to 0.36.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.35.0
+    "$PUB" global activate dartdoc 0.36.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -139,7 +139,6 @@ Future<void> main(List<String> arguments) async {
   final List<String> dartdocArgs = <String>[
     ...dartdocBaseArgs,
     '--allow-tools',
-    '--enable-experiment=non-nullable',
     if (args['json'] as bool) '--json',
     if (args['validate-links'] as bool) '--validate-links' else '--no-validate-links',
     '--link-to-source-excludes', '../../bin/cache',


### PR DESCRIPTION
## Description

This PR updates dartdoc to 0.36.0.  See the release notes below, but TL;DR for Flutter is several bugs were fixed that will correct some broken links and make it easier to refactor code.

## Related Issues

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.36.0

## Tests

Ran bot script and spot checked to be sure null safety tag still was in place and no new warnings were generated.