### PR TITLE
Fix: 'index == parameters.length': is not true

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -891,7 +891,7 @@ mixin WidgetInspectorService {
           }
           index++;
         }
-        assert(index == parameters.length);
+        assert(index == args.length);
         return <String, Object?>{'result': await callback(args)};
       },
     );


### PR DESCRIPTION
## Description

This is a tentative PR to fix the `'index == parameters.length': is not true` issue.

## Related Issues

TODO

## Tests

I added the following tests:

TODO

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.