### PR TITLE
Delay Route disposal until OverlayEntries are unmounted

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -534,15 +534,7 @@ class _HeroFlight {
     );
   }
 
-  void _handleAnimationUpdate(AnimationStatus status) {
-    // The animation will not finish until the user lifts their finger, so we
-    // should ignore the status update if the gesture is in progress.
-    //
-    // This also relies on the animation to update its status at the end of the
-    // gesture. See the _CupertinoBackGestureController.dragEnd for how
-    // cupertino page route achieves that.
-    if (manifest!.fromRoute.navigator?.userGestureInProgress == true)
-      return;
+  void _performAnimationUpdate(AnimationStatus status) {
     if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
       _proxyAnimation.parent = null;
 
@@ -558,6 +550,33 @@ class _HeroFlight {
       manifest!.toHero.endFlight(keepPlaceholder: status == AnimationStatus.dismissed);
       onFlightEnded(this);
     }
+  }
+
+  bool _scheduledPerformAnimtationUpdate = false;
+  void _handleAnimationUpdate(AnimationStatus status) {
+    // The animation will not finish until the user lifts their finger, so we
+    // should suppress the status update if the gesture is in progress, and
+    // delay it until the finger is lifted.
+    if (manifest!.fromRoute.navigator?.userGestureInProgress != true) {
+      _performAnimationUpdate(status);
+      return;
+    }
+
+    // The `navigator` must be null, or the first if clause would have returned.
+    final NavigatorState navigator = manifest!.fromRoute.navigator!;
+    if (_scheduledPerformAnimtationUpdate)
+      return;
+
+    void delayedPerformAnimtationUpdate() {
+      assert(!navigator.userGestureInProgress);
+      assert(_scheduledPerformAnimtationUpdate);
+      _scheduledPerformAnimtationUpdate = false;
+      navigator.userGestureInProgressNotifier.removeListener(delayedPerformAnimtationUpdate);
+      _performAnimationUpdate(_proxyAnimation.status);
+    }
+    assert(navigator.userGestureInProgress);
+    _scheduledPerformAnimtationUpdate = true;
+    navigator.userGestureInProgressNotifier.addListener(delayedPerformAnimtationUpdate);
   }
 
   // The simple case: we're either starting a push or a pop animation.

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -562,10 +562,12 @@ class _HeroFlight {
       return;
     }
 
-    // The `navigator` must be null, or the first if clause would have returned.
-    final NavigatorState navigator = manifest!.fromRoute.navigator!;
     if (_scheduledPerformAnimtationUpdate)
       return;
+
+    // The `navigator` must be non-null here, or the first if clause above would
+    // have returned from this method.
+    final NavigatorState navigator = manifest!.fromRoute.navigator!;
 
     void delayedPerformAnimtationUpdate() {
       assert(!navigator.userGestureInProgress);

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -51,7 +51,7 @@ import 'ticker_provider.dart';
 ///  * [OverlayState]
 ///  * [WidgetsApp]
 ///  * [MaterialApp]
-class OverlayEntry {
+class OverlayEntry extends ChangeNotifier {
   /// Creates an overlay entry.
   ///
   /// To insert the entry into an [Overlay], first find the overlay using
@@ -113,6 +113,19 @@ class OverlayEntry {
     _overlay!._didChangeEntryOpacity();
   }
 
+  /// Whether the [OverlayEntry] is currently mounted in the widget tree.
+  ///
+  /// The [OverlayEntry] notifies its listeners when this value changes.
+  bool get mounted => _mounted;
+  bool _mounted = false;
+  void _updateMounted(bool value) {
+    if (value == _mounted) {
+      return;
+    }
+    _mounted = value;
+    notifyListeners();
+  }
+
   OverlayState? _overlay;
   final GlobalKey<_OverlayEntryWidgetState> _key = GlobalKey<_OverlayEntryWidgetState>();
 
@@ -172,6 +185,18 @@ class _OverlayEntryWidget extends StatefulWidget {
 }
 
 class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.entry._updateMounted(true);
+  }
+
+  @override
+  void dispose() {
+    widget.entry._updateMounted(false);
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return TickerMode(

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -45,6 +45,10 @@ import 'ticker_provider.dart';
 /// if widgets in an overlay entry with [maintainState] set to true repeatedly
 /// call [State.setState], the user's battery will be drained unnecessarily.
 ///
+/// [OverlayEntry] is a [ChangeNotifier] that notifies when the widget built by
+/// [builder] is mounted or unmounted, whose exact state can be queried by
+/// [mounted].
+///
 /// See also:
 ///
 ///  * [Overlay]

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -189,7 +189,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         // removing the route and disposing it.
         if (!isActive) {
           navigator!.finalizeRoute(this);
-          assert(overlayEntries.isEmpty);
         }
         break;
     }

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -102,17 +102,15 @@ Future<void> runNavigatorTest(
   NavigatorState host,
   VoidCallback test,
   List<String> expectations, [
-  List<String>? expectationsAfterAnotherPump,
+  List<String>? expectationsAfterAnotherPump = const <String>[],
 ]) async {
   expect(host, isNotNull);
   test();
   expect(results, equals(expectations));
   results.clear();
   await tester.pump();
-  if (expectationsAfterAnotherPump != null) {
-    expect(results, equals(expectationsAfterAnotherPump));
-    results.clear();
-  }
+  expect(results, equals(expectationsAfterAnotherPump));
+  results.clear();
 }
 
 void main() {
@@ -194,8 +192,6 @@ void main() {
         'two: didReplace second',
         'two: didChangeNext third',
         'initial: didChangeNext two',
-      ],
-      <String>[
         'second: dispose',
       ],
     );
@@ -278,7 +274,6 @@ void main() {
       tester,
       host,
       () { host.removeRouteBelow(second); },
-      <String>[],
       <String>[
         'first: dispose',
       ],
@@ -324,8 +319,6 @@ void main() {
       () { host.removeRouteBelow(four); },
       <String>[
         'second: didChangeNext four',
-      ],
-      <String>[
         'three: dispose',
       ],
     );
@@ -403,8 +396,6 @@ void main() {
         'b: didReplace B',
         'b: didChangeNext C',
         'A: didChangeNext b',
-      ],
-      <String>[
         'B: dispose',
       ],
     );

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -105,6 +105,7 @@ Future<void> runNavigatorTest(
 ) async {
   expect(host, isNotNull);
   test();
+  await tester.pump();
   expect(results, equals(expectations));
   results.clear();
   await tester.pump();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -101,14 +101,18 @@ Future<void> runNavigatorTest(
   WidgetTester tester,
   NavigatorState host,
   VoidCallback test,
-  List<String> expectations,
-) async {
+  List<String> expectations, [
+  List<String>? expectationsAfterAnotherPump,
+]) async {
   expect(host, isNotNull);
   test();
-  await tester.pump();
   expect(results, equals(expectations));
   results.clear();
   await tester.pump();
+  if (expectationsAfterAnotherPump != null) {
+    expect(results, equals(expectationsAfterAnotherPump));
+    results.clear();
+  }
 }
 
 void main() {
@@ -190,6 +194,8 @@ void main() {
         'two: didReplace second',
         'two: didChangeNext third',
         'initial: didChangeNext two',
+      ],
+      <String>[
         'second: dispose',
       ],
     );
@@ -200,6 +206,8 @@ void main() {
       <String>[ // stack is: initial, two
         'third: didPop hello',
         'two: didPopNext third',
+      ],
+      <String>[
         'third: dispose',
       ],
     );
@@ -210,6 +218,8 @@ void main() {
       <String>[ // stack is: initial
         'two: didPop good bye',
         'initial: didPopNext two',
+      ],
+      <String>[
         'two: dispose',
       ],
     );
@@ -268,6 +278,7 @@ void main() {
       tester,
       host,
       () { host.removeRouteBelow(second); },
+      <String>[],
       <String>[
         'first: dispose',
       ],
@@ -279,6 +290,8 @@ void main() {
       <String>[
         'third: didPop good bye',
         'second: didPopNext third',
+      ],
+      <String>[
         'third: dispose',
       ],
     );
@@ -311,6 +324,8 @@ void main() {
       () { host.removeRouteBelow(four); },
       <String>[
         'second: didChangeNext four',
+      ],
+      <String>[
         'three: dispose',
       ],
     );
@@ -321,6 +336,8 @@ void main() {
       <String>[
         'four: didPop the end',
         'second: didPopNext four',
+      ],
+      <String>[
         'four: dispose',
       ],
     );
@@ -386,6 +403,8 @@ void main() {
         'b: didReplace B',
         'b: didChangeNext C',
         'A: didChangeNext b',
+      ],
+      <String>[
         'B: dispose',
       ],
     );
@@ -396,6 +415,8 @@ void main() {
       <String>[
         'C: didPop null',
         'b: didPopNext C',
+      ],
+      <String>[
         'C: dispose',
       ],
     );

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -102,7 +102,7 @@ Future<void> runNavigatorTest(
   NavigatorState host,
   VoidCallback test,
   List<String> expectations, [
-  List<String>? expectationsAfterAnotherPump = const <String>[],
+  List<String> expectationsAfterAnotherPump = const <String>[],
 ]) async {
   expect(host, isNotNull);
   test();


### PR DESCRIPTION
## Description

This PR changes the Navigator to only dispose a Route after all its OverlayEntries have been disposed.

_The following description of the problem was written by @dkwingsmt, who initially debugged the issue. Thank you!_

This fixes #63984. The issue is caused by programmatically popping a route while the back swipe is in progress (fingers held), which leads to the following series of event:

* A route is popped and disposed. During the disposal,
  * Its animation controller is disposed.
  * A PointerCancelEvent is synthesized for the active pointer.
* The disposal of the route should trigger the navigator to rebuild, removing all dependents of the controller, but this does not come until the widget tree is rebuilt in the next frame.
* Before the next frame, the cancel event is dispatched.
    * The drag gesture recognizer (which is not disposed until the next frame) receives the cancel event and starts to dispatch ending callbacks. The callback starts some animation, only to find the controller of the Route disposed, triggering assertion error.

The resources of a Route (e.g. the controller) must be held until after the widget tree of the route is disposed since widgets in the tree may hold on to resources of the Route. Therefore this PR no longer disposes the route entry synchronously from within _flushHistoryUpdates, but waits until all its overlay entries are disposed.

Some logic of _HeroFlight is also tweaked to fix a few test breakages. This is caused by a condition which skips Hero's end-flight operations when there are any on-going gestures, introduced by #58024. This was not an issue because the fromRoute.navigator had been null at that point, passing the condition unintentionally, which is exposed now that the lifecycle of fromRoute is extended. The _HeroFlight now postpones the operations until the gestures are cleared.

## Related Issues

Fixes #63984.

## Tests

I added the following tests:

* a test encoding the sequence of events described in #63984

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
