### PR TITLE
[devicelab] never run pub

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -107,7 +107,7 @@ void main() {
     ));
     final String originalSource = await nodeSourceFile.readAsString();
     try {
-      await runTest(); // first number is meaningless; could have had to build the tool, run pub get, have a cache, etc
+      await runTest(noPub: true); // first number is meaningless; could have had to build the tool, run pub get, have a cache, etc
       final int withoutChange = await runTest(noPub: true); // run test again with no change
       await nodeSourceFile.writeAsString( // only change implementation
         originalSource


### PR DESCRIPTION
## Description

This test cannot handle running pub, due to android embedding warnings:

```
[flutter_test_performance] [STDOUT] Executing: /Users/jonahwilliams/Documents/flutter/bin/flutter test flutter_test/trivial_widget_test.dart in /Users/jonahwilliams/Documents/flutter/dev/automated_tests
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): Running "flutter pub get" in automated_tests...                    490ms
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): Warning
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): ──────────────────────────────────────────────────────────────────────────────
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): Your Flutter application is created using an older version of the Android
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): embedding. It's being deprecated in favor of Android embedding v2. Follow the
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): steps at
[flutter_test_performance] [STDOUT] test stdout (TestStep.starting): 
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): https://flutter.dev/go/android-project-migration
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): 
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): to migrate your project.
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): 
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): 
[flutter_test_performance] [STDOUT] test stdout (TestStep.testWritesFirstCarriageReturn): 00:00 +0: loading /Users/jonahwilliams/Documents/flutter/dev/automated_tests/flutter_test/trivial_widget_test.dart                                                                                     
```

