### PR TITLE
[devicelab] mark uncaught exceptions as flaky

### DIFF
--- a/dev/devicelab/bin/tasks/uncaught_image_error_linux.dart
+++ b/dev/devicelab/bin/tasks/uncaught_image_error_linux.dart
@@ -37,6 +37,8 @@ Future<void> main() async {
         .transform(utf8.decoder)
         .transform(const LineSplitter());
 
+      process.stderr.listen(print);
+
       await for (final String line in lines) {
         print(line);
         if (line.contains('ERROR caught by framework')) {

--- a/dev/devicelab/bin/tasks/uncaught_image_error_linux.dart
+++ b/dev/devicelab/bin/tasks/uncaught_image_error_linux.dart
@@ -26,6 +26,8 @@ Future<void> main() async {
         '-t',
         'lib/main.dart',
         '-d',
+        '--no-pub',
+        '--no-android-gradle-daemon',
         deviceId,
       ];
       final Process process = await startProcess(

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -84,6 +84,7 @@ tasks:
       completer
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery_android__compile:
     description: >


### PR DESCRIPTION
## Description

Running pub more often should not cause this test to fail, assuming a problem with the test itself. Example output:

```
2020-10-23T11:12:42.529120: [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
2020-10-23T11:12:42.529228: [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
2020-10-23T11:12:42.609343: [  +79 ms] Running "flutter pub get" in image_loading...
2020-10-23T11:12:42.612634: [   +3 ms] executing: [/home/flutter/.cocoon/flutter/dev/integration_tests/image_loading/] /home/flutter/.cocoon/flutter/bin/cache/dart-sdk/bin/pub --verbose get --no-precompile
2020-10-23T11:12:42.709773: [  +56 ms] MSG : Resolving dependencies...
2020-10-23T11:12:43.010775: [   +2 ms] MSG : Overriding the upper bound Dart SDK constraint to <=2.11.0-242.0.dev for the following packages:
2020-10-23T11:12:43.011213: [        ]     | 
[        ]     | async, boolean_selector, characters, charcode, collection, js, matcher, meta, path, pedantic, pool, source_map_stack_trace, source_maps, source_span, stack_trace, stream_channel, string_scanner, term_glyph, test, test_api, test_core, typed_data, vector_math
[        ]     | 
2020-10-23T11:12:43.011537: [        ]     | To disable this you can set the PUB_ALLOW_PRERELEASE_SDK system environment variable to `false`, or you can silence this message by setting it to `quiet`.
2020-10-23T12:13:39.579859: Task execution finished

Task failed with the following reason:
Timeout waiting for task completion: Future not completed
```