### PR TITLE
Revert "Fix text field label width on outline input border"

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -980,7 +980,7 @@ class _RenderDecoration extends RenderBox {
       _boxSize(icon).width
       + contentPadding.left
       + _boxSize(prefixIcon).width
-      + (decoration.border!.isOutline ? 0.0 : _boxSize(suffixIcon).width)
+      + _boxSize(suffixIcon).width
       + contentPadding.right));
     boxToBaseline[label] = _layoutLineBox(
       label,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4253,40 +4253,6 @@ void main() {
     expect(getOpacity(tester, prefixText), 1.0);
   });
 
-  testWidgets('OutlineInputBorder with InputDecorator long label, width should ignore icon width', (WidgetTester tester) async {
-    // Related issue: https://github.com/flutter/flutter/issues/64427
-    const String labelText = 'Flutter is Google’s UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.';
-
-    Widget getLabeledInputDecorator(bool useOutlineBorder) => MaterialApp(
-        home: Material(
-          child: Container(
-            width: 300,
-            child: TextField(
-              decoration: InputDecoration(
-                border: useOutlineBorder ? const OutlineInputBorder(
-                  borderSide: BorderSide(color: Colors.greenAccent, width: 1.0),
-                ) : null,
-                suffixIcon: const Icon(Icons.arrow_drop_down),
-                floatingLabelBehavior: FloatingLabelBehavior.always,
-                labelText: labelText,
-              ),
-            ),
-          ),
-        ),
-      );
-
-    // Build with no OutlineInputBorder.
-    await tester.pumpWidget(getLabeledInputDecorator(false));
-
-    // Get the width of the label when there is no OutlineInputBorder.
-    final double labelWidth = tester.getSize(find.text(labelText)).width;
-
-    // Build with a OutlineInputBorder.
-    await tester.pumpWidget(getLabeledInputDecorator(true));
-
-    expect(tester.getSize(find.text(labelText)).width > labelWidth, isTrue);
-  });
-
   testWidgets('given enough space, constrained and unconstrained heights result in the same size widget', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/65572
     final UniqueKey keyUnconstrained = UniqueKey();


### PR DESCRIPTION
Reverts flutter/flutter#67736

That PR gave extra space to labels drawn in outlines, but the logic used missed the case where the label does not float in an outlined field when using FloatingLabelBehavior.

FYI @YeungKC.  Sorry I missed this corner case during review.  Would you be able to reopen this PR and fix the problem?