### PR TITLE
retry getting the main isolate

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -110,7 +110,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
       break;
     }
     if (isolateRef == null) {
-      throw DriverException('Failed to find main isolate after ${_kPauseBetweenReconnectAttempts.inSeconds * 10} seconds!');
+      throw DriverError('Failed to find main isolate after ${_kPauseBetweenReconnectAttempts.inSeconds * 10} seconds!');
     }
     _log('Isolate found with number: ${isolateRef.number}');
 

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -98,7 +98,8 @@ class VMServiceFlutterDriver extends FlutterDriver {
     final VMServiceClient client = connection.client;
 
     VMIsolateRef isolateRef;
-    for (int tries = 0; tries < 10; tries += 1) {
+    const int totalTries = 10;
+    for (int tries = 0; tries < totalTries; tries += 1) {
       final VM vm = await client.getVM();
       if (vm.isolates.isEmpty) {
         await Future<void>.delayed(_kPauseBetweenReconnectAttempts);
@@ -110,7 +111,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
       break;
     }
     if (isolateRef == null) {
-      throw DriverError('Failed to find main isolate after ${_kPauseBetweenReconnectAttempts.inSeconds * 10} seconds!');
+      throw DriverError('Failed to find main isolate after ${_kPauseBetweenReconnectAttempts.inSeconds * totalTries} seconds!');
     }
     _log('Isolate found with number: ${isolateRef.number}');
 


### PR DESCRIPTION
https://github.com/flutter/engine/pull/21820 introduced new isolate initialization logic, which seems to letting the service isolate start up earlier-enough than the root isolate where we can connect to the vm service but can't get a root isolate yet. Adds retry logic around getting the root isolate.

/cc @chinmaygarde @jason-simmons @zanderso 

No test because I am about to land a large refactor of this code that rewrites all the tests. I'll add a test to this in #68654 

Attempt to deflake issues discussed in b/171533206

