### PR TITLE
Clean up device logger and port forwarding on drive completion

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -386,6 +386,8 @@ $ex
         globals.printStatus('Stopping application instance.');
         await appStopper(this, package);
       }
+
+      await device.dispose();
     }
 
     return FlutterCommandResult.success();

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -387,7 +387,7 @@ $ex
         await appStopper(this, package);
       }
 
-      await device.dispose();
+      await device?.dispose();
     }
 
     return FlutterCommandResult.success();

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -228,6 +228,7 @@ void main() {
         '10',
       ];
       await createTestCommandRunner(command).run(args);
+      verify(mockDevice.dispose());
       expect(testLogger.errorText, isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
@@ -529,6 +530,7 @@ void main() {
                 prebuiltApplication: false,
                 userIdentifier: anyNamed('userIdentifier'),
         ));
+        verify(mockDevice.dispose());
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -558,6 +560,7 @@ void main() {
                 prebuiltApplication: false,
                 userIdentifier: anyNamed('userIdentifier'),
         ));
+        verify(mockDevice.dispose());
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

`flutter drive` is leaking a `iproxy` and `idevicesyslog` process (for <iOS 13) on every run.  Dispose of the device at the end of the `drive` run, which closes the logging streams and kills the iproxy, debugger, and logging processes.

## Related Issues

Maybe https://github.com/flutter/flutter/issues/68119 (let's monitor)
Fixes https://github.com/flutter/flutter/issues/53451