### PR TITLE
Move service extension to correct binding so images are repainted after enabling/disabling, update test

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -60,6 +60,17 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     assert(() {
       // these service extensions only work in debug mode
       registerBoolServiceExtension(
+        name: 'invertOversizedImages',
+        getter: () async => debugInvertOversizedImages,
+        setter: (bool value) async {
+          if (debugInvertOversizedImages != value) {
+            debugInvertOversizedImages = value;
+            return _forceRepaint();
+          }
+          return Future<void>.value();
+        },
+      );
+      registerBoolServiceExtension(
         name: 'debugPaint',
         getter: () async => debugPaintSizeEnabled,
         setter: (bool value) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -461,18 +461,6 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
 
     assert(() {
       registerBoolServiceExtension(
-        name: 'invertOversizedImages',
-        getter: () async => debugInvertOversizedImages,
-        setter: (bool value) async {
-          if (debugInvertOversizedImages != value) {
-            debugInvertOversizedImages = value;
-            return _forceRebuild();
-          }
-          return Future<void>.value();
-        },
-      );
-
-      registerBoolServiceExtension(
         name: 'debugAllowBanner',
         getter: () => Future<bool>.value(WidgetsApp.debugAllowBannerOverride),
         setter: (bool value) {
@@ -503,6 +491,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   }
 
   Future<void> _forceRebuild() {
+    print('renderViewElement $renderViewElement');
     if (renderViewElement != null) {
       buildOwner!.reassemble(renderViewElement!);
       return endOfFrame;

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -491,7 +491,6 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   }
 
   Future<void> _forceRebuild() {
-    print('renderViewElement $renderViewElement');
     if (renderViewElement != null) {
       buildOwner!.reassemble(renderViewElement!);
       return endOfFrame;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -399,21 +399,44 @@ void main() {
 
   test('Service extensions - invertOversizedImages', () async {
     Map<String, dynamic> result;
+    Future<Map<String, dynamic>> pendingResult;
+    bool completed;
 
     expect(binding.frameScheduled, isFalse);
     expect(debugInvertOversizedImages, false);
     result = await binding.testExtension('invertOversizedImages', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugInvertOversizedImages, false);
-    result = await binding.testExtension('invertOversizedImages', <String, String>{'enabled': 'true'});
+    expect(binding.frameScheduled, isFalse);
+
+    pendingResult = binding.testExtension('invertOversizedImages', <String, String>{'enabled': 'true'});
+    completed = false;
+    pendingResult.whenComplete(() { completed = true; });
+    await binding.flushMicrotasks();
+    expect(binding.frameScheduled, isTrue);
+    expect(completed, isFalse);
+    await binding.doFrame();
+    await binding.flushMicrotasks();
+    expect(completed, isTrue);
+    expect(binding.frameScheduled, isFalse);
+    result = await pendingResult;
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugInvertOversizedImages, true);
+
     result = await binding.testExtension('invertOversizedImages', <String, String>{});
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugInvertOversizedImages, true);
-    result = await binding.testExtension('invertOversizedImages', <String, String>{'enabled': 'false'});
+    expect(binding.frameScheduled, isFalse);
+
+    pendingResult = binding.testExtension('invertOversizedImages', <String, String>{'enabled': 'false'});
+    await binding.flushMicrotasks();
+    expect(binding.frameScheduled, isTrue);
+    await binding.doFrame();
+    expect(binding.frameScheduled, isFalse);
+    result = await pendingResult;
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugInvertOversizedImages, false);
+
     result = await binding.testExtension('invertOversizedImages', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugInvertOversizedImages, false);


### PR DESCRIPTION
While working on a demo related to this, I found it was not actually causing images to repaint. This is because it was reassembling the widget tree instead of the render tree. Updated the test and moved the service extension.