### PR TITLE
Migrate flutter_localizations to null safety.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -684,7 +684,7 @@ Future<void> _runFrameworkTests() async {
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_driver'), tableData: bigqueryApi?.tabledata, tests: <String>[path.join('test', 'src', 'real_tests')]);
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'integration_test'), tableData: bigqueryApi?.tabledata);
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_goldens'), tableData: bigqueryApi?.tabledata);
-    await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_localizations'), tableData: bigqueryApi?.tabledata);
+    await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_localizations'), tableData: bigqueryApi?.tabledata, options: soundNullSafetyOptions);
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_test'), tableData: bigqueryApi?.tabledata, options: soundNullSafetyOptions);
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'fuchsia_remote_debug_protocol'), tableData: bigqueryApi?.tabledata);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'non_nullable'), options: mixedModeNullSafetyOptions);

--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -381,16 +381,21 @@ $factoryDeclaration
 /// Typically "String", but some (e.g. "timeOfDayFormat") return enums.
 ///
 /// Used by [generateGetter] below.
-String generateType(Map<String, dynamic> attributes) {
+String generateType(String key, Map<String, dynamic> attributes) {
+  bool optional = false;
+  String type = 'String';
   if (attributes != null) {
+    optional = attributes.containsKey('optional');
     switch (attributes['x-flutter-type'] as String) {
       case 'icuShortTimePattern':
-        return 'TimeOfDayFormat';
+        type = 'TimeOfDayFormat';
+        break;
       case 'scriptCategory':
-        return 'ScriptCategory';
+        type = 'ScriptCategory';
+        break;
     }
   }
-  return 'String';
+  return type + (optional ? '?' : '');
 }
 
 /// Returns the appropriate name for getters with the given attributes.
@@ -474,7 +479,7 @@ String generateValue(String value, Map<String, dynamic> attributes, LocaleInfo l
 /// the source of getters for the GlobalMaterialLocalizations subclass.
 /// The locale is the locale for which the getter is being generated.
 String generateGetter(String key, String value, Map<String, dynamic> attributes, LocaleInfo locale) {
-  final String type = generateType(attributes);
+  final String type = generateType(key, attributes);
   key = generateKey(key, attributes);
   value = generateValue(value, attributes, locale);
       return '''

--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -381,7 +381,7 @@ $factoryDeclaration
 /// Typically "String", but some (e.g. "timeOfDayFormat") return enums.
 ///
 /// Used by [generateGetter] below.
-String generateType(String key, Map<String, dynamic> attributes) {
+String generateType(Map<String, dynamic> attributes) {
   bool optional = false;
   String type = 'String';
   if (attributes != null) {
@@ -479,7 +479,7 @@ String generateValue(String value, Map<String, dynamic> attributes, LocaleInfo l
 /// the source of getters for the GlobalMaterialLocalizations subclass.
 /// The locale is the locale for which the getter is being generated.
 String generateGetter(String key, String value, Map<String, dynamic> attributes, LocaleInfo locale) {
-  final String type = generateType(key, attributes);
+  final String type = generateType(attributes);
   key = generateKey(key, attributes);
   value = generateValue(value, attributes, locale);
       return '''

--- a/dev/tools/localization/gen_cupertino_localizations.dart
+++ b/dev/tools/localization/gen_cupertino_localizations.dart
@@ -16,7 +16,6 @@ HeaderGenerator generateCupertinoHeader = (String regenerateInstructions) {
 
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart' as intl;
 
@@ -40,14 +39,14 @@ ConstructorGenerator generateCupertinoConstructor = (LocaleInfo locale) {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalization${locale.camelCase()}({
     String localeName = '$localeName',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -64,7 +63,7 @@ ConstructorGenerator generateCupertinoConstructor = (LocaleInfo locale) {
 const String cupertinoFactoryName = 'getCupertinoTranslation';
 
 const String cupertinoFactoryDeclaration = '''
-GlobalCupertinoLocalizations getCupertinoTranslation(
+GlobalCupertinoLocalizations? getCupertinoTranslation(
   Locale locale,
   intl.DateFormat fullYearFormat,
   intl.DateFormat dayFormat,

--- a/dev/tools/localization/gen_material_localizations.dart
+++ b/dev/tools/localization/gen_material_localizations.dart
@@ -16,7 +16,6 @@ HeaderGenerator generateMaterialHeader = (String regenerateInstructions) {
 
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
 
@@ -40,15 +39,15 @@ ConstructorGenerator generateMaterialConstructor = (LocaleInfo locale) {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalization${locale.camelCase()}({
     String localeName = '$localeName',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -66,7 +65,7 @@ ConstructorGenerator generateMaterialConstructor = (LocaleInfo locale) {
 const String materialFactoryName = 'getMaterialTranslation';
 
 const String materialFactoryDeclaration = '''
-GlobalMaterialLocalizations getMaterialTranslation(
+GlobalMaterialLocalizations? getMaterialTranslation(
   Locale locale,
   intl.DateFormat fullYearFormat,
   intl.DateFormat compactDateFormat,

--- a/dev/tools/localization/localizations_validator.dart
+++ b/dev/tools/localization/localizations_validator.dart
@@ -67,8 +67,9 @@ void validateEnglishLocalizations(File file) {
       continue;
     }
 
+    final bool optional = atResource.containsKey('optional');
     final String description = atResource['description'] as String;
-    if (description == null)
+    if (description == null && !optional)
       errorMessages.writeln('No description specified for $atResourceId');
 
     final String plural = atResource['plural'] as String;
@@ -78,7 +79,7 @@ void validateEnglishLocalizations(File file) {
       if (!bundle.containsKey(resourceIdOther))
         errorMessages.writeln('Default plural resource $resourceIdOther undefined');
     } else {
-      if (!bundle.containsKey(resourceId))
+      if (!optional && !bundle.containsKey(resourceId))
         errorMessages.writeln('No matching $resourceId defined for $atResourceId');
     }
   }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1763,9 +1763,10 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
         });
       },
       children: List<Widget>.generate(24, (int index) {
+        final String label = localizations.timerPickerHourLabel(index) ?? '';
         final String semanticsLabel = textDirectionFactor == 1
-            ? localizations.timerPickerHour(index) + localizations.timerPickerHourLabel(index)
-            : localizations.timerPickerHourLabel(index) + localizations.timerPickerHour(index);
+            ? localizations.timerPickerHour(index) + label
+            : label + localizations.timerPickerHour(index);
 
         return Semantics(
           label: semanticsLabel,
@@ -1793,7 +1794,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           child: _buildHourPicker(additionalPadding, selectionOverlay),
         ),
         _buildLabel(
-          localizations.timerPickerHourLabel(lastSelectedHour ?? selectedHour!),
+          localizations.timerPickerHourLabel(lastSelectedHour ?? selectedHour!) ?? '',
           additionalPadding,
         ),
       ],
@@ -1826,10 +1827,10 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       },
       children: List<Widget>.generate(60 ~/ widget.minuteInterval, (int index) {
         final int minute = index * widget.minuteInterval;
-
+        final String label = localizations.timerPickerMinuteLabel(minute) ?? '';
         final String semanticsLabel = textDirectionFactor == 1
-            ? localizations.timerPickerMinute(minute) + localizations.timerPickerMinuteLabel(minute)
-            : localizations.timerPickerMinuteLabel(minute) + localizations.timerPickerMinute(minute);
+            ? localizations.timerPickerMinute(minute) + label
+            : label + localizations.timerPickerMinute(minute);
 
         return Semantics(
           label: semanticsLabel,
@@ -1857,7 +1858,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           child: _buildMinutePicker(additionalPadding, selectionOverlay),
         ),
         _buildLabel(
-          localizations.timerPickerMinuteLabel(lastSelectedMinute ?? selectedMinute),
+          localizations.timerPickerMinuteLabel(lastSelectedMinute ?? selectedMinute) ?? '',
           additionalPadding,
         ),
       ],
@@ -1890,10 +1891,10 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
       },
       children: List<Widget>.generate(60 ~/ widget.secondInterval, (int index) {
         final int second = index * widget.secondInterval;
-
+        final String label = localizations.timerPickerSecondLabel(second) ?? '';
         final String semanticsLabel = textDirectionFactor == 1
-            ? localizations.timerPickerSecond(second) + localizations.timerPickerSecondLabel(second)
-            : localizations.timerPickerSecondLabel(second) + localizations.timerPickerSecond(second);
+            ? localizations.timerPickerSecond(second) + label
+            : label + localizations.timerPickerSecond(second);
 
         return Semantics(
           label: semanticsLabel,
@@ -1921,7 +1922,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           child: _buildSecondPicker(additionalPadding, selectionOverlay),
         ),
         _buildLabel(
-          localizations.timerPickerSecondLabel(lastSelectedSecond ?? selectedSecond!),
+          localizations.timerPickerSecondLabel(lastSelectedSecond ?? selectedSecond!) ?? '',
           additionalPadding,
         ),
       ],

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -108,7 +108,7 @@ abstract class CupertinoLocalizations {
 
   /// Semantics label for the given hour value in [CupertinoDatePicker].
   // The global version uses the translated string from the arb file.
-  String datePickerHourSemanticsLabel(int hour);
+  String? datePickerHourSemanticsLabel(int hour);
 
   /// Minute that is shown in [CupertinoDatePicker] spinner corresponding
   /// to the given minute value.
@@ -122,7 +122,7 @@ abstract class CupertinoLocalizations {
 
   /// Semantics label for the given minute value in [CupertinoDatePicker].
   // The global version uses the translated string from the arb file.
-  String datePickerMinuteSemanticsLabel(int minute);
+  String? datePickerMinuteSemanticsLabel(int minute);
 
   /// The order of the date elements that will be shown in [CupertinoDatePicker].
   // The global version uses the translated string from the arb file.
@@ -190,7 +190,7 @@ abstract class CupertinoLocalizations {
   /// [CupertinoTimerPicker] when selected hour value is `hour`.
   /// This function will deal with pluralization based on the `hour` parameter.
   // The global version uses the translated string from the arb file.
-  String timerPickerHourLabel(int hour);
+  String? timerPickerHourLabel(int hour);
 
   /// All possible hour labels that appears next to the hour picker in
   /// [CupertinoTimerPicker]
@@ -200,7 +200,7 @@ abstract class CupertinoLocalizations {
   /// [CupertinoTimerPicker] when selected minute value is `minute`.
   /// This function will deal with pluralization based on the `minute` parameter.
   // The global version uses the translated string from the arb file.
-  String timerPickerMinuteLabel(int minute);
+  String? timerPickerMinuteLabel(int minute);
 
   /// All possible minute labels that appears next to the minute picker in
   /// [CupertinoTimerPicker]
@@ -210,7 +210,7 @@ abstract class CupertinoLocalizations {
   /// [CupertinoTimerPicker] when selected minute value is `second`.
   /// This function will deal with pluralization based on the `second` parameter.
   // The global version uses the translated string from the arb file.
-  String timerPickerSecondLabel(int second);
+  String? timerPickerSecondLabel(int second);
 
   /// All possible second labels that appears next to the second picker in
   /// [CupertinoTimerPicker]

--- a/packages/flutter_localizations/analysis_options.yaml
+++ b/packages/flutter_localizations/analysis_options.yaml
@@ -3,8 +3,6 @@
 include: ../analysis_options.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
   errors:
     always_require_non_null_named_parameters: false # not needed with nnbd
     type_init_formals: false # https://github.com/dart-lang/linter/issues/2192

--- a/packages/flutter_localizations/analysis_options.yaml
+++ b/packages/flutter_localizations/analysis_options.yaml
@@ -1,0 +1,13 @@
+# Use the parent analysis options settings and enable null-experiment.
+
+include: ../analysis_options.yaml
+
+analyzer:
+  enable-experiment:
+    - non-nullable
+  errors:
+    always_require_non_null_named_parameters: false # not needed with nnbd
+    type_init_formals: false # https://github.com/dart-lang/linter/issues/2192
+    unrelated_type_equality_checks: false # https://github.com/dart-lang/linter/issues/2196
+    void_checks: false # https://github.com/dart-lang/linter/issues/2185
+    unnecessary_null_comparison: false # Turned off until null-safe rollout is complete.

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -54,15 +54,15 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   /// The remaining '*Format' arguments uses the intl package to provide
   /// [DateFormat] configurations for the `localeName`.
   const GlobalCupertinoLocalizations({
-    @required String localeName,
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required String localeName,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : assert(localeName != null),
        _localeName = localeName,
        assert(fullYearFormat != null),
@@ -127,20 +127,20 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   }
 
   /// Subclasses should provide the optional zero pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelZero => null;
+  @protected String? get datePickerHourSemanticsLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelOne => null;
+  @protected String? get datePickerHourSemanticsLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelTwo => null;
+  @protected String? get datePickerHourSemanticsLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelFew => null;
+  @protected String? get datePickerHourSemanticsLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelMany => null;
+  @protected String? get datePickerHourSemanticsLabelMany => null;
   /// Subclasses should provide the required other pluralization of [datePickerHourSemanticsLabel] based on the ARB file.
-  @protected String get datePickerHourSemanticsLabelOther;
+  @protected String? get datePickerHourSemanticsLabelOther;
 
   @override
-  String datePickerHourSemanticsLabel(int hour) {
+  String? datePickerHourSemanticsLabel(int hour) {
     return intl.Intl.pluralLogic(
       hour,
       zero: datePickerHourSemanticsLabelZero,
@@ -150,24 +150,24 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       many: datePickerHourSemanticsLabelMany,
       other: datePickerHourSemanticsLabelOther,
       locale: _localeName,
-    ).replaceFirst(r'$hour', _decimalFormat.format(hour));
+    )?.replaceFirst(r'$hour', _decimalFormat.format(hour));
   }
 
   /// Subclasses should provide the optional zero pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelZero => null;
+  @protected String? get datePickerMinuteSemanticsLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelOne => null;
+  @protected String? get datePickerMinuteSemanticsLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelTwo => null;
+  @protected String? get datePickerMinuteSemanticsLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelFew => null;
+  @protected String? get datePickerMinuteSemanticsLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelMany => null;
+  @protected String? get datePickerMinuteSemanticsLabelMany => null;
   /// Subclasses should provide the required other pluralization of [datePickerMinuteSemanticsLabel] based on the ARB file.
-  @protected String get datePickerMinuteSemanticsLabelOther;
+  @protected String? get datePickerMinuteSemanticsLabelOther;
 
   @override
-  String datePickerMinuteSemanticsLabel(int minute) {
+  String? datePickerMinuteSemanticsLabel(int minute) {
     return intl.Intl.pluralLogic(
       minute,
       zero: datePickerMinuteSemanticsLabelZero,
@@ -177,7 +177,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       many: datePickerMinuteSemanticsLabelMany,
       other: datePickerMinuteSemanticsLabelOther,
       locale: _localeName,
-    ).replaceFirst(r'$minute', _decimalFormat.format(minute));
+    )?.replaceFirst(r'$minute', _decimalFormat.format(minute));
   }
 
   /// A string describing the [DatePickerDateOrder] enum value.
@@ -210,7 +210,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
           "locale $_localeName.\nNon conforming string for $_localeName's "
           '.arb file',
         );
-        return null;
+        return DatePickerDateOrder.mdy;
     }
   }
 
@@ -244,7 +244,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
           "for locale $_localeName.\nNon conforming string for $_localeName's "
           '.arb file',
         );
-        return null;
+        return DatePickerDateTimeOrder.date_time_dayPeriod;
     }
   }
 
@@ -254,7 +254,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   String get tabSemanticsLabelRaw;
 
   @override
-  String tabSemanticsLabel({ int tabIndex, int tabCount }) {
+  String tabSemanticsLabel({ required int tabIndex, required int tabCount }) {
     assert(tabIndex >= 1);
     assert(tabCount >= 1);
     final String template = tabSemanticsLabelRaw;
@@ -279,20 +279,20 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   }
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelZero => null;
+  @protected String? get timerPickerHourLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelOne => null;
+  @protected String? get timerPickerHourLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelTwo => null;
+  @protected String? get timerPickerHourLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelFew => null;
+  @protected String? get timerPickerHourLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelMany => null;
+  @protected String? get timerPickerHourLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerHourLabel] based on the ARB file.
-  @protected String get timerPickerHourLabelOther;
+  @protected String? get timerPickerHourLabelOther;
 
   @override
-  String timerPickerHourLabel(int hour) {
+  String? timerPickerHourLabel(int hour) {
     return intl.Intl.pluralLogic(
       hour,
       zero: timerPickerHourLabelZero,
@@ -302,34 +302,34 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       many: timerPickerHourLabelMany,
       other: timerPickerHourLabelOther,
       locale: _localeName,
-    ).replaceFirst(r'$hour', _decimalFormat.format(hour));
+    )?.replaceFirst(r'$hour', _decimalFormat.format(hour));
   }
 
   @override
   List<String> get timerPickerHourLabels => <String>[
-    timerPickerHourLabelZero,
-    timerPickerHourLabelOne,
-    timerPickerHourLabelTwo,
-    timerPickerHourLabelFew,
-    timerPickerHourLabelMany,
-    timerPickerHourLabelOther,
+    if (timerPickerHourLabelZero != null) timerPickerHourLabelZero!,
+    if (timerPickerHourLabelOne != null) timerPickerHourLabelOne!,
+    if (timerPickerHourLabelTwo != null) timerPickerHourLabelTwo!,
+    if (timerPickerHourLabelFew != null) timerPickerHourLabelFew!,
+    if (timerPickerHourLabelMany != null) timerPickerHourLabelMany!,
+    if (timerPickerHourLabelOther != null) timerPickerHourLabelOther!,
   ];
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelZero => null;
+  @protected String? get timerPickerMinuteLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelOne => null;
+  @protected String? get timerPickerMinuteLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelTwo => null;
+  @protected String? get timerPickerMinuteLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelFew => null;
+  @protected String? get timerPickerMinuteLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelMany => null;
+  @protected String? get timerPickerMinuteLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerMinuteLabel] based on the ARB file.
-  @protected String get timerPickerMinuteLabelOther;
+  @protected String? get timerPickerMinuteLabelOther;
 
   @override
-  String timerPickerMinuteLabel(int minute) {
+  String? timerPickerMinuteLabel(int minute) {
     return intl.Intl.pluralLogic(
       minute,
       zero: timerPickerMinuteLabelZero,
@@ -339,34 +339,34 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       many: timerPickerMinuteLabelMany,
       other: timerPickerMinuteLabelOther,
       locale: _localeName,
-    ).replaceFirst(r'$minute', _decimalFormat.format(minute));
+    )?.replaceFirst(r'$minute', _decimalFormat.format(minute));
   }
 
   @override
   List<String> get timerPickerMinuteLabels => <String>[
-    timerPickerMinuteLabelZero,
-    timerPickerMinuteLabelOne,
-    timerPickerMinuteLabelTwo,
-    timerPickerMinuteLabelFew,
-    timerPickerMinuteLabelMany,
-    timerPickerMinuteLabelOther,
+    if (timerPickerMinuteLabelZero != null) timerPickerMinuteLabelZero!,
+    if (timerPickerMinuteLabelOne != null) timerPickerMinuteLabelOne!,
+    if (timerPickerMinuteLabelTwo != null) timerPickerMinuteLabelTwo!,
+    if (timerPickerMinuteLabelFew != null) timerPickerMinuteLabelFew!,
+    if (timerPickerMinuteLabelMany != null) timerPickerMinuteLabelMany!,
+    if (timerPickerMinuteLabelOther != null) timerPickerMinuteLabelOther!,
   ];
 
   /// Subclasses should provide the optional zero pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelZero => null;
+  @protected String? get timerPickerSecondLabelZero => null;
   /// Subclasses should provide the optional one pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelOne => null;
+  @protected String? get timerPickerSecondLabelOne => null;
   /// Subclasses should provide the optional two pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelTwo => null;
+  @protected String? get timerPickerSecondLabelTwo => null;
   /// Subclasses should provide the optional few pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelFew => null;
+  @protected String? get timerPickerSecondLabelFew => null;
   /// Subclasses should provide the optional many pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelMany => null;
+  @protected String? get timerPickerSecondLabelMany => null;
   /// Subclasses should provide the required other pluralization of [timerPickerSecondLabel] based on the ARB file.
-  @protected String get timerPickerSecondLabelOther;
+  @protected String? get timerPickerSecondLabelOther;
 
   @override
-  String timerPickerSecondLabel(int second) {
+  String? timerPickerSecondLabel(int second) {
     return intl.Intl.pluralLogic(
       second,
       zero: timerPickerSecondLabelZero,
@@ -376,17 +376,17 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
       many: timerPickerSecondLabelMany,
       other: timerPickerSecondLabelOther,
       locale: _localeName,
-    ).replaceFirst(r'$second', _decimalFormat.format(second));
+    )?.replaceFirst(r'$second', _decimalFormat.format(second));
   }
 
   @override
   List<String> get timerPickerSecondLabels => <String>[
-    timerPickerSecondLabelZero,
-    timerPickerSecondLabelOne,
-    timerPickerSecondLabelTwo,
-    timerPickerSecondLabelFew,
-    timerPickerSecondLabelMany,
-    timerPickerSecondLabelOther,
+    if (timerPickerSecondLabelZero != null) timerPickerSecondLabelZero!,
+    if (timerPickerSecondLabelOne != null) timerPickerSecondLabelOne!,
+    if (timerPickerSecondLabelTwo != null) timerPickerSecondLabelTwo!,
+    if (timerPickerSecondLabelFew != null) timerPickerSecondLabelFew!,
+    if (timerPickerSecondLabelMany != null) timerPickerSecondLabelMany!,
+    if (timerPickerSecondLabelOther != null) timerPickerSecondLabelOther!,
   ];
 
   /// A [LocalizationsDelegate] for [CupertinoLocalizations].
@@ -444,18 +444,18 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         'might be $localeName',
       );
 
-      intl.DateFormat fullYearFormat;
-      intl.DateFormat dayFormat;
-      intl.DateFormat mediumDateFormat;
+      late intl.DateFormat fullYearFormat;
+      late intl.DateFormat dayFormat;
+      late intl.DateFormat mediumDateFormat;
       // We don't want any additional decoration here. The am/pm is handled in
       // the date picker. We just want an hour number localized.
-      intl.DateFormat singleDigitHourFormat;
-      intl.DateFormat singleDigitMinuteFormat;
-      intl.DateFormat doubleDigitMinuteFormat;
-      intl.DateFormat singleDigitSecondFormat;
-      intl.NumberFormat decimalFormat;
+      late intl.DateFormat singleDigitHourFormat;
+      late intl.DateFormat singleDigitMinuteFormat;
+      late intl.DateFormat doubleDigitMinuteFormat;
+      late intl.DateFormat singleDigitSecondFormat;
+      late intl.NumberFormat decimalFormat;
 
-      void loadFormats(String locale) {
+      void loadFormats(String? locale) {
         fullYearFormat = intl.DateFormat.y(locale);
         dayFormat = intl.DateFormat.d(locale);
         mediumDateFormat = intl.DateFormat.MMMEd(locale);
@@ -485,7 +485,7 @@ class _GlobalCupertinoLocalizationsDelegate extends LocalizationsDelegate<Cupert
         doubleDigitMinuteFormat,
         singleDigitSecondFormat,
         decimalFormat,
-      ));
+      )!);
     });
   }
 

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_en.arb
@@ -1,12 +1,42 @@
 {
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
   "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
   "datePickerHourSemanticsLabelOther": "$hour o'clock",
   "@datePickerHourSemanticsLabel": {
     "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
     "plural": "hour"
   },
 
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
   "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
   "datePickerMinuteSemanticsLabelOther": "$minute minutes",
   "@datePickerMinuteSemanticsLabel": {
     "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
@@ -49,21 +79,66 @@
     "parameters": "tabIndex, tabCount"
   },
 
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
   "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
   "timerPickerHourLabelOther": "hours",
   "@timerPickerHourLabel": {
     "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
     "plural": "hour"
   },
 
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
   "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
   "timerPickerMinuteLabelOther": "min.",
   "@timerPickerMinuteLabel": {
     "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
     "plural": "minute"
   },
 
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
   "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
   "timerPickerSecondLabelOther": "sec.",
   "@timerPickerSecondLabel": {
     "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -8,7 +8,6 @@
 
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart' as intl;
 
@@ -28,14 +27,14 @@ class CupertinoLocalizationAf extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationAf({
     String localeName = 'af',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -67,40 +66,40 @@ class CupertinoLocalizationAf extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour uur';
+  String? get datePickerHourSemanticsLabelOne => r'$hour uur';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour uur';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Maak toe';
@@ -121,58 +120,58 @@ class CupertinoLocalizationAf extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Oortjie $tabIndex van $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'uur';
+  String? get timerPickerHourLabelOne => 'uur';
 
   @override
   String get timerPickerHourLabelOther => 'uur';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Vandag';
@@ -185,14 +184,14 @@ class CupertinoLocalizationAm extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationAm({
     String localeName = 'am',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -224,40 +223,40 @@ class CupertinoLocalizationAm extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour ሰዓት';
+  String? get datePickerHourSemanticsLabelOne => r'$hour ሰዓት';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour ሰዓት';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 ደቂቃ';
+  String? get datePickerMinuteSemanticsLabelOne => '1 ደቂቃ';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute ደቂቃዎች';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'አሰናብት';
@@ -278,58 +277,58 @@ class CupertinoLocalizationAm extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'ትር $tabIndex ከ$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ሰዓት';
+  String? get timerPickerHourLabelOne => 'ሰዓት';
 
   @override
   String get timerPickerHourLabelOther => 'ሰዓቶች';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'ደቂቃ';
+  String? get timerPickerMinuteLabelOne => 'ደቂቃ';
 
   @override
   String get timerPickerMinuteLabelOther => 'ደቂቃ';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ሴኮ';
+  String? get timerPickerSecondLabelOne => 'ሴኮ';
 
   @override
   String get timerPickerSecondLabelOther => 'ሴኮ';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ዛሬ';
@@ -342,14 +341,14 @@ class CupertinoLocalizationAr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationAr({
     String localeName = 'ar',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -381,40 +380,40 @@ class CupertinoLocalizationAr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour بالضبط';
+  String? get datePickerHourSemanticsLabelFew => r'$hour بالضبط';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour بالضبط';
+  String? get datePickerHourSemanticsLabelMany => r'$hour بالضبط';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour بالضبط';
+  String? get datePickerHourSemanticsLabelOne => r'$hour بالضبط';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour بالضبط';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => r'$hour بالضبط';
+  String? get datePickerHourSemanticsLabelTwo => r'$hour بالضبط';
 
   @override
-  String get datePickerHourSemanticsLabelZero => r'$hour بالضبط';
+  String? get datePickerHourSemanticsLabelZero => r'$hour بالضبط';
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute دقائق';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute دقائق';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute دقيقة​';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute دقيقة​';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'دقيقة واحدة';
+  String? get datePickerMinuteSemanticsLabelOne => 'دقيقة واحدة';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute دقيقة​';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => r'دقيقتان ($minute)';
+  String? get datePickerMinuteSemanticsLabelTwo => r'دقيقتان ($minute)';
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => r'$minute دقيقة​';
+  String? get datePickerMinuteSemanticsLabelZero => r'$minute دقيقة​';
 
   @override
   String get modalBarrierDismissLabel => 'رفض';
@@ -435,58 +434,58 @@ class CupertinoLocalizationAr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'علامة التبويب $tabIndex من $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'ساعات';
+  String? get timerPickerHourLabelFew => 'ساعات';
 
   @override
-  String get timerPickerHourLabelMany => 'ساعة';
+  String? get timerPickerHourLabelMany => 'ساعة';
 
   @override
-  String get timerPickerHourLabelOne => 'ساعة';
+  String? get timerPickerHourLabelOne => 'ساعة';
 
   @override
   String get timerPickerHourLabelOther => 'ساعة';
 
   @override
-  String get timerPickerHourLabelTwo => 'ساعتان';
+  String? get timerPickerHourLabelTwo => 'ساعتان';
 
   @override
-  String get timerPickerHourLabelZero => 'ساعة';
+  String? get timerPickerHourLabelZero => 'ساعة';
 
   @override
-  String get timerPickerMinuteLabelFew => 'دقائق';
+  String? get timerPickerMinuteLabelFew => 'دقائق';
 
   @override
-  String get timerPickerMinuteLabelMany => 'دقيقة';
+  String? get timerPickerMinuteLabelMany => 'دقيقة';
 
   @override
-  String get timerPickerMinuteLabelOne => 'دقيقة واحدة';
+  String? get timerPickerMinuteLabelOne => 'دقيقة واحدة';
 
   @override
   String get timerPickerMinuteLabelOther => 'دقيقة';
 
   @override
-  String get timerPickerMinuteLabelTwo => 'دقيقتان';
+  String? get timerPickerMinuteLabelTwo => 'دقيقتان';
 
   @override
-  String get timerPickerMinuteLabelZero => 'دقيقة';
+  String? get timerPickerMinuteLabelZero => 'دقيقة';
 
   @override
-  String get timerPickerSecondLabelFew => 'ثوانٍ';
+  String? get timerPickerSecondLabelFew => 'ثوانٍ';
 
   @override
-  String get timerPickerSecondLabelMany => 'ثانية';
+  String? get timerPickerSecondLabelMany => 'ثانية';
 
   @override
-  String get timerPickerSecondLabelOne => 'ثانية واحدة';
+  String? get timerPickerSecondLabelOne => 'ثانية واحدة';
 
   @override
   String get timerPickerSecondLabelOther => 'ثانية';
 
   @override
-  String get timerPickerSecondLabelTwo => 'ثانيتان';
+  String? get timerPickerSecondLabelTwo => 'ثانيتان';
 
   @override
-  String get timerPickerSecondLabelZero => 'ثانية';
+  String? get timerPickerSecondLabelZero => 'ثانية';
 
   @override
   String get todayLabel => 'اليوم';
@@ -499,14 +498,14 @@ class CupertinoLocalizationAs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationAs({
     String localeName = 'as',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -538,40 +537,40 @@ class CupertinoLocalizationAs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour বাজিছে';
+  String? get datePickerHourSemanticsLabelOne => r'$hour বাজিছে';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour বাজিছে';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '১মিনিট';
+  String? get datePickerMinuteSemanticsLabelOne => '১মিনিট';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minuteমিনিট';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'অগ্ৰাহ্য কৰক';
@@ -592,58 +591,58 @@ class CupertinoLocalizationAs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount টা টেবৰ $tabIndex নম্বৰটো';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ঘণ্টা';
+  String? get timerPickerHourLabelOne => 'ঘণ্টা';
 
   @override
   String get timerPickerHourLabelOther => 'ঘণ্টা';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'মিনিট।';
+  String? get timerPickerMinuteLabelOne => 'মিনিট।';
 
   @override
   String get timerPickerMinuteLabelOther => 'মিনিট।';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ছেকেণ্ড।';
+  String? get timerPickerSecondLabelOne => 'ছেকেণ্ড।';
 
   @override
   String get timerPickerSecondLabelOther => 'ছেকেণ্ড।';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'আজি';
@@ -656,14 +655,14 @@ class CupertinoLocalizationAz extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationAz({
     String localeName = 'az',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -695,40 +694,40 @@ class CupertinoLocalizationAz extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Saat $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Saat $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Saat $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 dəqiqə';
+  String? get datePickerMinuteSemanticsLabelOne => '1 dəqiqə';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute dəqiqə';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'İmtina edin';
@@ -749,58 +748,58 @@ class CupertinoLocalizationAz extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'saat';
+  String? get timerPickerHourLabelOne => 'saat';
 
   @override
   String get timerPickerHourLabelOther => 'saat';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'dəq.';
+  String? get timerPickerMinuteLabelOne => 'dəq.';
 
   @override
   String get timerPickerMinuteLabelOther => 'dəq.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'san.';
+  String? get timerPickerSecondLabelOne => 'san.';
 
   @override
   String get timerPickerSecondLabelOther => 'san.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Bu gün';
@@ -813,14 +812,14 @@ class CupertinoLocalizationBe extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationBe({
     String localeName = 'be',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -852,40 +851,40 @@ class CupertinoLocalizationBe extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour гадзіны нуль хвілін';
+  String? get datePickerHourSemanticsLabelFew => r'$hour гадзіны нуль хвілін';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour гадзін нуль хвілін';
+  String? get datePickerHourSemanticsLabelMany => r'$hour гадзін нуль хвілін';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour гадзіна нуль хвілін';
+  String? get datePickerHourSemanticsLabelOne => r'$hour гадзіна нуль хвілін';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour гадзіны нуль хвілін';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute хвіліны';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute хвіліны';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute хвілін';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute хвілін';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 хвіліна';
+  String? get datePickerMinuteSemanticsLabelOne => '1 хвіліна';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute хвіліны';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Адхіліць';
@@ -906,58 +905,58 @@ class CupertinoLocalizationBe extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Укладка $tabIndex з $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'гадзіны';
+  String? get timerPickerHourLabelFew => 'гадзіны';
 
   @override
-  String get timerPickerHourLabelMany => 'гадзін';
+  String? get timerPickerHourLabelMany => 'гадзін';
 
   @override
-  String get timerPickerHourLabelOne => 'гадзіна';
+  String? get timerPickerHourLabelOne => 'гадзіна';
 
   @override
   String get timerPickerHourLabelOther => 'гадзіны';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'хв';
+  String? get timerPickerMinuteLabelFew => 'хв';
 
   @override
-  String get timerPickerMinuteLabelMany => 'хв';
+  String? get timerPickerMinuteLabelMany => 'хв';
 
   @override
-  String get timerPickerMinuteLabelOne => 'хв';
+  String? get timerPickerMinuteLabelOne => 'хв';
 
   @override
   String get timerPickerMinuteLabelOther => 'хв';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'с';
+  String? get timerPickerSecondLabelFew => 'с';
 
   @override
-  String get timerPickerSecondLabelMany => 'с';
+  String? get timerPickerSecondLabelMany => 'с';
 
   @override
-  String get timerPickerSecondLabelOne => 'с';
+  String? get timerPickerSecondLabelOne => 'с';
 
   @override
   String get timerPickerSecondLabelOther => 'с';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Сёння';
@@ -970,14 +969,14 @@ class CupertinoLocalizationBg extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationBg({
     String localeName = 'bg',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1009,40 +1008,40 @@ class CupertinoLocalizationBg extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour часа';
+  String? get datePickerHourSemanticsLabelOne => r'$hour часа';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour часа';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минута';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минута';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минути';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Отхвърляне';
@@ -1063,58 +1062,58 @@ class CupertinoLocalizationBg extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Раздел $tabIndex от $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'час';
+  String? get timerPickerHourLabelOne => 'час';
 
   @override
   String get timerPickerHourLabelOther => 'часа';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'мин';
+  String? get timerPickerMinuteLabelOne => 'мин';
 
   @override
   String get timerPickerMinuteLabelOther => 'мин';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'сек';
+  String? get timerPickerSecondLabelOne => 'сек';
 
   @override
   String get timerPickerSecondLabelOther => 'сек';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Днес';
@@ -1127,14 +1126,14 @@ class CupertinoLocalizationBn extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationBn({
     String localeName = 'bn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1166,40 +1165,40 @@ class CupertinoLocalizationBn extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hourটা বাজে';
+  String? get datePickerHourSemanticsLabelOne => r'$hourটা বাজে';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hourটা বাজে';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '১ মিনিট';
+  String? get datePickerMinuteSemanticsLabelOne => '১ মিনিট';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute মিনিট';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'খারিজ করুন';
@@ -1220,58 +1219,58 @@ class CupertinoLocalizationBn extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount-এর মধ্যে $tabIndex নম্বর ট্যাব';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ঘণ্টা';
+  String? get timerPickerHourLabelOne => 'ঘণ্টা';
 
   @override
   String get timerPickerHourLabelOther => 'ঘণ্টা';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'মিনিট।';
+  String? get timerPickerMinuteLabelOne => 'মিনিট।';
 
   @override
   String get timerPickerMinuteLabelOther => 'মিনিট।';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'সেকেন্ড।';
+  String? get timerPickerSecondLabelOne => 'সেকেন্ড।';
 
   @override
   String get timerPickerSecondLabelOther => 'সেকেন্ড।';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'আজ';
@@ -1284,14 +1283,14 @@ class CupertinoLocalizationBs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationBs({
     String localeName = 'bs',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1323,40 +1322,40 @@ class CupertinoLocalizationBs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour sata';
+  String? get datePickerHourSemanticsLabelFew => r'$hour sata';
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour sat';
+  String? get datePickerHourSemanticsLabelOne => r'$hour sat';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour sati';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minute';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuta';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Odbaci';
@@ -1377,58 +1376,58 @@ class CupertinoLocalizationBs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Kartica $tabIndex od $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'sata';
+  String? get timerPickerHourLabelFew => 'sata';
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'sat';
+  String? get timerPickerHourLabelOne => 'sat';
 
   @override
   String get timerPickerHourLabelOther => 'sati';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min.';
+  String? get timerPickerMinuteLabelFew => 'min.';
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'sec.';
+  String? get timerPickerSecondLabelFew => 'sec.';
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sec.';
+  String? get timerPickerSecondLabelOne => 'sec.';
 
   @override
   String get timerPickerSecondLabelOther => 'sec.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Danas';
@@ -1441,14 +1440,14 @@ class CupertinoLocalizationCa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationCa({
     String localeName = 'ca',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1480,40 +1479,40 @@ class CupertinoLocalizationCa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punt';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punt';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punt';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuts';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ignora';
@@ -1534,58 +1533,58 @@ class CupertinoLocalizationCa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Pestanya $tabIndex de $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'hora';
+  String? get timerPickerHourLabelOne => 'hora';
 
   @override
   String get timerPickerHourLabelOther => 'hores';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Avui';
@@ -1598,14 +1597,14 @@ class CupertinoLocalizationCs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationCs({
     String localeName = 'cs',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1637,40 +1636,40 @@ class CupertinoLocalizationCs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour hodiny';
+  String? get datePickerHourSemanticsLabelFew => r'$hour hodiny';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour hodiny';
+  String? get datePickerHourSemanticsLabelMany => r'$hour hodiny';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour hodina';
+  String? get datePickerHourSemanticsLabelOne => r'$hour hodina';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour hodin';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minuty';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minuty';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute minuty';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute minuty';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minut';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Zavřít';
@@ -1691,58 +1690,58 @@ class CupertinoLocalizationCs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Karta $tabIndex z $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'hodiny';
+  String? get timerPickerHourLabelFew => 'hodiny';
 
   @override
-  String get timerPickerHourLabelMany => 'hodiny';
+  String? get timerPickerHourLabelMany => 'hodiny';
 
   @override
-  String get timerPickerHourLabelOne => 'hodina';
+  String? get timerPickerHourLabelOne => 'hodina';
 
   @override
   String get timerPickerHourLabelOther => 'hodin';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelMany => 'min';
+  String? get timerPickerMinuteLabelMany => 'min';
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 's';
+  String? get timerPickerSecondLabelFew => 's';
 
   @override
-  String get timerPickerSecondLabelMany => 's';
+  String? get timerPickerSecondLabelMany => 's';
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Dnes';
@@ -1755,14 +1754,14 @@ class CupertinoLocalizationDa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationDa({
     String localeName = 'da',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1794,40 +1793,40 @@ class CupertinoLocalizationDa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'klokken $hour';
+  String? get datePickerHourSemanticsLabelOne => r'klokken $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'klokken $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutter';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Afvis';
@@ -1848,58 +1847,58 @@ class CupertinoLocalizationDa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Fane $tabIndex af $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'time';
+  String? get timerPickerHourLabelOne => 'time';
 
   @override
   String get timerPickerHourLabelOther => 'timer';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'I dag';
@@ -1912,14 +1911,14 @@ class CupertinoLocalizationDe extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationDe({
     String localeName = 'de',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1951,40 +1950,40 @@ class CupertinoLocalizationDe extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour Uhr';
+  String? get datePickerHourSemanticsLabelOne => r'$hour Uhr';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour Uhr';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 Minute';
+  String? get datePickerMinuteSemanticsLabelOne => '1 Minute';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute Minuten';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Schließen';
@@ -2005,58 +2004,58 @@ class CupertinoLocalizationDe extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex von $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'Stunde';
+  String? get timerPickerHourLabelOne => 'Stunde';
 
   @override
   String get timerPickerHourLabelOther => 'Stunden';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'Min.';
+  String? get timerPickerMinuteLabelOne => 'Min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'Min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Heute';
@@ -2069,14 +2068,14 @@ class CupertinoLocalizationDeCh extends CupertinoLocalizationDe {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationDeCh({
     String localeName = 'de_CH',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2100,14 +2099,14 @@ class CupertinoLocalizationEl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEl({
     String localeName = 'el',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2139,40 +2138,40 @@ class CupertinoLocalizationEl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour ακριβώς';
+  String? get datePickerHourSemanticsLabelOne => r'$hour ακριβώς';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour ακριβώς';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 λεπτό';
+  String? get datePickerMinuteSemanticsLabelOne => '1 λεπτό';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute λεπτά';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Παράβλεψη';
@@ -2193,58 +2192,58 @@ class CupertinoLocalizationEl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Καρτέλα $tabIndex από $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ώρα';
+  String? get timerPickerHourLabelOne => 'ώρα';
 
   @override
   String get timerPickerHourLabelOther => 'ώρες';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'λεπ.';
+  String? get timerPickerMinuteLabelOne => 'λεπ.';
 
   @override
   String get timerPickerMinuteLabelOther => 'λεπ.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'δευτ.';
+  String? get timerPickerSecondLabelOne => 'δευτ.';
 
   @override
   String get timerPickerSecondLabelOther => 'δευτ.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Σήμερα';
@@ -2257,14 +2256,14 @@ class CupertinoLocalizationEn extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEn({
     String localeName = 'en',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2296,40 +2295,40 @@ class CupertinoLocalizationEn extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r"$hour o'clock";
+  String? get datePickerHourSemanticsLabelOne => r"$hour o'clock";
 
   @override
   String get datePickerHourSemanticsLabelOther => r"$hour o'clock";
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minute';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minute';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutes';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Dismiss';
@@ -2350,58 +2349,58 @@ class CupertinoLocalizationEn extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex of $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'hour';
+  String? get timerPickerHourLabelOne => 'hour';
 
   @override
   String get timerPickerHourLabelOther => 'hours';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sec.';
+  String? get timerPickerSecondLabelOne => 'sec.';
 
   @override
   String get timerPickerSecondLabelOther => 'sec.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Today';
@@ -2414,14 +2413,14 @@ class CupertinoLocalizationEnAu extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnAu({
     String localeName = 'en_AU',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2448,14 +2447,14 @@ class CupertinoLocalizationEnCa extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnCa({
     String localeName = 'en_CA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2482,14 +2481,14 @@ class CupertinoLocalizationEnGb extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnGb({
     String localeName = 'en_GB',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2516,14 +2515,14 @@ class CupertinoLocalizationEnIe extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnIe({
     String localeName = 'en_IE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2550,14 +2549,14 @@ class CupertinoLocalizationEnIn extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnIn({
     String localeName = 'en_IN',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2584,14 +2583,14 @@ class CupertinoLocalizationEnNz extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnNz({
     String localeName = 'en_NZ',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2618,14 +2617,14 @@ class CupertinoLocalizationEnSg extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnSg({
     String localeName = 'en_SG',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2652,14 +2651,14 @@ class CupertinoLocalizationEnZa extends CupertinoLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEnZa({
     String localeName = 'en_ZA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2686,14 +2685,14 @@ class CupertinoLocalizationEs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEs({
     String localeName = 'es',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2725,40 +2724,40 @@ class CupertinoLocalizationEs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutos';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Cerrar';
@@ -2779,58 +2778,58 @@ class CupertinoLocalizationEs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Pestaña $tabIndex de $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'hora';
+  String? get timerPickerHourLabelOne => 'hora';
 
   @override
   String get timerPickerHourLabelOther => 'horas';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hoy';
@@ -2843,14 +2842,14 @@ class CupertinoLocalizationEs419 extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEs419({
     String localeName = 'es_419',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2864,7 +2863,7 @@ class CupertinoLocalizationEs419 extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -2886,14 +2885,14 @@ class CupertinoLocalizationEsAr extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsAr({
     String localeName = 'es_AR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2907,7 +2906,7 @@ class CupertinoLocalizationEsAr extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -2929,14 +2928,14 @@ class CupertinoLocalizationEsBo extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsBo({
     String localeName = 'es_BO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2950,7 +2949,7 @@ class CupertinoLocalizationEsBo extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -2972,14 +2971,14 @@ class CupertinoLocalizationEsCl extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsCl({
     String localeName = 'es_CL',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2993,7 +2992,7 @@ class CupertinoLocalizationEsCl extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3015,14 +3014,14 @@ class CupertinoLocalizationEsCo extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsCo({
     String localeName = 'es_CO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3036,7 +3035,7 @@ class CupertinoLocalizationEsCo extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3058,14 +3057,14 @@ class CupertinoLocalizationEsCr extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsCr({
     String localeName = 'es_CR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3079,7 +3078,7 @@ class CupertinoLocalizationEsCr extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3101,14 +3100,14 @@ class CupertinoLocalizationEsDo extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsDo({
     String localeName = 'es_DO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3122,7 +3121,7 @@ class CupertinoLocalizationEsDo extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3144,14 +3143,14 @@ class CupertinoLocalizationEsEc extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsEc({
     String localeName = 'es_EC',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3165,7 +3164,7 @@ class CupertinoLocalizationEsEc extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3187,14 +3186,14 @@ class CupertinoLocalizationEsGt extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsGt({
     String localeName = 'es_GT',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3208,7 +3207,7 @@ class CupertinoLocalizationEsGt extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3230,14 +3229,14 @@ class CupertinoLocalizationEsHn extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsHn({
     String localeName = 'es_HN',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3251,7 +3250,7 @@ class CupertinoLocalizationEsHn extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3273,14 +3272,14 @@ class CupertinoLocalizationEsMx extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsMx({
     String localeName = 'es_MX',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3294,7 +3293,7 @@ class CupertinoLocalizationEsMx extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3316,14 +3315,14 @@ class CupertinoLocalizationEsNi extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsNi({
     String localeName = 'es_NI',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3337,7 +3336,7 @@ class CupertinoLocalizationEsNi extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3359,14 +3358,14 @@ class CupertinoLocalizationEsPa extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsPa({
     String localeName = 'es_PA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3380,7 +3379,7 @@ class CupertinoLocalizationEsPa extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3402,14 +3401,14 @@ class CupertinoLocalizationEsPe extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsPe({
     String localeName = 'es_PE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3423,7 +3422,7 @@ class CupertinoLocalizationEsPe extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3445,14 +3444,14 @@ class CupertinoLocalizationEsPr extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsPr({
     String localeName = 'es_PR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3466,7 +3465,7 @@ class CupertinoLocalizationEsPr extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3488,14 +3487,14 @@ class CupertinoLocalizationEsPy extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsPy({
     String localeName = 'es_PY',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3509,7 +3508,7 @@ class CupertinoLocalizationEsPy extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3531,14 +3530,14 @@ class CupertinoLocalizationEsSv extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsSv({
     String localeName = 'es_SV',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3552,7 +3551,7 @@ class CupertinoLocalizationEsSv extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3574,14 +3573,14 @@ class CupertinoLocalizationEsUs extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsUs({
     String localeName = 'es_US',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3595,7 +3594,7 @@ class CupertinoLocalizationEsUs extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3617,14 +3616,14 @@ class CupertinoLocalizationEsUy extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsUy({
     String localeName = 'es_UY',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3638,7 +3637,7 @@ class CupertinoLocalizationEsUy extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3660,14 +3659,14 @@ class CupertinoLocalizationEsVe extends CupertinoLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEsVe({
     String localeName = 'es_VE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3681,7 +3680,7 @@ class CupertinoLocalizationEsVe extends CupertinoLocalizationEs {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
@@ -3703,14 +3702,14 @@ class CupertinoLocalizationEt extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEt({
     String localeName = 'et',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3742,40 +3741,40 @@ class CupertinoLocalizationEt extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Kell $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Kell $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Kell $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutit';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Loobu';
@@ -3796,58 +3795,58 @@ class CupertinoLocalizationEt extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabIndex. vaheleht $tabCount-st';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'tund';
+  String? get timerPickerHourLabelOne => 'tund';
 
   @override
   String get timerPickerHourLabelOther => 'tundi';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Täna';
@@ -3860,14 +3859,14 @@ class CupertinoLocalizationEu extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationEu({
     String localeName = 'eu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3899,40 +3898,40 @@ class CupertinoLocalizationEu extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Ordu$houra da';
+  String? get datePickerHourSemanticsLabelOne => r'Ordu$houra da';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hourak dira';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'Minutu bat';
+  String? get datePickerMinuteSemanticsLabelOne => 'Minutu bat';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutu';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Baztertu';
@@ -3953,58 +3952,58 @@ class CupertinoLocalizationEu extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabIndex/$tabCount fitxa';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ordu';
+  String? get timerPickerHourLabelOne => 'ordu';
 
   @override
   String get timerPickerHourLabelOther => 'ordu';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Gaur';
@@ -4017,14 +4016,14 @@ class CupertinoLocalizationFa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationFa({
     String localeName = 'fa',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4056,40 +4055,40 @@ class CupertinoLocalizationFa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'ساعت $hour';
+  String? get datePickerHourSemanticsLabelOne => r'ساعت $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'ساعت $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '۱ دقیقه';
+  String? get datePickerMinuteSemanticsLabelOne => '۱ دقیقه';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute دقیقه';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'نپذیرفتن';
@@ -4110,58 +4109,58 @@ class CupertinoLocalizationFa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'برگه $tabIndex از $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ساعت';
+  String? get timerPickerHourLabelOne => 'ساعت';
 
   @override
   String get timerPickerHourLabelOther => 'ساعت';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'دقیقه';
+  String? get timerPickerMinuteLabelOne => 'دقیقه';
 
   @override
   String get timerPickerMinuteLabelOther => 'دقیقه';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ثانیه';
+  String? get timerPickerSecondLabelOne => 'ثانیه';
 
   @override
   String get timerPickerSecondLabelOther => 'ثانیه';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'امروز';
@@ -4174,14 +4173,14 @@ class CupertinoLocalizationFi extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationFi({
     String localeName = 'fi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4213,40 +4212,40 @@ class CupertinoLocalizationFi extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'klo $hour';
+  String? get datePickerHourSemanticsLabelOne => r'klo $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'klo $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuutti';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuutti';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuuttia';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ohita';
@@ -4267,58 +4266,58 @@ class CupertinoLocalizationFi extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Välilehti $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'tunti';
+  String? get timerPickerHourLabelOne => 'tunti';
 
   @override
   String get timerPickerHourLabelOther => 'tuntia';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Tänään';
@@ -4331,14 +4330,14 @@ class CupertinoLocalizationFil extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationFil({
     String localeName = 'fil',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4370,40 +4369,40 @@ class CupertinoLocalizationFil extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Ala $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Ala $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Alas $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute na minuto';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'I-dismiss';
@@ -4424,58 +4423,58 @@ class CupertinoLocalizationFil extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex ng $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'oras';
+  String? get timerPickerHourLabelOne => 'oras';
 
   @override
   String get timerPickerHourLabelOther => 'na oras';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'na min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'seg.';
+  String? get timerPickerSecondLabelOne => 'seg.';
 
   @override
   String get timerPickerSecondLabelOther => 'na seg.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Ngayon';
@@ -4488,14 +4487,14 @@ class CupertinoLocalizationFr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationFr({
     String localeName = 'fr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4527,40 +4526,40 @@ class CupertinoLocalizationFr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour heure';
+  String? get datePickerHourSemanticsLabelOne => r'$hour heure';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour heures';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minute';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minute';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutes';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ignorer';
@@ -4581,58 +4580,58 @@ class CupertinoLocalizationFr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Onglet $tabIndex sur $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'heure';
+  String? get timerPickerHourLabelOne => 'heure';
 
   @override
   String get timerPickerHourLabelOther => 'heures';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'minute';
+  String? get timerPickerMinuteLabelOne => 'minute';
 
   @override
   String get timerPickerMinuteLabelOther => 'minutes';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => "aujourd'hui";
@@ -4645,14 +4644,14 @@ class CupertinoLocalizationFrCa extends CupertinoLocalizationFr {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationFrCa({
     String localeName = 'fr_CA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4666,7 +4665,7 @@ class CupertinoLocalizationFrCa extends CupertinoLocalizationFr {
   );
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour heure';
+  String? get datePickerHourSemanticsLabelOne => r'$hour heure';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour heures';
@@ -4681,7 +4680,7 @@ class CupertinoLocalizationFrCa extends CupertinoLocalizationFr {
   String get todayLabel => "Aujourd'hui";
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
@@ -4697,14 +4696,14 @@ class CupertinoLocalizationGl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationGl({
     String localeName = 'gl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4736,40 +4735,40 @@ class CupertinoLocalizationGl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour en punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour en punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour en punto';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutos';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ignorar';
@@ -4790,58 +4789,58 @@ class CupertinoLocalizationGl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Pestana $tabIndex de $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'hora';
+  String? get timerPickerHourLabelOne => 'hora';
 
   @override
   String get timerPickerHourLabelOther => 'horas';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hoxe';
@@ -4854,14 +4853,14 @@ class CupertinoLocalizationGsw extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationGsw({
     String localeName = 'gsw',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4893,40 +4892,40 @@ class CupertinoLocalizationGsw extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour Uhr';
+  String? get datePickerHourSemanticsLabelOne => r'$hour Uhr';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour Uhr';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 Minute';
+  String? get datePickerMinuteSemanticsLabelOne => '1 Minute';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute Minuten';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Schließen';
@@ -4947,58 +4946,58 @@ class CupertinoLocalizationGsw extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex von $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'Stunde';
+  String? get timerPickerHourLabelOne => 'Stunde';
 
   @override
   String get timerPickerHourLabelOther => 'Stunden';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'Min.';
+  String? get timerPickerMinuteLabelOne => 'Min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'Min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Heute';
@@ -5011,14 +5010,14 @@ class CupertinoLocalizationGu extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationGu({
     String localeName = 'gu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5050,40 +5049,40 @@ class CupertinoLocalizationGu extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour વાગ્યો છે';
+  String? get datePickerHourSemanticsLabelOne => r'$hour વાગ્યો છે';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour વાગ્યા છે';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 મિનિટ';
+  String? get datePickerMinuteSemanticsLabelOne => '1 મિનિટ';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute મિનિટ';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'છોડી દો';
@@ -5104,58 +5103,58 @@ class CupertinoLocalizationGu extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCountમાંથી $tabIndex ટૅબ';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'કલાક';
+  String? get timerPickerHourLabelOne => 'કલાક';
 
   @override
   String get timerPickerHourLabelOther => 'કલાક';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'મિનિટ';
+  String? get timerPickerMinuteLabelOne => 'મિનિટ';
 
   @override
   String get timerPickerMinuteLabelOther => 'મિનિટ';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'સેકન્ડ';
+  String? get timerPickerSecondLabelOne => 'સેકન્ડ';
 
   @override
   String get timerPickerSecondLabelOther => 'સેકન્ડ';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'આજે';
@@ -5168,14 +5167,14 @@ class CupertinoLocalizationHe extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationHe({
     String localeName = 'he',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5207,40 +5206,40 @@ class CupertinoLocalizationHe extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour בדיוק';
+  String? get datePickerHourSemanticsLabelMany => r'$hour בדיוק';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour בדיוק';
+  String? get datePickerHourSemanticsLabelOne => r'$hour בדיוק';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour בדיוק';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => r'$hour בדיוק';
+  String? get datePickerHourSemanticsLabelTwo => r'$hour בדיוק';
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute דקות';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute דקות';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'דקה אחת';
+  String? get datePickerMinuteSemanticsLabelOne => 'דקה אחת';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute דקות';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => r'$minute דקות';
+  String? get datePickerMinuteSemanticsLabelTwo => r'$minute דקות';
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'סגירה';
@@ -5261,58 +5260,58 @@ class CupertinoLocalizationHe extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'כרטיסייה $tabIndex מתוך $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => 'שעות';
+  String? get timerPickerHourLabelMany => 'שעות';
 
   @override
-  String get timerPickerHourLabelOne => 'שעה';
+  String? get timerPickerHourLabelOne => 'שעה';
 
   @override
   String get timerPickerHourLabelOther => 'שעות';
 
   @override
-  String get timerPickerHourLabelTwo => 'שעות';
+  String? get timerPickerHourLabelTwo => 'שעות';
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => 'דק’';
+  String? get timerPickerMinuteLabelMany => 'דק’';
 
   @override
-  String get timerPickerMinuteLabelOne => 'דק’';
+  String? get timerPickerMinuteLabelOne => 'דק’';
 
   @override
   String get timerPickerMinuteLabelOther => 'דק’';
 
   @override
-  String get timerPickerMinuteLabelTwo => 'דק’';
+  String? get timerPickerMinuteLabelTwo => 'דק’';
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => 'שנ’';
+  String? get timerPickerSecondLabelMany => 'שנ’';
 
   @override
-  String get timerPickerSecondLabelOne => 'שנ’';
+  String? get timerPickerSecondLabelOne => 'שנ’';
 
   @override
   String get timerPickerSecondLabelOther => 'שנ’';
 
   @override
-  String get timerPickerSecondLabelTwo => 'שנ’';
+  String? get timerPickerSecondLabelTwo => 'שנ’';
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'היום';
@@ -5325,14 +5324,14 @@ class CupertinoLocalizationHi extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationHi({
     String localeName = 'hi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5364,40 +5363,40 @@ class CupertinoLocalizationHi extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour बजे';
+  String? get datePickerHourSemanticsLabelOne => r'$hour बजे';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour बजे';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 मिनट';
+  String? get datePickerMinuteSemanticsLabelOne => '1 मिनट';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute मिनट';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'खारिज करें';
@@ -5418,58 +5417,58 @@ class CupertinoLocalizationHi extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount का टैब $tabIndex';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'घंटा';
+  String? get timerPickerHourLabelOne => 'घंटा';
 
   @override
   String get timerPickerHourLabelOther => 'घंटे';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'मिनट';
+  String? get timerPickerMinuteLabelOne => 'मिनट';
 
   @override
   String get timerPickerMinuteLabelOther => 'मिनट';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'सेकंड';
+  String? get timerPickerSecondLabelOne => 'सेकंड';
 
   @override
   String get timerPickerSecondLabelOther => 'सेकंड';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'आज';
@@ -5482,14 +5481,14 @@ class CupertinoLocalizationHr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationHr({
     String localeName = 'hr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5521,40 +5520,40 @@ class CupertinoLocalizationHr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour sata';
+  String? get datePickerHourSemanticsLabelFew => r'$hour sata';
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour sat';
+  String? get datePickerHourSemanticsLabelOne => r'$hour sat';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour sati';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minute';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'Jedna minuta';
+  String? get datePickerMinuteSemanticsLabelOne => 'Jedna minuta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuta';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Odbaci';
@@ -5575,58 +5574,58 @@ class CupertinoLocalizationHr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Kartica $tabIndex od $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'sata';
+  String? get timerPickerHourLabelFew => 'sata';
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'sat';
+  String? get timerPickerHourLabelOne => 'sat';
 
   @override
   String get timerPickerHourLabelOther => 'sati';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 's';
+  String? get timerPickerSecondLabelFew => 's';
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Danas';
@@ -5639,14 +5638,14 @@ class CupertinoLocalizationHu extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationHu({
     String localeName = 'hu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5678,40 +5677,40 @@ class CupertinoLocalizationHu extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_dayPeriod_time';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour óra';
+  String? get datePickerHourSemanticsLabelOne => r'$hour óra';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour óra';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 perc';
+  String? get datePickerMinuteSemanticsLabelOne => '1 perc';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute perc';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Elvetés';
@@ -5732,58 +5731,58 @@ class CupertinoLocalizationHu extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount/$tabIndex. lap';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'óra';
+  String? get timerPickerHourLabelOne => 'óra';
 
   @override
   String get timerPickerHourLabelOther => 'óra';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'perc';
+  String? get timerPickerMinuteLabelOne => 'perc';
 
   @override
   String get timerPickerMinuteLabelOther => 'perc';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'mp';
+  String? get timerPickerSecondLabelOne => 'mp';
 
   @override
   String get timerPickerSecondLabelOther => 'mp';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Ma';
@@ -5796,14 +5795,14 @@ class CupertinoLocalizationHy extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationHy({
     String localeName = 'hy',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5835,40 +5834,40 @@ class CupertinoLocalizationHy extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour:00';
+  String? get datePickerHourSemanticsLabelOne => r'$hour:00';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour:00';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 րոպե';
+  String? get datePickerMinuteSemanticsLabelOne => '1 րոպե';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute րոպե';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Փակել';
@@ -5889,58 +5888,58 @@ class CupertinoLocalizationHy extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Ներդիր $tabIndex՝ $tabCount-ից';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ժամ';
+  String? get timerPickerHourLabelOne => 'ժամ';
 
   @override
   String get timerPickerHourLabelOther => 'ժամ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'րոպե';
+  String? get timerPickerMinuteLabelOne => 'րոպե';
 
   @override
   String get timerPickerMinuteLabelOther => 'րոպե';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'վրկ';
+  String? get timerPickerSecondLabelOne => 'վրկ';
 
   @override
   String get timerPickerSecondLabelOther => 'վրկ';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Այսօր';
@@ -5953,14 +5952,14 @@ class CupertinoLocalizationId extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationId({
     String localeName = 'id',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5992,40 +5991,40 @@ class CupertinoLocalizationId extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour tepat';
+  String? get datePickerHourSemanticsLabelOne => r'$hour tepat';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour tepat';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 menit';
+  String? get datePickerMinuteSemanticsLabelOne => '1 menit';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute menit';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Tutup';
@@ -6046,58 +6045,58 @@ class CupertinoLocalizationId extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex dari $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'jam';
+  String? get timerPickerHourLabelOne => 'jam';
 
   @override
   String get timerPickerHourLabelOther => 'jam';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'mnt.';
+  String? get timerPickerMinuteLabelOne => 'mnt.';
 
   @override
   String get timerPickerMinuteLabelOther => 'mnt.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'dtk.';
+  String? get timerPickerSecondLabelOne => 'dtk.';
 
   @override
   String get timerPickerSecondLabelOther => 'dtk.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hari ini';
@@ -6110,14 +6109,14 @@ class CupertinoLocalizationIs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationIs({
     String localeName = 'is',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6149,40 +6148,40 @@ class CupertinoLocalizationIs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'klukkan $hour';
+  String? get datePickerHourSemanticsLabelOne => r'klukkan $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'klukkan $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 mínúta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 mínúta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute mínútur';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Hunsa';
@@ -6203,58 +6202,58 @@ class CupertinoLocalizationIs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Flipi $tabIndex af $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'klukkustund';
+  String? get timerPickerHourLabelOne => 'klukkustund';
 
   @override
   String get timerPickerHourLabelOther => 'klukkustundir';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'mín.';
+  String? get timerPickerMinuteLabelOne => 'mín.';
 
   @override
   String get timerPickerMinuteLabelOther => 'mín.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Í dag';
@@ -6267,14 +6266,14 @@ class CupertinoLocalizationIt extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationIt({
     String localeName = 'it',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6306,40 +6305,40 @@ class CupertinoLocalizationIt extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour in punto';
+  String? get datePickerHourSemanticsLabelOne => r'$hour in punto';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour in punto';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuti';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ignora';
@@ -6360,58 +6359,58 @@ class CupertinoLocalizationIt extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Scheda $tabIndex di $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ora';
+  String? get timerPickerHourLabelOne => 'ora';
 
   @override
   String get timerPickerHourLabelOther => 'ore';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sec.';
+  String? get timerPickerSecondLabelOne => 'sec.';
 
   @override
   String get timerPickerSecondLabelOther => 'sec.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Oggi';
@@ -6424,14 +6423,14 @@ class CupertinoLocalizationJa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationJa({
     String localeName = 'ja',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6463,40 +6462,40 @@ class CupertinoLocalizationJa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour時';
+  String? get datePickerHourSemanticsLabelOne => r'$hour時';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour時';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1分';
+  String? get datePickerMinuteSemanticsLabelOne => '1分';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute分';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => '閉じる';
@@ -6517,58 +6516,58 @@ class CupertinoLocalizationJa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'タブ: $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => '時間';
+  String? get timerPickerHourLabelOne => '時間';
 
   @override
   String get timerPickerHourLabelOther => '時間';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => '分';
+  String? get timerPickerMinuteLabelOne => '分';
 
   @override
   String get timerPickerMinuteLabelOther => '分';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => '秒';
+  String? get timerPickerSecondLabelOne => '秒';
 
   @override
   String get timerPickerSecondLabelOther => '秒';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => '今日';
@@ -6581,14 +6580,14 @@ class CupertinoLocalizationKa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKa({
     String localeName = 'ka',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6620,40 +6619,40 @@ class CupertinoLocalizationKa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_dayPeriod_time';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour საათი';
+  String? get datePickerHourSemanticsLabelOne => r'$hour საათი';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour საათი';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 წუთი';
+  String? get datePickerMinuteSemanticsLabelOne => '1 წუთი';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute წუთი';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'დახურვა';
@@ -6674,58 +6673,58 @@ class CupertinoLocalizationKa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'ჩანართი $tabIndex / $tabCount-დან';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'საათი';
+  String? get timerPickerHourLabelOne => 'საათი';
 
   @override
   String get timerPickerHourLabelOther => 'საათი';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'წთ';
+  String? get timerPickerMinuteLabelOne => 'წთ';
 
   @override
   String get timerPickerMinuteLabelOther => 'წთ';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'წმ';
+  String? get timerPickerSecondLabelOne => 'წმ';
 
   @override
   String get timerPickerSecondLabelOther => 'წმ';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'დღეს';
@@ -6738,14 +6737,14 @@ class CupertinoLocalizationKk extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKk({
     String localeName = 'kk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6777,40 +6776,40 @@ class CupertinoLocalizationKk extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Сағат: $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Сағат: $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Сағат: $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минут';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минут';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минут';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Жабу';
@@ -6831,58 +6830,58 @@ class CupertinoLocalizationKk extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Қойынды: $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'сағат';
+  String? get timerPickerHourLabelOne => 'сағат';
 
   @override
   String get timerPickerHourLabelOther => 'сағат';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'мин';
+  String? get timerPickerMinuteLabelOne => 'мин';
 
   @override
   String get timerPickerMinuteLabelOther => 'мин';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'сек';
+  String? get timerPickerSecondLabelOne => 'сек';
 
   @override
   String get timerPickerSecondLabelOther => 'сек';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Бүгін';
@@ -6895,14 +6894,14 @@ class CupertinoLocalizationKm extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKm({
     String localeName = 'km',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6934,40 +6933,40 @@ class CupertinoLocalizationKm extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'ម៉ោង $hour';
+  String? get datePickerHourSemanticsLabelOne => r'ម៉ោង $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'ម៉ោង $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 នាទី';
+  String? get datePickerMinuteSemanticsLabelOne => '1 នាទី';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute នាទី';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ច្រាន​ចោល';
@@ -6988,58 +6987,58 @@ class CupertinoLocalizationKm extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'ផ្ទាំងទី $tabIndex នៃ $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ម៉ោង';
+  String? get timerPickerHourLabelOne => 'ម៉ោង';
 
   @override
   String get timerPickerHourLabelOther => 'ម៉ោង';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'នាទី';
+  String? get timerPickerMinuteLabelOne => 'នាទី';
 
   @override
   String get timerPickerMinuteLabelOther => 'នាទី';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'វិនាទី';
+  String? get timerPickerSecondLabelOne => 'វិនាទី';
 
   @override
   String get timerPickerSecondLabelOther => 'វិនាទី';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ថ្ងៃនេះ';
@@ -7052,14 +7051,14 @@ class CupertinoLocalizationKn extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKn({
     String localeName = 'kn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7091,40 +7090,40 @@ class CupertinoLocalizationKn extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => '\u{24}\u{68}\u{6f}\u{75}\u{72}\u{20}\u{c97}\u{c82}\u{c9f}\u{cc6}';
+  String? get datePickerHourSemanticsLabelOne => '\u{24}\u{68}\u{6f}\u{75}\u{72}\u{20}\u{c97}\u{c82}\u{c9f}\u{cc6}';
 
   @override
   String get datePickerHourSemanticsLabelOther => '\u{24}\u{68}\u{6f}\u{75}\u{72}\u{20}\u{c97}\u{c82}\u{c9f}\u{cc6}';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '\u{31}\u{20}\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{cb7}';
+  String? get datePickerMinuteSemanticsLabelOne => '\u{31}\u{20}\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{cb7}';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => '\u{24}\u{6d}\u{69}\u{6e}\u{75}\u{74}\u{65}\u{20}\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{cb7}\u{c97}\u{cb3}\u{cc1}';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => '\u{cb5}\u{c9c}\u{cbe}\u{c97}\u{cca}\u{cb3}\u{cbf}\u{cb8}\u{cbf}';
@@ -7145,58 +7144,58 @@ class CupertinoLocalizationKn extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => '\u{24}\u{74}\u{61}\u{62}\u{43}\u{6f}\u{75}\u{6e}\u{74}\u{20}\u{cb0}\u{cb2}\u{ccd}\u{cb2}\u{cbf}\u{ca8}\u{20}\u{24}\u{74}\u{61}\u{62}\u{49}\u{6e}\u{64}\u{65}\u{78}\u{20}\u{c9f}\u{ccd}\u{caf}\u{cbe}\u{cac}\u{ccd}';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => '\u{c97}\u{c82}\u{c9f}\u{cc6}';
+  String? get timerPickerHourLabelOne => '\u{c97}\u{c82}\u{c9f}\u{cc6}';
 
   @override
   String get timerPickerHourLabelOther => '\u{c97}\u{c82}\u{c9f}\u{cc6}\u{c97}\u{cb3}\u{cc1}';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => '\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{2e}';
+  String? get timerPickerMinuteLabelOne => '\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{2e}';
 
   @override
   String get timerPickerMinuteLabelOther => '\u{ca8}\u{cbf}\u{cae}\u{cbf}\u{2e}';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => '\u{cb8}\u{cc6}\u{2e}';
+  String? get timerPickerSecondLabelOne => '\u{cb8}\u{cc6}\u{2e}';
 
   @override
   String get timerPickerSecondLabelOther => '\u{cb8}\u{cc6}\u{2e}';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => '\u{c87}\u{c82}\u{ca6}\u{cc1}';
@@ -7209,14 +7208,14 @@ class CupertinoLocalizationKo extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKo({
     String localeName = 'ko',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7248,40 +7247,40 @@ class CupertinoLocalizationKo extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour시 정각';
+  String? get datePickerHourSemanticsLabelOne => r'$hour시 정각';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour시 정각';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1분';
+  String? get datePickerMinuteSemanticsLabelOne => '1분';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute분';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => '닫기';
@@ -7302,58 +7301,58 @@ class CupertinoLocalizationKo extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'탭 $tabCount개 중 $tabIndex번째';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => '시간';
+  String? get timerPickerHourLabelOne => '시간';
 
   @override
   String get timerPickerHourLabelOther => '시간';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => '분';
+  String? get timerPickerMinuteLabelOne => '분';
 
   @override
   String get timerPickerMinuteLabelOther => '분';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => '초';
+  String? get timerPickerSecondLabelOne => '초';
 
   @override
   String get timerPickerSecondLabelOther => '초';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => '오늘';
@@ -7366,14 +7365,14 @@ class CupertinoLocalizationKy extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationKy({
     String localeName = 'ky',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7405,40 +7404,40 @@ class CupertinoLocalizationKy extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Саат $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Саат $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Саат $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 мүнөт';
+  String? get datePickerMinuteSemanticsLabelOne => '1 мүнөт';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute мүнөт';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Жабуу';
@@ -7459,58 +7458,58 @@ class CupertinoLocalizationKy extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount ичинен $tabIndex-өтмөк';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'саат';
+  String? get timerPickerHourLabelOne => 'саат';
 
   @override
   String get timerPickerHourLabelOther => 'саат';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'мүн.';
+  String? get timerPickerMinuteLabelOne => 'мүн.';
 
   @override
   String get timerPickerMinuteLabelOther => 'мүн.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'сек.';
+  String? get timerPickerSecondLabelOne => 'сек.';
 
   @override
   String get timerPickerSecondLabelOther => 'сек.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Бүгүн';
@@ -7523,14 +7522,14 @@ class CupertinoLocalizationLo extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationLo({
     String localeName = 'lo',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7562,40 +7561,40 @@ class CupertinoLocalizationLo extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour ໂມງກົງ';
+  String? get datePickerHourSemanticsLabelOne => r'$hour ໂມງກົງ';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour ໂມງກົງ';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 ນາທີ';
+  String? get datePickerMinuteSemanticsLabelOne => '1 ນາທີ';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute ນາທີ';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ປິດໄວ້';
@@ -7616,58 +7615,58 @@ class CupertinoLocalizationLo extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'ແຖບທີ $tabIndex ຈາກທັງໝົດ $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ຊົ່ວໂມງ';
+  String? get timerPickerHourLabelOne => 'ຊົ່ວໂມງ';
 
   @override
   String get timerPickerHourLabelOther => 'ຊົ່ວໂມງ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'ນທ.';
+  String? get timerPickerMinuteLabelOne => 'ນທ.';
 
   @override
   String get timerPickerMinuteLabelOther => 'ນທ.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ວິ.';
+  String? get timerPickerSecondLabelOne => 'ວິ.';
 
   @override
   String get timerPickerSecondLabelOther => 'ວິ.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ມື້ນີ້';
@@ -7680,14 +7679,14 @@ class CupertinoLocalizationLt extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationLt({
     String localeName = 'lt',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7719,40 +7718,40 @@ class CupertinoLocalizationLt extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour val.';
+  String? get datePickerHourSemanticsLabelFew => r'$hour val.';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour val.';
+  String? get datePickerHourSemanticsLabelMany => r'$hour val.';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour val.';
+  String? get datePickerHourSemanticsLabelOne => r'$hour val.';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour val.';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute min.';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute min.';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute min.';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute min.';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 min.';
+  String? get datePickerMinuteSemanticsLabelOne => '1 min.';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute min.';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Atsisakyti';
@@ -7773,58 +7772,58 @@ class CupertinoLocalizationLt extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabIndex skirtukas iš $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'val.';
+  String? get timerPickerHourLabelFew => 'val.';
 
   @override
-  String get timerPickerHourLabelMany => 'val.';
+  String? get timerPickerHourLabelMany => 'val.';
 
   @override
-  String get timerPickerHourLabelOne => 'val.';
+  String? get timerPickerHourLabelOne => 'val.';
 
   @override
   String get timerPickerHourLabelOther => 'val.';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min.';
+  String? get timerPickerMinuteLabelFew => 'min.';
 
   @override
-  String get timerPickerMinuteLabelMany => 'min.';
+  String? get timerPickerMinuteLabelMany => 'min.';
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'sek.';
+  String? get timerPickerSecondLabelFew => 'sek.';
 
   @override
-  String get timerPickerSecondLabelMany => 'sek.';
+  String? get timerPickerSecondLabelMany => 'sek.';
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Šiandien';
@@ -7837,14 +7836,14 @@ class CupertinoLocalizationLv extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationLv({
     String localeName = 'lv',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7876,40 +7875,40 @@ class CupertinoLocalizationLv extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'plkst. $hour';
+  String? get datePickerHourSemanticsLabelOne => r'plkst. $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'plkst. $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => r'plkst. $hour';
+  String? get datePickerHourSemanticsLabelZero => r'plkst. $hour';
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minūte';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minūte';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minūtes';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => r'$minute minūtes';
+  String? get datePickerMinuteSemanticsLabelZero => r'$minute minūtes';
 
   @override
   String get modalBarrierDismissLabel => 'Nerādīt';
@@ -7930,58 +7929,58 @@ class CupertinoLocalizationLv extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabIndex. cilne no $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'h';
+  String? get timerPickerHourLabelOne => 'h';
 
   @override
   String get timerPickerHourLabelOther => 'h';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => 'h';
+  String? get timerPickerHourLabelZero => 'h';
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => 'min';
+  String? get timerPickerMinuteLabelZero => 'min';
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => 's';
+  String? get timerPickerSecondLabelZero => 's';
 
   @override
   String get todayLabel => 'Šodien';
@@ -7994,14 +7993,14 @@ class CupertinoLocalizationMk extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMk({
     String localeName = 'mk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8033,40 +8032,40 @@ class CupertinoLocalizationMk extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour часот';
+  String? get datePickerHourSemanticsLabelOne => r'$hour часот';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour часот';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минута';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минута';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минути';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Отфрли';
@@ -8087,58 +8086,58 @@ class CupertinoLocalizationMk extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Картичка $tabIndex од $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'час';
+  String? get timerPickerHourLabelOne => 'час';
 
   @override
   String get timerPickerHourLabelOther => 'часа';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'мин.';
+  String? get timerPickerMinuteLabelOne => 'мин.';
 
   @override
   String get timerPickerMinuteLabelOther => 'мин.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'сек.';
+  String? get timerPickerSecondLabelOne => 'сек.';
 
   @override
   String get timerPickerSecondLabelOther => 'сек.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Денес';
@@ -8151,14 +8150,14 @@ class CupertinoLocalizationMl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMl({
     String localeName = 'ml',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8190,40 +8189,40 @@ class CupertinoLocalizationMl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour മണി';
+  String? get datePickerHourSemanticsLabelOne => r'$hour മണി';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour മണി';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'ഒരു മിനിറ്റ്';
+  String? get datePickerMinuteSemanticsLabelOne => 'ഒരു മിനിറ്റ്';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute മിനിറ്റ്';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'നിരസിക്കുക';
@@ -8244,58 +8243,58 @@ class CupertinoLocalizationMl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount ടാബിൽ $tabIndex-ാമത്തേത്';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'മണിക്കൂർ';
+  String? get timerPickerHourLabelOne => 'മണിക്കൂർ';
 
   @override
   String get timerPickerHourLabelOther => 'മണിക്കൂർ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'മിനിറ്റ്';
+  String? get timerPickerMinuteLabelOne => 'മിനിറ്റ്';
 
   @override
   String get timerPickerMinuteLabelOther => 'മിനിറ്റ്';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'സെക്കൻഡ്';
+  String? get timerPickerSecondLabelOne => 'സെക്കൻഡ്';
 
   @override
   String get timerPickerSecondLabelOther => 'സെക്കൻഡ്';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ഇന്ന്';
@@ -8308,14 +8307,14 @@ class CupertinoLocalizationMn extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMn({
     String localeName = 'mn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8347,40 +8346,40 @@ class CupertinoLocalizationMn extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour цаг';
+  String? get datePickerHourSemanticsLabelOne => r'$hour цаг';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour цаг';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минут';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минут';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минут';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Үл хэрэгсэх';
@@ -8401,58 +8400,58 @@ class CupertinoLocalizationMn extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount-н $tabIndex-р таб';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'цаг';
+  String? get timerPickerHourLabelOne => 'цаг';
 
   @override
   String get timerPickerHourLabelOther => 'цаг';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'минут.';
+  String? get timerPickerMinuteLabelOne => 'минут.';
 
   @override
   String get timerPickerMinuteLabelOther => 'минут.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'секунд.';
+  String? get timerPickerSecondLabelOne => 'секунд.';
 
   @override
   String get timerPickerSecondLabelOther => 'секунд.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Өнөөдөр';
@@ -8465,14 +8464,14 @@ class CupertinoLocalizationMr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMr({
     String localeName = 'mr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8504,40 +8503,40 @@ class CupertinoLocalizationMr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour वाजता';
+  String? get datePickerHourSemanticsLabelOne => r'$hour वाजता';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour वाजता';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'एक मिनिट';
+  String? get datePickerMinuteSemanticsLabelOne => 'एक मिनिट';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute मिनिटे';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'डिसमिस करा';
@@ -8558,58 +8557,58 @@ class CupertinoLocalizationMr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount पैकी $tabIndex टॅब';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'तास';
+  String? get timerPickerHourLabelOne => 'तास';
 
   @override
   String get timerPickerHourLabelOther => 'तास';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'मि.';
+  String? get timerPickerMinuteLabelOne => 'मि.';
 
   @override
   String get timerPickerMinuteLabelOther => 'मि.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'से.';
+  String? get timerPickerSecondLabelOne => 'से.';
 
   @override
   String get timerPickerSecondLabelOther => 'से.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'आज';
@@ -8622,14 +8621,14 @@ class CupertinoLocalizationMs extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMs({
     String localeName = 'ms',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8661,40 +8660,40 @@ class CupertinoLocalizationMs extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Pukul $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Pukul $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Pukul $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minit';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minit';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minit';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Tolak';
@@ -8715,58 +8714,58 @@ class CupertinoLocalizationMs extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex daripada $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'jam';
+  String? get timerPickerHourLabelOne => 'jam';
 
   @override
   String get timerPickerHourLabelOther => 'jam';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'minit';
+  String? get timerPickerMinuteLabelOne => 'minit';
 
   @override
   String get timerPickerMinuteLabelOther => 'minit';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'saat';
+  String? get timerPickerSecondLabelOne => 'saat';
 
   @override
   String get timerPickerSecondLabelOther => 'saat';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hari ini';
@@ -8779,14 +8778,14 @@ class CupertinoLocalizationMy extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationMy({
     String localeName = 'my',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8818,40 +8817,40 @@ class CupertinoLocalizationMy extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour နာရီ';
+  String? get datePickerHourSemanticsLabelOne => r'$hour နာရီ';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour နာရီ';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '၁ မိနစ်';
+  String? get datePickerMinuteSemanticsLabelOne => '၁ မိနစ်';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute မိနစ်';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ပယ်ရန်';
@@ -8872,58 +8871,58 @@ class CupertinoLocalizationMy extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'တဘ် $tabCount ခုအနက် $tabIndex ခု';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'နာရီ';
+  String? get timerPickerHourLabelOne => 'နာရီ';
 
   @override
   String get timerPickerHourLabelOther => 'နာရီ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'မိနစ်';
+  String? get timerPickerMinuteLabelOne => 'မိနစ်';
 
   @override
   String get timerPickerMinuteLabelOther => 'မိနစ်';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'စက္ကန့်';
+  String? get timerPickerSecondLabelOne => 'စက္ကန့်';
 
   @override
   String get timerPickerSecondLabelOther => 'စက္ကန့်';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ယနေ့';
@@ -8936,14 +8935,14 @@ class CupertinoLocalizationNb extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationNb({
     String localeName = 'nb',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8975,40 +8974,40 @@ class CupertinoLocalizationNb extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour null-null';
+  String? get datePickerHourSemanticsLabelOne => r'$hour null-null';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour null-null';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minutt';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minutt';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutter';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Avvis';
@@ -9029,58 +9028,58 @@ class CupertinoLocalizationNb extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Fane $tabIndex av $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'time';
+  String? get timerPickerHourLabelOne => 'time';
 
   @override
   String get timerPickerHourLabelOther => 'timer';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'I dag';
@@ -9093,14 +9092,14 @@ class CupertinoLocalizationNe extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationNe({
     String localeName = 'ne',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9132,40 +9131,40 @@ class CupertinoLocalizationNe extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour बजे';
+  String? get datePickerHourSemanticsLabelOne => r'$hour बजे';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour बजे';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '१ मिनेट';
+  String? get datePickerMinuteSemanticsLabelOne => '१ मिनेट';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute मिनेट';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'खारेज गर्नुहोस्';
@@ -9186,58 +9185,58 @@ class CupertinoLocalizationNe extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount मध्ये $tabIndex ट्याब';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'घन्टा';
+  String? get timerPickerHourLabelOne => 'घन्टा';
 
   @override
   String get timerPickerHourLabelOther => 'घन्टा';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'मिनेट';
+  String? get timerPickerMinuteLabelOne => 'मिनेट';
 
   @override
   String get timerPickerMinuteLabelOther => 'मिनेट';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'सेकेन्ड';
+  String? get timerPickerSecondLabelOne => 'सेकेन्ड';
 
   @override
   String get timerPickerSecondLabelOther => 'सेकेन्ड';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'आज';
@@ -9250,14 +9249,14 @@ class CupertinoLocalizationNl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationNl({
     String localeName = 'nl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9289,40 +9288,40 @@ class CupertinoLocalizationNl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour uur';
+  String? get datePickerHourSemanticsLabelOne => r'$hour uur';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour uur';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuten';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Sluiten';
@@ -9343,58 +9342,58 @@ class CupertinoLocalizationNl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tabblad $tabIndex van $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'uur';
+  String? get timerPickerHourLabelOne => 'uur';
 
   @override
   String get timerPickerHourLabelOther => 'uur';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sec.';
+  String? get timerPickerSecondLabelOne => 'sec.';
 
   @override
   String get timerPickerSecondLabelOther => 'sec.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Vandaag';
@@ -9407,14 +9406,14 @@ class CupertinoLocalizationNo extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationNo({
     String localeName = 'no',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9446,40 +9445,40 @@ class CupertinoLocalizationNo extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour null-null';
+  String? get datePickerHourSemanticsLabelOne => r'$hour null-null';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour null-null';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minutt';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minutt';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutter';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Avvis';
@@ -9500,58 +9499,58 @@ class CupertinoLocalizationNo extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Fane $tabIndex av $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'time';
+  String? get timerPickerHourLabelOne => 'time';
 
   @override
   String get timerPickerHourLabelOther => 'timer';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'I dag';
@@ -9564,14 +9563,14 @@ class CupertinoLocalizationOr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationOr({
     String localeName = 'or',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9603,40 +9602,40 @@ class CupertinoLocalizationOr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hourଟା';
+  String? get datePickerHourSemanticsLabelOne => r'$hourଟା';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hourଟା';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 ମିନିଟ୍';
+  String? get datePickerMinuteSemanticsLabelOne => '1 ମିନିଟ୍';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute ମିନିଟ୍';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ଖାରଜ କରନ୍ତୁ';
@@ -9657,58 +9656,58 @@ class CupertinoLocalizationOr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCountର $tabIndex ଟାବ୍';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ଘଣ୍ଟା';
+  String? get timerPickerHourLabelOne => 'ଘଣ୍ଟା';
 
   @override
   String get timerPickerHourLabelOther => 'ଘଣ୍ଟା';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'ମିନିଟ୍';
+  String? get timerPickerMinuteLabelOne => 'ମିନିଟ୍';
 
   @override
   String get timerPickerMinuteLabelOther => 'ମିନିଟ୍';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ସେକେଣ୍ଡ';
+  String? get timerPickerSecondLabelOne => 'ସେକେଣ୍ଡ';
 
   @override
   String get timerPickerSecondLabelOther => 'ସେକେଣ୍ଡ';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ଆଜି';
@@ -9721,14 +9720,14 @@ class CupertinoLocalizationPa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationPa({
     String localeName = 'pa',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9760,40 +9759,40 @@ class CupertinoLocalizationPa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour ਵਜੇ';
+  String? get datePickerHourSemanticsLabelOne => r'$hour ਵਜੇ';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour ਵਜੇ';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 ਮਿੰਟ';
+  String? get datePickerMinuteSemanticsLabelOne => '1 ਮਿੰਟ';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute ਮਿੰਟ';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ਖਾਰਜ ਕਰੋ';
@@ -9814,58 +9813,58 @@ class CupertinoLocalizationPa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount ਵਿੱਚੋਂ $tabIndex ਟੈਬ';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ਘੰਟਾ';
+  String? get timerPickerHourLabelOne => 'ਘੰਟਾ';
 
   @override
   String get timerPickerHourLabelOther => 'ਘੰਟੇ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'ਮਿੰ.';
+  String? get timerPickerMinuteLabelOne => 'ਮਿੰ.';
 
   @override
   String get timerPickerMinuteLabelOther => 'ਮਿੰ.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'ਸਕਿੰ.';
+  String? get timerPickerSecondLabelOne => 'ਸਕਿੰ.';
 
   @override
   String get timerPickerSecondLabelOther => 'ਸਕਿੰ.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ਅੱਜ';
@@ -9878,14 +9877,14 @@ class CupertinoLocalizationPl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationPl({
     String localeName = 'pl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9917,40 +9916,40 @@ class CupertinoLocalizationPl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour';
+  String? get datePickerHourSemanticsLabelFew => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour';
+  String? get datePickerHourSemanticsLabelMany => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour';
+  String? get datePickerHourSemanticsLabelOne => r'$hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minuty';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minuty';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute minut';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute minut';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuty';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Zamknij';
@@ -9971,58 +9970,58 @@ class CupertinoLocalizationPl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Karta $tabIndex z $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'godziny';
+  String? get timerPickerHourLabelFew => 'godziny';
 
   @override
-  String get timerPickerHourLabelMany => 'godzin';
+  String? get timerPickerHourLabelMany => 'godzin';
 
   @override
-  String get timerPickerHourLabelOne => 'godzina';
+  String? get timerPickerHourLabelOne => 'godzina';
 
   @override
   String get timerPickerHourLabelOther => 'godziny';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelMany => 'min';
+  String? get timerPickerMinuteLabelMany => 'min';
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 's';
+  String? get timerPickerSecondLabelFew => 's';
 
   @override
-  String get timerPickerSecondLabelMany => 's';
+  String? get timerPickerSecondLabelMany => 's';
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Dziś';
@@ -10035,14 +10034,14 @@ class CupertinoLocalizationPt extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationPt({
     String localeName = 'pt',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10074,40 +10073,40 @@ class CupertinoLocalizationPt extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour hora';
+  String? get datePickerHourSemanticsLabelOne => r'$hour hora';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour horas';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minutos';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Dispensar';
@@ -10128,58 +10127,58 @@ class CupertinoLocalizationPt extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Guia $tabIndex de $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'hora';
+  String? get timerPickerHourLabelOne => 'hora';
 
   @override
   String get timerPickerHourLabelOther => 'horas';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hoje';
@@ -10192,14 +10191,14 @@ class CupertinoLocalizationPtPt extends CupertinoLocalizationPt {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationPtPt({
     String localeName = 'pt_PT',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10219,7 +10218,7 @@ class CupertinoLocalizationPtPt extends CupertinoLocalizationPt {
   String get datePickerHourSemanticsLabelOther => r'$hour hora';
 
   @override
-  String get timerPickerSecondLabelOne => 'seg';
+  String? get timerPickerSecondLabelOne => 'seg';
 
   @override
   String get timerPickerSecondLabelOther => 'seg';
@@ -10238,14 +10237,14 @@ class CupertinoLocalizationRo extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationRo({
     String localeName = 'ro',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10277,40 +10276,40 @@ class CupertinoLocalizationRo extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'Ora $hour';
+  String? get datePickerHourSemanticsLabelFew => r'Ora $hour';
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Ora $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Ora $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Ora $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minute';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute de minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Închideți';
@@ -10331,58 +10330,58 @@ class CupertinoLocalizationRo extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Fila $tabIndex din $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'ore';
+  String? get timerPickerHourLabelFew => 'ore';
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'oră';
+  String? get timerPickerHourLabelOne => 'oră';
 
   @override
   String get timerPickerHourLabelOther => 'de ore';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min.';
+  String? get timerPickerMinuteLabelFew => 'min.';
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'sec.';
+  String? get timerPickerSecondLabelFew => 'sec.';
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sec.';
+  String? get timerPickerSecondLabelOne => 'sec.';
 
   @override
   String get timerPickerSecondLabelOther => 'sec.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Azi';
@@ -10395,14 +10394,14 @@ class CupertinoLocalizationRu extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationRu({
     String localeName = 'ru',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10434,40 +10433,40 @@ class CupertinoLocalizationRu extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour часа';
+  String? get datePickerHourSemanticsLabelFew => r'$hour часа';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour часов';
+  String? get datePickerHourSemanticsLabelMany => r'$hour часов';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour час';
+  String? get datePickerHourSemanticsLabelOne => r'$hour час';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour часа';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute минуты';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute минуты';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute минут';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute минут';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минута';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минута';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минуты';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Закрыть';
@@ -10488,58 +10487,58 @@ class CupertinoLocalizationRu extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Вкладка $tabIndex из $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'часа';
+  String? get timerPickerHourLabelFew => 'часа';
 
   @override
-  String get timerPickerHourLabelMany => 'часов';
+  String? get timerPickerHourLabelMany => 'часов';
 
   @override
-  String get timerPickerHourLabelOne => 'час';
+  String? get timerPickerHourLabelOne => 'час';
 
   @override
   String get timerPickerHourLabelOther => 'часа';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'мин.';
+  String? get timerPickerMinuteLabelFew => 'мин.';
 
   @override
-  String get timerPickerMinuteLabelMany => 'мин.';
+  String? get timerPickerMinuteLabelMany => 'мин.';
 
   @override
-  String get timerPickerMinuteLabelOne => 'мин.';
+  String? get timerPickerMinuteLabelOne => 'мин.';
 
   @override
   String get timerPickerMinuteLabelOther => 'мин.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'сек.';
+  String? get timerPickerSecondLabelFew => 'сек.';
 
   @override
-  String get timerPickerSecondLabelMany => 'сек.';
+  String? get timerPickerSecondLabelMany => 'сек.';
 
   @override
-  String get timerPickerSecondLabelOne => 'сек.';
+  String? get timerPickerSecondLabelOne => 'сек.';
 
   @override
   String get timerPickerSecondLabelOther => 'сек.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Сегодня';
@@ -10552,14 +10551,14 @@ class CupertinoLocalizationSi extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSi({
     String localeName = 'si',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10591,40 +10590,40 @@ class CupertinoLocalizationSi extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_dayPeriod_time';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hourයි';
+  String? get datePickerHourSemanticsLabelOne => r'$hourයි';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hourයි';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'මිනිත්තු 1';
+  String? get datePickerMinuteSemanticsLabelOne => 'මිනිත්තු 1';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'මිනිත්තු $minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ඉවත ලන්න';
@@ -10645,58 +10644,58 @@ class CupertinoLocalizationSi extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'ටැබ $tabCount න් $tabIndex';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'පැය';
+  String? get timerPickerHourLabelOne => 'පැය';
 
   @override
   String get timerPickerHourLabelOther => 'පැය';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'මිනි.';
+  String? get timerPickerMinuteLabelOne => 'මිනි.';
 
   @override
   String get timerPickerMinuteLabelOther => 'මිනි.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'තත්.';
+  String? get timerPickerSecondLabelOne => 'තත්.';
 
   @override
   String get timerPickerSecondLabelOther => 'තත්.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'අද';
@@ -10709,14 +10708,14 @@ class CupertinoLocalizationSk extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSk({
     String localeName = 'sk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10748,40 +10747,40 @@ class CupertinoLocalizationSk extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour hodiny';
+  String? get datePickerHourSemanticsLabelFew => r'$hour hodiny';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour hodiny';
+  String? get datePickerHourSemanticsLabelMany => r'$hour hodiny';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour hodina';
+  String? get datePickerHourSemanticsLabelOne => r'$hour hodina';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour hodín';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minúty';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minúty';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute minúty';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute minúty';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minúta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minúta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minút';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Odmietnuť';
@@ -10802,58 +10801,58 @@ class CupertinoLocalizationSk extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Karta $tabIndex z $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'hodiny';
+  String? get timerPickerHourLabelFew => 'hodiny';
 
   @override
-  String get timerPickerHourLabelMany => 'hodiny';
+  String? get timerPickerHourLabelMany => 'hodiny';
 
   @override
-  String get timerPickerHourLabelOne => 'hodina';
+  String? get timerPickerHourLabelOne => 'hodina';
 
   @override
   String get timerPickerHourLabelOther => 'hodín';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelMany => 'min';
+  String? get timerPickerMinuteLabelMany => 'min';
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 's';
+  String? get timerPickerSecondLabelFew => 's';
 
   @override
-  String get timerPickerSecondLabelMany => 's';
+  String? get timerPickerSecondLabelMany => 's';
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Dnes';
@@ -10866,14 +10865,14 @@ class CupertinoLocalizationSl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSl({
     String localeName = 'sl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10905,40 +10904,40 @@ class CupertinoLocalizationSl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour';
+  String? get datePickerHourSemanticsLabelFew => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour';
+  String? get datePickerHourSemanticsLabelOne => r'$hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => r'$hour';
+  String? get datePickerHourSemanticsLabelTwo => r'$hour';
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minute';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuta';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuta';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minut';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => r'$minute minuti';
+  String? get datePickerMinuteSemanticsLabelTwo => r'$minute minuti';
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Opusti';
@@ -10959,58 +10958,58 @@ class CupertinoLocalizationSl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Zavihek $tabIndex od $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'ure';
+  String? get timerPickerHourLabelFew => 'ure';
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ura';
+  String? get timerPickerHourLabelOne => 'ura';
 
   @override
   String get timerPickerHourLabelOther => 'ure';
 
   @override
-  String get timerPickerHourLabelTwo => 'ure';
+  String? get timerPickerHourLabelTwo => 'ure';
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => 'min';
+  String? get timerPickerMinuteLabelTwo => 'min';
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 's';
+  String? get timerPickerSecondLabelFew => 's';
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 's';
+  String? get timerPickerSecondLabelOne => 's';
 
   @override
   String get timerPickerSecondLabelOther => 's';
 
   @override
-  String get timerPickerSecondLabelTwo => 's';
+  String? get timerPickerSecondLabelTwo => 's';
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Danes';
@@ -11023,14 +11022,14 @@ class CupertinoLocalizationSq extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSq({
     String localeName = 'sq',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11062,40 +11061,40 @@ class CupertinoLocalizationSq extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour fiks';
+  String? get datePickerHourSemanticsLabelOne => r'$hour fiks';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour fiks';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minutë';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minutë';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuta';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Hiq';
@@ -11116,58 +11115,58 @@ class CupertinoLocalizationSq extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Skeda $tabIndex nga $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'orë';
+  String? get timerPickerHourLabelOne => 'orë';
 
   @override
   String get timerPickerHourLabelOther => 'orë';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek.';
+  String? get timerPickerSecondLabelOne => 'sek.';
 
   @override
   String get timerPickerSecondLabelOther => 'sek.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Sot';
@@ -11180,14 +11179,14 @@ class CupertinoLocalizationSr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSr({
     String localeName = 'sr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11219,40 +11218,40 @@ class CupertinoLocalizationSr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour сата';
+  String? get datePickerHourSemanticsLabelFew => r'$hour сата';
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour сат';
+  String? get datePickerHourSemanticsLabelOne => r'$hour сат';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour сати';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute минута';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute минута';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 минут';
+  String? get datePickerMinuteSemanticsLabelOne => '1 минут';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute минута';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Одбаци';
@@ -11273,58 +11272,58 @@ class CupertinoLocalizationSr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabIndex. картица од $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'сата';
+  String? get timerPickerHourLabelFew => 'сата';
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'сат';
+  String? get timerPickerHourLabelOne => 'сат';
 
   @override
   String get timerPickerHourLabelOther => 'сати';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'мин';
+  String? get timerPickerMinuteLabelFew => 'мин';
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'мин';
+  String? get timerPickerMinuteLabelOne => 'мин';
 
   @override
   String get timerPickerMinuteLabelOther => 'мин';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'сек';
+  String? get timerPickerSecondLabelFew => 'сек';
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'сек';
+  String? get timerPickerSecondLabelOne => 'сек';
 
   @override
   String get timerPickerSecondLabelOther => 'сек';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Данас';
@@ -11337,14 +11336,14 @@ class CupertinoLocalizationSrCyrl extends CupertinoLocalizationSr {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSrCyrl({
     String localeName = 'sr_Cyrl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11365,14 +11364,14 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSrLatn({
     String localeName = 'sr_Latn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11398,19 +11397,19 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   String get cutButtonLabel => 'Iseci';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour sata';
+  String? get datePickerHourSemanticsLabelFew => r'$hour sata';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour sat';
+  String? get datePickerHourSemanticsLabelOne => r'$hour sat';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour sati';
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minuta';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute minuta';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuta';
@@ -11431,28 +11430,28 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   String get tabSemanticsLabelRaw => r'$tabIndex. kartica od $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'sata';
+  String? get timerPickerHourLabelFew => 'sata';
 
   @override
-  String get timerPickerHourLabelOne => 'sat';
+  String? get timerPickerHourLabelOne => 'sat';
 
   @override
   String get timerPickerHourLabelOther => 'sati';
 
   @override
-  String get timerPickerMinuteLabelFew => 'min';
+  String? get timerPickerMinuteLabelFew => 'min';
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerSecondLabelFew => 'sek';
+  String? get timerPickerSecondLabelFew => 'sek';
 
   @override
-  String get timerPickerSecondLabelOne => 'sek';
+  String? get timerPickerSecondLabelOne => 'sek';
 
   @override
   String get timerPickerSecondLabelOther => 'sek';
@@ -11468,14 +11467,14 @@ class CupertinoLocalizationSv extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSv({
     String localeName = 'sv',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11507,40 +11506,40 @@ class CupertinoLocalizationSv extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Klockan $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Klockan $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Klockan $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minut';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuter';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Stäng';
@@ -11561,58 +11560,58 @@ class CupertinoLocalizationSv extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Flik $tabIndex av $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'timme';
+  String? get timerPickerHourLabelOne => 'timme';
 
   @override
   String get timerPickerHourLabelOther => 'timmar';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min';
+  String? get timerPickerMinuteLabelOne => 'min';
 
   @override
   String get timerPickerMinuteLabelOther => 'min';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sek';
+  String? get timerPickerSecondLabelOne => 'sek';
 
   @override
   String get timerPickerSecondLabelOther => 'sek';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'I dag';
@@ -11625,14 +11624,14 @@ class CupertinoLocalizationSw extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationSw({
     String localeName = 'sw',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11664,40 +11663,40 @@ class CupertinoLocalizationSw extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Saa $hour kamili';
+  String? get datePickerHourSemanticsLabelOne => r'Saa $hour kamili';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Saa $hour kamili';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => 'Dakika 1';
+  String? get datePickerMinuteSemanticsLabelOne => 'Dakika 1';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'Dakika $minute';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Ondoa';
@@ -11718,58 +11717,58 @@ class CupertinoLocalizationSw extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Kichupo cha $tabIndex kati ya $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'saa';
+  String? get timerPickerHourLabelOne => 'saa';
 
   @override
   String get timerPickerHourLabelOther => 'saa';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'dakika';
+  String? get timerPickerMinuteLabelOne => 'dakika';
 
   @override
   String get timerPickerMinuteLabelOther => 'dakika';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sekunde';
+  String? get timerPickerSecondLabelOne => 'sekunde';
 
   @override
   String get timerPickerSecondLabelOther => 'sekunde';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Leo';
@@ -11782,14 +11781,14 @@ class CupertinoLocalizationTa extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationTa({
     String localeName = 'ta',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11821,40 +11820,40 @@ class CupertinoLocalizationTa extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour மணி';
+  String? get datePickerHourSemanticsLabelOne => r'$hour மணி';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour மணி';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 நிமிடம்';
+  String? get datePickerMinuteSemanticsLabelOne => '1 நிமிடம்';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute நிமிடங்கள்';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'நிராகரிக்கும்';
@@ -11875,58 +11874,58 @@ class CupertinoLocalizationTa extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'தாவல் $tabIndex / $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'மணிநேரம்';
+  String? get timerPickerHourLabelOne => 'மணிநேரம்';
 
   @override
   String get timerPickerHourLabelOther => 'மணிநேரம்';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'நிமி.';
+  String? get timerPickerMinuteLabelOne => 'நிமி.';
 
   @override
   String get timerPickerMinuteLabelOther => 'நிமி.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'வி.';
+  String? get timerPickerSecondLabelOne => 'வி.';
 
   @override
   String get timerPickerSecondLabelOther => 'வி.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'இன்று';
@@ -11939,14 +11938,14 @@ class CupertinoLocalizationTe extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationTe({
     String localeName = 'te',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11978,40 +11977,40 @@ class CupertinoLocalizationTe extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour అవుతుంది';
+  String? get datePickerHourSemanticsLabelOne => r'$hour అవుతుంది';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour అవుతుంది';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 నిమిషం';
+  String? get datePickerMinuteSemanticsLabelOne => '1 నిమిషం';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute నిమిషాలు';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'విస్మరించు';
@@ -12032,58 +12031,58 @@ class CupertinoLocalizationTe extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCountలో $tabIndexవ ట్యాబ్';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'గంట';
+  String? get timerPickerHourLabelOne => 'గంట';
 
   @override
   String get timerPickerHourLabelOther => 'గంటలు';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'నిమి.';
+  String? get timerPickerMinuteLabelOne => 'నిమి.';
 
   @override
   String get timerPickerMinuteLabelOther => 'నిమి.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'సెకన్లు.';
+  String? get timerPickerSecondLabelOne => 'సెకన్లు.';
 
   @override
   String get timerPickerSecondLabelOther => 'సెకన్లు.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'ఈరోజు';
@@ -12096,14 +12095,14 @@ class CupertinoLocalizationTh extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationTh({
     String localeName = 'th',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12135,40 +12134,40 @@ class CupertinoLocalizationTh extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour นาฬิกา';
+  String? get datePickerHourSemanticsLabelOne => r'$hour นาฬิกา';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour นาฬิกา';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 นาที';
+  String? get datePickerMinuteSemanticsLabelOne => '1 นาที';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute นาที';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'ปิด';
@@ -12189,58 +12188,58 @@ class CupertinoLocalizationTh extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'แท็บที่ $tabIndex จาก $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ชั่วโมง';
+  String? get timerPickerHourLabelOne => 'ชั่วโมง';
 
   @override
   String get timerPickerHourLabelOther => 'ชั่วโมง';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'นาที';
+  String? get timerPickerMinuteLabelOne => 'นาที';
 
   @override
   String get timerPickerMinuteLabelOther => 'นาที';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'วินาที';
+  String? get timerPickerSecondLabelOne => 'วินาที';
 
   @override
   String get timerPickerSecondLabelOther => 'วินาที';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'วันนี้';
@@ -12253,14 +12252,14 @@ class CupertinoLocalizationTl extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationTl({
     String localeName = 'tl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12292,40 +12291,40 @@ class CupertinoLocalizationTl extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Ala $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Ala $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Alas $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 minuto';
+  String? get datePickerMinuteSemanticsLabelOne => '1 minuto';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute na minuto';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'I-dismiss';
@@ -12346,58 +12345,58 @@ class CupertinoLocalizationTl extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Tab $tabIndex ng $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'oras';
+  String? get timerPickerHourLabelOne => 'oras';
 
   @override
   String get timerPickerHourLabelOther => 'na oras';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'min.';
+  String? get timerPickerMinuteLabelOne => 'min.';
 
   @override
   String get timerPickerMinuteLabelOther => 'na min.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'seg.';
+  String? get timerPickerSecondLabelOne => 'seg.';
 
   @override
   String get timerPickerSecondLabelOther => 'na seg.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Ngayon';
@@ -12410,14 +12409,14 @@ class CupertinoLocalizationTr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationTr({
     String localeName = 'tr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12449,40 +12448,40 @@ class CupertinoLocalizationTr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'Saat $hour';
+  String? get datePickerHourSemanticsLabelOne => r'Saat $hour';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'Saat $hour';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 dakika';
+  String? get datePickerMinuteSemanticsLabelOne => '1 dakika';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute dakika';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Kapat';
@@ -12503,58 +12502,58 @@ class CupertinoLocalizationTr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Sekme $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'saat';
+  String? get timerPickerHourLabelOne => 'saat';
 
   @override
   String get timerPickerHourLabelOther => 'saat';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'dk.';
+  String? get timerPickerMinuteLabelOne => 'dk.';
 
   @override
   String get timerPickerMinuteLabelOther => 'dk.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'sn.';
+  String? get timerPickerSecondLabelOne => 'sn.';
 
   @override
   String get timerPickerSecondLabelOther => 'sn.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Bugün';
@@ -12567,14 +12566,14 @@ class CupertinoLocalizationUk extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationUk({
     String localeName = 'uk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12606,40 +12605,40 @@ class CupertinoLocalizationUk extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => r'$hour години';
+  String? get datePickerHourSemanticsLabelFew => r'$hour години';
 
   @override
-  String get datePickerHourSemanticsLabelMany => r'$hour годин';
+  String? get datePickerHourSemanticsLabelMany => r'$hour годин';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour година';
+  String? get datePickerHourSemanticsLabelOne => r'$hour година';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour години';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute хвилини';
+  String? get datePickerMinuteSemanticsLabelFew => r'$minute хвилини';
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => r'$minute хвилин';
+  String? get datePickerMinuteSemanticsLabelMany => r'$minute хвилин';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 хвилина';
+  String? get datePickerMinuteSemanticsLabelOne => '1 хвилина';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute хвилини';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Закрити';
@@ -12660,58 +12659,58 @@ class CupertinoLocalizationUk extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Вкладка $tabIndex з $tabCount';
 
   @override
-  String get timerPickerHourLabelFew => 'години';
+  String? get timerPickerHourLabelFew => 'години';
 
   @override
-  String get timerPickerHourLabelMany => 'годин';
+  String? get timerPickerHourLabelMany => 'годин';
 
   @override
-  String get timerPickerHourLabelOne => 'година';
+  String? get timerPickerHourLabelOne => 'година';
 
   @override
   String get timerPickerHourLabelOther => 'години';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => 'хв';
+  String? get timerPickerMinuteLabelFew => 'хв';
 
   @override
-  String get timerPickerMinuteLabelMany => 'хв';
+  String? get timerPickerMinuteLabelMany => 'хв';
 
   @override
-  String get timerPickerMinuteLabelOne => 'хв';
+  String? get timerPickerMinuteLabelOne => 'хв';
 
   @override
   String get timerPickerMinuteLabelOther => 'хв';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => 'с';
+  String? get timerPickerSecondLabelFew => 'с';
 
   @override
-  String get timerPickerSecondLabelMany => 'с';
+  String? get timerPickerSecondLabelMany => 'с';
 
   @override
-  String get timerPickerSecondLabelOne => 'с';
+  String? get timerPickerSecondLabelOne => 'с';
 
   @override
   String get timerPickerSecondLabelOther => 'с';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Сьогодні';
@@ -12724,14 +12723,14 @@ class CupertinoLocalizationUr extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationUr({
     String localeName = 'ur',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12763,40 +12762,40 @@ class CupertinoLocalizationUr extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour بجے';
+  String? get datePickerHourSemanticsLabelOne => r'$hour بجے';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour بجے';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 منٹ';
+  String? get datePickerMinuteSemanticsLabelOne => '1 منٹ';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute منٹس';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'برخاست کریں';
@@ -12817,58 +12816,58 @@ class CupertinoLocalizationUr extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount میں سے $tabIndex ٹیب';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'گھنٹہ';
+  String? get timerPickerHourLabelOne => 'گھنٹہ';
 
   @override
   String get timerPickerHourLabelOther => 'گھنٹے';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'منٹ۔';
+  String? get timerPickerMinuteLabelOne => 'منٹ۔';
 
   @override
   String get timerPickerMinuteLabelOther => 'منٹ۔';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'سیکنڈ۔';
+  String? get timerPickerSecondLabelOne => 'سیکنڈ۔';
 
   @override
   String get timerPickerSecondLabelOther => 'سیکنڈ۔';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'آج';
@@ -12881,14 +12880,14 @@ class CupertinoLocalizationUz extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationUz({
     String localeName = 'uz',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12920,40 +12919,40 @@ class CupertinoLocalizationUz extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour soat';
+  String? get datePickerHourSemanticsLabelOne => r'$hour soat';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour soat';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 daqiqa';
+  String? get datePickerMinuteSemanticsLabelOne => '1 daqiqa';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute daqiqa';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Yopish';
@@ -12974,58 +12973,58 @@ class CupertinoLocalizationUz extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'$tabCount varaqdan $tabIndex';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'soat';
+  String? get timerPickerHourLabelOne => 'soat';
 
   @override
   String get timerPickerHourLabelOther => 'soat';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'daqiqa';
+  String? get timerPickerMinuteLabelOne => 'daqiqa';
 
   @override
   String get timerPickerMinuteLabelOther => 'daqiqa';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'soniya';
+  String? get timerPickerSecondLabelOne => 'soniya';
 
   @override
   String get timerPickerSecondLabelOther => 'soniya';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Bugun';
@@ -13038,14 +13037,14 @@ class CupertinoLocalizationVi extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationVi({
     String localeName = 'vi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13077,40 +13076,40 @@ class CupertinoLocalizationVi extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour giờ';
+  String? get datePickerHourSemanticsLabelOne => r'$hour giờ';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour giờ';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 phút';
+  String? get datePickerMinuteSemanticsLabelOne => '1 phút';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute phút';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Bỏ qua';
@@ -13131,58 +13130,58 @@ class CupertinoLocalizationVi extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Thẻ $tabIndex/$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'giờ';
+  String? get timerPickerHourLabelOne => 'giờ';
 
   @override
   String get timerPickerHourLabelOther => 'giờ';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'phút';
+  String? get timerPickerMinuteLabelOne => 'phút';
 
   @override
   String get timerPickerMinuteLabelOther => 'phút';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'giây';
+  String? get timerPickerSecondLabelOne => 'giây';
 
   @override
   String get timerPickerSecondLabelOther => 'giây';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Hôm nay';
@@ -13195,14 +13194,14 @@ class CupertinoLocalizationZh extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZh({
     String localeName = 'zh',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13234,40 +13233,40 @@ class CupertinoLocalizationZh extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour 点';
+  String? get datePickerHourSemanticsLabelOne => r'$hour 点';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour 点';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 分钟';
+  String? get datePickerMinuteSemanticsLabelOne => '1 分钟';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute 分钟';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => '关闭';
@@ -13288,58 +13287,58 @@ class CupertinoLocalizationZh extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'第 $tabIndex 个标签，共 $tabCount 个';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => '小时';
+  String? get timerPickerHourLabelOne => '小时';
 
   @override
   String get timerPickerHourLabelOther => '小时';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => '分钟';
+  String? get timerPickerMinuteLabelOne => '分钟';
 
   @override
   String get timerPickerMinuteLabelOther => '分钟';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => '秒';
+  String? get timerPickerSecondLabelOne => '秒';
 
   @override
   String get timerPickerSecondLabelOther => '秒';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => '今天';
@@ -13352,14 +13351,14 @@ class CupertinoLocalizationZhHans extends CupertinoLocalizationZh {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZhHans({
     String localeName = 'zh_Hans',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13380,14 +13379,14 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZhHant({
     String localeName = 'zh_Hant',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13413,13 +13412,13 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
   String get datePickerDateTimeOrderString => 'date_dayPeriod_time';
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour 點';
+  String? get datePickerHourSemanticsLabelOne => r'$hour 點';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour 點';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 分鐘';
+  String? get datePickerMinuteSemanticsLabelOne => '1 分鐘';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute 分鐘';
@@ -13437,13 +13436,13 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
   String get tabSemanticsLabelRaw => r'$tabCount 個分頁中嘅第 $tabIndex 個';
 
   @override
-  String get timerPickerHourLabelOne => '小時';
+  String? get timerPickerHourLabelOne => '小時';
 
   @override
   String get timerPickerHourLabelOther => '小時';
 
   @override
-  String get timerPickerMinuteLabelOne => '分鐘';
+  String? get timerPickerMinuteLabelOne => '分鐘';
 
   @override
   String get timerPickerMinuteLabelOther => '分鐘';
@@ -13456,14 +13455,14 @@ class CupertinoLocalizationZhHantHk extends CupertinoLocalizationZhHant {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZhHantHk({
     String localeName = 'zh_Hant_HK',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13484,14 +13483,14 @@ class CupertinoLocalizationZhHantTw extends CupertinoLocalizationZhHant {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZhHantTw({
     String localeName = 'zh_Hant_TW',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13508,7 +13507,7 @@ class CupertinoLocalizationZhHantTw extends CupertinoLocalizationZhHant {
   String get tabSemanticsLabelRaw => r'第 $tabIndex 個分頁標籤，共 $tabCount 個';
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 分';
+  String? get datePickerMinuteSemanticsLabelOne => '1 分';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute 分';
@@ -13520,7 +13519,7 @@ class CupertinoLocalizationZhHantTw extends CupertinoLocalizationZhHant {
   String get alertDialogLabel => '快訊';
 
   @override
-  String get timerPickerMinuteLabelOne => '分';
+  String? get timerPickerMinuteLabelOne => '分';
 
   @override
   String get timerPickerMinuteLabelOther => '分';
@@ -13536,14 +13535,14 @@ class CupertinoLocalizationZu extends GlobalCupertinoLocalizations {
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
   const CupertinoLocalizationZu({
     String localeName = 'zu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat dayFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat singleDigitHourFormat,
-    @required intl.DateFormat singleDigitMinuteFormat,
-    @required intl.DateFormat doubleDigitMinuteFormat,
-    @required intl.DateFormat singleDigitSecondFormat,
-    @required intl.NumberFormat decimalFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat dayFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat singleDigitHourFormat,
+    required intl.DateFormat singleDigitMinuteFormat,
+    required intl.DateFormat doubleDigitMinuteFormat,
+    required intl.DateFormat singleDigitSecondFormat,
+    required intl.NumberFormat decimalFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13575,40 +13574,40 @@ class CupertinoLocalizationZu extends GlobalCupertinoLocalizations {
   String get datePickerDateTimeOrderString => 'date_time_dayPeriod';
 
   @override
-  String get datePickerHourSemanticsLabelFew => null;
+  String? get datePickerHourSemanticsLabelFew => null;
 
   @override
-  String get datePickerHourSemanticsLabelMany => null;
+  String? get datePickerHourSemanticsLabelMany => null;
 
   @override
-  String get datePickerHourSemanticsLabelOne => r'$hour ezimpondweni';
+  String? get datePickerHourSemanticsLabelOne => r'$hour ezimpondweni';
 
   @override
   String get datePickerHourSemanticsLabelOther => r'$hour ezimpondweni';
 
   @override
-  String get datePickerHourSemanticsLabelTwo => null;
+  String? get datePickerHourSemanticsLabelTwo => null;
 
   @override
-  String get datePickerHourSemanticsLabelZero => null;
+  String? get datePickerHourSemanticsLabelZero => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelFew => null;
+  String? get datePickerMinuteSemanticsLabelFew => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelMany => null;
+  String? get datePickerMinuteSemanticsLabelMany => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelOne => '1 iminithi';
+  String? get datePickerMinuteSemanticsLabelOne => '1 iminithi';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute amaminithi';
 
   @override
-  String get datePickerMinuteSemanticsLabelTwo => null;
+  String? get datePickerMinuteSemanticsLabelTwo => null;
 
   @override
-  String get datePickerMinuteSemanticsLabelZero => null;
+  String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
   String get modalBarrierDismissLabel => 'Cashisa';
@@ -13629,58 +13628,58 @@ class CupertinoLocalizationZu extends GlobalCupertinoLocalizations {
   String get tabSemanticsLabelRaw => r'Ithebhu $tabIndex kwangu-$tabCount';
 
   @override
-  String get timerPickerHourLabelFew => null;
+  String? get timerPickerHourLabelFew => null;
 
   @override
-  String get timerPickerHourLabelMany => null;
+  String? get timerPickerHourLabelMany => null;
 
   @override
-  String get timerPickerHourLabelOne => 'ihora';
+  String? get timerPickerHourLabelOne => 'ihora';
 
   @override
   String get timerPickerHourLabelOther => 'amahora';
 
   @override
-  String get timerPickerHourLabelTwo => null;
+  String? get timerPickerHourLabelTwo => null;
 
   @override
-  String get timerPickerHourLabelZero => null;
+  String? get timerPickerHourLabelZero => null;
 
   @override
-  String get timerPickerMinuteLabelFew => null;
+  String? get timerPickerMinuteLabelFew => null;
 
   @override
-  String get timerPickerMinuteLabelMany => null;
+  String? get timerPickerMinuteLabelMany => null;
 
   @override
-  String get timerPickerMinuteLabelOne => 'iminithi.';
+  String? get timerPickerMinuteLabelOne => 'iminithi.';
 
   @override
   String get timerPickerMinuteLabelOther => 'iminithi.';
 
   @override
-  String get timerPickerMinuteLabelTwo => null;
+  String? get timerPickerMinuteLabelTwo => null;
 
   @override
-  String get timerPickerMinuteLabelZero => null;
+  String? get timerPickerMinuteLabelZero => null;
 
   @override
-  String get timerPickerSecondLabelFew => null;
+  String? get timerPickerSecondLabelFew => null;
 
   @override
-  String get timerPickerSecondLabelMany => null;
+  String? get timerPickerSecondLabelMany => null;
 
   @override
-  String get timerPickerSecondLabelOne => 'isekhondi.';
+  String? get timerPickerSecondLabelOne => 'isekhondi.';
 
   @override
   String get timerPickerSecondLabelOther => 'isekhondi.';
 
   @override
-  String get timerPickerSecondLabelTwo => null;
+  String? get timerPickerSecondLabelTwo => null;
 
   @override
-  String get timerPickerSecondLabelZero => null;
+  String? get timerPickerSecondLabelZero => null;
 
   @override
   String get todayLabel => 'Namuhla';
@@ -13868,7 +13867,7 @@ final Set<String> kCupertinoSupportedLanguages = HashSet<String>.from(const <Str
 ///
 /// Generally speaking, this method is only intended to be used by
 /// [GlobalCupertinoLocalizations.delegate].
-GlobalCupertinoLocalizations getCupertinoTranslation(
+GlobalCupertinoLocalizations? getCupertinoTranslation(
   Locale locale,
   intl.DateFormat fullYearFormat,
   intl.DateFormat dayFormat,

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -8,7 +8,6 @@
 
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
 
@@ -28,15 +27,15 @@ class MaterialLocalizationAf extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationAf({
     String localeName = 'af',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -150,22 +149,22 @@ class MaterialLocalizationAf extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => "Voer 'n geldige tyd in";
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisensie';
+  String? get licensesPackageDetailTextOne => '1 lisensie';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisensies';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lisensies';
@@ -213,22 +212,22 @@ class MaterialLocalizationAf extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Herlaai';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 karakter oor';
+  String? get remainingTextFieldCharacterCountOne => '1 karakter oor';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount karakters oor';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Skuif af';
@@ -267,22 +266,22 @@ class MaterialLocalizationAf extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Kies jaar';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item is gekies';
+  String? get selectedRowCountTitleOne => '1 item is gekies';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount items is gekies';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Wys rekeninge';
@@ -334,15 +333,15 @@ class MaterialLocalizationAm extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationAm({
     String localeName = 'am',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -456,22 +455,22 @@ class MaterialLocalizationAm extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'የሚሠራ ሰዓት ያስገቡ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 ፈቃድ';
+  String? get licensesPackageDetailTextOne => '1 ፈቃድ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ፈቃዶች';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ፈቃዶች';
@@ -519,22 +518,22 @@ class MaterialLocalizationAm extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'አድስ';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 ቁምፊ ይቀራል';
+  String? get remainingTextFieldCharacterCountOne => '1 ቁምፊ ይቀራል';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount ቁምፊዎች ይቀራሉ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'ወደ ታች ውሰድ';
@@ -573,22 +572,22 @@ class MaterialLocalizationAm extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ዓመት ይምረጡ';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 ንጥል ተመርጧል';
+  String? get selectedRowCountTitleOne => '1 ንጥል ተመርጧል';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount ንጥሎች ተመርጠዋል';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'መለያዎችን አሳይ';
@@ -640,15 +639,15 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationAr({
     String localeName = 'ar',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -762,22 +761,22 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'يُرجى إدخال وقت صالح.';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount تراخيص';
+  String? get licensesPackageDetailTextFew => r'$licenseCount تراخيص';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount ترخيصًا';
+  String? get licensesPackageDetailTextMany => r'$licenseCount ترخيصًا';
 
   @override
-  String get licensesPackageDetailTextOne => 'ترخيص واحد';
+  String? get licensesPackageDetailTextOne => 'ترخيص واحد';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ترخيص';
 
   @override
-  String get licensesPackageDetailTextTwo => r'ترخيصان ($licenseCount)';
+  String? get licensesPackageDetailTextTwo => r'ترخيصان ($licenseCount)';
 
   @override
-  String get licensesPackageDetailTextZero => 'ما مِن تراخيص';
+  String? get licensesPackageDetailTextZero => 'ما مِن تراخيص';
 
   @override
   String get licensesPageTitle => 'التراخيص';
@@ -825,22 +824,22 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'إعادة تحميل';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'$remainingCount أحرف متبقية';
+  String? get remainingTextFieldCharacterCountFew => r'$remainingCount أحرف متبقية';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'$remainingCount حرفًا متبقيًا';
+  String? get remainingTextFieldCharacterCountMany => r'$remainingCount حرفًا متبقيًا';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'حرف واحد متبقٍ';
+  String? get remainingTextFieldCharacterCountOne => 'حرف واحد متبقٍ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount حرف متبقٍ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => r'حرفان ($remainingCount) متبقيان';
+  String? get remainingTextFieldCharacterCountTwo => r'حرفان ($remainingCount) متبقيان';
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'لا أحرف متبقية';
+  String? get remainingTextFieldCharacterCountZero => 'لا أحرف متبقية';
 
   @override
   String get reorderItemDown => 'نقل لأسفل';
@@ -879,22 +878,22 @@ class MaterialLocalizationAr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'اختيار العام';
 
   @override
-  String get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
+  String? get selectedRowCountTitleFew => r'تم اختيار $selectedRowCount عنصر';
 
   @override
-  String get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
+  String? get selectedRowCountTitleMany => r'تم اختيار $selectedRowCount عنصرًا';
 
   @override
-  String get selectedRowCountTitleOne => 'تم اختيار عنصر واحد';
+  String? get selectedRowCountTitleOne => 'تم اختيار عنصر واحد';
 
   @override
   String get selectedRowCountTitleOther => r'تم اختيار $selectedRowCount عنصر';
 
   @override
-  String get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
+  String? get selectedRowCountTitleTwo => r'تم اختيار عنصرين ($selectedRowCount)';
 
   @override
-  String get selectedRowCountTitleZero => 'لم يتم اختيار أي عنصر';
+  String? get selectedRowCountTitleZero => 'لم يتم اختيار أي عنصر';
 
   @override
   String get showAccountsLabel => 'إظهار الحسابات';
@@ -946,15 +945,15 @@ class MaterialLocalizationAs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationAs({
     String localeName = 'as',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1068,22 +1067,22 @@ class MaterialLocalizationAs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'এটা মান্য সময় দিয়ক';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '১ খন অনুজ্ঞাপত্ৰ';
+  String? get licensesPackageDetailTextOne => '১ খন অনুজ্ঞাপত্ৰ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount খন অনুজ্ঞাপত্ৰ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'অনুজ্ঞাপত্ৰসমূহ';
@@ -1131,22 +1130,22 @@ class MaterialLocalizationAs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ৰিফ্ৰেশ্ব কৰক';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '১টা বর্ণ বাকী আছে';
+  String? get remainingTextFieldCharacterCountOne => '১টা বর্ণ বাকী আছে';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCountটা বর্ণ বাকী আছে';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'তললৈ স্থানান্তৰ কৰক';
@@ -1185,22 +1184,22 @@ class MaterialLocalizationAs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'বছৰ বাছনি কৰক';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => "১টা বস্তু বাছনি কৰা হ'ল";
+  String? get selectedRowCountTitleOne => "১টা বস্তু বাছনি কৰা হ'ল";
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCountটা বস্তু বাছনি কৰা হ’ল';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'একাউণ্টসমূহ দেখুৱাওক';
@@ -1252,15 +1251,15 @@ class MaterialLocalizationAz extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationAz({
     String localeName = 'az',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1374,22 +1373,22 @@ class MaterialLocalizationAz extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Düzgün vaxt daxil edin';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisenziya';
+  String? get licensesPackageDetailTextOne => '1 lisenziya';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisenziya';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lisenziyalar';
@@ -1437,22 +1436,22 @@ class MaterialLocalizationAz extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Yeniləyin';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 simvol qalır';
+  String? get remainingTextFieldCharacterCountOne => '1 simvol qalır';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount simvol qalır';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Aşağı köçürün';
@@ -1491,22 +1490,22 @@ class MaterialLocalizationAz extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'İl seçin';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 element seçildi';
+  String? get selectedRowCountTitleOne => '1 element seçildi';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount element seçildi';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Hesabları göstərin';
@@ -1558,15 +1557,15 @@ class MaterialLocalizationBe extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationBe({
     String localeName = 'be',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1680,22 +1679,22 @@ class MaterialLocalizationBe extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Увядзіце дапушчальны час';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount ліцэнзіі';
+  String? get licensesPackageDetailTextFew => r'$licenseCount ліцэнзіі';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount ліцэнзій';
+  String? get licensesPackageDetailTextMany => r'$licenseCount ліцэнзій';
 
   @override
-  String get licensesPackageDetailTextOne => '1 ліцэнзія';
+  String? get licensesPackageDetailTextOne => '1 ліцэнзія';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ліцэнзіі';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Ліцэнзіі';
@@ -1743,22 +1742,22 @@ class MaterialLocalizationBe extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Абнавіць';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Засталося $remainingCount сімвалы';
+  String? get remainingTextFieldCharacterCountFew => r'Засталося $remainingCount сімвалы';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Засталося $remainingCount сімвалаў';
+  String? get remainingTextFieldCharacterCountMany => r'Засталося $remainingCount сімвалаў';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Застаўся 1 сімвал';
+  String? get remainingTextFieldCharacterCountOne => 'Застаўся 1 сімвал';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Засталося $remainingCount сімвала';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Перамясціць уніз';
@@ -1797,22 +1796,22 @@ class MaterialLocalizationBe extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Выберыце год';
 
   @override
-  String get selectedRowCountTitleFew => r'Выбрана $selectedRowCount элементы';
+  String? get selectedRowCountTitleFew => r'Выбрана $selectedRowCount элементы';
 
   @override
-  String get selectedRowCountTitleMany => r'Выбрана $selectedRowCount элементаў';
+  String? get selectedRowCountTitleMany => r'Выбрана $selectedRowCount элементаў';
 
   @override
-  String get selectedRowCountTitleOne => 'Выбраны 1 элемент';
+  String? get selectedRowCountTitleOne => 'Выбраны 1 элемент';
 
   @override
   String get selectedRowCountTitleOther => r'Выбрана $selectedRowCount элемента';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Паказаць уліковыя запісы';
@@ -1864,15 +1863,15 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationBg({
     String localeName = 'bg',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -1986,22 +1985,22 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Въведете валиден час';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 лиценз';
+  String? get licensesPackageDetailTextOne => '1 лиценз';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лиценза';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лицензи';
@@ -2049,22 +2048,22 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Опресняване';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Остава 1 знак';
+  String? get remainingTextFieldCharacterCountOne => 'Остава 1 знак';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Остават $remainingCount знака';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Преместване надолу';
@@ -2103,22 +2102,22 @@ class MaterialLocalizationBg extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Избиране на година';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Избран е 1 елемент';
+  String? get selectedRowCountTitleOne => 'Избран е 1 елемент';
 
   @override
   String get selectedRowCountTitleOther => r'Избрани са $selectedRowCount елемента';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Показване на профилите';
@@ -2170,15 +2169,15 @@ class MaterialLocalizationBn extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationBn({
     String localeName = 'bn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2292,22 +2291,22 @@ class MaterialLocalizationBn extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'সঠিক সময় লিখুন';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '১টি লাইসেন্স';
+  String? get licensesPackageDetailTextOne => '১টি লাইসেন্স';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCountটি লাইসেন্স';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'লাইসেন্স';
@@ -2355,22 +2354,22 @@ class MaterialLocalizationBn extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'রিফ্রেশ করুন';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'আর ১টি অক্ষর লেখা যাবে';
+  String? get remainingTextFieldCharacterCountOne => 'আর ১টি অক্ষর লেখা যাবে';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'আর $remainingCountটি অক্ষর লেখা যাবে';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'নিচের দিকে সরান';
@@ -2409,22 +2408,22 @@ class MaterialLocalizationBn extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'বছর বেছে নিন';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '১টি আইটেম বেছে নেওয়া হয়েছে';
+  String? get selectedRowCountTitleOne => '১টি আইটেম বেছে নেওয়া হয়েছে';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCountটি আইটেম বেছে নেওয়া হয়েছে';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'অ্যাকাউন্টগুলি দেখান';
@@ -2476,15 +2475,15 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationBs({
     String localeName = 'bs',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2598,22 +2597,22 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Unesite ispravno vrijeme';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licence';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenca';
+  String? get licensesPackageDetailTextOne => '1 licenca';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenci';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licence';
@@ -2661,22 +2660,22 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Osvježi';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Još $remainingCount znaka';
+  String? get remainingTextFieldCharacterCountFew => r'Još $remainingCount znaka';
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Još jedan znak';
+  String? get remainingTextFieldCharacterCountOne => 'Još jedan znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Još $remainingCount znakova';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Pomjeri nadolje';
@@ -2715,22 +2714,22 @@ class MaterialLocalizationBs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Odaberite godinu';
 
   @override
-  String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
+  String? get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Odabrana je jedna stavka';
+  String? get selectedRowCountTitleOne => 'Odabrana je jedna stavka';
 
   @override
   String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Prikaži račune';
@@ -2782,15 +2781,15 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationCa({
     String localeName = 'ca',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -2904,22 +2903,22 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Introdueix una hora vàlida';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 llicència';
+  String? get licensesPackageDetailTextOne => '1 llicència';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount llicències';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Llicències';
@@ -2967,22 +2966,22 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Actualitza';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Queda 1 caràcter';
+  String? get remainingTextFieldCharacterCountOne => 'Queda 1 caràcter';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Queden $remainingCount caràcters';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Mou avall';
@@ -3021,22 +3020,22 @@ class MaterialLocalizationCa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Selecciona un any';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => "S'ha seleccionat 1 element";
+  String? get selectedRowCountTitleOne => "S'ha seleccionat 1 element";
 
   @override
   String get selectedRowCountTitleOther => r"S'han seleccionat $selectedRowCount elements";
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Mostra els comptes';
@@ -3088,15 +3087,15 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationCs({
     String localeName = 'cs',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3210,22 +3209,22 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Zadejte platný čas';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licence';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount licence';
+  String? get licensesPackageDetailTextMany => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licencí';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licence';
@@ -3273,22 +3272,22 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Obnovit';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Zbývají $remainingCount znaky';
+  String? get remainingTextFieldCharacterCountFew => r'Zbývají $remainingCount znaky';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Zbývá $remainingCount znaku';
+  String? get remainingTextFieldCharacterCountMany => r'Zbývá $remainingCount znaku';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Zbývá 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Zbývá 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Zbývá $remainingCount znaků';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Přesunout dolů';
@@ -3327,22 +3326,22 @@ class MaterialLocalizationCs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Vyberte rok';
 
   @override
-  String get selectedRowCountTitleFew => r'Jsou vybrány $selectedRowCount položky';
+  String? get selectedRowCountTitleFew => r'Jsou vybrány $selectedRowCount položky';
 
   @override
-  String get selectedRowCountTitleMany => r'Je vybráno $selectedRowCount položky';
+  String? get selectedRowCountTitleMany => r'Je vybráno $selectedRowCount položky';
 
   @override
-  String get selectedRowCountTitleOne => 'Je vybrána 1 položka';
+  String? get selectedRowCountTitleOne => 'Je vybrána 1 položka';
 
   @override
   String get selectedRowCountTitleOther => r'Je vybráno $selectedRowCount položek';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Zobrazit účty';
@@ -3394,15 +3393,15 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationDa({
     String localeName = 'da',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3516,22 +3515,22 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Angiv et gyldigt tidspunkt';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licens';
+  String? get licensesPackageDetailTextOne => '1 licens';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenser';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenser';
@@ -3579,22 +3578,22 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Opdater';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Ét tegn tilbage';
+  String? get remainingTextFieldCharacterCountOne => 'Ét tegn tilbage';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount tegn tilbage';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Flyt ned';
@@ -3633,22 +3632,22 @@ class MaterialLocalizationDa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Vælg år';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 element er valgt';
+  String? get selectedRowCountTitleOne => '1 element er valgt';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Vis konti';
@@ -3700,15 +3699,15 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationDe({
     String localeName = 'de',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -3822,22 +3821,22 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Gib eine gültige Uhrzeit ein';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 Lizenz';
+  String? get licensesPackageDetailTextOne => '1 Lizenz';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount Lizenzen';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lizenzen';
@@ -3885,22 +3884,22 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Aktualisieren';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Noch 1 Zeichen';
+  String? get remainingTextFieldCharacterCountOne => 'Noch 1 Zeichen';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Noch $remainingCount Zeichen';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Nach unten verschieben';
@@ -3939,22 +3938,22 @@ class MaterialLocalizationDe extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Jahr auswählen';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 Element ausgewählt';
+  String? get selectedRowCountTitleOne => '1 Element ausgewählt';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Keine Objekte ausgewählt';
+  String? get selectedRowCountTitleZero => 'Keine Objekte ausgewählt';
 
   @override
   String get showAccountsLabel => 'Konten anzeigen';
@@ -4006,15 +4005,15 @@ class MaterialLocalizationDeCh extends MaterialLocalizationDe {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationDeCh({
     String localeName = 'de_CH',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4045,15 +4044,15 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEl({
     String localeName = 'el',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4167,22 +4166,22 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Εισαγάγετε μια έγκυρη ώρα';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 άδεια';
+  String? get licensesPackageDetailTextOne => '1 άδεια';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount άδειες';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Άδειες';
@@ -4230,22 +4229,22 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Ανανέωση';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'απομένει 1 χαρακτήρας';
+  String? get remainingTextFieldCharacterCountOne => 'απομένει 1 χαρακτήρας';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'απομένουν $remainingCount χαρακτήρες';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Μετακίνηση προς τα κάτω';
@@ -4284,22 +4283,22 @@ class MaterialLocalizationEl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Επιλογή έτους';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Επιλέχθηκε 1 στοιχείο';
+  String? get selectedRowCountTitleOne => 'Επιλέχθηκε 1 στοιχείο';
 
   @override
   String get selectedRowCountTitleOther => r'Επιλέχθηκαν $selectedRowCount στοιχεία';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Εμφάνιση λογαριασμών';
@@ -4351,15 +4350,15 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEn({
     String localeName = 'en',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4473,22 +4472,22 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Enter a valid time';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 license';
+  String? get licensesPackageDetailTextOne => '1 license';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenses';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenses';
@@ -4536,22 +4535,22 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Refresh';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 character remaining';
+  String? get remainingTextFieldCharacterCountOne => '1 character remaining';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount characters remaining';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'No characters remaining';
+  String? get remainingTextFieldCharacterCountZero => 'No characters remaining';
 
   @override
   String get reorderItemDown => 'Move down';
@@ -4590,22 +4589,22 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Select year';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item selected';
+  String? get selectedRowCountTitleOne => '1 item selected';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'No items selected';
+  String? get selectedRowCountTitleZero => 'No items selected';
 
   @override
   String get showAccountsLabel => 'Show accounts';
@@ -4657,15 +4656,15 @@ class MaterialLocalizationEnAu extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnAu({
     String localeName = 'en_AU',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4695,10 +4694,10 @@ class MaterialLocalizationEnAu extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -4726,15 +4725,15 @@ class MaterialLocalizationEnCa extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnCa({
     String localeName = 'en_CA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4764,10 +4763,10 @@ class MaterialLocalizationEnCa extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -4795,15 +4794,15 @@ class MaterialLocalizationEnGb extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnGb({
     String localeName = 'en_GB',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4839,10 +4838,10 @@ class MaterialLocalizationEnGb extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -4867,15 +4866,15 @@ class MaterialLocalizationEnIe extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnIe({
     String localeName = 'en_IE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4911,10 +4910,10 @@ class MaterialLocalizationEnIe extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -4939,15 +4938,15 @@ class MaterialLocalizationEnIn extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnIn({
     String localeName = 'en_IN',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -4977,10 +4976,10 @@ class MaterialLocalizationEnIn extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -5008,15 +5007,15 @@ class MaterialLocalizationEnNz extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnNz({
     String localeName = 'en_NZ',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5046,10 +5045,10 @@ class MaterialLocalizationEnNz extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -5077,15 +5076,15 @@ class MaterialLocalizationEnSg extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnSg({
     String localeName = 'en_SG',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5115,10 +5114,10 @@ class MaterialLocalizationEnSg extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -5146,15 +5145,15 @@ class MaterialLocalizationEnZa extends MaterialLocalizationEn {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEnZa({
     String localeName = 'en_ZA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5190,10 +5189,10 @@ class MaterialLocalizationEnZa extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licences';
+  String? get licensesPackageDetailTextZero => 'No licences';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
@@ -5218,15 +5217,15 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEs({
     String localeName = 'es',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5340,22 +5339,22 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Indica una hora válida';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licencias';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencias';
@@ -5403,22 +5402,22 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Actualizar';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Queda 1 carácter.';
+  String? get remainingTextFieldCharacterCountOne => 'Queda 1 carácter.';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Quedan $remainingCount caracteres';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Mover hacia abajo';
@@ -5457,22 +5456,22 @@ class MaterialLocalizationEs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Seleccionar año';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 elemento seleccionado';
+  String? get selectedRowCountTitleOne => '1 elemento seleccionado';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementos seleccionados';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'No se han seleccionado elementos';
+  String? get selectedRowCountTitleZero => 'No se han seleccionado elementos';
 
   @override
   String get showAccountsLabel => 'Mostrar cuentas';
@@ -5524,15 +5523,15 @@ class MaterialLocalizationEs419 extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEs419({
     String localeName = 'es_419',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5547,7 +5546,7 @@ class MaterialLocalizationEs419 extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -5622,7 +5621,7 @@ class MaterialLocalizationEs419 extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -5653,15 +5652,15 @@ class MaterialLocalizationEsAr extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsAr({
     String localeName = 'es_AR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5676,7 +5675,7 @@ class MaterialLocalizationEsAr extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -5751,7 +5750,7 @@ class MaterialLocalizationEsAr extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -5782,15 +5781,15 @@ class MaterialLocalizationEsBo extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsBo({
     String localeName = 'es_BO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5805,7 +5804,7 @@ class MaterialLocalizationEsBo extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -5883,7 +5882,7 @@ class MaterialLocalizationEsBo extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -5911,15 +5910,15 @@ class MaterialLocalizationEsCl extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsCl({
     String localeName = 'es_CL',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -5934,7 +5933,7 @@ class MaterialLocalizationEsCl extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6012,7 +6011,7 @@ class MaterialLocalizationEsCl extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6040,15 +6039,15 @@ class MaterialLocalizationEsCo extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsCo({
     String localeName = 'es_CO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6063,7 +6062,7 @@ class MaterialLocalizationEsCo extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6141,7 +6140,7 @@ class MaterialLocalizationEsCo extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6169,15 +6168,15 @@ class MaterialLocalizationEsCr extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsCr({
     String localeName = 'es_CR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6192,7 +6191,7 @@ class MaterialLocalizationEsCr extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6270,7 +6269,7 @@ class MaterialLocalizationEsCr extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6298,15 +6297,15 @@ class MaterialLocalizationEsDo extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsDo({
     String localeName = 'es_DO',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6321,7 +6320,7 @@ class MaterialLocalizationEsDo extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6399,7 +6398,7 @@ class MaterialLocalizationEsDo extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6427,15 +6426,15 @@ class MaterialLocalizationEsEc extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsEc({
     String localeName = 'es_EC',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6450,7 +6449,7 @@ class MaterialLocalizationEsEc extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6528,7 +6527,7 @@ class MaterialLocalizationEsEc extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6556,15 +6555,15 @@ class MaterialLocalizationEsGt extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsGt({
     String localeName = 'es_GT',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6579,7 +6578,7 @@ class MaterialLocalizationEsGt extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6657,7 +6656,7 @@ class MaterialLocalizationEsGt extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6685,15 +6684,15 @@ class MaterialLocalizationEsHn extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsHn({
     String localeName = 'es_HN',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6708,7 +6707,7 @@ class MaterialLocalizationEsHn extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6786,7 +6785,7 @@ class MaterialLocalizationEsHn extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6814,15 +6813,15 @@ class MaterialLocalizationEsMx extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsMx({
     String localeName = 'es_MX',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6837,7 +6836,7 @@ class MaterialLocalizationEsMx extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -6915,7 +6914,7 @@ class MaterialLocalizationEsMx extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -6943,15 +6942,15 @@ class MaterialLocalizationEsNi extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsNi({
     String localeName = 'es_NI',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -6966,7 +6965,7 @@ class MaterialLocalizationEsNi extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7044,7 +7043,7 @@ class MaterialLocalizationEsNi extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7072,15 +7071,15 @@ class MaterialLocalizationEsPa extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsPa({
     String localeName = 'es_PA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7095,7 +7094,7 @@ class MaterialLocalizationEsPa extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7173,7 +7172,7 @@ class MaterialLocalizationEsPa extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7201,15 +7200,15 @@ class MaterialLocalizationEsPe extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsPe({
     String localeName = 'es_PE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7224,7 +7223,7 @@ class MaterialLocalizationEsPe extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7302,7 +7301,7 @@ class MaterialLocalizationEsPe extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7330,15 +7329,15 @@ class MaterialLocalizationEsPr extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsPr({
     String localeName = 'es_PR',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7353,7 +7352,7 @@ class MaterialLocalizationEsPr extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7431,7 +7430,7 @@ class MaterialLocalizationEsPr extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7459,15 +7458,15 @@ class MaterialLocalizationEsPy extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsPy({
     String localeName = 'es_PY',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7482,7 +7481,7 @@ class MaterialLocalizationEsPy extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7560,7 +7559,7 @@ class MaterialLocalizationEsPy extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7588,15 +7587,15 @@ class MaterialLocalizationEsSv extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsSv({
     String localeName = 'es_SV',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7611,7 +7610,7 @@ class MaterialLocalizationEsSv extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7689,7 +7688,7 @@ class MaterialLocalizationEsSv extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7717,15 +7716,15 @@ class MaterialLocalizationEsUs extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsUs({
     String localeName = 'es_US',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7740,7 +7739,7 @@ class MaterialLocalizationEsUs extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7818,7 +7817,7 @@ class MaterialLocalizationEsUs extends MaterialLocalizationEs {
   String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow de $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7849,15 +7848,15 @@ class MaterialLocalizationEsUy extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsUy({
     String localeName = 'es_UY',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -7872,7 +7871,7 @@ class MaterialLocalizationEsUy extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -7950,7 +7949,7 @@ class MaterialLocalizationEsUy extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -7978,15 +7977,15 @@ class MaterialLocalizationEsVe extends MaterialLocalizationEs {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEsVe({
     String localeName = 'es_VE',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8001,7 +8000,7 @@ class MaterialLocalizationEsVe extends MaterialLocalizationEs {
   );
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get timePickerInputHelpText => 'INGRESAR HORA';
@@ -8079,7 +8078,7 @@ class MaterialLocalizationEsVe extends MaterialLocalizationEs {
   String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow de aproximadamente $rowCount';
 
   @override
-  String get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
+  String? get selectedRowCountTitleOne => 'Se seleccionó 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Se seleccionaron $selectedRowCount elementos';
@@ -8107,15 +8106,15 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEt({
     String localeName = 'et',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8229,22 +8228,22 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Sisestage sobiv kellaaeg';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 litsents';
+  String? get licensesPackageDetailTextOne => '1 litsents';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount litsentsi';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Litsentsid';
@@ -8292,22 +8291,22 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Värskendamine';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Jäänud on 1 tähemärk';
+  String? get remainingTextFieldCharacterCountOne => 'Jäänud on 1 tähemärk';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Jäänud on $remainingCount tähemärki';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Teisalda alla';
@@ -8346,22 +8345,22 @@ class MaterialLocalizationEt extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Valige aasta';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Valitud on 1 üksus';
+  String? get selectedRowCountTitleOne => 'Valitud on 1 üksus';
 
   @override
   String get selectedRowCountTitleOther => r'Valitud on $selectedRowCount üksust';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Kuva kontod';
@@ -8413,15 +8412,15 @@ class MaterialLocalizationEu extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationEu({
     String localeName = 'eu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8535,22 +8534,22 @@ class MaterialLocalizationEu extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Idatzi balio duen ordu bat';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lizentzia';
+  String? get licensesPackageDetailTextOne => '1 lizentzia';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lizentzia';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lizentziak';
@@ -8598,22 +8597,22 @@ class MaterialLocalizationEu extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Freskatu';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 karaktere geratzen da';
+  String? get remainingTextFieldCharacterCountOne => '1 karaktere geratzen da';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount karaktere geratzen dira';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Eraman behera';
@@ -8652,22 +8651,22 @@ class MaterialLocalizationEu extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Hautatu urtea';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 elementu hautatu da';
+  String? get selectedRowCountTitleOne => '1 elementu hautatu da';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementu hautatu dira';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Erakutsi kontuak';
@@ -8719,15 +8718,15 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationFa({
     String localeName = 'fa',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -8841,22 +8840,22 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'زمان معتبری وارد کنید';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '۱ پروانه';
+  String? get licensesPackageDetailTextOne => '۱ پروانه';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount پروانه';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'مجوزها';
@@ -8904,22 +8903,22 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'بازخوانی';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '۱ نویسه باقی مانده است';
+  String? get remainingTextFieldCharacterCountOne => '۱ نویسه باقی مانده است';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount نویسه باقی مانده است';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'انتقال به پایین';
@@ -8958,22 +8957,22 @@ class MaterialLocalizationFa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'انتخاب سال';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '۱ مورد انتخاب شد';
+  String? get selectedRowCountTitleOne => '۱ مورد انتخاب شد';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount مورد انتخاب شدند';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'نشان دادن حساب‌ها';
@@ -9025,15 +9024,15 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationFi({
     String localeName = 'fi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9147,22 +9146,22 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Lisää kelvollinen aika';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisenssi';
+  String? get licensesPackageDetailTextOne => '1 lisenssi';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisenssiä';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lisenssit';
@@ -9210,22 +9209,22 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Päivitys';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 merkki jäljellä';
+  String? get remainingTextFieldCharacterCountOne => '1 merkki jäljellä';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount merkkiä jäljellä';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Siirrä alas';
@@ -9264,22 +9263,22 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Valitse vuosi';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 kohde valittu';
+  String? get selectedRowCountTitleOne => '1 kohde valittu';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount kohdetta valittu';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Näytä tilit';
@@ -9331,15 +9330,15 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationFil({
     String localeName = 'fil',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9453,22 +9452,22 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Maglagay ng valid na oras';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisensya';
+  String? get licensesPackageDetailTextOne => '1 lisensya';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount na lisensya';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Mga Lisensya';
@@ -9516,22 +9515,22 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Nagre-refresh';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 character ang natitira';
+  String? get remainingTextFieldCharacterCountOne => '1 character ang natitira';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount na character ang natitira';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Ilipat pababa';
@@ -9570,22 +9569,22 @@ class MaterialLocalizationFil extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Pumili ng taon';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item ang napili';
+  String? get selectedRowCountTitleOne => '1 item ang napili';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Ipakita ang mga account';
@@ -9637,15 +9636,15 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationFr({
     String localeName = 'fr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -9759,22 +9758,22 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Veuillez indiquer une heure valide';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licences';
@@ -9822,22 +9821,22 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Actualiser';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 caractère restant';
+  String? get remainingTextFieldCharacterCountOne => '1 caractère restant';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount caractères restants';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Déplacer vers le bas';
@@ -9876,22 +9875,22 @@ class MaterialLocalizationFr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Sélectionner une année';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 élément sélectionné';
+  String? get selectedRowCountTitleOne => '1 élément sélectionné';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount éléments sélectionnés';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Aucun élément sélectionné';
+  String? get selectedRowCountTitleZero => 'Aucun élément sélectionné';
 
   @override
   String get showAccountsLabel => 'Afficher les comptes';
@@ -9943,15 +9942,15 @@ class MaterialLocalizationFrCa extends MaterialLocalizationFr {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationFrCa({
     String localeName = 'fr_CA',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10045,15 +10044,15 @@ class MaterialLocalizationGl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationGl({
     String localeName = 'gl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10167,22 +10166,22 @@ class MaterialLocalizationGl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Escribe unha hora válida';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenza';
+  String? get licensesPackageDetailTextOne => '1 licenza';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenzas';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenzas';
@@ -10230,22 +10229,22 @@ class MaterialLocalizationGl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Actualizar';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 carácter restante';
+  String? get remainingTextFieldCharacterCountOne => '1 carácter restante';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount caracteres restantes';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Mover cara abaixo';
@@ -10284,22 +10283,22 @@ class MaterialLocalizationGl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Seleccionar ano';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Seleccionouse 1 elemento';
+  String? get selectedRowCountTitleOne => 'Seleccionouse 1 elemento';
 
   @override
   String get selectedRowCountTitleOther => r'Seleccionáronse $selectedRowCount elementos';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Non se seleccionaron elementos';
+  String? get selectedRowCountTitleZero => 'Non se seleccionaron elementos';
 
   @override
   String get showAccountsLabel => 'Mostrar contas';
@@ -10351,15 +10350,15 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationGsw({
     String localeName = 'gsw',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10473,22 +10472,22 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Gib eine gültige Uhrzeit ein';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 Lizenz';
+  String? get licensesPackageDetailTextOne => '1 Lizenz';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount Lizenzen';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lizenzen';
@@ -10536,22 +10535,22 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Aktualisieren';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Noch 1 Zeichen';
+  String? get remainingTextFieldCharacterCountOne => 'Noch 1 Zeichen';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Noch $remainingCount Zeichen';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Nach unten verschieben';
@@ -10590,22 +10589,22 @@ class MaterialLocalizationGsw extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Jahr auswählen';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 Element ausgewählt';
+  String? get selectedRowCountTitleOne => '1 Element ausgewählt';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount Elemente ausgewählt';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Konten anzeigen';
@@ -10657,15 +10656,15 @@ class MaterialLocalizationGu extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationGu({
     String localeName = 'gu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -10779,22 +10778,22 @@ class MaterialLocalizationGu extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'માન્ય સમય દાખલ કરો';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 લાઇસન્સ';
+  String? get licensesPackageDetailTextOne => '1 લાઇસન્સ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount લાઇસન્સ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'લાઇસન્સ';
@@ -10842,22 +10841,22 @@ class MaterialLocalizationGu extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'રિફ્રેશ કરો';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 અક્ષર બાકી';
+  String? get remainingTextFieldCharacterCountOne => '1 અક્ષર બાકી';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount અક્ષર બાકી';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'નીચે ખસેડો';
@@ -10896,22 +10895,22 @@ class MaterialLocalizationGu extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'વર્ષ પસંદ કરો';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 આઇટમ પસંદ કરી';
+  String? get selectedRowCountTitleOne => '1 આઇટમ પસંદ કરી';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount આઇટમ પસંદ કરી';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'એકાઉન્ટ બતાવો';
@@ -10963,15 +10962,15 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationHe({
     String localeName = 'he',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11085,22 +11084,22 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'יש להזין שעה תקינה';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount רישיונות';
+  String? get licensesPackageDetailTextMany => r'$licenseCount רישיונות';
 
   @override
-  String get licensesPackageDetailTextOne => 'רישיון אחד';
+  String? get licensesPackageDetailTextOne => 'רישיון אחד';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount רישיונות';
 
   @override
-  String get licensesPackageDetailTextTwo => r'$licenseCount רישיונות';
+  String? get licensesPackageDetailTextTwo => r'$licenseCount רישיונות';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'רישיונות';
@@ -11148,22 +11147,22 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'רענון';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'נותרו $remainingCount תווים';
+  String? get remainingTextFieldCharacterCountMany => r'נותרו $remainingCount תווים';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'נותר תו אחד';
+  String? get remainingTextFieldCharacterCountOne => 'נותר תו אחד';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'נותרו $remainingCount תווים';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => r'נותרו $remainingCount תווים';
+  String? get remainingTextFieldCharacterCountTwo => r'נותרו $remainingCount תווים';
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'העברה למטה';
@@ -11202,22 +11201,22 @@ class MaterialLocalizationHe extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'בחירת שנה';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
+  String? get selectedRowCountTitleMany => r'$selectedRowCount פריטים נבחרו';
 
   @override
-  String get selectedRowCountTitleOne => 'פריט אחד נבחר';
+  String? get selectedRowCountTitleOne => 'פריט אחד נבחר';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount פריטים נבחרו';
 
   @override
-  String get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
+  String? get selectedRowCountTitleTwo => r'$selectedRowCount פריטים נבחרו';
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'הצגת החשבונות';
@@ -11269,15 +11268,15 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationHi({
     String localeName = 'hi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11391,22 +11390,22 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'मान्य समय डालें';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 लाइसेंस';
+  String? get licensesPackageDetailTextOne => '1 लाइसेंस';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount लाइसेंस';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'लाइसेंस';
@@ -11454,22 +11453,22 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'रीफ़्रेश करें';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'एक वर्ण आैर डाला जा सकता है';
+  String? get remainingTextFieldCharacterCountOne => 'एक वर्ण आैर डाला जा सकता है';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount वर्ण आैर डाले जा सकते हैं';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'नीचे ले जाएं';
@@ -11508,22 +11507,22 @@ class MaterialLocalizationHi extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'साल चुनें';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 चीज़ चुनी गई';
+  String? get selectedRowCountTitleOne => '1 चीज़ चुनी गई';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount चीज़ें चुनी गईं';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'खाते दिखाएं';
@@ -11575,15 +11574,15 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationHr({
     String localeName = 'hr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -11697,22 +11696,22 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Unesite važeće vrijeme';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licence';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenca';
+  String? get licensesPackageDetailTextOne => '1 licenca';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenci';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licence';
@@ -11760,22 +11759,22 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Osvježi';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
+  String? get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Preostao je 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Preostao je 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Preostalo je $remainingCount znakova';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Pomakni prema dolje';
@@ -11814,22 +11813,22 @@ class MaterialLocalizationHr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Odaberite godinu';
 
   @override
-  String get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
+  String? get selectedRowCountTitleFew => r'Odabrane su $selectedRowCount stavke';
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Odabrana je jedna stavka';
+  String? get selectedRowCountTitleOne => 'Odabrana je jedna stavka';
 
   @override
   String get selectedRowCountTitleOther => r'Odabrano je $selectedRowCount stavki';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Prikažite račune';
@@ -11881,15 +11880,15 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationHu({
     String localeName = 'hu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12003,22 +12002,22 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Érvényes formátumban adja meg az időt';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenc';
+  String? get licensesPackageDetailTextOne => '1 licenc';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenc';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencek';
@@ -12066,22 +12065,22 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Frissítés';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 karakter maradt';
+  String? get remainingTextFieldCharacterCountOne => '1 karakter maradt';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount karakter maradt';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Áthelyezés lefelé';
@@ -12120,22 +12119,22 @@ class MaterialLocalizationHu extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Válassza ki az évet';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 elem kiválasztva';
+  String? get selectedRowCountTitleOne => '1 elem kiválasztva';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elem kiválasztva';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Fiókok megjelenítése';
@@ -12187,15 +12186,15 @@ class MaterialLocalizationHy extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationHy({
     String localeName = 'hy',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12309,22 +12308,22 @@ class MaterialLocalizationHy extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Մուտքագրեք վավեր ժամ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 լիցենզիա';
+  String? get licensesPackageDetailTextOne => '1 լիցենզիա';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount լիցենզիա';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Արտոնագրեր';
@@ -12372,22 +12371,22 @@ class MaterialLocalizationHy extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Թարմացնել';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Մնաց $remainingCount նիշ';
+  String? get remainingTextFieldCharacterCountFew => r'Մնաց $remainingCount նիշ';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Մնաց $remainingCount նիշ';
+  String? get remainingTextFieldCharacterCountMany => r'Մնաց $remainingCount նիշ';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Մնացել է 1 նիշ';
+  String? get remainingTextFieldCharacterCountOne => 'Մնացել է 1 նիշ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Մնացել է $remainingCount նիշ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'Նիշի հնարավորություն չկա';
+  String? get remainingTextFieldCharacterCountZero => 'Նիշի հնարավորություն չկա';
 
   @override
   String get reorderItemDown => 'Տեղափոխել ներքև';
@@ -12426,22 +12425,22 @@ class MaterialLocalizationHy extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Ընտրել տարին';
 
   @override
-  String get selectedRowCountTitleFew => r'Ընտրված է $selectedRowCount օբյեկտ';
+  String? get selectedRowCountTitleFew => r'Ընտրված է $selectedRowCount օբյեկտ';
 
   @override
-  String get selectedRowCountTitleMany => r'Ընտրված է $selectedRowCount օբյեկտ';
+  String? get selectedRowCountTitleMany => r'Ընտրված է $selectedRowCount օբյեկտ';
 
   @override
-  String get selectedRowCountTitleOne => 'Ընտրվել է 1 տարր';
+  String? get selectedRowCountTitleOne => 'Ընտրվել է 1 տարր';
 
   @override
   String get selectedRowCountTitleOther => r'Ընտրվել է $selectedRowCount տարր';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Տողերը ընտրված չեն';
+  String? get selectedRowCountTitleZero => 'Տողերը ընտրված չեն';
 
   @override
   String get showAccountsLabel => 'Ցույց տալ հաշիվները';
@@ -12493,15 +12492,15 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationId({
     String localeName = 'id',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12615,22 +12614,22 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Masukkan waktu yang valid';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisensi';
+  String? get licensesPackageDetailTextOne => '1 lisensi';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisensi';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lisensi';
@@ -12678,22 +12677,22 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Memuat ulang';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Sisa 1 karakter';
+  String? get remainingTextFieldCharacterCountOne => 'Sisa 1 karakter';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Sisa $remainingCount karakter';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Turunkan';
@@ -12732,22 +12731,22 @@ class MaterialLocalizationId extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Pilih tahun';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item dipilih';
+  String? get selectedRowCountTitleOne => '1 item dipilih';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Tampilkan akun';
@@ -12799,15 +12798,15 @@ class MaterialLocalizationIs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationIs({
     String localeName = 'is',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -12921,22 +12920,22 @@ class MaterialLocalizationIs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Færðu inn gildan tíma';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 leyfi';
+  String? get licensesPackageDetailTextOne => '1 leyfi';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount leyfi';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Leyfi';
@@ -12984,22 +12983,22 @@ class MaterialLocalizationIs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Endurnýja';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 stafur eftir';
+  String? get remainingTextFieldCharacterCountOne => '1 stafur eftir';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount stafir eftir';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Færa niður';
@@ -13038,22 +13037,22 @@ class MaterialLocalizationIs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Velja ár';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 atriði valið';
+  String? get selectedRowCountTitleOne => '1 atriði valið';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount atriði valin';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Sýna reikninga';
@@ -13105,15 +13104,15 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationIt({
     String localeName = 'it',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13227,22 +13226,22 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Inserisci un orario valido';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenza';
+  String? get licensesPackageDetailTextOne => '1 licenza';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenze';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenze';
@@ -13290,22 +13289,22 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Aggiorna';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 carattere rimanente';
+  String? get remainingTextFieldCharacterCountOne => '1 carattere rimanente';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount caratteri rimanenti';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Sposta giù';
@@ -13344,22 +13343,22 @@ class MaterialLocalizationIt extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Seleziona anno';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 elemento selezionato';
+  String? get selectedRowCountTitleOne => '1 elemento selezionato';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementi selezionati';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Mostra account';
@@ -13411,15 +13410,15 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationJa({
     String localeName = 'ja',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13533,22 +13532,22 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => '有効な時刻を入力してください';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'ライセンス: 1 件';
+  String? get licensesPackageDetailTextOne => 'ライセンス: 1 件';
 
   @override
   String get licensesPackageDetailTextOther => r'ライセンス: $licenseCount 件';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ライセンス';
@@ -13596,22 +13595,22 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => '更新';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '残り 1 文字（半角相当）';
+  String? get remainingTextFieldCharacterCountOne => '残り 1 文字（半角相当）';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'残り $remainingCount 文字（半角相当）';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => '下に移動';
@@ -13650,22 +13649,22 @@ class MaterialLocalizationJa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => '年を選択';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 件のアイテムを選択中';
+  String? get selectedRowCountTitleOne => '1 件のアイテムを選択中';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount 件のアイテムを選択中';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'アカウントを表示';
@@ -13717,15 +13716,15 @@ class MaterialLocalizationKa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKa({
     String localeName = 'ka',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -13839,22 +13838,22 @@ class MaterialLocalizationKa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'შეიყვანეთ სწორი დრო';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 ლიცენზია';
+  String? get licensesPackageDetailTextOne => '1 ლიცენზია';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ლიცენზია';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ლიცენზიები';
@@ -13902,22 +13901,22 @@ class MaterialLocalizationKa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'განახლება';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'დარჩა 1 სიმბოლო';
+  String? get remainingTextFieldCharacterCountOne => 'დარჩა 1 სიმბოლო';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'დარჩა $remainingCount სიმბოლო';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'ქვემოთ გადატანა';
@@ -13956,22 +13955,22 @@ class MaterialLocalizationKa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'აირჩიეთ წელი';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'არჩეულია 1 ერთეული';
+  String? get selectedRowCountTitleOne => 'არჩეულია 1 ერთეული';
 
   @override
   String get selectedRowCountTitleOther => r'არჩეულია $selectedRowCount ერთეული';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ანგარიშების ჩვენება';
@@ -14023,15 +14022,15 @@ class MaterialLocalizationKk extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKk({
     String localeName = 'kk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -14145,22 +14144,22 @@ class MaterialLocalizationKk extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Жарамды уақыт мәліметін енгізіңіз.';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 лицензия';
+  String? get licensesPackageDetailTextOne => '1 лицензия';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лицензия';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лицензиялар';
@@ -14208,22 +14207,22 @@ class MaterialLocalizationKk extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Жаңарту';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 таңба қалды.';
+  String? get remainingTextFieldCharacterCountOne => '1 таңба қалды.';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount таңба қалды.';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'Таңбалар қалмады';
+  String? get remainingTextFieldCharacterCountZero => 'Таңбалар қалмады';
 
   @override
   String get reorderItemDown => 'Төменге жылжыту';
@@ -14262,22 +14261,22 @@ class MaterialLocalizationKk extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Жылды таңдау';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 элемент таңдалды.';
+  String? get selectedRowCountTitleOne => '1 элемент таңдалды.';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount элемент таңдалды.';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Тармақ таңдалмаған';
+  String? get selectedRowCountTitleZero => 'Тармақ таңдалмаған';
 
   @override
   String get showAccountsLabel => 'Есептік жазбаларды көрсету';
@@ -14329,15 +14328,15 @@ class MaterialLocalizationKm extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKm({
     String localeName = 'km',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -14451,22 +14450,22 @@ class MaterialLocalizationKm extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'បញ្ចូលពេលវេលា​ដែល​ត្រឹមត្រូវ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'អាជ្ញាបណ្ណ 1';
+  String? get licensesPackageDetailTextOne => 'អាជ្ញាបណ្ណ 1';
 
   @override
   String get licensesPackageDetailTextOther => r'អាជ្ញាបណ្ណ $licenseCount';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'អាជ្ញាបណ្ណ';
@@ -14514,22 +14513,22 @@ class MaterialLocalizationKm extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ផ្ទុកឡើងវិញ';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'នៅសល់​ 1 តួ​ទៀត';
+  String? get remainingTextFieldCharacterCountOne => 'នៅសល់​ 1 តួ​ទៀត';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'នៅសល់ $remainingCount តួ​ទៀត';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'ផ្លាស់ទី​ចុះ​ក្រោម';
@@ -14568,22 +14567,22 @@ class MaterialLocalizationKm extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ជ្រើសរើសឆ្នាំ';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'បាន​ជ្រើស​រើស​ធាតុ 1';
+  String? get selectedRowCountTitleOne => 'បាន​ជ្រើស​រើស​ធាតុ 1';
 
   @override
   String get selectedRowCountTitleOther => r'បាន​ជ្រើស​រើស​ធាតុ $selectedRowCount';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'បង្ហាញគណនី';
@@ -14635,15 +14634,15 @@ class MaterialLocalizationKn extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKn({
     String localeName = 'kn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -14757,22 +14756,22 @@ class MaterialLocalizationKn extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => '\u{cae}\u{cbe}\u{ca8}\u{ccd}\u{caf}\u{cb5}\u{cbe}\u{ca6}\u{20}\u{cb8}\u{cae}\u{caf}\u{cb5}\u{ca8}\u{ccd}\u{ca8}\u{cc1}\u{20}\u{ca8}\u{cae}\u{cc2}\u{ca6}\u{cbf}\u{cb8}\u{cbf}';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '\u{31}\u{20}\u{caa}\u{cb0}\u{cb5}\u{cbe}\u{ca8}\u{c97}\u{cbf}';
+  String? get licensesPackageDetailTextOne => '\u{31}\u{20}\u{caa}\u{cb0}\u{cb5}\u{cbe}\u{ca8}\u{c97}\u{cbf}';
 
   @override
   String get licensesPackageDetailTextOther => '\u{24}\u{6c}\u{69}\u{63}\u{65}\u{6e}\u{73}\u{65}\u{43}\u{6f}\u{75}\u{6e}\u{74}\u{20}\u{caa}\u{cb0}\u{cb5}\u{cbe}\u{ca8}\u{c97}\u{cbf}\u{c97}\u{cb3}\u{cc1}';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => '\u{caa}\u{cb0}\u{cb5}\u{cbe}\u{ca8}\u{c97}\u{cbf}\u{c97}\u{cb3}\u{cc1}';
@@ -14820,22 +14819,22 @@ class MaterialLocalizationKn extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => '\u{cb0}\u{cbf}\u{cab}\u{ccd}\u{cb0}\u{cc6}\u{cb6}\u{ccd}\u{20}\u{cae}\u{cbe}\u{ca1}\u{cbf}';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '\u{31}\u{20}\u{c85}\u{c95}\u{ccd}\u{cb7}\u{cb0}\u{20}\u{c89}\u{cb3}\u{cbf}\u{ca6}\u{cbf}\u{ca6}\u{cc6}';
+  String? get remainingTextFieldCharacterCountOne => '\u{31}\u{20}\u{c85}\u{c95}\u{ccd}\u{cb7}\u{cb0}\u{20}\u{c89}\u{cb3}\u{cbf}\u{ca6}\u{cbf}\u{ca6}\u{cc6}';
 
   @override
   String get remainingTextFieldCharacterCountOther => '\u{24}\u{72}\u{65}\u{6d}\u{61}\u{69}\u{6e}\u{69}\u{6e}\u{67}\u{43}\u{6f}\u{75}\u{6e}\u{74}\u{20}\u{c85}\u{c95}\u{ccd}\u{cb7}\u{cb0}\u{c97}\u{cb3}\u{cc1}\u{20}\u{c89}\u{cb3}\u{cbf}\u{ca6}\u{cbf}\u{cb5}\u{cc6}';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => '\u{c95}\u{cc6}\u{cb3}\u{c97}\u{cc6}\u{20}\u{cb8}\u{cb0}\u{cbf}\u{cb8}\u{cbf}';
@@ -14874,22 +14873,22 @@ class MaterialLocalizationKn extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => '\u{cb5}\u{cb0}\u{ccd}\u{cb7}\u{cb5}\u{ca8}\u{ccd}\u{ca8}\u{cc1}\u{20}\u{c86}\u{caf}\u{ccd}\u{c95}\u{cc6}\u{cae}\u{cbe}\u{ca1}\u{cbf}';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '\u{31}\u{20}\u{c90}\u{c9f}\u{c82}\u{20}\u{c86}\u{caf}\u{ccd}\u{c95}\u{cc6}\u{20}\u{cae}\u{cbe}\u{ca1}\u{cb2}\u{cbe}\u{c97}\u{cbf}\u{ca6}\u{cc6}';
+  String? get selectedRowCountTitleOne => '\u{31}\u{20}\u{c90}\u{c9f}\u{c82}\u{20}\u{c86}\u{caf}\u{ccd}\u{c95}\u{cc6}\u{20}\u{cae}\u{cbe}\u{ca1}\u{cb2}\u{cbe}\u{c97}\u{cbf}\u{ca6}\u{cc6}';
 
   @override
   String get selectedRowCountTitleOther => '\u{24}\u{73}\u{65}\u{6c}\u{65}\u{63}\u{74}\u{65}\u{64}\u{52}\u{6f}\u{77}\u{43}\u{6f}\u{75}\u{6e}\u{74}\u{20}\u{c90}\u{c9f}\u{c82}\u{c97}\u{cb3}\u{ca8}\u{ccd}\u{ca8}\u{cc1}\u{20}\u{c86}\u{caf}\u{ccd}\u{c95}\u{cc6}\u{20}\u{cae}\u{cbe}\u{ca1}\u{cb2}\u{cbe}\u{c97}\u{cbf}\u{ca6}\u{cc6}';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => '\u{c96}\u{cbe}\u{ca4}\u{cc6}\u{c97}\u{cb3}\u{ca8}\u{ccd}\u{ca8}\u{cc1}\u{20}\u{ca4}\u{ccb}\u{cb0}\u{cbf}\u{cb8}\u{cbf}';
@@ -14941,15 +14940,15 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKo({
     String localeName = 'ko',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -15063,22 +15062,22 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => '유효한 시간을 입력하세요.';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '라이선스 1개';
+  String? get licensesPackageDetailTextOne => '라이선스 1개';
 
   @override
   String get licensesPackageDetailTextOther => r'라이선스 $licenseCount개';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => '라이선스';
@@ -15126,22 +15125,22 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => '새로고침';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1자 남음';
+  String? get remainingTextFieldCharacterCountOne => '1자 남음';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount자 남음';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => '아래로 이동';
@@ -15180,22 +15179,22 @@ class MaterialLocalizationKo extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => '연도 선택';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '항목 1개 선택됨';
+  String? get selectedRowCountTitleOne => '항목 1개 선택됨';
 
   @override
   String get selectedRowCountTitleOther => r'항목 $selectedRowCount개 선택됨';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => '계정 표시';
@@ -15247,15 +15246,15 @@ class MaterialLocalizationKy extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationKy({
     String localeName = 'ky',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -15369,22 +15368,22 @@ class MaterialLocalizationKy extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Убакытты туура көрсөтүңүз';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 уруксаттама';
+  String? get licensesPackageDetailTextOne => '1 уруксаттама';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount уруксаттама';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Уруксаттамалар';
@@ -15432,22 +15431,22 @@ class MaterialLocalizationKy extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Жаңыртуу';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 белги калды';
+  String? get remainingTextFieldCharacterCountOne => '1 белги калды';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount белги калды';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Төмөн жылдыруу';
@@ -15486,22 +15485,22 @@ class MaterialLocalizationKy extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Жылды тандоо';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 нерсе тандалды';
+  String? get selectedRowCountTitleOne => '1 нерсе тандалды';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount нерсе тандалды';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Аккаунттарды көрсөтүү';
@@ -15553,15 +15552,15 @@ class MaterialLocalizationLo extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationLo({
     String localeName = 'lo',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -15675,22 +15674,22 @@ class MaterialLocalizationLo extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'ລະບຸເວລາທີ່ຖືກຕ້ອງ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 ໃບອະນຸຍາດ';
+  String? get licensesPackageDetailTextOne => '1 ໃບອະນຸຍາດ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ໃບອະນຸຍາດ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ໃບອະນຸຍາດ';
@@ -15738,22 +15737,22 @@ class MaterialLocalizationLo extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ໂຫຼດຄືນໃໝ່';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'ຍັງອີກ 1 ຕົວອັກສອນ';
+  String? get remainingTextFieldCharacterCountOne => 'ຍັງອີກ 1 ຕົວອັກສອນ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'ຍັງອີກ $remainingCount ຕົວອັກສອນ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'ຍ້າຍລົງ';
@@ -15792,22 +15791,22 @@ class MaterialLocalizationLo extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ເລືອກ​ປີ';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'ເລືອກ 1 ລາຍການແລ້ວ';
+  String? get selectedRowCountTitleOne => 'ເລືອກ 1 ລາຍການແລ້ວ';
 
   @override
   String get selectedRowCountTitleOther => r'ເລືອກ $selectedRowCount ລາຍການແລ້ວ';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ສະແດງບັນຊີ';
@@ -15859,15 +15858,15 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationLt({
     String localeName = 'lt',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -15981,22 +15980,22 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Įveskite tinkamą laiką';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licencijos';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licencijos';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount licencijos';
+  String? get licensesPackageDetailTextMany => r'$licenseCount licencijos';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencija';
+  String? get licensesPackageDetailTextOne => '1 licencija';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licencijų';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencijos';
@@ -16044,22 +16043,22 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Atnaujinti';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Liko $remainingCount simboliai';
+  String? get remainingTextFieldCharacterCountFew => r'Liko $remainingCount simboliai';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Liko $remainingCount simbolio';
+  String? get remainingTextFieldCharacterCountMany => r'Liko $remainingCount simbolio';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Liko 1 simbolis';
+  String? get remainingTextFieldCharacterCountOne => 'Liko 1 simbolis';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Liko $remainingCount simbolių';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Perkelti žemyn';
@@ -16098,22 +16097,22 @@ class MaterialLocalizationLt extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Pasirinkite metus';
 
   @override
-  String get selectedRowCountTitleFew => r'Pasirinkti $selectedRowCount elementai';
+  String? get selectedRowCountTitleFew => r'Pasirinkti $selectedRowCount elementai';
 
   @override
-  String get selectedRowCountTitleMany => r'Pasirinkta $selectedRowCount elemento';
+  String? get selectedRowCountTitleMany => r'Pasirinkta $selectedRowCount elemento';
 
   @override
-  String get selectedRowCountTitleOne => 'Pasirinktas 1 elementas';
+  String? get selectedRowCountTitleOne => 'Pasirinktas 1 elementas';
 
   @override
   String get selectedRowCountTitleOther => r'Pasirinkta $selectedRowCount elementų';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Rodyti paskyras';
@@ -16165,15 +16164,15 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationLv({
     String localeName = 'lv',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -16287,22 +16286,22 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Ievadiet derīgu laiku.';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licence';
+  String? get licensesPackageDetailTextOne => '1 licence';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licences';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'Nav licenču';
+  String? get licensesPackageDetailTextZero => 'Nav licenču';
 
   @override
   String get licensesPageTitle => 'Licences';
@@ -16350,22 +16349,22 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Atsvaidzināt';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Atlikusi 1 rakstzīme.';
+  String? get remainingTextFieldCharacterCountOne => 'Atlikusi 1 rakstzīme.';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Atlikušas $remainingCount rakstzīmes.';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'Nav atlikusi neviena rakstzīme.';
+  String? get remainingTextFieldCharacterCountZero => 'Nav atlikusi neviena rakstzīme.';
 
   @override
   String get reorderItemDown => 'Pārvietot uz leju';
@@ -16404,22 +16403,22 @@ class MaterialLocalizationLv extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Atlasiet gadu';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Atlasīts 1 vienums';
+  String? get selectedRowCountTitleOne => 'Atlasīts 1 vienums';
 
   @override
   String get selectedRowCountTitleOther => r'Atlasīti $selectedRowCount vienumi';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Nav atlasītu vienumu';
+  String? get selectedRowCountTitleZero => 'Nav atlasītu vienumu';
 
   @override
   String get showAccountsLabel => 'Rādīt kontus';
@@ -16471,15 +16470,15 @@ class MaterialLocalizationMk extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMk({
     String localeName = 'mk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -16593,22 +16592,22 @@ class MaterialLocalizationMk extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Внесете важечко време';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 лиценца';
+  String? get licensesPackageDetailTextOne => '1 лиценца';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лиценци';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лиценци';
@@ -16656,22 +16655,22 @@ class MaterialLocalizationMk extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Освежи';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Преостанува уште 1 знак';
+  String? get remainingTextFieldCharacterCountOne => 'Преостанува уште 1 знак';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Преостануваат уште $remainingCount знаци';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Преместете надолу';
@@ -16710,22 +16709,22 @@ class MaterialLocalizationMk extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Изберете година';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Избрана е 1 ставка';
+  String? get selectedRowCountTitleOne => 'Избрана е 1 ставка';
 
   @override
   String get selectedRowCountTitleOther => r'Избрани се $selectedRowCount ставки';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Прикажи сметки';
@@ -16777,15 +16776,15 @@ class MaterialLocalizationMl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMl({
     String localeName = 'ml',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -16899,22 +16898,22 @@ class MaterialLocalizationMl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'സാധുവായ സമയം നൽകുക';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'ഒരു ലൈസൻസ്';
+  String? get licensesPackageDetailTextOne => 'ഒരു ലൈസൻസ്';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ലൈസൻസുകൾ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ലൈസൻസുകൾ';
@@ -16962,22 +16961,22 @@ class MaterialLocalizationMl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'പുതുക്കിയെടുക്കുക';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'ഒരു പ്രതീകം ശേഷിക്കുന്നു';
+  String? get remainingTextFieldCharacterCountOne => 'ഒരു പ്രതീകം ശേഷിക്കുന്നു';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount പ്രതീകങ്ങൾ ശേഷിക്കുന്നു';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'താഴോട്ട് നീക്കുക';
@@ -17016,22 +17015,22 @@ class MaterialLocalizationMl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'വർഷം തിരഞ്ഞെടുക്കുക';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'ഒരു ഇനം തിരഞ്ഞെടുത്തു';
+  String? get selectedRowCountTitleOne => 'ഒരു ഇനം തിരഞ്ഞെടുത്തു';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount ഇനങ്ങൾ തിരഞ്ഞെടുത്തു';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'അക്കൗണ്ടുകൾ കാണിക്കുക';
@@ -17083,15 +17082,15 @@ class MaterialLocalizationMn extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMn({
     String localeName = 'mn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -17205,22 +17204,22 @@ class MaterialLocalizationMn extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Цагийг зөв оруулна уу';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 лиценз';
+  String? get licensesPackageDetailTextOne => '1 лиценз';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лиценз';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лиценз';
@@ -17268,22 +17267,22 @@ class MaterialLocalizationMn extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Сэргээх';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 тэмдэгт үлдсэн';
+  String? get remainingTextFieldCharacterCountOne => '1 тэмдэгт үлдсэн';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount тэмдэгт үлдсэн';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'No characters remaining';
+  String? get remainingTextFieldCharacterCountZero => 'No characters remaining';
 
   @override
   String get reorderItemDown => 'Доош зөөх';
@@ -17322,22 +17321,22 @@ class MaterialLocalizationMn extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Жил сонгох';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 зүйл сонгосон';
+  String? get selectedRowCountTitleOne => '1 зүйл сонгосон';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount зүйл сонгосон';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Бичлэг сонгоогүй байна';
+  String? get selectedRowCountTitleZero => 'Бичлэг сонгоогүй байна';
 
   @override
   String get showAccountsLabel => 'Бүртгэлүүдийг харуулах';
@@ -17389,15 +17388,15 @@ class MaterialLocalizationMr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMr({
     String localeName = 'mr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -17511,22 +17510,22 @@ class MaterialLocalizationMr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'योग्य वेळ एंटर करा';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'एक परवाना';
+  String? get licensesPackageDetailTextOne => 'एक परवाना';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount परवाने';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'परवाने';
@@ -17574,22 +17573,22 @@ class MaterialLocalizationMr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'रिफ्रेश करा';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'एक वर्ण शिल्लक';
+  String? get remainingTextFieldCharacterCountOne => 'एक वर्ण शिल्लक';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount वर्ण शिल्लक';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'कोणतेही वर्ण शिल्लक नाहीत';
+  String? get remainingTextFieldCharacterCountZero => 'कोणतेही वर्ण शिल्लक नाहीत';
 
   @override
   String get reorderItemDown => 'खाली हलवा';
@@ -17628,22 +17627,22 @@ class MaterialLocalizationMr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'वर्ष निवडा';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'एक आयटम निवडला';
+  String? get selectedRowCountTitleOne => 'एक आयटम निवडला';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount आयटम निवडले';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'कोणतेही आयटम निवडलेले नाहीत';
+  String? get selectedRowCountTitleZero => 'कोणतेही आयटम निवडलेले नाहीत';
 
   @override
   String get showAccountsLabel => 'खाती दर्शवा';
@@ -17695,15 +17694,15 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMs({
     String localeName = 'ms',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -17817,22 +17816,22 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Masukkan masa yang sah';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lesen';
+  String? get licensesPackageDetailTextOne => '1 lesen';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lesen';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lesen';
@@ -17880,22 +17879,22 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Muat semula';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 aksara lagi';
+  String? get remainingTextFieldCharacterCountOne => '1 aksara lagi';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount aksara lagi';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Alih ke bawah';
@@ -17934,22 +17933,22 @@ class MaterialLocalizationMs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Pilih tahun';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item dipilih';
+  String? get selectedRowCountTitleOne => '1 item dipilih';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount item dipilih';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Tiada item dipilih';
+  String? get selectedRowCountTitleZero => 'Tiada item dipilih';
 
   @override
   String get showAccountsLabel => 'Tunjukkan akaun';
@@ -18001,15 +18000,15 @@ class MaterialLocalizationMy extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationMy({
     String localeName = 'my',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -18123,22 +18122,22 @@ class MaterialLocalizationMy extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'မှန်ကန်သည့်အချိန် ထည့်ပါ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'လိုင်စင် 1 ခု';
+  String? get licensesPackageDetailTextOne => 'လိုင်စင် 1 ခု';
 
   @override
   String get licensesPackageDetailTextOther => r'လိုင်စင် $licenseCount ခု';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'လိုင်စင်များ';
@@ -18186,22 +18185,22 @@ class MaterialLocalizationMy extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ပြန်လည်စတင်ရန်';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'အက္ခရာ ၁ လုံးကျန်သည်';
+  String? get remainingTextFieldCharacterCountOne => 'အက္ခရာ ၁ လုံးကျန်သည်';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'အက္ခရာ $remainingCount လုံးကျန်သည်';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'အောက်သို့ရွှေ့ရန်';
@@ -18240,22 +18239,22 @@ class MaterialLocalizationMy extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ခုနှစ် ရွေးရန်';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '၁ ခု ရွေးထားသည်';
+  String? get selectedRowCountTitleOne => '၁ ခု ရွေးထားသည်';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount ခု ရွေးထားသည်';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'အကောင့်များကို ပြရန်';
@@ -18307,15 +18306,15 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationNb({
     String localeName = 'nb',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -18429,22 +18428,22 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Angi et gyldig klokkeslett';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisens';
+  String? get licensesPackageDetailTextOne => '1 lisens';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisenser';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => null;
+  String? get licensesPackageDetailTextZero => null;
 
   @override
   String get licensesPageTitle => 'Lisenser';
@@ -18492,22 +18491,22 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Laster inn på nytt';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 tegn gjenstår';
+  String? get remainingTextFieldCharacterCountOne => '1 tegn gjenstår';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount tegn gjenstår';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Flytt ned';
@@ -18546,22 +18545,22 @@ class MaterialLocalizationNb extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Velg året';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 element er valgt';
+  String? get selectedRowCountTitleOne => '1 element er valgt';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Vis kontoer';
@@ -18613,15 +18612,15 @@ class MaterialLocalizationNe extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationNe({
     String localeName = 'ne',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -18735,22 +18734,22 @@ class MaterialLocalizationNe extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'वैध समय प्रविष्टि गर्नुहोस्';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'एउटा इजाजतपत्र';
+  String? get licensesPackageDetailTextOne => 'एउटा इजाजतपत्र';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount वटा इजाजतपत्र';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'इजाजतपत्रहरू';
@@ -18798,22 +18797,22 @@ class MaterialLocalizationNe extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'पुनः ताजा गर्नुहोस्';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '१ वर्ण बाँकी';
+  String? get remainingTextFieldCharacterCountOne => '१ वर्ण बाँकी';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount वर्णहरू बाँकी';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'तल सार्नुहोस्';
@@ -18852,22 +18851,22 @@ class MaterialLocalizationNe extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'वर्ष छान्नुहोस्';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '१ वस्तु चयन गरियो';
+  String? get selectedRowCountTitleOne => '१ वस्तु चयन गरियो';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount वस्तुहरू चयन गरिए';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'खाताहरू देखाउनुहोस्';
@@ -18919,15 +18918,15 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationNl({
     String localeName = 'nl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -19041,22 +19040,22 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Geef een geldige tijd op';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licentie';
+  String? get licensesPackageDetailTextOne => '1 licentie';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenties';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenties';
@@ -19104,22 +19103,22 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Vernieuwen';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 teken resterend';
+  String? get remainingTextFieldCharacterCountOne => '1 teken resterend';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount tekens resterend';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Omlaag verplaatsen';
@@ -19158,22 +19157,22 @@ class MaterialLocalizationNl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Jaar selecteren';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item geselecteerd';
+  String? get selectedRowCountTitleOne => '1 item geselecteerd';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount items geselecteerd';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Accounts weergeven';
@@ -19225,15 +19224,15 @@ class MaterialLocalizationNo extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationNo({
     String localeName = 'no',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -19347,22 +19346,22 @@ class MaterialLocalizationNo extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Angi et gyldig klokkeslett';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisens';
+  String? get licensesPackageDetailTextOne => '1 lisens';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisenser';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => null;
+  String? get licensesPackageDetailTextZero => null;
 
   @override
   String get licensesPageTitle => 'Lisenser';
@@ -19410,22 +19409,22 @@ class MaterialLocalizationNo extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Laster inn på nytt';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 tegn gjenstår';
+  String? get remainingTextFieldCharacterCountOne => '1 tegn gjenstår';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount tegn gjenstår';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Flytt ned';
@@ -19464,22 +19463,22 @@ class MaterialLocalizationNo extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Velg året';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 element er valgt';
+  String? get selectedRowCountTitleOne => '1 element er valgt';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount elementer er valgt';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Vis kontoer';
@@ -19531,15 +19530,15 @@ class MaterialLocalizationOr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationOr({
     String localeName = 'or',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -19653,22 +19652,22 @@ class MaterialLocalizationOr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'ଏକ ବୈଧ ସମୟ ଲେଖନ୍ତୁ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1ଟି ଲାଇସେନ୍ସ';
+  String? get licensesPackageDetailTextOne => '1ଟି ଲାଇସେନ୍ସ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCountଟି ଲାଇସେନ୍ସ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ଲାଇସେନ୍ସଗୁଡ଼କ';
@@ -19716,22 +19715,22 @@ class MaterialLocalizationOr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ରିଫ୍ରେସ୍ କରନ୍ତୁ';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1ଟି ଅକ୍ଷର ବାକି ଅଛି';
+  String? get remainingTextFieldCharacterCountOne => '1ଟି ଅକ୍ଷର ବାକି ଅଛି';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCountଟି ଅକ୍ଷର ବାକି ଅଛି';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'ତଳକୁ ଯାଆନ୍ତୁ';
@@ -19770,22 +19769,22 @@ class MaterialLocalizationOr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ବର୍ଷ ଚୟନ କରନ୍ତୁ';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1ଟି ଆଇଟମ୍ ଚୟନ କରାଯାଇଛି';
+  String? get selectedRowCountTitleOne => '1ଟି ଆଇଟମ୍ ଚୟନ କରାଯାଇଛି';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCountଟି ଆଇଟମ୍ ଚୟନ କରାଯାଇଛି';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ଆକାଉଣ୍ଟ ଦେଖାନ୍ତୁ';
@@ -19837,15 +19836,15 @@ class MaterialLocalizationPa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationPa({
     String localeName = 'pa',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -19959,22 +19958,22 @@ class MaterialLocalizationPa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'ਵੈਧ ਸਮਾਂ ਦਾਖਲ ਕਰੋ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 ਲਾਇਸੰਸ';
+  String? get licensesPackageDetailTextOne => '1 ਲਾਇਸੰਸ';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ਲਾਇਸੰਸ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ਲਾਇਸੰਸ';
@@ -20022,22 +20021,22 @@ class MaterialLocalizationPa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ਰਿਫ੍ਰੈਸ਼ ਕਰੋ';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 ਅੱਖਰ-ਚਿੰਨ੍ਹ ਬਾਕੀ';
+  String? get remainingTextFieldCharacterCountOne => '1 ਅੱਖਰ-ਚਿੰਨ੍ਹ ਬਾਕੀ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount ਅੱਖਰ-ਚਿੰਨ੍ਹ ਬਾਕੀ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'ਹੇਠਾਂ ਲਿਜਾਓ';
@@ -20076,22 +20075,22 @@ class MaterialLocalizationPa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ਸਾਲ ਚੁਣੋ';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 ਆਈਟਮ ਚੁਣੀ ਗਈ';
+  String? get selectedRowCountTitleOne => '1 ਆਈਟਮ ਚੁਣੀ ਗਈ';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount ਆਈਟਮਾਂ ਚੁਣੀਆਂ ਗਈਆਂ';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ਖਾਤੇ ਦਿਖਾਓ';
@@ -20143,15 +20142,15 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationPl({
     String localeName = 'pl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -20265,22 +20264,22 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Wpisz prawidłową godzinę';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licencje';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licencje';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount licencji';
+  String? get licensesPackageDetailTextMany => r'$licenseCount licencji';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencja';
+  String? get licensesPackageDetailTextOne => '1 licencja';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licencji';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencje';
@@ -20328,22 +20327,22 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Odśwież';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Pozostały $remainingCount znaki';
+  String? get remainingTextFieldCharacterCountFew => r'Pozostały $remainingCount znaki';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Pozostało $remainingCount znaków';
+  String? get remainingTextFieldCharacterCountMany => r'Pozostało $remainingCount znaków';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Jeszcze 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Jeszcze 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Pozostało $remainingCount znaków';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Przenieś w dół';
@@ -20382,22 +20381,22 @@ class MaterialLocalizationPl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Wybierz rok';
 
   @override
-  String get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
+  String? get selectedRowCountTitleFew => r'$selectedRowCount wybrane elementy';
 
   @override
-  String get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
+  String? get selectedRowCountTitleMany => r'$selectedRowCount wybranych elementów';
 
   @override
-  String get selectedRowCountTitleOne => '1 wybrany element';
+  String? get selectedRowCountTitleOne => '1 wybrany element';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount wybranych elementów';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Pokaż konta';
@@ -20449,15 +20448,15 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationPs({
     String localeName = 'ps',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -20478,7 +20477,7 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get alertDialogLabel => 'خبرتیا';
 
   @override
-  String get anteMeridiemAbbreviation => null;
+  String get anteMeridiemAbbreviation => 'AM';
 
   @override
   String get backButtonTooltip => 'شاته';
@@ -20571,22 +20570,22 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Enter a valid time';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 license';
+  String? get licensesPackageDetailTextOne => '1 license';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenses';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'جوازونه';
@@ -20622,7 +20621,7 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get popupMenuLabel => 'د پاپ اپ مینو';
 
   @override
-  String get postMeridiemAbbreviation => null;
+  String get postMeridiemAbbreviation => 'PM';
 
   @override
   String get previousMonthTooltip => 'تیره میاشت';
@@ -20634,22 +20633,22 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Refresh';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 character remaining';
+  String? get remainingTextFieldCharacterCountOne => '1 character remaining';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount characters remaining';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'No characters remaining';
+  String? get remainingTextFieldCharacterCountZero => 'No characters remaining';
 
   @override
   String get reorderItemDown => 'Move down';
@@ -20688,22 +20687,22 @@ class MaterialLocalizationPs extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Select year';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => null;
+  String? get selectedRowCountTitleOne => null;
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount توکي غوره شوي';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'حسابونه ښکاره کړئ';
@@ -20755,15 +20754,15 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationPt({
     String localeName = 'pt',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -20877,22 +20876,22 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Insira um horário válido';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licença';
+  String? get licensesPackageDetailTextOne => '1 licença';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenças';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenças';
@@ -20940,22 +20939,22 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Atualizar';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 caractere restante';
+  String? get remainingTextFieldCharacterCountOne => '1 caractere restante';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount caracteres restantes';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Mover para baixo';
@@ -20994,22 +20993,22 @@ class MaterialLocalizationPt extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Selecione o ano';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item selecionado';
+  String? get selectedRowCountTitleOne => '1 item selecionado';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount itens selecionados';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Mostrar contas';
@@ -21061,15 +21060,15 @@ class MaterialLocalizationPtPt extends MaterialLocalizationPt {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationPtPt({
     String localeName = 'pt_PT',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -21174,7 +21173,7 @@ class MaterialLocalizationPtPt extends MaterialLocalizationPt {
   String get expandedIconTapHint => 'Reduzir';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Resta 1 caráter';
+  String? get remainingTextFieldCharacterCountOne => 'Resta 1 caráter';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Restam $remainingCount carateres';
@@ -21187,15 +21186,15 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationRo({
     String localeName = 'ro',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -21309,22 +21308,22 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Introduceți o oră validă';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licențe';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licențe';
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'O licență';
+  String? get licensesPackageDetailTextOne => 'O licență';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount de licențe';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licențe';
@@ -21372,22 +21371,22 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Actualizați';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'$remainingCount caractere rămase';
+  String? get remainingTextFieldCharacterCountFew => r'$remainingCount caractere rămase';
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'un caracter rămas';
+  String? get remainingTextFieldCharacterCountOne => 'un caracter rămas';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount de caractere rămase';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Mutați în jos';
@@ -21426,22 +21425,22 @@ class MaterialLocalizationRo extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Selectați anul';
 
   @override
-  String get selectedRowCountTitleFew => r'$selectedRowCount articole selectate';
+  String? get selectedRowCountTitleFew => r'$selectedRowCount articole selectate';
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Un articol selectat';
+  String? get selectedRowCountTitleOne => 'Un articol selectat';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount de articole selectate';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Nu există elemente selectate';
+  String? get selectedRowCountTitleZero => 'Nu există elemente selectate';
 
   @override
   String get showAccountsLabel => 'Afișați conturile';
@@ -21493,15 +21492,15 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationRu({
     String localeName = 'ru',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -21615,22 +21614,22 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Указано недопустимое время.';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount лицензии';
+  String? get licensesPackageDetailTextFew => r'$licenseCount лицензии';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount лицензий';
+  String? get licensesPackageDetailTextMany => r'$licenseCount лицензий';
 
   @override
-  String get licensesPackageDetailTextOne => '1 лицензия';
+  String? get licensesPackageDetailTextOne => '1 лицензия';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лицензии';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лицензии';
@@ -21678,22 +21677,22 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Обновление';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Осталось $remainingCount символа';
+  String? get remainingTextFieldCharacterCountFew => r'Осталось $remainingCount символа';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Осталось $remainingCount символов';
+  String? get remainingTextFieldCharacterCountMany => r'Осталось $remainingCount символов';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Остался 1 символ';
+  String? get remainingTextFieldCharacterCountOne => 'Остался 1 символ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Осталось $remainingCount символа';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Переместить вниз';
@@ -21732,22 +21731,22 @@ class MaterialLocalizationRu extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Выберите год';
 
   @override
-  String get selectedRowCountTitleFew => r'Выбрано $selectedRowCount объекта';
+  String? get selectedRowCountTitleFew => r'Выбрано $selectedRowCount объекта';
 
   @override
-  String get selectedRowCountTitleMany => r'Выбрано $selectedRowCount объектов';
+  String? get selectedRowCountTitleMany => r'Выбрано $selectedRowCount объектов';
 
   @override
-  String get selectedRowCountTitleOne => 'Выбран 1 объект';
+  String? get selectedRowCountTitleOne => 'Выбран 1 объект';
 
   @override
   String get selectedRowCountTitleOther => r'Выбрано $selectedRowCount объекта';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Строки не выбраны';
+  String? get selectedRowCountTitleZero => 'Строки не выбраны';
 
   @override
   String get showAccountsLabel => 'Показать аккаунты';
@@ -21799,15 +21798,15 @@ class MaterialLocalizationSi extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSi({
     String localeName = 'si',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -21921,22 +21920,22 @@ class MaterialLocalizationSi extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'වලංගු වේලාවක් ඇතුළු කරන්න';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'බලපත්‍ර 1';
+  String? get licensesPackageDetailTextOne => 'බලපත්‍ර 1';
 
   @override
   String get licensesPackageDetailTextOther => r'බලපත්‍ර $licenseCount';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'බලපත්‍ර';
@@ -21984,22 +21983,22 @@ class MaterialLocalizationSi extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'නැවුම් කරන්න';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'අනුලකුණු 1ක් ඉතිරිය';
+  String? get remainingTextFieldCharacterCountOne => 'අනුලකුණු 1ක් ඉතිරිය';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'අනුලකුණු $remainingCountක් ඉතිරිය';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'පහළට ගෙන යන්න';
@@ -22038,22 +22037,22 @@ class MaterialLocalizationSi extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'වර්ෂය තෝරන්න';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'අයිතම 1ක් තෝරන ලදී';
+  String? get selectedRowCountTitleOne => 'අයිතම 1ක් තෝරන ලදී';
 
   @override
   String get selectedRowCountTitleOther => r'අයිතම $selectedRowCountක් තෝරන ලදී';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ගිණුම් පෙන්වන්න';
@@ -22105,15 +22104,15 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSk({
     String localeName = 'sk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -22227,22 +22226,22 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Zadajte platný čas';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licencie';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licencie';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount licenses';
+  String? get licensesPackageDetailTextMany => r'$licenseCount licenses';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencia';
+  String? get licensesPackageDetailTextOne => '1 licencia';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licencií';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencie';
@@ -22290,22 +22289,22 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Obnoviť';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Zostávajú $remainingCount znaky';
+  String? get remainingTextFieldCharacterCountFew => r'Zostávajú $remainingCount znaky';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'$remainingCount characters remaining';
+  String? get remainingTextFieldCharacterCountMany => r'$remainingCount characters remaining';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Zostáva 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Zostáva 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Zostáva $remainingCount znakov';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Presunúť nadol';
@@ -22344,22 +22343,22 @@ class MaterialLocalizationSk extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Vyberte rok';
 
   @override
-  String get selectedRowCountTitleFew => r'$selectedRowCount vybraté položky';
+  String? get selectedRowCountTitleFew => r'$selectedRowCount vybraté položky';
 
   @override
-  String get selectedRowCountTitleMany => r'$selectedRowCount items selected';
+  String? get selectedRowCountTitleMany => r'$selectedRowCount items selected';
 
   @override
-  String get selectedRowCountTitleOne => '1 vybratá položka';
+  String? get selectedRowCountTitleOne => '1 vybratá položka';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount vybratých položiek';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Zobraziť účty';
@@ -22411,15 +22410,15 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSl({
     String localeName = 'sl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -22533,22 +22532,22 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Vnesite veljaven čas';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licence';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenca';
+  String? get licensesPackageDetailTextOne => '1 licenca';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenc';
 
   @override
-  String get licensesPackageDetailTextTwo => r'$licenseCount licenci';
+  String? get licensesPackageDetailTextTwo => r'$licenseCount licenci';
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licence';
@@ -22596,22 +22595,22 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Osveži';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Še $remainingCount znaki';
+  String? get remainingTextFieldCharacterCountFew => r'Še $remainingCount znaki';
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Še 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Še 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Še $remainingCount znakov';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => r'Še $remainingCount znaka';
+  String? get remainingTextFieldCharacterCountTwo => r'Še $remainingCount znaka';
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Premakni navzdol';
@@ -22650,22 +22649,22 @@ class MaterialLocalizationSl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Izberite leto';
 
   @override
-  String get selectedRowCountTitleFew => r'Izbrani so $selectedRowCount elementi';
+  String? get selectedRowCountTitleFew => r'Izbrani so $selectedRowCount elementi';
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Izbran je 1 element';
+  String? get selectedRowCountTitleOne => 'Izbran je 1 element';
 
   @override
   String get selectedRowCountTitleOther => r'Izbranih je $selectedRowCount elementov';
 
   @override
-  String get selectedRowCountTitleTwo => r'Izbrana sta $selectedRowCount elementa';
+  String? get selectedRowCountTitleTwo => r'Izbrana sta $selectedRowCount elementa';
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Prikaz računov';
@@ -22717,15 +22716,15 @@ class MaterialLocalizationSq extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSq({
     String localeName = 'sq',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -22839,22 +22838,22 @@ class MaterialLocalizationSq extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Fut një kohë të vlefshme';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licencë';
+  String? get licensesPackageDetailTextOne => '1 licencë';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenca';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licencat';
@@ -22902,22 +22901,22 @@ class MaterialLocalizationSq extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Rifresko';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 karakter i mbetur';
+  String? get remainingTextFieldCharacterCountOne => '1 karakter i mbetur';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount karaktere të mbetura';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Lëvize poshtë';
@@ -22956,22 +22955,22 @@ class MaterialLocalizationSq extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Zgjidh vitin';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'U zgjodh 1 artikull';
+  String? get selectedRowCountTitleOne => 'U zgjodh 1 artikull';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount artikuj u zgjodhën';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Shfaq llogaritë';
@@ -23023,15 +23022,15 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSr({
     String localeName = 'sr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -23145,22 +23144,22 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Унесите важеће време';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount лиценце';
+  String? get licensesPackageDetailTextFew => r'$licenseCount лиценце';
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 лиценца';
+  String? get licensesPackageDetailTextOne => '1 лиценца';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount лиценци';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Лиценце';
@@ -23208,22 +23207,22 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Освежи';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Преостала су $remainingCount знака';
+  String? get remainingTextFieldCharacterCountFew => r'Преостала су $remainingCount знака';
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Преостао је 1 знак';
+  String? get remainingTextFieldCharacterCountOne => 'Преостао је 1 знак';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Преостало је $remainingCount знакова';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Померите надоле';
@@ -23262,22 +23261,22 @@ class MaterialLocalizationSr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Изаберите годину';
 
   @override
-  String get selectedRowCountTitleFew => r'Изабране су $selectedRowCount ставке';
+  String? get selectedRowCountTitleFew => r'Изабране су $selectedRowCount ставке';
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Изабрана је 1 ставка';
+  String? get selectedRowCountTitleOne => 'Изабрана је 1 ставка';
 
   @override
   String get selectedRowCountTitleOther => r'Изабрано је $selectedRowCount ставки';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Прикажи налоге';
@@ -23329,15 +23328,15 @@ class MaterialLocalizationSrCyrl extends MaterialLocalizationSr {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSrCyrl({
     String localeName = 'sr_Cyrl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -23359,15 +23358,15 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSrLatn({
     String localeName = 'sr_Latn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -23478,10 +23477,10 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   String get invalidTimeLabel => 'Unesite važeće vreme';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount licence';
+  String? get licensesPackageDetailTextFew => r'$licenseCount licence';
 
   @override
-  String get licensesPackageDetailTextOne => '1 licenca';
+  String? get licensesPackageDetailTextOne => '1 licenca';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenci';
@@ -23532,10 +23531,10 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   String get refreshIndicatorSemanticLabel => 'Osveži';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
+  String? get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Preostao je 1 znak';
+  String? get remainingTextFieldCharacterCountOne => 'Preostao je 1 znak';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Preostalo je $remainingCount znakova';
@@ -23574,10 +23573,10 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   String get selectYearSemanticsLabel => 'Izaberite godinu';
 
   @override
-  String get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
+  String? get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
 
   @override
-  String get selectedRowCountTitleOne => 'Izabrana je 1 stavka';
+  String? get selectedRowCountTitleOne => 'Izabrana je 1 stavka';
 
   @override
   String get selectedRowCountTitleOther => r'Izabrano je $selectedRowCount stavki';
@@ -23629,15 +23628,15 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSv({
     String localeName = 'sv',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -23751,22 +23750,22 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Ange en giltig tid';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 licens';
+  String? get licensesPackageDetailTextOne => '1 licens';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount licenser';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Licenser';
@@ -23814,22 +23813,22 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Uppdatera';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 tecken kvar';
+  String? get remainingTextFieldCharacterCountOne => '1 tecken kvar';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount tecken kvar';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Flytta nedåt';
@@ -23868,22 +23867,22 @@ class MaterialLocalizationSv extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Välj år';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 objekt har markerats';
+  String? get selectedRowCountTitleOne => '1 objekt har markerats';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount objekt har markerats';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Visa konton';
@@ -23935,15 +23934,15 @@ class MaterialLocalizationSw extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationSw({
     String localeName = 'sw',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -24057,22 +24056,22 @@ class MaterialLocalizationSw extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Weka saa sahihi';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'Leseni moja';
+  String? get licensesPackageDetailTextOne => 'Leseni moja';
 
   @override
   String get licensesPackageDetailTextOther => r'Leseni $licenseCount';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Leseni';
@@ -24120,22 +24119,22 @@ class MaterialLocalizationSw extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Onyesha upya';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Imesalia herufi 1';
+  String? get remainingTextFieldCharacterCountOne => 'Imesalia herufi 1';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Zimesalia herufi $remainingCount';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'Hapana herufi zilizo baki';
+  String? get remainingTextFieldCharacterCountZero => 'Hapana herufi zilizo baki';
 
   @override
   String get reorderItemDown => 'Sogeza chini';
@@ -24174,22 +24173,22 @@ class MaterialLocalizationSw extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Chagua mwaka';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Umechagua kipengee 1';
+  String? get selectedRowCountTitleOne => 'Umechagua kipengee 1';
 
   @override
   String get selectedRowCountTitleOther => r'Umechagua vipengee $selectedRowCount';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'Hamna kilicho chaguliwa';
+  String? get selectedRowCountTitleZero => 'Hamna kilicho chaguliwa';
 
   @override
   String get showAccountsLabel => 'Onyesha akaunti';
@@ -24241,15 +24240,15 @@ class MaterialLocalizationTa extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationTa({
     String localeName = 'ta',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -24363,22 +24362,22 @@ class MaterialLocalizationTa extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'சரியான நேரத்தை உள்ளிடவும்';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 உரிமம்';
+  String? get licensesPackageDetailTextOne => '1 உரிமம்';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount உரிமங்கள்';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'உரிமங்கள்';
@@ -24426,22 +24425,22 @@ class MaterialLocalizationTa extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ரெஃப்ரெஷ் செய்யும்';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 எழுத்து மீதமுள்ளது';
+  String? get remainingTextFieldCharacterCountOne => '1 எழுத்து மீதமுள்ளது';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount எழுத்துகள் மீதமுள்ளன';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'எழுத்துக்கள் எதுவும் இல்லை';
+  String? get remainingTextFieldCharacterCountZero => 'எழுத்துக்கள் எதுவும் இல்லை';
 
   @override
   String get reorderItemDown => 'கீழே நகர்த்தவும்';
@@ -24480,22 +24479,22 @@ class MaterialLocalizationTa extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'ஆண்டைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 வரிசை தேர்ந்தெடுக்கப்பட்டது';
+  String? get selectedRowCountTitleOne => '1 வரிசை தேர்ந்தெடுக்கப்பட்டது';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount வரிசைகள் தேர்ந்தெடுக்கப்பட்டன';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => 'எந்த வரிசையும் தேர்ந்தெடுக்கவில்லை';
+  String? get selectedRowCountTitleZero => 'எந்த வரிசையும் தேர்ந்தெடுக்கவில்லை';
 
   @override
   String get showAccountsLabel => 'கணக்குகளைக் காட்டும்';
@@ -24547,15 +24546,15 @@ class MaterialLocalizationTe extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationTe({
     String localeName = 'te',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -24669,22 +24668,22 @@ class MaterialLocalizationTe extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'చెల్లుబాటు అయ్యే సమయాన్ని ఎంటర్ చేయండి';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 లైసెన్స్';
+  String? get licensesPackageDetailTextOne => '1 లైసెన్స్';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount లైసెన్స్‌లు';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'లైసెన్స్‌లు';
@@ -24732,22 +24731,22 @@ class MaterialLocalizationTe extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'రిఫ్రెష్ చేయి';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 అక్షరం మిగిలి ఉంది';
+  String? get remainingTextFieldCharacterCountOne => '1 అక్షరం మిగిలి ఉంది';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount అక్షరాలు మిగిలి ఉన్నాయి';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'కిందికు జరుపు';
@@ -24786,22 +24785,22 @@ class MaterialLocalizationTe extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'సంవత్సరాన్ని ఎంచుకోండి';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 అంశం ఎంచుకోబడింది';
+  String? get selectedRowCountTitleOne => '1 అంశం ఎంచుకోబడింది';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount అంశాలు ఎంచుకోబడ్డాయి';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'ఖాతాలను చూపు';
@@ -24853,15 +24852,15 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationTh({
     String localeName = 'th',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -24975,22 +24974,22 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'ป้อนเวลาที่ถูกต้อง';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'ใบอนุญาต 1 ใบ';
+  String? get licensesPackageDetailTextOne => 'ใบอนุญาต 1 ใบ';
 
   @override
   String get licensesPackageDetailTextOther => r'ใบอนุญาต $licenseCount ใบ';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'ใบอนุญาต';
@@ -25038,22 +25037,22 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'รีเฟรช';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'เหลือ 1 อักขระ';
+  String? get remainingTextFieldCharacterCountOne => 'เหลือ 1 อักขระ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'เหลือ $remainingCount อักขระ';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'ย้ายลง';
@@ -25092,22 +25091,22 @@ class MaterialLocalizationTh extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'เลือกปี';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'เลือกแล้ว 1 รายการ';
+  String? get selectedRowCountTitleOne => 'เลือกแล้ว 1 รายการ';
 
   @override
   String get selectedRowCountTitleOther => r'เลือกแล้ว $selectedRowCount รายการ';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'แสดงบัญชี';
@@ -25159,15 +25158,15 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationTl({
     String localeName = 'tl',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -25281,22 +25280,22 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Maglagay ng valid na oras';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisensya';
+  String? get licensesPackageDetailTextOne => '1 lisensya';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount na lisensya';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Mga Lisensya';
@@ -25344,22 +25343,22 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Nagre-refresh';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 character ang natitira';
+  String? get remainingTextFieldCharacterCountOne => '1 character ang natitira';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount na character ang natitira';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Ilipat pababa';
@@ -25398,22 +25397,22 @@ class MaterialLocalizationTl extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Pumili ng taon';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 item ang napili';
+  String? get selectedRowCountTitleOne => '1 item ang napili';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount na item ang napili';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Ipakita ang mga account';
@@ -25465,15 +25464,15 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationTr({
     String localeName = 'tr',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -25587,22 +25586,22 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Geçerli bir saat girin';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 lisans';
+  String? get licensesPackageDetailTextOne => '1 lisans';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount lisans';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Lisanslar';
@@ -25650,22 +25649,22 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Yenile';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 karakter kaldı';
+  String? get remainingTextFieldCharacterCountOne => '1 karakter kaldı';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount karakter kaldı';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Aşağı taşı';
@@ -25704,22 +25703,22 @@ class MaterialLocalizationTr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Yılı seçin';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 öğe seçildi';
+  String? get selectedRowCountTitleOne => '1 öğe seçildi';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount öğe seçildi';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Hesapları göster';
@@ -25771,15 +25770,15 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationUk({
     String localeName = 'uk',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -25893,22 +25892,22 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Введіть дійсний час';
 
   @override
-  String get licensesPackageDetailTextFew => r'$licenseCount ліцензії';
+  String? get licensesPackageDetailTextFew => r'$licenseCount ліцензії';
 
   @override
-  String get licensesPackageDetailTextMany => r'$licenseCount ліцензій';
+  String? get licensesPackageDetailTextMany => r'$licenseCount ліцензій';
 
   @override
-  String get licensesPackageDetailTextOne => '1 ліцензія';
+  String? get licensesPackageDetailTextOne => '1 ліцензія';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ліцензії';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Ліцензії';
@@ -25956,22 +25955,22 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Оновити';
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Залишилося $remainingCount символи';
+  String? get remainingTextFieldCharacterCountFew => r'Залишилося $remainingCount символи';
 
   @override
-  String get remainingTextFieldCharacterCountMany => r'Залишилося $remainingCount символів';
+  String? get remainingTextFieldCharacterCountMany => r'Залишилося $remainingCount символів';
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Залишився 1 символ';
+  String? get remainingTextFieldCharacterCountOne => 'Залишився 1 символ';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Залишилося $remainingCount символу';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Перемістити вниз';
@@ -26010,22 +26009,22 @@ class MaterialLocalizationUk extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Виберіть рік';
 
   @override
-  String get selectedRowCountTitleFew => r'Вибрано $selectedRowCount елементи';
+  String? get selectedRowCountTitleFew => r'Вибрано $selectedRowCount елементи';
 
   @override
-  String get selectedRowCountTitleMany => r'Вибрано $selectedRowCount елементів';
+  String? get selectedRowCountTitleMany => r'Вибрано $selectedRowCount елементів';
 
   @override
-  String get selectedRowCountTitleOne => 'Вибрано 1 елемент';
+  String? get selectedRowCountTitleOne => 'Вибрано 1 елемент';
 
   @override
   String get selectedRowCountTitleOther => r'Вибрано $selectedRowCount елемента';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Показати облікові записи';
@@ -26077,15 +26076,15 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationUr({
     String localeName = 'ur',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -26199,22 +26198,22 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'درست وقت درج کریں';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 لائسنس';
+  String? get licensesPackageDetailTextOne => '1 لائسنس';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount لائسنسز';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'لائسنسز';
@@ -26262,22 +26261,22 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'ریفریش کریں';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 حرف باقی ہے';
+  String? get remainingTextFieldCharacterCountOne => '1 حرف باقی ہے';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount حروف باقی ہیں';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'نیچے منتقل کریں';
@@ -26316,22 +26315,22 @@ class MaterialLocalizationUr extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'سال منتخب کریں';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 آئٹم منتخب کیا گیا';
+  String? get selectedRowCountTitleOne => '1 آئٹم منتخب کیا گیا';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount آئٹمز منتخب کیے گئے';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'اکاؤنٹس دکھائیں';
@@ -26383,15 +26382,15 @@ class MaterialLocalizationUz extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationUz({
     String localeName = 'uz',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -26505,22 +26504,22 @@ class MaterialLocalizationUz extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Vaqt xato kiritildi';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 ta litsenziya';
+  String? get licensesPackageDetailTextOne => '1 ta litsenziya';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount ta litsenziya';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Litsenziyalar';
@@ -26568,22 +26567,22 @@ class MaterialLocalizationUz extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Yangilash';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 ta belgi qoldi';
+  String? get remainingTextFieldCharacterCountOne => '1 ta belgi qoldi';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount ta belgi qoldi';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Pastga siljitish';
@@ -26622,22 +26621,22 @@ class MaterialLocalizationUz extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Yilni tanlang';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 ta element tanlandi';
+  String? get selectedRowCountTitleOne => '1 ta element tanlandi';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount ta element tanlandi';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Hisoblarni koʻrsatish';
@@ -26689,15 +26688,15 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationVi({
     String localeName = 'vi',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -26811,22 +26810,22 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Nhập thời gian hợp lệ';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 giấy phép';
+  String? get licensesPackageDetailTextOne => '1 giấy phép';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount giấy phép';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Giấy phép';
@@ -26874,22 +26873,22 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Làm mới';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => 'Còn lại 1 ký tự';
+  String? get remainingTextFieldCharacterCountOne => 'Còn lại 1 ký tự';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'Còn lại $remainingCount ký tự';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => 'Di chuyển xuống';
@@ -26928,22 +26927,22 @@ class MaterialLocalizationVi extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Chọn năm';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => 'Đã chọn 1 mục';
+  String? get selectedRowCountTitleOne => 'Đã chọn 1 mục';
 
   @override
   String get selectedRowCountTitleOther => r'Đã chọn $selectedRowCount mục';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Hiển thị tài khoản';
@@ -26995,15 +26994,15 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZh({
     String localeName = 'zh',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27117,22 +27116,22 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => '请输入有效的时间';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => '1 份许可';
+  String? get licensesPackageDetailTextOne => '1 份许可';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount 份许可';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => '许可';
@@ -27180,22 +27179,22 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => '刷新';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '还可输入 1 个字符';
+  String? get remainingTextFieldCharacterCountOne => '还可输入 1 个字符';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'还可输入 $remainingCount 个字符';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => 'TBD';
+  String? get remainingTextFieldCharacterCountZero => 'TBD';
 
   @override
   String get reorderItemDown => '下移';
@@ -27234,22 +27233,22 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => '选择年份';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '已选择 1 项内容';
+  String? get selectedRowCountTitleOne => '已选择 1 项内容';
 
   @override
   String get selectedRowCountTitleOther => r'已选择 $selectedRowCount 项内容';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => '显示帐号';
@@ -27301,15 +27300,15 @@ class MaterialLocalizationZhHans extends MaterialLocalizationZh {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZhHans({
     String localeName = 'zh_Hans',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27331,15 +27330,15 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZhHant({
     String localeName = 'zh_Hant',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27441,7 +27440,7 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   String get invalidTimeLabel => '請輸入有效的時間';
 
   @override
-  String get licensesPackageDetailTextOne => '1 項授權';
+  String? get licensesPackageDetailTextOne => '1 項授權';
 
   @override
   String get licensesPackageDetailTextOther => r'$licenseCount 項授權';
@@ -27486,7 +27485,7 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   String get refreshIndicatorSemanticLabel => '重新整理';
 
   @override
-  String get remainingTextFieldCharacterCountOne => '尚餘 1 個字元';
+  String? get remainingTextFieldCharacterCountOne => '尚餘 1 個字元';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'尚餘 $remainingCount 個字元';
@@ -27525,7 +27524,7 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   String get selectYearSemanticsLabel => '揀年份';
 
   @override
-  String get selectedRowCountTitleOne => '已選取 1 個項目';
+  String? get selectedRowCountTitleOne => '已選取 1 個項目';
 
   @override
   String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
@@ -27574,15 +27573,15 @@ class MaterialLocalizationZhHantHk extends MaterialLocalizationZhHant {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZhHantHk({
     String localeName = 'zh_Hant_HK',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27604,15 +27603,15 @@ class MaterialLocalizationZhHantTw extends MaterialLocalizationZhHant {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZhHantTw({
     String localeName = 'zh_Hant_TW',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27630,7 +27629,7 @@ class MaterialLocalizationZhHantTw extends MaterialLocalizationZhHant {
   String get dialModeButtonLabel => '切換至鐘面挑選器模式';
 
   @override
-  String get licensesPackageDetailTextOne => '1 個授權';
+  String? get licensesPackageDetailTextOne => '1 個授權';
 
   @override
   String get timePickerHourLabel => '時';
@@ -27696,7 +27695,7 @@ class MaterialLocalizationZhHantTw extends MaterialLocalizationZhHant {
   String get reorderItemToEnd => '移至結尾';
 
   @override
-  String get remainingTextFieldCharacterCountOne => '還可輸入 1 個字元';
+  String? get remainingTextFieldCharacterCountOne => '還可輸入 1 個字元';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'還可輸入 $remainingCount 個字元';
@@ -27709,15 +27708,15 @@ class MaterialLocalizationZu extends GlobalMaterialLocalizations {
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
   const MaterialLocalizationZu({
     String localeName = 'zu',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
     localeName: localeName,
     fullYearFormat: fullYearFormat,
@@ -27831,22 +27830,22 @@ class MaterialLocalizationZu extends GlobalMaterialLocalizations {
   String get invalidTimeLabel => 'Faka igama elivumelekile';
 
   @override
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   @override
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   @override
-  String get licensesPackageDetailTextOne => 'ilayisense e-1';
+  String? get licensesPackageDetailTextOne => 'ilayisense e-1';
 
   @override
   String get licensesPackageDetailTextOther => r'amalayisense angu-$licenseCount';
 
   @override
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   @override
-  String get licensesPackageDetailTextZero => 'No licenses';
+  String? get licensesPackageDetailTextZero => 'No licenses';
 
   @override
   String get licensesPageTitle => 'Amalayisense';
@@ -27894,22 +27893,22 @@ class MaterialLocalizationZu extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => 'Vuselela';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
-  String get remainingTextFieldCharacterCountOne => '1 uhlamvu olusele';
+  String? get remainingTextFieldCharacterCountOne => '1 uhlamvu olusele';
 
   @override
   String get remainingTextFieldCharacterCountOther => r'$remainingCount izinhlamvu ezisele';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
-  String get remainingTextFieldCharacterCountZero => null;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   @override
   String get reorderItemDown => 'Iya phansi';
@@ -27948,22 +27947,22 @@ class MaterialLocalizationZu extends GlobalMaterialLocalizations {
   String get selectYearSemanticsLabel => 'Khetha unyaka';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
-  String get selectedRowCountTitleOne => '1 into ekhethiwe';
+  String? get selectedRowCountTitleOne => '1 into ekhethiwe';
 
   @override
   String get selectedRowCountTitleOther => r'$selectedRowCount izinto ezikhethiwe';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   @override
   String get showAccountsLabel => 'Bonisa ama-akhawunti';
@@ -28192,7 +28191,7 @@ final Set<String> kMaterialSupportedLanguages = HashSet<String>.from(const <Stri
 ///
 /// Generally speaking, this method is only intended to be used by
 /// [GlobalMaterialLocalizations.delegate].
-GlobalMaterialLocalizations getMaterialTranslation(
+GlobalMaterialLocalizations? getMaterialTranslation(
   Locale locale,
   intl.DateFormat fullYearFormat,
   intl.DateFormat compactDateFormat,

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -73,7 +73,22 @@
   },
 
   "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
   "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
   "licensesPackageDetailTextOther": "$licenseCount licenses",
   "@licensesPackageDetailText": {
     "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
@@ -104,7 +119,22 @@
   },
 
   "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
   "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
   "selectedRowCountTitleOther": "$selectedRowCount items selected",
   "@selectedRowCountTitle": {
     "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
@@ -389,7 +419,22 @@
   },
 
   "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
   "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
   "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
   "@remainingTextFieldCharacterCount": {
     "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",

--- a/packages/flutter_localizations/lib/src/l10n/material_ps.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ps.arb
@@ -1,7 +1,9 @@
 {
   "scriptCategory": "tall",
   "timeOfDayFormat": "HH:mm",
+  "anteMeridiemAbbreviation": "AM",
   "@anteMeridiemAbbreviation": {"notUsed":"Pashto time format does not use a.m. indicator"},
+  "postMeridiemAbbreviation": "PM",
   "@postMeridiemAbbreviation": {"notUsed":"Pashto time format does not use p.m. indicator"},
   "openAppDrawerTooltip": "د پرانیستی نیینګ مینو",
   "backButtonTooltip": "شاته",

--- a/packages/flutter_localizations/lib/src/material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/material_localizations.dart
@@ -87,16 +87,16 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   /// The [narrowWeekdays] and [firstDayOfWeekIndex] properties use the values
   /// from the [intl.DateFormat] used by [formatFullDate].
   const GlobalMaterialLocalizations({
-    @required String localeName,
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required String localeName,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : assert(localeName != null),
        _localeName = localeName,
        assert(fullYearFormat != null),
@@ -140,7 +140,6 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
         final int hour = timeOfDay.hourOfPeriod;
         return formatDecimal(hour == 0 ? 12 : hour);
     }
-    return null;
   }
 
   @override
@@ -184,9 +183,9 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   }
 
   @override
-  DateTime parseCompactDate(String inputString) {
+  DateTime? parseCompactDate(String? inputString) {
     try {
-      return _compactDateFormat.parseStrict(inputString);
+      return inputString != null ? _compactDateFormat.parseStrict(inputString) : null;
     } on FormatException {
       return null;
     }
@@ -219,28 +218,26 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
     final String minute = formatMinute(timeOfDay);
     switch (timeOfDayFormat(alwaysUse24HourFormat: alwaysUse24HourFormat)) {
       case TimeOfDayFormat.h_colon_mm_space_a:
-        return '$hour:$minute ${_formatDayPeriod(timeOfDay)}';
+        return '$hour:$minute ${_formatDayPeriod(timeOfDay)!}';
       case TimeOfDayFormat.H_colon_mm:
       case TimeOfDayFormat.HH_colon_mm:
         return '$hour:$minute';
       case TimeOfDayFormat.HH_dot_mm:
         return '$hour.$minute';
       case TimeOfDayFormat.a_space_h_colon_mm:
-        return '${_formatDayPeriod(timeOfDay)} $hour:$minute';
+        return '${_formatDayPeriod(timeOfDay)!} $hour:$minute';
       case TimeOfDayFormat.frenchCanadian:
         return '$hour h $minute';
     }
-    return null;
   }
 
-  String _formatDayPeriod(TimeOfDay timeOfDay) {
+  String? _formatDayPeriod(TimeOfDay timeOfDay) {
     switch (timeOfDay.period) {
       case DayPeriod.am:
         return anteMeridiemAbbreviation;
       case DayPeriod.pm:
         return postMeridiemAbbreviation;
     }
-    return null;
   }
 
   /// The raw version of [dateRangeStartDateSemanticLabel], with `$formattedDate` verbatim
@@ -288,7 +285,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   @override
   String pageRowsInfoTitle(int firstRow, int lastRow, int rowCount, bool rowCountIsApproximate) {
-    String text = rowCountIsApproximate ? pageRowsInfoTitleApproximateRaw : null;
+    String? text = rowCountIsApproximate ? pageRowsInfoTitleApproximateRaw : null;
     text ??= pageRowsInfoTitleRaw;
     assert(text != null, 'A $_localeName localization was not found for pageRowsInfoTitle or pageRowsInfoTitleApproximate');
     return text
@@ -303,7 +300,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   String get tabLabelRaw;
 
   @override
-  String tabLabel({ int tabIndex, int tabCount }) {
+  String tabLabel({ required int tabIndex, required int tabCount }) {
     assert(tabIndex >= 1);
     assert(tabCount >= 1);
     final String template = tabLabelRaw;
@@ -325,7 +322,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [selectedRowCountTitleMany], the "many" form
   ///  * [selectedRowCountTitleOther], the "other" form
   @protected
-  String get selectedRowCountTitleZero => null;
+  String? get selectedRowCountTitleZero => null;
 
   /// The "one" form of [selectedRowCountTitle].
   ///
@@ -340,7 +337,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [selectedRowCountTitleMany], the "many" form
   ///  * [selectedRowCountTitleOther], the "other" form
   @protected
-  String get selectedRowCountTitleOne => null;
+  String? get selectedRowCountTitleOne => null;
 
   /// The "two" form of [selectedRowCountTitle].
   ///
@@ -355,7 +352,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [selectedRowCountTitleMany], the "many" form
   ///  * [selectedRowCountTitleOther], the "other" form
   @protected
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   /// The "few" form of [selectedRowCountTitle].
   ///
@@ -370,7 +367,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [selectedRowCountTitleMany], the "many" form
   ///  * [selectedRowCountTitleOther], the "other" form
   @protected
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   /// The "many" form of [selectedRowCountTitle].
   ///
@@ -385,7 +382,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [selectedRowCountTitleFew], the "few" form
   ///  * [selectedRowCountTitleOther], the "other" form
   @protected
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   /// The "other" form of [selectedRowCountTitle].
   ///
@@ -458,7 +455,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [licensesPackageDetailTextMany], the "many" form
   ///  * [licensesPackageDetailTextOther], the "other" form
   @protected
-  String get licensesPackageDetailTextZero => null;
+  String? get licensesPackageDetailTextZero => null;
 
   /// The "one" form of [licensesPackageDetailText].
   ///
@@ -473,7 +470,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [licensesPackageDetailTextMany], the "many" form
   ///  * [licensesPackageDetailTextOther], the "other" form
   @protected
-  String get licensesPackageDetailTextOne => null;
+  String? get licensesPackageDetailTextOne => null;
 
   /// The "two" form of [licensesPackageDetailText].
   ///
@@ -489,7 +486,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [licensesPackageDetailTextMany], the "many" form
   ///  * [licensesPackageDetailTextOther], the "other" form
   @protected
-  String get licensesPackageDetailTextTwo => null;
+  String? get licensesPackageDetailTextTwo => null;
 
   /// The "many" form of [licensesPackageDetailText].
   ///
@@ -505,7 +502,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [licensesPackageDetailTextMany], the "many" form
   ///  * [licensesPackageDetailTextOther], the "other" form
   @protected
-  String get licensesPackageDetailTextMany => null;
+  String? get licensesPackageDetailTextMany => null;
 
   /// The "few" form of [licensesPackageDetailText].
   ///
@@ -521,7 +518,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [licensesPackageDetailTextMany], the "many" form
   ///  * [licensesPackageDetailTextOther], the "other" form
   @protected
-  String get licensesPackageDetailTextFew => null;
+  String? get licensesPackageDetailTextFew => null;
 
   /// The "other" form of [licensesPackageDetailText].
   ///
@@ -555,7 +552,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
 
   /// The "zero" form of [remainingTextFieldCharacterCount].
   ///
-  /// This form is required.
+  /// This form is optional.
   ///
   /// See also:
   ///
@@ -567,7 +564,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [remainingTextFieldCharacterCountMany], the "many" form
   ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
-  String get remainingTextFieldCharacterCountZero;
+  String? get remainingTextFieldCharacterCountZero => null;
 
   /// The "one" form of [remainingTextFieldCharacterCount].
   ///
@@ -582,7 +579,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [remainingTextFieldCharacterCountMany], the "many" form
   ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
-  String get remainingTextFieldCharacterCountOne => null;
+  String? get remainingTextFieldCharacterCountOne => null;
 
   /// The "two" form of [remainingTextFieldCharacterCount].
   ///
@@ -598,7 +595,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [remainingTextFieldCharacterCountMany], the "many" form
   ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   /// The "many" form of [remainingTextFieldCharacterCount].
   ///
@@ -614,7 +611,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [remainingTextFieldCharacterCountMany], the "many" form
   ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   /// The "few" form of [remainingTextFieldCharacterCount].
   ///
@@ -630,7 +627,7 @@ abstract class GlobalMaterialLocalizations implements MaterialLocalizations {
   ///  * [remainingTextFieldCharacterCountMany], the "many" form
   ///  * [remainingTextFieldCharacterCountOther], the "other" form
   @protected
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   /// The "other" form of [remainingTextFieldCharacterCount].
   ///
@@ -714,7 +711,6 @@ TimeOfDayFormat _get24HourVersionOf(TimeOfDayFormat original) {
     case TimeOfDayFormat.a_space_h_colon_mm:
       return TimeOfDayFormat.HH_colon_mm;
   }
-  return TimeOfDayFormat.HH_colon_mm;
 }
 
 class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
@@ -795,7 +791,7 @@ class _MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocal
         shortMonthDayFormat,
         decimalFormat,
         twoDigitZeroPaddedFormat,
-      ));
+      )!);
     });
   }
 

--- a/packages/flutter_localizations/lib/src/utils/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/utils/date_localizations.dart
@@ -28,7 +28,7 @@ void loadDateIntlDataIfNotLoaded() {
         // Strip scriptCode from the locale, as we do not distinguish between scripts
         // for dates.
         final List<String> codes = locale.split('_');
-        String countryCode;
+        String? countryCode;
         if (codes.length == 2) {
           countryCode = codes[1].length < 4 ? codes[1] : null;
         } else if (codes.length == 3) {

--- a/packages/flutter_localizations/lib/src/widgets_localizations.dart
+++ b/packages/flutter_localizations/lib/src/widgets_localizations.dart
@@ -43,7 +43,7 @@ class GlobalWidgetsLocalizations implements WidgetsLocalizations {
 
   @override
   TextDirection get textDirection => _textDirection;
-  TextDirection _textDirection;
+  late TextDirection _textDirection;
 
   /// Creates an object that provides localized resource values for the
   /// lowest levels of the Flutter framework.

--- a/packages/flutter_localizations/pubspec.yaml
+++ b/packages/flutter_localizations/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_localizations
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -63,7 +63,7 @@ void main() {
       )
     );
 
-    await tester.binding.setLocale('zh', null);
+    await tester.binding.setLocale('zh', '');
     await tester.pump();
     await tester.binding.setLocale('es', 'US');
     await tester.pump();
@@ -87,18 +87,18 @@ class _DummyLocalizationsDelegate extends LocalizationsDelegate<DummyLocalizatio
 class DummyLocalizations {}
 
 class LocalizationTracker extends StatefulWidget {
-  const LocalizationTracker({Key key}) : super(key: key);
+  const LocalizationTracker({Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => LocalizationTrackerState();
 }
 
 class LocalizationTrackerState extends State<LocalizationTracker> {
-  double captionFontSize;
+  late double captionFontSize;
 
   @override
   Widget build(BuildContext context) {
-    captionFontSize = Theme.of(context).textTheme.caption.fontSize;
+    captionFontSize = Theme.of(context)!.textTheme.caption!.fontSize!;
     return Container();
   }
 }

--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -98,7 +98,7 @@ class LocalizationTrackerState extends State<LocalizationTracker> {
 
   @override
   Widget build(BuildContext context) {
-    captionFontSize = Theme.of(context)!.textTheme.caption!.fontSize!;
+    captionFontSize = Theme.of(context).textTheme.caption!.fontSize!;
     return Container();
   }
 }

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -166,6 +166,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/36704.
   testWidgets('kn arb file should be properly Unicode escaped', (WidgetTester tester) async {
+    print('DMA: $rootDirectoryPath');
     final File file = File(
       path.join(rootDirectoryPath, 'lib', 'src', 'l10n', 'cupertino_kn.arb'),
     );

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -166,7 +166,6 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/36704.
   testWidgets('kn arb file should be properly Unicode escaped', (WidgetTester tester) async {
-    print('DMA: $rootDirectoryPath');
     final File file = File(
       path.join(rootDirectoryPath, 'lib', 'src', 'l10n', 'cupertino_kn.arb'),
     );

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -9,9 +9,9 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  DateTime firstDate;
-  DateTime lastDate;
-  DateTime initialDate;
+  late DateTime firstDate;
+  late DateTime lastDate;
+  late DateTime initialDate;
 
   setUp(() {
     firstDate = DateTime(2001, DateTime.january, 1);
@@ -53,10 +53,10 @@ void main() {
 
     for (final Locale locale in testLocales.keys) {
       testWidgets('shows dates for $locale', (WidgetTester tester) async {
-        final List<String> expectedDaysOfWeek = testLocales[locale]['expectedDaysOfWeek'] as List<String>;
-        final List<String> expectedDaysOfMonth = testLocales[locale]['expectedDaysOfMonth'] as List<String>;
-        final String expectedMonthYearHeader = testLocales[locale]['expectedMonthYearHeader'] as String;
-        final TextDirection textDirection = testLocales[locale]['textDirection'] as TextDirection;
+        final List<String> expectedDaysOfWeek = testLocales[locale]!['expectedDaysOfWeek'] as List<String>;
+        final List<String> expectedDaysOfMonth = testLocales[locale]!['expectedDaysOfMonth'] as List<String>;
+        final String expectedMonthYearHeader = testLocales[locale]!['expectedMonthYearHeader'] as String;
+        final TextDirection textDirection = testLocales[locale]!['textDirection'] as TextDirection;
         final DateTime baseDate = DateTime(2017, 9, 27);
 
         await _pumpBoilerplate(tester, CalendarDatePicker(
@@ -72,7 +72,7 @@ void main() {
           expect(find.text(dayOfWeek), findsWidgets);
         }
 
-        Offset previousCellOffset;
+        Offset? previousCellOffset;
         for (final String dayOfMonth in expectedDaysOfMonth) {
           final Finder dayCell = find.descendant(of: find.byType(GridView), matching: find.text(dayOfMonth));
           expect(dayCell, findsOneWidget);

--- a/packages/flutter_localizations/test/material/date_time_test.dart
+++ b/packages/flutter_localizations/test/material/date_time_test.dart
@@ -163,7 +163,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/67644.
   testWidgets('en_US is initialized correctly by Flutter when DateFormat is used', (WidgetTester tester) async {
-    DateFormat dateFormat;
+    late DateFormat dateFormat;
 
     await tester.pumpWidget(MaterialApp(
       supportedLocales: const <Locale>[
@@ -180,7 +180,7 @@ void main() {
       }),
     ));
 
-    expect(dateFormat?.locale, 'en_US');
+    expect(dateFormat.locale, 'en_US');
   });
 }
 

--- a/packages/flutter_localizations/test/material/time_picker_test.dart
+++ b/packages/flutter_localizations/test/material/time_picker_test.dart
@@ -9,13 +9,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _TimePickerLauncher extends StatelessWidget {
   const _TimePickerLauncher({
-    Key key,
+    Key? key,
     this.onChanged,
-    this.locale,
+    required this.locale,
     this.entryMode = TimePickerEntryMode.dial,
   }) : super(key: key);
 
-  final ValueChanged<TimeOfDay> onChanged;
+  final ValueChanged<TimeOfDay?>? onChanged;
   final Locale locale;
   final TimePickerEntryMode entryMode;
 
@@ -32,7 +32,7 @@ class _TimePickerLauncher extends StatelessWidget {
               return ElevatedButton(
                 child: const Text('X'),
                 onPressed: () async {
-                  onChanged(await showTimePicker(
+                  onChanged?.call(await showTimePicker(
                     context: context,
                     initialEntryMode: entryMode,
                     initialTime: const TimeOfDay(hour: 7, minute: 0),
@@ -49,7 +49,7 @@ class _TimePickerLauncher extends StatelessWidget {
 
 Future<Offset> startPicker(
   WidgetTester tester,
-  ValueChanged<TimeOfDay> onChanged, {
+  ValueChanged<TimeOfDay?> onChanged, {
     Locale locale = const Locale('en', 'US'),
 }) async {
   await tester.pumpWidget(_TimePickerLauncher(onChanged: onChanged, locale: locale,));
@@ -89,7 +89,7 @@ void main() {
     ];
 
     for (final Locale locale in locales) {
-      final Offset center = await startPicker(tester, (TimeOfDay time) { }, locale: locale);
+      final Offset center = await startPicker(tester, (TimeOfDay? time) { }, locale: locale);
       final Text stringFragmentText = tester.widget(stringFragmentTextFinder);
       final double hourLeftOffset = tester.getTopLeft(hourControlFinder).dx;
       final double minuteLeftOffset = tester.getTopLeft(minuteControlFinder).dx;
@@ -133,8 +133,8 @@ void main() {
       await finishPicker(tester);
     }
 
-    tester.binding.window.physicalSizeTestValue = null;
-    tester.binding.window.devicePixelRatioTestValue = null;
+    tester.binding.window.clearPhysicalSizeTestValue();
+    tester.binding.window.clearDevicePixelRatioTestValue();
   });
 
   testWidgets('can localize the header in all known formats - landscape', (WidgetTester tester) async {
@@ -161,7 +161,7 @@ void main() {
     ];
 
     for (final Locale locale in locales) {
-      final Offset center = await startPicker(tester, (TimeOfDay time) { }, locale: locale);
+      final Offset center = await startPicker(tester, (TimeOfDay? time) { }, locale: locale);
       final Text stringFragmentText = tester.widget(stringFragmentTextFinder);
       final double hourLeftOffset = tester.getTopLeft(hourControlFinder).dx;
       final double hourTopOffset = tester.getTopLeft(hourControlFinder).dy;
@@ -210,8 +210,8 @@ void main() {
       await finishPicker(tester);
     }
 
-    tester.binding.window.physicalSizeTestValue = null;
-    tester.binding.window.devicePixelRatioTestValue = null;
+    tester.binding.window.clearPhysicalSizeTestValue();
+    tester.binding.window.clearDevicePixelRatioTestValue();
   });
 
   testWidgets('can localize input mode in all known formats', (WidgetTester tester) async {
@@ -234,7 +234,7 @@ void main() {
     ];
 
     for (final Locale locale in locales) {
-      await tester.pumpWidget(_TimePickerLauncher(onChanged: (TimeOfDay time) { }, locale: locale, entryMode: TimePickerEntryMode.input));
+      await tester.pumpWidget(_TimePickerLauncher(onChanged: (TimeOfDay? time) { }, locale: locale, entryMode: TimePickerEntryMode.input));
       await tester.tap(find.text('X'));
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
@@ -292,8 +292,8 @@ void main() {
       // 12:00 AM position. Because there's only one ring, no matter where you
       // tap the time will be the same.
       for (int i = 1; i < 10; i++) {
-        TimeOfDay result;
-        final Offset center = await startPicker(tester, (TimeOfDay time) { result = time; }, locale: locale);
+        TimeOfDay? result;
+        final Offset center = await startPicker(tester, (TimeOfDay? time) { result = time; }, locale: locale);
         final Size size = tester.getSize(find.byKey(const Key('time-picker-dial')));
         final double dy = (size.height / 2.0 / 10) * i;
         await tester.tapAt(Offset(center.dx, center.dy - dy));
@@ -348,13 +348,13 @@ void main() {
     final dynamic dialPainter = dialPaint.painter;
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text as TextSpan).text),
+      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
       labels12To11,
     );
 
     final List<dynamic> secondaryLabels = dialPainter.secondaryLabels as List<dynamic>;
     expect(
-      secondaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text as TextSpan).text),
+      secondaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
       labels12To11,
     );
   });
@@ -366,13 +366,13 @@ void main() {
     final dynamic dialPainter = dialPaint.painter;
     final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
     expect(
-      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text as TextSpan).text),
+      primaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
       labels00To22TwoDigit,
     );
 
     final List<dynamic> secondaryLabels = dialPainter.secondaryLabels as List<dynamic>;
     expect(
-      secondaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text as TextSpan).text),
+      secondaryLabels.map<String>((dynamic tp) => ((tp.painter as TextPainter).text! as TextSpan).text!),
       labels00To22TwoDigit,
     );
   });

--- a/packages/flutter_localizations/test/override_test.dart
+++ b/packages/flutter_localizations/test/override_test.dart
@@ -53,10 +53,10 @@ class FooMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLoc
 }
 
 Widget buildFrame({
-  Locale locale,
+  Locale? locale,
   Iterable<LocalizationsDelegate<dynamic>> delegates = GlobalMaterialLocalizations.delegates,
-  WidgetBuilder buildContent,
-  LocaleResolutionCallback localeResolutionCallback,
+  required WidgetBuilder buildContent,
+  LocaleResolutionCallback? localeResolutionCallback,
   Iterable<Locale> supportedLocales = const <Locale>[
     Locale('en', 'US'),
     Locale('es', 'ES'),
@@ -210,7 +210,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         // Accept whatever locale we're given
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) => locale,
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) => locale,
         delegates: <FooMaterialLocalizationsDelegate>[
           const FooMaterialLocalizationsDelegate(supportedLanguage: 'allLanguages'),
         ],

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(topRight, const Offset(477.0, 347.5));
     expect(bottomLeft, const Offset(392.0, 364.5));
     expect(bottomRight, const Offset(477.0, 364.5));
-  }, skip: !isLinux);
+  });
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
     // This test in combination with 'Text baseline with CJK locale' verify the baselines
@@ -164,7 +164,6 @@ void main() {
     Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
-
     expect(topLeft, const Offset(392.0, 300.0));
     expect(topRight, const Offset(584.0, 300.0));
     expect(bottomLeft, const Offset(392.0, 316));
@@ -179,5 +178,5 @@ void main() {
     expect(topRight, const Offset(472.0, 348.0));
     expect(bottomLeft, const Offset(392.0, 364.0));
     expect(bottomRight, const Offset(472.0, 364.0));
-  }, skip: !isLinux);
+  });
 }

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -576,7 +576,7 @@ void main() {
             child: Builder(
               builder: (BuildContext context) {
                 final Locale locale = Localizations.localeOf(context)!;
-                final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
+                final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
                 return Text('$locale $direction');
               },
             ),
@@ -617,7 +617,7 @@ void main() {
             child: Builder(
               builder: (BuildContext context) {
                 final Locale locale = Localizations.localeOf(context)!;
-                final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
+                final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
                 return Text('$locale $direction');
               },
             ),
@@ -653,7 +653,7 @@ void main() {
         ],
         buildContent: (BuildContext context) {
           final Locale locale = Localizations.localeOf(context)!;
-          final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
+          final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
           return Text('$locale $direction');
         },
       )

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -13,19 +13,21 @@ class TestLocalizations {
   TestLocalizations(this.locale, this.prefix);
 
   final Locale locale;
-  final String prefix;
+  final String? prefix;
 
-  static Future<TestLocalizations> loadSync(Locale locale, String prefix) {
+  static Future<TestLocalizations> loadSync(Locale locale, String? prefix) {
     return SynchronousFuture<TestLocalizations>(TestLocalizations(locale, prefix));
   }
 
-  static Future<TestLocalizations> loadAsync(Locale locale, String prefix) {
-    return Future<TestLocalizations>.delayed(const Duration(milliseconds: 100))
-      .then((_) => TestLocalizations(locale, prefix));
+  static Future<TestLocalizations> loadAsync(Locale locale, String? prefix) {
+    return Future<TestLocalizations>.delayed(
+      const Duration(milliseconds: 100),
+      () => TestLocalizations(locale, prefix)
+    );
   }
 
   static TestLocalizations of(BuildContext context) {
-    return Localizations.of<TestLocalizations>(context, TestLocalizations);
+    return Localizations.of<TestLocalizations>(context, TestLocalizations)!;
   }
 
   String get message => '${prefix ?? ""}$locale';
@@ -34,7 +36,7 @@ class TestLocalizations {
 class SyncTestLocalizationsDelegate extends LocalizationsDelegate<TestLocalizations> {
   SyncTestLocalizationsDelegate([this.prefix]);
 
-  final String prefix; // Changing this value triggers a rebuild
+  final String? prefix; // Changing this value triggers a rebuild
   final List<bool> shouldReloadValues = <bool>[];
 
   @override
@@ -56,7 +58,7 @@ class SyncTestLocalizationsDelegate extends LocalizationsDelegate<TestLocalizati
 class AsyncTestLocalizationsDelegate extends LocalizationsDelegate<TestLocalizations> {
   AsyncTestLocalizationsDelegate([this.prefix]);
 
-  final String prefix; // Changing this value triggers a rebuild
+  final String? prefix; // Changing this value triggers a rebuild
   final List<bool> shouldReloadValues = <bool>[];
 
   @override
@@ -85,12 +87,14 @@ class MoreLocalizations {
   }
 
   static Future<MoreLocalizations> loadAsync(Locale locale) {
-    return Future<MoreLocalizations>.delayed(const Duration(milliseconds: 100))
-      .then((_) => MoreLocalizations(locale));
+    return Future<MoreLocalizations>.delayed(
+      const Duration(milliseconds: 100),
+      () => MoreLocalizations(locale)
+    );
   }
 
   static MoreLocalizations of(BuildContext context) {
-    return Localizations.of<MoreLocalizations>(context, MoreLocalizations);
+    return Localizations.of<MoreLocalizations>(context, MoreLocalizations)!;
   }
 
   String get message => '$locale';
@@ -139,10 +143,10 @@ class OnlyRTLDefaultWidgetsLocalizationsDelegate extends LocalizationsDelegate<W
 }
 
 Widget buildFrame({
-  Locale locale,
-  Iterable<LocalizationsDelegate<dynamic>> delegates,
-  WidgetBuilder buildContent,
-  LocaleResolutionCallback localeResolutionCallback,
+  Locale? locale,
+  Iterable<LocalizationsDelegate<dynamic>>? delegates,
+  required WidgetBuilder buildContent,
+  LocaleResolutionCallback? localeResolutionCallback,
   List<Locale> supportedLocales = const <Locale>[
     Locale('en', 'US'),
     Locale('en', 'GB'),
@@ -183,7 +187,7 @@ class SyncLoadTestState extends State<SyncLoadTest> {
 
 void main() {
   testWidgets('Localizations.localeFor in a WidgetsApp with system locale', (WidgetTester tester) async {
-    BuildContext pageContext;
+    late BuildContext pageContext;
 
     await tester.pumpWidget(
       buildFrame(
@@ -205,7 +209,7 @@ void main() {
 
   testWidgets('Localizations.localeFor in a WidgetsApp with an explicit locale', (WidgetTester tester) async {
     const Locale locale = Locale('en', 'US');
-    BuildContext pageContext;
+    late BuildContext pageContext;
 
     await tester.pumpWidget(
       buildFrame(
@@ -477,7 +481,7 @@ void main() {
   });
 
   testWidgets('Directionality tracks system locale', (WidgetTester tester) async {
-    BuildContext pageContext;
+    late BuildContext pageContext;
 
     await tester.pumpWidget(
       buildFrame(
@@ -507,7 +511,7 @@ void main() {
   testWidgets('localeResolutionCallback override', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildFrame(
-        localeResolutionCallback: (Locale newLocale, Iterable<Locale> supportedLocales) {
+        localeResolutionCallback: (Locale? newLocale, Iterable<Locale> supportedLocales) {
           return const Locale('foo', 'BAR');
         },
         buildContent: (BuildContext context) {
@@ -562,7 +566,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         // Accept whatever locale we're given
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) => locale,
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) => locale,
         delegates: const <LocalizationsDelegate<dynamic>>[
           GlobalWidgetsLocalizations.delegate,
         ],
@@ -571,8 +575,8 @@ void main() {
             context: context,
             child: Builder(
               builder: (BuildContext context) {
-                final Locale locale = Localizations.localeOf(context);
-                final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
+                final Locale locale = Localizations.localeOf(context)!;
+                final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
                 return Text('$locale $direction');
               },
             ),
@@ -602,7 +606,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         // Accept whatever locale we're given
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) => locale,
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) => locale,
         buildContent: (BuildContext context) {
           return Localizations.override(
             context: context,
@@ -612,8 +616,8 @@ void main() {
             ],
             child: Builder(
               builder: (BuildContext context) {
-                final Locale locale = Localizations.localeOf(context);
-                final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
+                final Locale locale = Localizations.localeOf(context)!;
+                final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
                 return Text('$locale $direction');
               },
             ),
@@ -643,13 +647,13 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         // Accept whatever locale we're given
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) => locale,
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) => locale,
         delegates: <OnlyRTLDefaultWidgetsLocalizationsDelegate>[
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
-          final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
+          final Locale locale = Localizations.localeOf(context)!;
+          final TextDirection direction = WidgetsLocalizations.of(context)!.textDirection;
           return Text('$locale $direction');
         },
       )
@@ -680,13 +684,13 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         // Accept whatever locale we're given
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) => locale,
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) => locale,
         delegates: <OnlyRTLDefaultWidgetsLocalizationsDelegate>[
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale1 = ui.window.locales.first;
-          final Locale locale2 = ui.window.locales[1];
+          final Locale locale1 = ui.window.locales!.first;
+          final Locale locale2 = ui.window.locales![1];
           return Text('$locale1 $locale2');
         },
       )
@@ -756,7 +760,7 @@ void main() {
           Locale('ja'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -779,7 +783,7 @@ void main() {
           Locale('zh', 'TW'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -811,7 +815,7 @@ void main() {
           Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -952,7 +956,7 @@ void main() {
           Locale.fromSubtags(languageCode: 'zh'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1092,7 +1096,7 @@ void main() {
           Locale('it', 'IT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1115,7 +1119,7 @@ void main() {
           Locale('it', 'IT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1148,7 +1152,7 @@ void main() {
           Locale('pt', 'PT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1215,7 +1219,7 @@ void main() {
           Locale('de', 'DE'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1279,7 +1283,7 @@ void main() {
           Locale('vi'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1425,13 +1429,13 @@ void main() {
           Locale('en', 'AU'),
           Locale('de', 'DE'),
         ],
-        localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
+        localeResolutionCallback: (Locale? locale, Iterable<Locale> supportedLocales) {
           if (locale == null)
             return const Locale('und', 'US');
           return const Locale('en', 'US');
         },
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context);
+          final Locale locale = Localizations.localeOf(context)!;
           return Text('$locale');
         },
       )
@@ -1442,10 +1446,6 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('en_US'), findsOneWidget);
-
-    await tester.binding.setLocales(null);
-    await tester.pumpAndSettle();
-    expect(find.text('und_US'), findsOneWidget);
 
     await tester.binding.setLocales(const <Locale>[]);
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

This PR migrates the `flutter_localizations` package to null safety.

Needed to add some functionality to the arb files to flag some values as optional so that we can get the type correct in the generation. 
