### PR TITLE
Ignore "unused" analysis for dart:ui imports for web-only API.

### DIFF
--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -7,7 +7,7 @@
 @TestOn('chrome') // Uses web-only Flutter SDK
 
 import 'dart:async';
-import 'dart:ui' as ui;
+import 'dart:ui' as ui; // ignore: unused_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -7,7 +7,7 @@
 @TestOn('chrome') // Uses web-only Flutter SDK
 
 import 'dart:async';
-import 'dart:ui' as ui; // ignore: unused_import
+import 'dart:ui' as ui; // ignore: unused_import, it looks unused as web-only elements are the only elements used.
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -6,7 +6,7 @@
 
 @TestOn('chrome') // Uses web-only Flutter SDK
 
-import 'dart:ui' as ui; // ignore: unused_import
+import 'dart:ui' as ui; // ignore: unused_import, it looks unused as web-only elements are the only elements used.
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -6,7 +6,7 @@
 
 @TestOn('chrome') // Uses web-only Flutter SDK
 
-import 'dart:ui' as ui;
+import 'dart:ui' as ui; // ignore: unused_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Description

The dart analyzer has a bug in its analysis of "unused imports" which caused
these import directives to not be reported.
https://github.com/dart-lang/sdk/issues/38784. I'm fixing this bug, so we need
to ignore the new "unused_import" reports ahead of time.

The analyzer thinks that these are unused because it does not know about the
"web-only" API hack (see https://github.com/flutter/flutter/issues/52899).


*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).*

## Related Issues

https://github.com/flutter/flutter/issues/52899

## Tests

I added no following tests:

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
