### PR TITLE
[devicelab] mark uncaught exception test flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -84,6 +84,7 @@ tasks:
       completer
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery_android__compile:
     description: >
@@ -428,7 +429,6 @@ tasks:
       Verifies that track-widget-creation can be enabled and disabled.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-    flaky: true
 
   android_defines_test:
     description: >
@@ -648,7 +648,6 @@ tasks:
       Verifies that track-widget-creation can be enabled and disabled.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: true
 
   macos_chrome_dev_mode:
     description: >
@@ -915,7 +914,6 @@ tasks:
        Verifies that track-widget-creation can be enabled and disabled.
      stage: devicelab
      required_agent_capabilities: ["linux-vm"]
-     flaky: true
 
   # android_splash_screen_integration_test:
   #   description: >


### PR DESCRIPTION
## Description

This test is hanging on CI but passes locally. Running pub get more times should not cause this sort of failure, assuming a problem with the testbed
