### PR TITLE
[null-safety] swap tool unit tests to dart test until tester supports null safety by default

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -308,22 +308,12 @@ Future<void> _runToolTests() async {
       final String suffix = Platform.isWindows && subshard == 'commands'
         ? 'permeable'
         : '';
-      // Try out tester on unit test shard
-      if (subshard == 'general') {
-        await _pubRunTester(
-          toolsPath,
-          testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
-          // Detect unit test time regressions (poor time delay handling, etc).
-          perTestTimeout: (subshard == 'general') ? 15 : null,
-        );
-      } else {
-        await _pubRunTest(
-          toolsPath,
-          forceSingleCore: true,
-          testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
-          enableFlutterToolAsserts: true,
-        );
-      }
+      await _pubRunTest(
+        toolsPath,
+        forceSingleCore: subshard != 'general',
+        testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
+        enableFlutterToolAsserts: subshard != 'general',
+      );
     },
   );
 
@@ -929,68 +919,6 @@ Future<void> _runFlutterWebTest(String workingDirectory, List<String> tests) asy
       'FLUTTER_WEB': 'true',
       'FLUTTER_LOW_RESOURCE_MODE': 'true',
     },
-  );
-}
-
-const String _supportedTesterVersion = '0.0.2-dev7';
-
-Future<void> _pubRunTester(String workingDirectory, {
-  List<String> testPaths,
-  bool forceSingleCore = false,
-  int perTestTimeout,
-}) async {
-  int cpus;
-  final String cpuVariable = Platform.environment['CPU']; // CPU is set in cirrus.yml
-  if (cpuVariable != null) {
-    cpus = int.tryParse(cpuVariable, radix: 10);
-    if (cpus == null) {
-      print('${red}The CPU environment variable, if set, must be set to the integer number of available cores.$reset');
-      print('Actual value: "$cpuVariable"');
-      exit(1);
-    }
-  } else {
-    cpus = 2; // Don't default to 1, otherwise we won't catch race conditions.
-  }
-  // Integration tests that depend on external processes like chrome
-  // can get stuck if there are multiple instances running at once.
-  if (forceSingleCore) {
-    cpus = 1;
-  }
-  final List<String> args = <String>[
-    'global',
-    'activate',
-    'tester',
-    _supportedTesterVersion
-  ];
-  final Map<String, String> pubEnvironment = <String, String>{
-    'FLUTTER_ROOT': flutterRoot,
-  };
-  if (Directory(pubCache).existsSync()) {
-    pubEnvironment['PUB_CACHE'] = pubCache;
-  }
-  await runCommand(
-    pub,
-    args,
-    workingDirectory: workingDirectory,
-    environment: pubEnvironment,
-  );
-  await runCommand(
-    pub,
-    <String>[
-      'global',
-      'run',
-      'tester',
-      '-j$cpus',
-      '-v',
-      '--ci',
-      if (perTestTimeout != null)
-        '--timeout=$perTestTimeout'
-      else
-        '--timeout=-1',
-      ...testPaths,
-    ],
-    workingDirectory: workingDirectory,
-    environment: pubEnvironment,
   );
 }
 


### PR DESCRIPTION
## Description

tester needs updates for null safety, swap back to dart test for CI. 

Fixes https://github.com/flutter/flutter/issues/68730