### PR TITLE
[flutter_tools] null safety mode is used for dill naming

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -155,6 +155,7 @@ Future<void> run(List<String> args) async {
       icudtlPath: globals.fs.path.absolute(argResults[_kOptionIcudtl] as String),
       coverageDirectory: coverageDirectory,
       extraFrontEndOptions: <String>[],
+      buildInfo: BuildInfo.debug,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -27,10 +27,14 @@ const String defaultAssetBasePath = '.';
 const String defaultManifestPath = 'pubspec.yaml';
 String get defaultDepfilePath => globals.fs.path.join(getBuildDirectory(), 'snapshot_blob.bin.d');
 
-String getDefaultApplicationKernelPath({ @required bool trackWidgetCreation }) {
+String getDefaultApplicationKernelPath({
+  @required bool trackWidgetCreation,
+  @required NullSafetyMode nullSafetyMode,
+}) {
   return getKernelPathForTransformerOptions(
     globals.fs.path.join(getBuildDirectory(), 'app.dill'),
     trackWidgetCreation: trackWidgetCreation,
+    nullSafetyMode: nullSafetyMode,
   );
 }
 
@@ -38,6 +42,7 @@ String getDefaultCachedKernelPath({
   @required bool trackWidgetCreation,
   @required List<String> dartDefines,
   @required List<String> extraFrontEndOptions,
+  @required NullSafetyMode nullSafetyMode,
 }) {
   final StringBuffer buffer = StringBuffer();
   buffer.writeAll(dartDefines);
@@ -51,13 +56,21 @@ String getDefaultCachedKernelPath({
   return getKernelPathForTransformerOptions(
     globals.fs.path.join(getBuildDirectory(), '${buildPrefix}cache.dill'),
     trackWidgetCreation: trackWidgetCreation,
+    nullSafetyMode: nullSafetyMode,
   );
 }
 
 String getKernelPathForTransformerOptions(
   String path, {
   @required bool trackWidgetCreation,
+  @required NullSafetyMode nullSafetyMode,
 }) {
+  // Temporary work around until --initialize-from-dill accounts for sound mode.
+  // The tool does not know the compilation mode if [NullSafetyMode.autodetect] is
+  // selected.
+  if (nullSafetyMode == NullSafetyMode.sound) {
+    path += '.sound';
+  }
   if (trackWidgetCreation) {
     path += '.track.dill';
   }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -235,8 +235,8 @@ class TestCommand extends FlutterCommand {
       watcher = collector;
     }
 
-    final bool disableServiceAuthCodes =
-      boolArg('disable-service-auth-codes');
+    final bool disableServiceAuthCodes = boolArg('disable-service-auth-codes');
+    final BuildInfo buildInfo = getBuildInfo(forcedBuildMode: BuildMode.debug);
 
     final int result = await testRunner.runTests(
       testWrapper,
@@ -261,8 +261,9 @@ class TestCommand extends FlutterCommand {
       flutterProject: flutterProject,
       web: stringArg('platform') == 'chrome',
       randomSeed: stringArg('test-randomize-ordering-seed'),
-      extraFrontEndOptions: getBuildInfo(forcedBuildMode: BuildMode.debug).extraFrontEndOptions,
+      extraFrontEndOptions: buildInfo.extraFrontEndOptions,
       nullAssertions: boolArg(FlutterOptions.kNullAssertions),
+      buildInfo: buildInfo,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -16,7 +16,6 @@ import 'base/logger.dart';
 import 'base/net.dart';
 import 'base/os.dart';
 import 'build_info.dart';
-import 'bundle.dart';
 import 'compile.dart';
 import 'convert.dart' show base64, utf8;
 import 'vmservice.dart';
@@ -477,12 +476,12 @@ class DevFS {
     @required String pathToReload,
     @required List<Uri> invalidatedFiles,
     @required PackageConfig packageConfig,
+    @required String dillOutputPath,
     DevFSWriter devFSWriter,
     String target,
     AssetBundle bundle,
     DateTime firstBuildTime,
     bool bundleFirstUpload = false,
-    String dillOutputPath,
     bool fullRestart = false,
     String projectRootPath,
   }) async {
@@ -508,7 +507,7 @@ class DevFS {
     final Future<CompilerOutput> pendingCompilerOutput = generator.recompile(
       mainUri,
       invalidatedFiles,
-      outputPath: dillOutputPath ?? getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation),
+      outputPath: dillOutputPath,
       packageConfig: packageConfig,
     );
     if (bundle != null) {

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -815,12 +815,12 @@ class WebDevFS implements DevFS {
     @required String pathToReload,
     @required List<Uri> invalidatedFiles,
     @required PackageConfig packageConfig,
+    @required String dillOutputPath,
     DevFSWriter devFSWriter,
     String target,
     AssetBundle bundle,
     DateTime firstBuildTime,
     bool bundleFirstUpload = false,
-    String dillOutputPath,
     bool fullRestart = false,
     String projectRootPath,
   }) async {
@@ -878,8 +878,7 @@ class WebDevFS implements DevFS {
         path: '/' + mainUri.pathSegments.last,
       ),
       invalidatedFiles,
-      outputPath: dillOutputPath ??
-        getDefaultApplicationKernelPath(trackWidgetCreation: trackWidgetCreation),
+      outputPath: dillOutputPath,
       packageConfig: packageConfig,
     );
     if (compilerOutput == null || compilerOutput.errorCount > 0) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -118,7 +118,8 @@ class FlutterDevice {
         initializeFromDill: getDefaultCachedKernelPath(
           trackWidgetCreation: buildInfo.trackWidgetCreation,
           dartDefines: buildInfo.dartDefines,
-          extraFrontEndOptions: extraFrontEndOptions
+          extraFrontEndOptions: extraFrontEndOptions,
+          nullSafetyMode: buildInfo.nullSafetyMode,
         ),
         targetModel: TargetModel.dartdevc,
         extraFrontEndOptions: extraFrontEndOptions,
@@ -160,6 +161,7 @@ class FlutterDevice {
           trackWidgetCreation: buildInfo.trackWidgetCreation,
           dartDefines: buildInfo.dartDefines,
           extraFrontEndOptions: extraFrontEndOptions,
+          nullSafetyMode: buildInfo.nullSafetyMode,
         ),
         packagesPath: buildInfo.packagesPath,
         artifacts: globals.artifacts,
@@ -1183,6 +1185,7 @@ abstract class ResidentRunner {
         trackWidgetCreation: trackWidgetCreation,
         dartDefines: debuggingOptions.buildInfo.dartDefines,
         extraFrontEndOptions: debuggingOptions.buildInfo.extraFrontEndOptions,
+        nullSafetyMode: debuggingOptions.buildInfo.nullSafetyMode,
       );
       globals.fs
           .file(copyPath)

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -321,7 +321,10 @@ class HotRunner extends ResidentRunner {
             // should only be displayed once.
             suppressErrors: applicationBinary == null,
             outputPath: dillOutputPath ??
-              getDefaultApplicationKernelPath(trackWidgetCreation: debuggingOptions.buildInfo.trackWidgetCreation),
+              getDefaultApplicationKernelPath(
+                trackWidgetCreation: debuggingOptions.buildInfo.trackWidgetCreation,
+                nullSafetyMode: debuggingOptions.buildInfo.nullSafetyMode,
+              ),
             packageConfig: packageConfig,
           ).then((CompilerOutput output) => output?.errorCount == 0)
         );

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -67,6 +67,7 @@ FlutterPlatform installHook({
   // Deprecated, use extraFrontEndOptions.
   List<String> dartExperiments,
   bool nullAssertions = false,
+  BuildInfo buildInfo, // TODO(jonahwilliams): make the default
 }) {
   assert(testWrapper != null);
   assert(enableObservatory || (!startPaused && observatoryPort == null));
@@ -102,6 +103,7 @@ FlutterPlatform installHook({
     icudtlPath: icudtlPath,
     extraFrontEndOptions: extraFrontEndOptions,
     nullAssertions: nullAssertions,
+    buildInfo: buildInfo,
   );
   platformPluginRegistration(platform);
   return platform;
@@ -246,6 +248,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.flutterProject,
     this.icudtlPath,
     this.nullAssertions = false,
+    this.buildInfo,
     @required this.extraFrontEndOptions,
   }) : assert(shellPath != null);
 
@@ -270,6 +273,7 @@ class FlutterPlatform extends PlatformPlugin {
   final String icudtlPath;
   final List<String> extraFrontEndOptions;
   final bool nullAssertions;
+  final BuildInfo buildInfo;
 
   Directory fontsDirectory;
 
@@ -444,7 +448,7 @@ class FlutterPlatform extends PlatformPlugin {
 
       if (precompiledDillPath == null && precompiledDillFiles == null) {
         // Lazily instantiate compiler so it is built only if it is actually used.
-        compiler ??= TestCompiler(buildMode, trackWidgetCreation, flutterProject, extraFrontEndOptions);
+        compiler ??= TestCompiler(buildInfo ?? BuildInfo(buildMode, '', trackWidgetCreation: trackWidgetCreation, treeShakeIcons: false), flutterProject, extraFrontEndOptions);
         mainDart = await compiler.compile(globals.fs.file(mainDart).uri);
 
         if (mainDart == null) {

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -67,7 +67,7 @@ class FlutterWebPlatform extends PlatformPlugin {
 
     _testGoldenComparator = TestGoldenComparator(
       shellPath,
-      () => TestCompiler(BuildMode.debug, false, flutterProject, <String>[]),
+      () => TestCompiler(BuildInfo.debug, flutterProject, <String>[]),
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -52,6 +52,7 @@ abstract class FlutterTestRunner {
     String randomSeed,
     @required List<String> extraFrontEndOptions,
     bool nullAssertions = false,
+    BuildInfo buildInfo, // TODO(jonahwilliams): make the default
   });
 }
 
@@ -88,6 +89,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     String randomSeed,
     @required List<String> extraFrontEndOptions,
     bool nullAssertions = false,
+    BuildInfo buildInfo // TODO(jonahwilliams): make the default argument
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -182,6 +184,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       icudtlPath: icudtlPath,
       extraFrontEndOptions: extraFrontEndOptions,
       nullAssertions: nullAssertions,
+      buildInfo: buildInfo,
     );
 
     // Make the global packages path absolute.

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -37,14 +37,19 @@ class TestCompiler {
   ///
   /// [flutterProject] is the project for which we are running tests.
   TestCompiler(
-    this.buildMode,
-    this.trackWidgetCreation,
+    this.buildInfo,
     this.flutterProject,
     this.extraFrontEndOptions,
-  ) : testFilePath = getKernelPathForTransformerOptions(
-        globals.fs.path.join(flutterProject.directory.path, getBuildDirectory(), 'testfile.dill'),
-        trackWidgetCreation: trackWidgetCreation,
-      ) {
+  ) : testFilePath = globals.fs.path.join(
+        flutterProject.directory.path,
+        getBuildDirectory(),
+        'test_cache',
+        getDefaultCachedKernelPath(
+          trackWidgetCreation: buildInfo.trackWidgetCreation,
+          nullSafetyMode: buildInfo.nullSafetyMode,
+          dartDefines: buildInfo.dartDefines,
+          extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+        )) {
     // Compiler maintains and updates single incremental dill file.
     // Incremental compilation requests done for each test copy that file away
     // for independent execution.
@@ -61,8 +66,7 @@ class TestCompiler {
   final StreamController<_CompilationRequest> compilerController = StreamController<_CompilationRequest>();
   final List<_CompilationRequest> compilationQueue = <_CompilationRequest>[];
   final FlutterProject flutterProject;
-  final BuildMode buildMode;
-  final bool trackWidgetCreation;
+  final BuildInfo buildInfo;
   final String testFilePath;
   final List<String> extraFrontEndOptions;
 
@@ -101,11 +105,11 @@ class TestCompiler {
       artifacts: globals.artifacts,
       logger: globals.logger,
       processManager: globals.processManager,
-      buildMode: buildMode,
-      trackWidgetCreation: trackWidgetCreation,
+      buildMode: buildInfo.mode,
+      trackWidgetCreation: buildInfo.trackWidgetCreation,
       initializeFromDill: testFilePath,
       unsafePackageSerialization: false,
-      dartDefines: const <String>[],
+      dartDefines: buildInfo.dartDefines,
       packagesPath: globalPackagesPath,
       extraFrontEndOptions: extraFrontEndOptions,
       platform: globals.platform,

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -153,6 +153,7 @@ class FlutterTesterDevice extends Device {
     final String applicationKernelFilePath = getKernelPathForTransformerOptions(
       _fileSystem.path.join(_buildDirectory, 'flutter-tester-app.dill'),
       trackWidgetCreation: buildInfo.trackWidgetCreation,
+      nullSafetyMode: buildInfo.nullSafetyMode,
     );
     // Build assets and perform initial compilation.
     await BundleBuilder().build(

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -187,6 +187,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     String randomSeed,
     @override List<String> extraFrontEndOptions,
     bool nullAssertions = false,
+    BuildInfo buildInfo,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     return exitCode;

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -175,6 +175,7 @@ void main() {
         enableObservatory: false,
         startPaused: true,
         extraFrontEndOptions: <String>[],
+        buildInfo: BuildInfo.debug,
       ), throwsAssertionError);
 
       expect(() => installHook(
@@ -184,6 +185,7 @@ void main() {
         startPaused: false,
         observatoryPort: 123,
         extraFrontEndOptions: <String>[],
+        buildInfo: BuildInfo.debug,
       ), throwsAssertionError);
 
       FlutterPlatform capturedPlatform;
@@ -205,6 +207,7 @@ void main() {
         serverType: InternetAddressType.IPv6,
         icudtlPath: 'ghi',
         extraFrontEndOptions: <String>[],
+        buildInfo: BuildInfo.debug,
         platformPluginRegistration: (FlutterPlatform platform) {
           capturedPlatform = platform;
         });

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2286,6 +2286,38 @@ void main() {
     expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
   }));
 
+  testUsingContext('HotRunner copies compiled app.dill to cache during startup with --sound-null-safety', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    setWsAddress(testUri, fakeVmServiceHost.vmService);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        trackWidgetCreation: true,
+        nullSafetyMode: NullSafetyMode.sound,
+      )),
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+    when(mockFlutterDevice.runHot(
+      hotRunner: anyNamed('hotRunner'),
+      route: anyNamed('route'),
+    )).thenAnswer((Invocation invocation) async {
+      return 0;
+    });
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.sound.track.dill')).readAsString(), 'ABC');
+  }));
+
 
   testUsingContext('HotRunner unforwards device ports', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[

--- a/packages/flutter_tools/test/general.shard/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test_compiler_test.dart
@@ -39,8 +39,7 @@ void main() {
 
   testUsingContext('TestCompiler reports a dill file when compile is successful', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
-      BuildMode.debug,
-      false,
+      BuildInfo.debug,
       FlutterProject.current(),
       residentCompiler,
     );
@@ -65,8 +64,7 @@ void main() {
 
   testUsingContext('TestCompiler reports null when a compile fails', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
-      BuildMode.debug,
-      false,
+      BuildInfo.debug,
       FlutterProject.current(),
       residentCompiler,
     );
@@ -92,8 +90,7 @@ void main() {
 
   testUsingContext('TestCompiler disposing test compiler shuts down backing compiler', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
-      BuildMode.debug,
-      false,
+      BuildInfo.debug,
       FlutterProject.current(),
       residentCompiler,
     );
@@ -114,8 +111,7 @@ void main() {
 
   testUsingContext('TestCompiler reports an error when there is no dependency on flutter_test', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
-      BuildMode.debug,
-      false,
+      BuildInfo.debug,
       FlutterProject.current(),
       residentCompiler,
     );
@@ -140,11 +136,10 @@ void main() {
 /// Override the creation of the Resident Compiler to simplify testing.
 class FakeTestCompiler extends TestCompiler {
   FakeTestCompiler(
-    BuildMode buildMode,
-    bool trackWidgetCreation,
+    BuildInfo buildInfo,
     FlutterProject flutterProject,
     this.residentCompiler,
-  ) : super(buildMode, trackWidgetCreation, flutterProject, <String>[]);
+  ) : super(buildInfo, flutterProject, <String>[]);
 
   final MockResidentCompiler residentCompiler;
 

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -669,6 +669,7 @@ void main() {
       invalidatedFiles: <Uri>[],
       packageConfig: PackageConfig.empty,
       pathToReload: '',
+      dillOutputPath: 'out.dill',
     );
 
     expect(webDevFS.webAssetServer.getFile('require.js'), isNotNull);
@@ -784,6 +785,7 @@ void main() {
       invalidatedFiles: <Uri>[],
       packageConfig: PackageConfig.empty,
       pathToReload: '',
+      dillOutputPath: '',
     );
 
     expect(webDevFS.webAssetServer.getFile('require.js'), isNotNull);


### PR DESCRIPTION
## Description

A dill compiled in sound/unsound mode cannot be reused in `--initialize-from-dill` for compiling unsound/sound mode. Rename the file if sound mode is detected via command line argument.

This does not work in the case of autodetect.

Fixes https://github.com/flutter/flutter/issues/68891