### PR TITLE
Turn off CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER in CocoaPod targets

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -32,6 +32,7 @@ def flutter_additional_ios_build_settings(target)
   # [target.deployment_target] is a [String] formatted as "8.0".
   inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
   target.build_configurations.each do |build_configuration|
+    build_configuration.build_settings['CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER'] = 'NO'
     build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
     # Suppress warning when pod supports a version lower than the minimum supported by Xcode (Xcode 12 - iOS 9).
     # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.


### PR DESCRIPTION
## Description

CocoaPods 1.10 does this as of https://github.com/CocoaPods/CocoaPods/issues/9902 to avoid warnings and errors in Xcode 12.  Duplicate the behavior in Flutter for users on older versions (minimum required is 1.6, 1.8 is recommended).

This warning plays poorly with pods that also opt into treating warnings as errors, which causes compilation failures, not just warnings:
https://github.com/CocoaPods/Specs/blob/master/Specs/b/c/f/GoogleDataTransportCCTSupport/3.2.0/GoogleDataTransportCCTSupport.podspec.json#L56

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68813

## Tests
I'm not sure how to test this, but I reproduced the compilation failure locally, and confirmed it no longer produces errors or warnings related to quoted includes.

1. Downgrade from 1.10.
```
sudo gem uninstall cocoapods
sudo gem install cocoapods -v 1.9.3
```

2. Add any Flutter plugin to a project to produce the `ios/Podfile`, then to that add `GoogleDataTransportCCTSupport`
```ruby
target 'Runner' do
  use_frameworks!
  use_modular_headers!

  pod 'GoogleDataTransportCCTSupport', '3.2.0'
...
```
3. `cd ios && pod install`
4. Open `ios/Runner.xcworkspace` in Xcode 12 and turn on "Quoted Include in Framework Header" build setting in the Pods target or run the "Update build settings" migrator thing.
5. `flutter build ios` fails
```
                      In file included from <module-includes>:1:
                      ios/Pods/Target Support Files/nanopb/nanopb-umbrella.h:13:9: error: double-quoted include "pb.h" in framework header, expected angle-bracketed instead
                      [-Werror,-Wquoted-include-in-framework-header]
                      #import "pb.h"
                              ^~~~~~
                              <pb.h>
```

Apply this patch, no more failures.
