### PR TITLE
Add maybeLocaleOf to Localizations

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5487,7 +5487,7 @@ class RichText extends MultiChildRenderObjectWidget {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
-      locale: locale ?? Localizations.localeOf(context, nullOk: true),
+      locale: locale ?? Localizations.maybeLocaleOf(context),
     );
   }
 
@@ -5505,7 +5505,7 @@ class RichText extends MultiChildRenderObjectWidget {
       ..strutStyle = strutStyle
       ..textWidthBasis = textWidthBasis
       ..textHeightBehavior = textHeightBehavior
-      ..locale = locale ?? Localizations.localeOf(context, nullOk: true);
+      ..locale = locale ?? Localizations.maybeLocaleOf(context);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2779,7 +2779,7 @@ class _Editable extends LeafRenderObjectWidget {
       textScaleFactor: textScaleFactor,
       textAlign: textAlign,
       textDirection: textDirection,
-      locale: locale ?? Localizations.localeOf(context, nullOk: true),
+      locale: locale ?? Localizations.maybeLocaleOf(context),
       selection: value.selection,
       offset: offset,
       onSelectionChanged: onSelectionChanged,
@@ -2824,7 +2824,7 @@ class _Editable extends LeafRenderObjectWidget {
       ..textScaleFactor = textScaleFactor
       ..textAlign = textAlign
       ..textDirection = textDirection
-      ..locale = locale ?? Localizations.localeOf(context, nullOk: true)
+      ..locale = locale ?? Localizations.maybeLocaleOf(context)
       ..selection = value.selection
       ..offset = offset
       ..onSelectionChanged = onSelectionChanged

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -51,7 +51,7 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size? s
   return ImageConfiguration(
     bundle: DefaultAssetBundle.of(context),
     devicePixelRatio: MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
-    locale: Localizations.localeOf(context, nullOk: true),
+    locale: Localizations.maybeLocaleOf(context),
     textDirection: Directionality.maybeOf(context),
     size: size,
     platform: defaultTargetPlatform,

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -390,7 +390,7 @@ class Localizations extends StatefulWidget {
       mergedDelegates.insertAll(0, delegates);
     return Localizations(
       key: key,
-      locale: locale ?? Localizations.localeOf(context)!,
+      locale: locale ?? Localizations.localeOf(context),
       delegates: mergedDelegates,
       child: child,
     );
@@ -411,17 +411,38 @@ class Localizations extends StatefulWidget {
   /// The locale of the Localizations widget for the widget tree that
   /// corresponds to [BuildContext] `context`.
   ///
-  /// If no [Localizations] widget is in scope then the [Localizations.localeOf]
-  /// method will throw an exception, unless the `nullOk` argument is set to
-  /// true, in which case it returns null.
-  static Locale? localeOf(BuildContext context, { bool nullOk = false }) {
+  /// If no [Localizations] widget is in scope then this function will assert in
+  /// debug mode, and throw an exception in release mode.
+  static Locale localeOf(BuildContext context) {
     assert(context != null);
-    assert(nullOk != null);
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();
-    if (nullOk && scope == null)
-      return null;
-    assert(scope != null, 'a Localizations ancestor was not found');
-    return scope!.localizationsState.locale;
+    assert(() {
+      if (scope == null) {
+        throw FlutterError(
+          'Localizations operation requested with a context that does not include Localizations.\n'
+          'The context used to retrieve the Localizations widget must be that of a widget that '
+          'is a descendant of a Localizations widget.'
+        );
+      }
+      if (scope.localizationsState.locale == null) {
+        throw FlutterError(
+          'Localizations.localeOf found a Localizations widget that had a null locale.\n'
+        );
+      }
+      return true;
+    }());
+    return scope!.localizationsState.locale!;
+  }
+
+  /// The locale of the Localizations widget for the widget tree that
+  /// corresponds to [BuildContext] `context`.
+  ///
+  /// If no [Localizations] widget is in scope then this function will return
+  /// null.
+  static Locale? maybeLocaleOf(BuildContext context) {
+    assert(context != null);
+    final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();
+    return scope?.localizationsState.locale;
   }
 
   // There doesn't appear to be a need to make this public. See the

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -390,7 +390,7 @@ class Localizations extends StatefulWidget {
       mergedDelegates.insertAll(0, delegates);
     return Localizations(
       key: key,
-      locale: locale ?? Localizations.localeOf(context),
+      locale: locale ?? Localizations.localeOf(context)!,
       delegates: mergedDelegates,
       child: child,
     );
@@ -411,35 +411,37 @@ class Localizations extends StatefulWidget {
   /// The locale of the Localizations widget for the widget tree that
   /// corresponds to [BuildContext] `context`.
   ///
-  /// If no [Localizations] widget is in scope then this function will assert in
-  /// debug mode, and throw an exception in release mode.
-  static Locale localeOf(BuildContext context, { bool nullOk = false }) {
+  /// If no [Localizations] widget is in scope then the [Localizations.localeOf]
+  /// method will throw an exception, unless the `nullOk` argument is set to
+  /// true, in which case it returns null.
+  static Locale? localeOf(BuildContext context, { bool nullOk = false }) {
     assert(context != null);
-    assert(!nullOk, 'nullOk == true is no longer supported, use maybeLocaleOf instead.');
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();
+    if (nullOk && scope == null)
+      return null;
     assert(() {
       if (scope == null) {
         throw FlutterError(
-          'Localizations operation requested with a context that does not include Localizations.\n'
-          'The context used to retrieve the Localizations widget must be that of a widget that '
-          'is a descendant of a Localizations widget.'
+          'Requested the Locale of a context that does not include a Localizations ancestor.\n'
+          'To request the Locale, the context used to retrieve the Localizations widget must '
+          'be that of a widget that is a descendant of a Localizations widget.'
         );
       }
-      if (scope.localizationsState.locale == null) {
+      if (!nullOk && scope.localizationsState.locale == null) {
         throw FlutterError(
-          'Localizations.localeOf found a Localizations widget that had a null locale.\n'
+          'Localizations.localeOf found a Localizations widget that had a unexpected null locale.\n'
         );
       }
       return true;
     }());
-    return scope!.localizationsState.locale!;
+    return scope!.localizationsState.locale;
   }
 
   /// The locale of the Localizations widget for the widget tree that
   /// corresponds to [BuildContext] `context`.
   ///
   /// If no [Localizations] widget is in scope then this function will return
-  /// null.
+  /// null. Equivalent to calling [localeOf] with `nullOk` set to true.
   static Locale? maybeLocaleOf(BuildContext context) {
     assert(context != null);
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -413,8 +413,9 @@ class Localizations extends StatefulWidget {
   ///
   /// If no [Localizations] widget is in scope then this function will assert in
   /// debug mode, and throw an exception in release mode.
-  static Locale localeOf(BuildContext context) {
+  static Locale localeOf(BuildContext context, { bool nullOk = false }) {
     assert(context != null);
+    assert(!nullOk, 'nullOk == true is no longer supported, use maybeLocaleOf instead.');
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();
     assert(() {
       if (scope == null) {

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(() => Localizations.localeOf(contextKey.currentContext!), throwsA(isAssertionError.having(
           (AssertionError e) => e.message,
       'message',
-      contains('Localizations operation requested with a context that does not include Localizations'),
+      contains('does not include a Localizations ancestor'),
     )));
   });
 

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -34,6 +34,24 @@ void main() {
     await tester.pump();
     expect(find.text('loaded'), findsOneWidget);
   });
+
+  testWidgets('Localizations.localeOf throws when no localizations exist', (WidgetTester tester) async {
+    final GlobalKey contextKey = GlobalKey(debugLabel: 'Test Key');
+    await tester.pumpWidget(Container(key: contextKey));
+
+    expect(() => Localizations.localeOf(contextKey.currentContext!), throwsA(isAssertionError.having(
+          (AssertionError e) => e.message,
+      'message',
+      contains('Localizations operation requested with a context that does not include Localizations'),
+    )));
+  });
+
+  testWidgets('Localizations.maybeLocaleOf returns null when no localizations exist', (WidgetTester tester) async {
+    final GlobalKey contextKey = GlobalKey(debugLabel: 'Test Key');
+    await tester.pumpWidget(Container(key: contextKey));
+
+    expect(Localizations.maybeLocaleOf(contextKey.currentContext!), isNull);
+  });
 }
 
 class FakeLocalizationsDelegate extends LocalizationsDelegate<String> {


### PR DESCRIPTION
## Description

This removes the `nullOk` parameter from `Localizations.localeOf`, and creates`Localizations.maybeLocaleOf`.  `Localizations.localeOf`now returns a non-nullable value, and the `Localizations.maybeLocaleOf` returns a nullable value.

## Related Issues

- https://github.com/flutter/flutter/issues/68637

## Tests

- Updated tests to use `maybeOf`.

## Breaking Change

- [X] Yes, this is a breaking change that will require a migration guide.
  - [X] I wrote a [design doc](https://flutter.dev/go/eliminating-nullok-parameters)
   - [X] I submitted it for input from the developer relations team, specifically from: @RedBrogdon
   - [X] I wrote a migration guide: In https://github.com/flutter/website/pull/4921