### PR TITLE
Remove the defaults for textBaseline

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -14,6 +14,8 @@ import 'table_border.dart';
 /// Parent data used by [RenderTable] for its children.
 class TableCellParentData extends BoxParentData {
   /// Where this cell should be placed vertically.
+  ///
+  /// When using [TableCellVerticalAlignment.baseline], the text baseline must be set as well.
   TableCellVerticalAlignment? verticalAlignment;
 
   /// The column that the child was in the last time it was laid out.
@@ -1049,7 +1051,7 @@ class RenderTable extends RenderBox {
           childParentData.y = y;
           switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
             case TableCellVerticalAlignment.baseline:
-              assert(textBaseline != null);
+              assert(textBaseline != null, 'An explicit textBaseline is required when using baseline alignment.');
               child.layout(BoxConstraints.tightFor(width: widths[x]), parentUsesSize: true);
               final double? childBaseline = child.getDistanceToBaseline(textBaseline!, onlyReal: true);
               if (childBaseline != null) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3966,7 +3966,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.crossAxisAlignment = CrossAxisAlignment.center,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
-    this.textBaseline = TextBaseline.alphabetic,
+    this.textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
     this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
   }) : assert(direction != null),
@@ -4064,7 +4064,8 @@ class Flex extends MultiChildRenderObjectWidget {
 
   /// If aligning items according to their baseline, which baseline to use.
   ///
-  /// Defaults to [TextBaseline.alphabetic].
+  /// This must be set if using baseline alignment. There is no default because there is no
+  /// way for the framework to know the correct baseline _a priori_.
   final TextBaseline? textBaseline;
 
   /// {@macro flutter.widgets.Clip}
@@ -4341,7 +4342,7 @@ class Row extends Flex {
     CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
     TextDirection? textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
-    TextBaseline textBaseline = TextBaseline.alphabetic,
+    TextBaseline? textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
     List<Widget> children = const <Widget>[],
   }) : super(
     children: children,

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -116,10 +116,11 @@ class Table extends RenderObjectWidget {
     this.textDirection,
     this.border,
     this.defaultVerticalAlignment = TableCellVerticalAlignment.top,
-    this.textBaseline = TextBaseline.alphabetic,
+    this.textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
   }) : assert(children != null),
        assert(defaultColumnWidth != null),
        assert(defaultVerticalAlignment != null),
+       assert(defaultVerticalAlignment != TableCellVerticalAlignment.baseline || textBaseline != null, 'textBaseline is required if you specify the defaultVerticalAlignment with TableCellVerticalAlignment.baseline'),
        assert(() {
          if (children.any((TableRow row) => row.children == null)) {
            throw FlutterError(
@@ -231,8 +232,9 @@ class Table extends RenderObjectWidget {
 
   /// The text baseline to use when aligning rows using [TableCellVerticalAlignment.baseline].
   ///
-  /// Defaults to [TextBaseline.alphabetic].
-  final TextBaseline textBaseline;
+  /// This must be set if using baseline alignment. There is no default because there is no
+  /// way for the framework to know the correct baseline _a priori_.
+  final TextBaseline? textBaseline;
 
   final List<Decoration?>? _rowDecorations;
 

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -32,8 +32,8 @@ void main() {
           '   If multiple keyed nodes exist as children of another node, they\n'
           '   must have unique keys.\n'
           '   Flex(direction: vertical, mainAxisAlignment: start,\n'
-          '   crossAxisAlignment: center, textBaseline: alphabetic) has\n'
-          "   multiple children with key [<'key'>].\n",
+          '   crossAxisAlignment: center) has multiple children with key\n'
+          '   [<\'key\'>].\n',
         ),
       );
     }

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -930,29 +930,15 @@ void main() {
     },
   );
 
-  testWidgets(
-    'Table widget - Default textBaseline is set to TableBaseline.alphabetic',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Table(
-            defaultVerticalAlignment: TableCellVerticalAlignment.baseline,
-            children: const <TableRow>[
-              TableRow(
-                children: <Widget>[
-                  Text('Some Text'),
-                ],
-              ),
-            ],
-          ),
-        ),
-      );
-
-      final RenderTable table = tester.renderObject(find.byType(Table));
-      expect(table.textBaseline, TextBaseline.alphabetic);
-    },
-  );
+  testWidgets('Table widget - Default textBaseline is null', (WidgetTester tester) async {
+    expect(
+      () => Table(defaultVerticalAlignment: TableCellVerticalAlignment.baseline),
+      throwsA(
+        isAssertionError
+          .having((AssertionError error) => error.message, 'exception message', contains('baseline')),
+      ),
+    );
+  });
 
   testWidgets(
     'Table widget requires all TableRows to have non-null children',


### PR DESCRIPTION
We can't know what the correct default is. It depends entirely on the application's locale.

cc @tvolkert @ramnavan 

Reverts https://github.com/flutter/flutter/pull/60586, https://github.com/flutter/flutter/pull/61425. See also https://github.com/flutter/flutter/issues/58053.