### PR TITLE
Fix grammer mistake, clarify

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1037,10 +1037,10 @@ abstract class RouteInformationParser<T> {
 /// widget upon asked.
 ///
 /// When implementing subclass, consider defining a listenable app state to be
-/// used for building the navigating widget. The router delegate should update
-/// the app state accordingly and notify the listener know the app state has
-/// changed when it receive route related engine intents (e.g.
-/// [setNewRoutePath], [setInitialRoutePath], or [popRoute]).
+/// used for building the navigating widget. When the router delegate receives
+/// route related engine intents (e.g. [setNewRoutePath], [setInitialRoutePath],
+/// or [popRoute]), it should update the app state accordingly and notify the
+/// listener that the app state has changed.
 ///
 /// All subclass must implement [setNewRoutePath], [popRoute], and [build].
 ///


### PR DESCRIPTION
Makes the cause the start of the sentence, and the reaction to the cause the end.

## Description
There is a small grammar mistake in [the docs](https://master-api.flutter.dev/flutter/widgets/RouterDelegate-class.html), made bold below.
> The router delegate should update the app state accordingly and **notify the listener know** the app state has changed when it **receive** route related engine intents

I found it hard to grok the sentence, having to go through quite a bit of heavy content without having any idea what was going on until I saw the end ("when it receive" (sic)). I think it's easier to understand a sentence when the cause precedes the effect.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] All existing and new tests are passing.
- [ x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
