### PR TITLE
The ability to add a bottom to the search AppBar 

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -67,8 +67,8 @@ Future<T> showSearch<T>({
 ///
 /// The search page always shows an [AppBar] at the top where users can
 /// enter their search queries. The buttons shown before and after the search
-/// query text field can be customized via [SearchDelegate.buildLeading] and
-/// [SearchDelegate.buildActions].
+/// query text field can be customized via [SearchDelegate.buildLeading]
+/// [SearchDelegate.buildBottom] and [SearchDelegate.buildActions].
 ///
 /// The body below the [AppBar] can either show suggested queries (returned by
 /// [SearchDelegate.buildSuggestions]) or - once the user submits a search  - the
@@ -92,7 +92,6 @@ Future<T> showSearch<T>({
 /// ## Handling emojis and other complex characters
 /// {@macro flutter.widgets.editableText.complexCharacters}
 abstract class SearchDelegate<T> {
-
   /// Constructor to be called by subclasses which may specify [searchFieldLabel], [keyboardType] and/or
   /// [textInputAction].
   ///
@@ -109,6 +108,11 @@ abstract class SearchDelegate<T> {
   ///
   ///   @override
   ///   Widget buildLeading(BuildContext context) => Text("leading");
+  ///
+  ///   @override
+  ///   PreferredSizeWidget buildBottom(BuildContext) => PreferredSize(
+  ///        preferredSize: Size.fromHeight(56.0),
+  ///        child: Text("bottom"));
   ///
   ///   @override
   ///   Widget buildSuggestions(BuildContext context) => Text("suggestions");
@@ -184,6 +188,13 @@ abstract class SearchDelegate<T> {
   ///  * [AppBar.actions], the intended use for the return value of this method.
   List<Widget> buildActions(BuildContext context);
 
+  /// Widget to display across the bottom of the [AppBar].
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.bottom], the intended use for the return value of this method.
+  PreferredSizeWidget buildBottom(BuildContext context);
+
   /// The theme used to style the [AppBar].
   ///
   /// By default, a white theme is used.
@@ -247,7 +258,8 @@ abstract class SearchDelegate<T> {
   ///
   ///  * [showResults] to show the search results.
   void showSuggestions(BuildContext context) {
-    assert(_focusNode != null, '_focusNode must be set by route before showSuggestions is called.');
+    assert(_focusNode != null,
+        '_focusNode must be set by route before showSuggestions is called.');
     _focusNode!.requestFocus();
     _currentBody = _SearchBody.suggestions;
   }
@@ -301,9 +313,11 @@ abstract class SearchDelegate<T> {
 
   final TextEditingController _queryTextController = TextEditingController();
 
-  final ProxyAnimation _proxyAnimation = ProxyAnimation(kAlwaysDismissedAnimation);
+  final ProxyAnimation _proxyAnimation =
+      ProxyAnimation(kAlwaysDismissedAnimation);
 
-  final ValueNotifier<_SearchBody?> _currentBodyNotifier = ValueNotifier<_SearchBody?>(null);
+  final ValueNotifier<_SearchBody?> _currentBodyNotifier =
+      ValueNotifier<_SearchBody?>(null);
 
   _SearchBody? get _currentBody => _currentBodyNotifier.value;
   set _currentBody(_SearchBody? value) {
@@ -449,7 +463,8 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
     if (widget.delegate != oldWidget.delegate) {
       oldWidget.delegate._queryTextController.removeListener(_onQueryChanged);
       widget.delegate._queryTextController.addListener(_onQueryChanged);
-      oldWidget.delegate._currentBodyNotifier.removeListener(_onSearchBodyChanged);
+      oldWidget.delegate._currentBodyNotifier
+          .removeListener(_onSearchBodyChanged);
       widget.delegate._currentBodyNotifier.addListener(_onSearchBodyChanged);
       oldWidget.delegate._focusNode = null;
       widget.delegate._focusNode = focusNode;
@@ -457,7 +472,8 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
   }
 
   void _onFocusChanged() {
-    if (focusNode.hasFocus && widget.delegate._currentBody != _SearchBody.suggestions) {
+    if (focusNode.hasFocus &&
+        widget.delegate._currentBody != _SearchBody.suggestions) {
       widget.delegate.showSuggestions(context);
     }
   }
@@ -478,12 +494,12 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = widget.delegate.appBarTheme(context);
-    final String searchFieldLabel = widget.delegate.searchFieldLabel
-      ?? MaterialLocalizations.of(context)!.searchFieldLabel;
-    final TextStyle? searchFieldStyle = widget.delegate.searchFieldStyle
-      ?? theme.inputDecorationTheme.hintStyle;
+    final String searchFieldLabel = widget.delegate.searchFieldLabel ??
+        MaterialLocalizations.of(context)!.searchFieldLabel;
+    final TextStyle? searchFieldStyle = widget.delegate.searchFieldStyle ??
+        theme.inputDecorationTheme.hintStyle;
     Widget? body;
-    switch(widget.delegate._currentBody) {
+    switch (widget.delegate._currentBody) {
       case _SearchBody.suggestions:
         body = KeyedSubtree(
           key: const ValueKey<_SearchBody>(_SearchBody.suggestions),
@@ -539,6 +555,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
               hintStyle: searchFieldStyle,
             ),
           ),
+          bottom: widget.delegate.buildBottom(context),
           actions: widget.delegate.buildActions(context),
         ),
         body: AnimatedSwitcher(

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -32,7 +32,8 @@ void main() {
   setUp(() async {
     // Fill the clipboard so that the Paste option is available in the text
     // selection menu.
-    SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
+    SystemChannels.platform
+        .setMockMethodCallHandler(mockClipboard.handleMethodCall);
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
 
@@ -61,6 +62,7 @@ void main() {
     expect(find.text('HomeBody'), findsNothing);
     expect(find.text('HomeTitle'), findsNothing);
     expect(find.text('Suggestions'), findsOneWidget);
+    expect(find.text('Bottom'), findsOneWidget);
     expect(selectedResults, hasLength(0));
 
     final TextField textField = tester.widget(find.byType(TextField));
@@ -76,7 +78,8 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can close search with system back button to return null', (WidgetTester tester) async {
+  testWidgets('Can close search with system back button to return null',
+      (WidgetTester tester) async {
     // regression test for https://github.com/flutter/flutter/issues/18145
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
@@ -101,8 +104,10 @@ void main() {
     expect(find.text('Suggestions'), findsOneWidget);
 
     // Simulate system back button
-    final ByteData message = const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
-    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    final ByteData message =
+        const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
+    await ServicesBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage('flutter/navigation', message, (_) {});
     await tester.pumpAndSettle();
 
     expect(selectedResults, <void>[null]);
@@ -130,7 +135,8 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
-    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+    final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
     final Color hintColor = textField.decoration!.hintStyle!.color!;
     expect(hintColor, delegate.hintTextColor);
   });
@@ -200,7 +206,8 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can switch between results and suggestions', (WidgetTester tester) async {
+  testWidgets('Can switch between results and suggestions',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -270,7 +277,8 @@ void main() {
     expect(textField.focusNode!.hasFocus, isFalse);
   });
 
-  testWidgets('Fresh search always starts with empty query', (WidgetTester tester) async {
+  testWidgets('Fresh search always starts with empty query',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -306,7 +314,8 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Initial query null re-used previous query', (WidgetTester tester) async {
+  testWidgets('Initial query null re-used previous query',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     delegate.query = 'Foo';
@@ -322,7 +331,8 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Changing query shows up in search field', (WidgetTester tester) async {
+  testWidgets('Changing query shows up in search field',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -344,7 +354,8 @@ void main() {
     expect(find.text('Bar'), findsOneWidget);
   });
 
-  testWidgets('transitionAnimation runs while search fades in/out', (WidgetTester tester) async {
+  testWidgets('transitionAnimation runs while search fades in/out',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -373,7 +384,8 @@ void main() {
     expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
   });
 
-  testWidgets('Closing nested search returns to search', (WidgetTester tester) async {
+  testWidgets('Closing nested search returns to search',
+      (WidgetTester tester) async {
     final List<String> nestedSearchResults = <String>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
       suggestions: 'Nested Suggestions',
@@ -437,7 +449,9 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Closing search with nested search shown goes back to underlying route', (WidgetTester tester) async {
+  testWidgets(
+      'Closing search with nested search shown goes back to underlying route',
+      (WidgetTester tester) async {
     late _TestSearchDelegate delegate;
     final List<String?> nestedSearchResults = <String?>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
@@ -511,9 +525,11 @@ void main() {
 
   testWidgets('Custom searchFieldLabel value', (WidgetTester tester) async {
     const String searchHint = 'custom search hint';
-    final String defaultSearchHint = const DefaultMaterialLocalizations().searchFieldLabel;
+    final String defaultSearchHint =
+        const DefaultMaterialLocalizations().searchFieldLabel;
 
-    final _TestSearchDelegate delegate = _TestSearchDelegate(searchHint: searchHint);
+    final _TestSearchDelegate delegate =
+        _TestSearchDelegate(searchHint: searchHint);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -525,8 +541,10 @@ void main() {
     expect(find.text(defaultSearchHint), findsNothing);
   });
 
-  testWidgets('Default searchFieldLabel is used when it is set to null', (WidgetTester tester) async {
-    final String searchHint = const DefaultMaterialLocalizations().searchFieldLabel;
+  testWidgets('Default searchFieldLabel is used when it is set to null',
+      (WidgetTester tester) async {
+    final String searchHint =
+        const DefaultMaterialLocalizations().searchFieldLabel;
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
@@ -542,21 +560,23 @@ void main() {
   testWidgets('Custom searchFieldStyle value', (WidgetTester tester) async {
     const TextStyle searchStyle = TextStyle(color: Colors.red, fontSize: 3);
 
-    final _TestSearchDelegate delegate = _TestSearchDelegate(searchFieldStyle: searchStyle);
+    final _TestSearchDelegate delegate =
+        _TestSearchDelegate(searchFieldStyle: searchStyle);
 
-    await tester.pumpWidget(
-      TestHomePage(
+    await tester.pumpWidget(TestHomePage(
       delegate: delegate,
     ));
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
-    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+    final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
     final TextStyle hintStyle = textField.decoration!.hintStyle!;
     expect(hintStyle, delegate.searchFieldStyle);
   });
 
-  testWidgets('keyboard show search button by default', (WidgetTester tester) async {
+  testWidgets('keyboard show search button by default',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -567,11 +587,15 @@ void main() {
 
     await tester.showKeyboard(find.byType(TextField));
 
-    expect(tester.testTextInput.setClientArgs!['inputAction'], TextInputAction.search.toString());
+    expect(tester.testTextInput.setClientArgs!['inputAction'],
+        TextInputAction.search.toString());
   });
 
-  testWidgets('Custom textInputAction results in keyboard with corresponding button', (WidgetTester tester) async {
-    final _TestSearchDelegate delegate = _TestSearchDelegate(textInputAction: TextInputAction.done);
+  testWidgets(
+      'Custom textInputAction results in keyboard with corresponding button',
+      (WidgetTester tester) async {
+    final _TestSearchDelegate delegate =
+        _TestSearchDelegate(textInputAction: TextInputAction.done);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -579,11 +603,12 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.showKeyboard(find.byType(TextField));
-    expect(tester.testTextInput.setClientArgs!['inputAction'], TextInputAction.done.toString());
+    expect(tester.testTextInput.setClientArgs!['inputAction'],
+        TextInputAction.done.toString());
   });
 
   group('contributes semantics', () {
-    TestSemantics buildExpected({ required String routeName }) {
+    TestSemantics buildExpected({required String routeName}) {
       return TestSemantics.root(
         children: <TestSemantics>[
           TestSemantics(
@@ -623,8 +648,11 @@ void main() {
                               SemanticsFlag.isTextField,
                               SemanticsFlag.isFocused,
                               SemanticsFlag.isHeader,
-                              if (debugDefaultTargetPlatformOverride != TargetPlatform.iOS &&
-                                debugDefaultTargetPlatformOverride != TargetPlatform.macOS) SemanticsFlag.namesRoute,
+                              if (debugDefaultTargetPlatformOverride !=
+                                      TargetPlatform.iOS &&
+                                  debugDefaultTargetPlatformOverride !=
+                                      TargetPlatform.macOS)
+                                SemanticsFlag.namesRoute,
                             ],
                             actions: <SemanticsAction>[
                               SemanticsAction.tap,
@@ -633,7 +661,8 @@ void main() {
                             ],
                             label: 'Search',
                             textDirection: TextDirection.ltr,
-                            textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
+                            textSelection: const TextSelection(
+                                baseOffset: 0, extentOffset: 0),
                           ),
                         ],
                       ),
@@ -669,8 +698,10 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(semantics, hasSemantics(buildExpected(routeName: 'Search'),
-          ignoreId: true, ignoreRect: true, ignoreTransform: true));
+      expect(
+          semantics,
+          hasSemantics(buildExpected(routeName: 'Search'),
+              ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
       semantics.dispose();
     });
@@ -685,11 +716,15 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(semantics, hasSemantics(buildExpected(routeName: ''),
-          ignoreId: true, ignoreRect: true, ignoreTransform: true));
+      expect(
+          semantics,
+          hasSemantics(buildExpected(routeName: ''),
+              ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
       semantics.dispose();
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+    },
+        variant: const TargetPlatformVariant(
+            <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS}));
   });
 }
 
@@ -752,7 +787,10 @@ class _TestSearchDelegate extends SearchDelegate<String> {
     TextStyle? searchFieldStyle,
     String? searchHint,
     TextInputAction textInputAction = TextInputAction.search,
-  }) : super(searchFieldLabel: searchHint, textInputAction: textInputAction, searchFieldStyle: searchFieldStyle);
+  }) : super(
+            searchFieldLabel: searchHint,
+            textInputAction: textInputAction,
+            searchFieldStyle: searchFieldStyle);
 
   final String suggestions;
   final String result;
@@ -763,7 +801,8 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   ThemeData appBarTheme(BuildContext context) {
     final ThemeData theme = Theme.of(context)!;
     return theme.copyWith(
-      inputDecorationTheme: InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
+      inputDecorationTheme:
+          InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
     );
   }
 
@@ -801,5 +840,13 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   @override
   List<Widget> buildActions(BuildContext context) {
     return actions;
+  }
+
+  @override
+  PreferredSizeWidget buildBottom(BuildContext context) {
+    return PreferredSize(
+      preferredSize: Size.fromHeight(56.0),
+      child: Text('Bottom'),
+    );
   }
 }


### PR DESCRIPTION
## Description

Currently, you cannot add anything to the "bottom" of the AppBar. I have updated search.dart, to allow you to pass in a PreferredSize widget to the bottom. 

## Tests

I added tests: search_test.dart

* This is a working example: cl/338056388