### PR TITLE
Apple silicon arch -arm64 to -arm64e

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -174,7 +174,7 @@ class Xcode {
   /// tools and properties.
   ///
   /// Returns `xcrun` on x86 macOS.
-  /// Returns `/usr/bin/arch -arm64 xcrun` on ARM macOS to force Xcode commands
+  /// Returns `/usr/bin/arch -arm64e xcrun` on ARM macOS to force Xcode commands
   /// to run outside the x86 Rosetta translation, which may cause crashes.
   List<String> xcrunCommand() {
     final List<String> xcrunCommand = <String>[];
@@ -182,7 +182,7 @@ class Xcode {
       // Force Xcode commands to run outside Rosetta.
       xcrunCommand.addAll(<String>[
         '/usr/bin/arch',
-        '-arm64',
+        '-arm64e',
       ]);
     }
     xcrunCommand.add('xcrun');

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -265,7 +265,7 @@ void main() {
 
           expect(xcode.xcrunCommand(), <String>[
             '/usr/bin/arch',
-            '-arm64',
+            '-arm64e',
             'xcrun',
           ]);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);


### PR DESCRIPTION
## Description

Confirmed `arch -arm64e` worked on Big Sur beta 10, suggested by @alexmarkley at https://github.com/flutter/flutter/pull/68050#issuecomment-708775876

## Related Issues

Adjustment of https://github.com/flutter/flutter/pull/68050
Fixes https://github.com/flutter/flutter/issues/65133

## Tests

Update xcode_test.dart.