### PR TITLE
[devicelab] de-flake iOS launch

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -423,7 +423,7 @@ class IOSDevice extends Device {
           deviceLogReader,
           portForwarder: portForwarder,
           throttleDuration: fallbackPollingDelay,
-          throttleTimeout: fallbackThrottleTimeout ?? const Duration(seconds: 20),
+          throttleTimeout: fallbackThrottleTimeout ?? const Duration(minutes: 5),
           hostPort: debuggingOptions.hostVmServicePort,
           devicePort: debuggingOptions.deviceVmServicePort,
           ipv6: ipv6,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -423,7 +423,7 @@ class IOSDevice extends Device {
           deviceLogReader,
           portForwarder: portForwarder,
           throttleDuration: fallbackPollingDelay,
-          throttleTimeout: fallbackThrottleTimeout ?? const Duration(seconds: 5),
+          throttleTimeout: fallbackThrottleTimeout ?? const Duration(seconds: 20),
           hostPort: debuggingOptions.hostVmServicePort,
           devicePort: debuggingOptions.deviceVmServicePort,
           ipv6: ipv6,


### PR DESCRIPTION
## Description

Prove that https://github.com/flutter/flutter/pull/68756 is the correct fix by increasing the timeout and observing if the flakes on run decrease