### PR TITLE
Remove nullOk parameter from Router.of and make it return a non-nullable value

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -298,10 +298,18 @@ class Router<T> extends StatefulWidget {
   /// This method provides access to the delegates in the [Router]. For example,
   /// this can be used to access the [backButtonDispatcher] of the parent router
   /// when creating a [ChildBackButtonDispatcher] for a nested [Router].
-  static Router<dynamic>? of(BuildContext context, {bool nullOk = false}) {
+  ///
+  /// If no [Router] ancestor exists for the given context, this will assert in
+  /// debug mode, and throw an exception in release mode.
+  ///
+  /// See also:
+  ///
+  ///  * [maybeOf], which is a similar function, but it will return null instead
+  ///    of throwing an exception if no [Router] ancestor exists.
+  static Router<dynamic> of(BuildContext context) {
     final _RouterScope? scope = context.dependOnInheritedWidgetOfExactType<_RouterScope>();
     assert(() {
-      if (scope == null && !nullOk) {
+      if (scope == null) {
         throw FlutterError(
           'Router operation requested with a context that does not include a Router.\n'
           'The context used to retrieve the Router must be that of a widget that '
@@ -310,6 +318,24 @@ class Router<T> extends StatefulWidget {
       }
       return true;
     }());
+    return scope!.routerState.widget;
+  }
+
+  /// Retrieves the immediate [Router] ancestor from the given context.
+  ///
+  /// This method provides access to the delegates in the [Router]. For example,
+  /// this can be used to access the [backButtonDispatcher] of the parent router
+  /// when creating a [ChildBackButtonDispatcher] for a nested [Router].
+  ///
+  /// If no `Router` ancestor exists for the given context, this will return
+  /// null.
+  ///
+  /// See also:
+  ///
+  ///  * [of], a similar method that returns a non-nullable value, and will
+  ///    throw if no [Router] ancestor exists.
+  static Router<dynamic>? maybeOf(BuildContext context) {
+    final _RouterScope? scope = context.dependOnInheritedWidgetOfExactType<_RouterScope>();
     return scope?.routerState.widget;
   }
 

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -77,7 +77,7 @@ void main() {
     });
   });
 
-  testWidgets('Router.of can be null', (WidgetTester tester) async {
+  testWidgets('Router.maybeOf can be null', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(buildBoilerPlate(
       Text('dummy', key: key)
@@ -85,7 +85,7 @@ void main() {
     final BuildContext textContext = key.currentContext!;
 
     // This should not throw error.
-    Router<dynamic>? router = Router.of(textContext, nullOk: true);
+    Router<dynamic>? router = Router.maybeOf(textContext);
     expect(router, isNull);
 
     // Test when the nullOk is not specified.


### PR DESCRIPTION
## Description

This removes the `nullOk` parameter from `Router.of`, and creates`Router.maybeOf`.  `Router.of`now returns a non-nullable value, and the `Router.maybeOf` returns a nullable value.

## Related Issues

- https://github.com/flutter/flutter/issues/68637

## Tests

- Updated tests to use `maybeOf`.

## Breaking Change

- [X] Yes, this is a breaking change that will require a migration guide.
  - [X] I wrote a [design doc](https://flutter.dev/go/eliminating-nullok-parameters)
   - [X] I submitted it for input from the developer relations team, specifically from: @RedBrogdon
   - [X] I wrote a migration guide: In https://github.com/flutter/website/pull/4921