### PR TITLE
[flutter_tools] Add --verify-only flag to flutter upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -112,13 +112,13 @@ class UpgradeCommandRunner {
       globals.printStatus('Flutter is already up to date on channel ${flutterVersion.channel}');
       globals.printStatus('$flutterVersion');
       return;
-    } else if(verifyOnly) {
+    } else if (verifyOnly) {
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
       // TODO(fujino): use a [FlutterVersion] once that class supports arbitrary revisions.
       globals.printStatus('The latest revision: $upstreamRevision\n', emphasis: true);
       globals.printStatus('Your current version: ${flutterVersion.frameworkRevision}');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
-      if(flutterVersion.channel == 'stable'){
+      if (flutterVersion.channel == 'stable') {
         globals.printStatus('\nSee the announcement and release notes:');
         globals.printStatus('https://flutter.dev/docs/development/tools/sdk/release-notes');
       }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -113,9 +113,10 @@ class UpgradeCommandRunner {
       globals.printStatus('$flutterVersion');
       return;
     } else if(verifyOnly) {
-      globals.printStatus('A new version of Flutter is available!\n');
-      globals.printStatus('Installed: ${flutterVersion.frameworkRevision}');
-      globals.printStatus('Available: $upstreamRevision\n', emphasis: true);
+      globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
+      // TODO(fujino): use a [FlutterVersion] once that class supports arbitrary revisions.
+      globals.printStatus('The latest revision: $upstreamRevision\n', emphasis: true);
+      globals.printStatus('Your current version: ${flutterVersion.frameworkRevision}');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
       if(flutterVersion.channel == 'stable'){
         globals.printStatus('\nSee the announcement and release notes:');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -117,6 +117,10 @@ class UpgradeCommandRunner {
       globals.printStatus('Installed: ${flutterVersion.frameworkRevision}');
       globals.printStatus('Available: $upstreamRevision\n', emphasis: true);
       globals.printStatus('To upgrade now, run "flutter upgrade".');
+      if(flutterVersion.channel == 'stable'){
+        globals.printStatus('\nSee the announcement and release notes:');
+        globals.printStatus('https://flutter.dev/docs/development/tools/sdk/release-notes');
+      }
       return;
     }
     if (!force && gitTagVersion == const GitTagVersion.unknown()) {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -112,7 +112,7 @@ class UpgradeCommandRunner {
       globals.printStatus('Flutter is already up to date on channel ${flutterVersion.channel}');
       globals.printStatus('$flutterVersion');
       return;
-    }else if(verifyOnly){
+    } else if(verifyOnly) {
       globals.printStatus('A new version of Flutter is available!\n');
       globals.printStatus('Installed: ${flutterVersion.frameworkRevision}');
       globals.printStatus('Available: $upstreamRevision\n', emphasis: true);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -115,7 +115,8 @@ class UpgradeCommandRunner {
     }else if(verifyOnly){
       globals.printStatus('A new version of Flutter is available!\n');
       globals.printStatus('Installed: ${flutterVersion.frameworkRevision}');
-      globals.printStatus('Available: $upstreamRevision', emphasis: true);
+      globals.printStatus('Available: $upstreamRevision\n', emphasis: true);
+      globals.printStatus('To upgrade now, run "flutter upgrade".');
       return;
     }
     if (!force && gitTagVersion == const GitTagVersion.unknown()) {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -115,8 +115,8 @@ class UpgradeCommandRunner {
     } else if (verifyOnly) {
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
       // TODO(fujino): use a [FlutterVersion] once that class supports arbitrary revisions.
-      globals.printStatus('The latest revision: $upstreamRevision\n', emphasis: true);
-      globals.printStatus('Your current version: ${flutterVersion.frameworkRevision}');
+      globals.printStatus('The latest revision: $upstreamRevision', emphasis: true);
+      globals.printStatus('Your current version: ${flutterVersion.frameworkRevision}\n');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
       if (flutterVersion.channel == 'stable') {
         globals.printStatus('\nSee the announcement and release notes:');

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -54,6 +54,7 @@ void main() {
         testFlow: false,
         gitTagVersion: const GitTagVersion.unknown(),
         flutterVersion: flutterVersion,
+        verifyOnly: false,
       );
       expect(result, throwsToolExit());
       expect(processManager.hasRemainingExpectations, isFalse);
@@ -69,6 +70,7 @@ void main() {
         testFlow: false,
         gitTagVersion: gitTagVersion,
         flutterVersion: flutterVersion,
+        verifyOnly: false,
       );
       expect(result, throwsToolExit());
       expect(processManager.hasRemainingExpectations, isFalse);
@@ -87,9 +89,32 @@ void main() {
         testFlow: false,
         gitTagVersion: gitTagVersion,
         flutterVersion: flutterVersion,
+        verifyOnly: false,
       );
       expect(await result, FlutterCommandResult.success());
       expect(testLogger.statusText, contains('Flutter is already up to date'));
+      expect(processManager.hasRemainingExpectations, isFalse);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => processManager,
+      Platform: () => fakePlatform,
+    });
+
+    testUsingContext('Correctly provides upgrade version on verify only', () async {
+      const String revision = 'abc123';
+      when(flutterVersion.frameworkRevision).thenReturn(revision);
+      fakeCommandRunner.alreadyUpToDate = false;
+      final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
+        force: false,
+        continueFlow: false,
+        testFlow: false,
+        gitTagVersion: gitTagVersion,
+        flutterVersion: flutterVersion,
+        verifyOnly: true,
+      );
+      expect(await result, FlutterCommandResult.success());
+      expect(testLogger.statusText, contains('A new version of Flutter is available!'));
+      expect(testLogger.statusText, contains(revision));
+      expect(testLogger.statusText, contains(fakeCommandRunner.remoteRevision));
       expect(processManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
@@ -255,6 +280,7 @@ void main() {
           testFlow: false,
           gitTagVersion: const GitTagVersion.unknown(),
           flutterVersion: flutterVersion,
+          verifyOnly: false,
         );
         expect(await result, FlutterCommandResult.success());
         expect(processManager.hasRemainingExpectations, isFalse);
@@ -272,6 +298,7 @@ void main() {
           testFlow: false,
           gitTagVersion: gitTagVersion,
           flutterVersion: flutterVersion,
+          verifyOnly: false,
         );
         expect(await result, FlutterCommandResult.success());
         expect(processManager.hasRemainingExpectations, isFalse);
@@ -287,6 +314,7 @@ void main() {
           testFlow: false,
           gitTagVersion: gitTagVersion,
           flutterVersion: flutterVersion,
+          verifyOnly: false,
         );
         expect(await result, FlutterCommandResult.success());
         expect(processManager.hasRemainingExpectations, isFalse);

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -112,9 +112,9 @@ void main() {
         verifyOnly: true,
       );
       expect(await result, FlutterCommandResult.success());
-      expect(testLogger.statusText, contains('A new version of Flutter is available!'));
-      expect(testLogger.statusText, contains(revision));
+      expect(testLogger.statusText, contains('A new version of Flutter is available'));
       expect(testLogger.statusText, contains(fakeCommandRunner.remoteRevision));
+      expect(testLogger.statusText, contains(revision));
       expect(processManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,


### PR DESCRIPTION
## Description

This PR adds a new flag for `flutter upgrade`, `--verify-only`, which will _only_ check for and inform available updates, if any.

Adding this flag to `flutter upgrade` _will not_ fetch updates.

<pre>
$ flutter upgrade --verify-only
A new version of Flutter is available on channel &lt;user channel&gt;

<b>The latest revision: &lt;update version&gt;</b>
Your current version: &lt;user installed version&gt;

To upgrade now, run "flutter upgrade".
$
</pre>

Moreover, if the user is on **`stable`** channel, it displays an url to see the release notes/changelog:

```
See the announcement and release notes:
https://flutter.dev/docs/development/tools/sdk/release-notes
```

## Related Issues

Fixes #67532.

## Tests

I added the following tests:

- Test to check whether the upgrade message is printed with correct user and update versions of flutter.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
