### PR TITLE
Fix floating behavior of long label and outline input border

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -976,11 +976,15 @@ class _RenderDecoration extends RenderBox {
       + contentPadding.right));
     // Increase the available width for the label when it is scaled down.
     final double invertedLabelScale = lerpDouble(1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress)!;
+    double suffixIconWidth = _boxSize(suffixIcon).width;
+    if (decoration.border!.isOutline) {
+      suffixIconWidth = lerpDouble(suffixIconWidth, 0.0, decoration.floatingLabelProgress)!;
+    }
     final double labelWidth = math.max(0.0, constraints.maxWidth - (
       _boxSize(icon).width
       + contentPadding.left
       + _boxSize(prefixIcon).width
-      + (decoration.border!.isOutline ? 0.0 : _boxSize(suffixIcon).width)
+      + suffixIconWidth
       + contentPadding.right));
     boxToBaseline[label] = _layoutLineBox(
       label,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4294,10 +4294,11 @@ void main() {
 
     // Click for Focus.
     await tester.tap(find.byType(TextField));
-    // The default animation duration is 200 millisecond.
+    // Default animation duration is 200 millisecond.
     await tester.pumpFrames(target, const Duration(milliseconds: 100));
 
     expect(getLabelRect(tester).width > labelWidth, isTrue);
+    expect(getLabelRect(tester).width < floatedLabelWidth, isTrue);
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4253,21 +4253,21 @@ void main() {
     expect(getOpacity(tester, prefixText), 1.0);
   });
 
-  testWidgets('OutlineInputBorder with InputDecorator long label, width should ignore icon width', (WidgetTester tester) async {
-    // Related issue: https://github.com/flutter/flutter/issues/64427
+  // Related issue: https://github.com/flutter/flutter/issues/64427
+  testWidgets('OutlineInputBorder and InputDecorator long labels and in Floating, the width should ignore the icon width', (WidgetTester tester) async {
     const String labelText = 'Flutter is Google’s UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.';
 
-    Widget getLabeledInputDecorator(bool useOutlineBorder) => MaterialApp(
+    Widget getLabeledInputDecorator(FloatingLabelBehavior floatingLabelBehavior) => MaterialApp(
         home: Material(
           child: Container(
             width: 300,
             child: TextField(
               decoration: InputDecoration(
-                border: useOutlineBorder ? const OutlineInputBorder(
+                border: const OutlineInputBorder(
                   borderSide: BorderSide(color: Colors.greenAccent, width: 1.0),
-                ) : null,
+                ),
                 suffixIcon: const Icon(Icons.arrow_drop_down),
-                floatingLabelBehavior: FloatingLabelBehavior.always,
+                floatingLabelBehavior: floatingLabelBehavior,
                 labelText: labelText,
               ),
             ),
@@ -4275,16 +4275,33 @@ void main() {
         ),
       );
 
-    // Build with no OutlineInputBorder.
-    await tester.pumpWidget(getLabeledInputDecorator(false));
+    await tester.pumpWidget(getLabeledInputDecorator(FloatingLabelBehavior.never));
 
-    // Get the width of the label when there is no OutlineInputBorder.
-    final double labelWidth = tester.getSize(find.text(labelText)).width;
+    final double labelWidth = getLabelRect(tester).width;
 
-    // Build with a OutlineInputBorder.
-    await tester.pumpWidget(getLabeledInputDecorator(true));
+    await tester.pumpWidget(getLabeledInputDecorator(FloatingLabelBehavior.always));
+    await tester.pumpAndSettle();
 
-    expect(tester.getSize(find.text(labelText)).width > labelWidth, isTrue);
+    final double floatedLabelWidth = getLabelRect(tester).width;
+
+    expect(floatedLabelWidth > labelWidth, isTrue);
+
+    final Widget target = getLabeledInputDecorator(FloatingLabelBehavior.auto);
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    expect(getLabelRect(tester).width, labelWidth);
+
+    // Click for Focus.
+    await tester.tap(find.byType(TextField));
+    // The default animation duration is 200 millisecond.
+    await tester.pumpFrames(target, const Duration(milliseconds: 100));
+
+    expect(getLabelRect(tester).width > labelWidth, isTrue);
+
+    await tester.pumpAndSettle();
+
+    expect(getLabelRect(tester).width, floatedLabelWidth);
   });
 
   testWidgets('given enough space, constrained and unconstrained heights result in the same size widget', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This unreverts and fixes a bug in https://github.com/flutter/flutter/pull/68672.

before
![before](https://user-images.githubusercontent.com/48603081/91425625-032a1d80-e879-11ea-9dd8-0900f8ef6a90.png)
after
![after](https://user-images.githubusercontent.com/11473691/95595180-7761fe80-0a7e-11eb-8918-7d88fb022d39.png)

## Related Issues

#64427 #68672
Original PR: https://github.com/flutter/flutter/pull/67736

## Tests

I added the following tests:

input_decorator_test.dart:
 + OutlineInputBorder with InputDecorator long label, width should ignore icon width

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

