### PR TITLE
Error on FocusTraversalGroup or Focus docs

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1445,7 +1445,7 @@ class FocusTraversalOrder extends InheritedWidget {
 /// By default, traverses in reading order using [ReadingOrderTraversalPolicy].
 ///
 /// To prevent the members of the group from being focused, set the
-/// [descendantsAreFocusable] attribute to true.
+/// [descendantsAreFocusable] attribute to false.
 ///
 /// {@tool dartpad --template=stateless_widget_material}
 /// This sample shows three rows of buttons, each grouped by a


### PR DESCRIPTION
I am reading the docs on `FocusTraversalGroup` and it doesn't make much sense to me what the docs are saying. It also doesn't match what the docs on `Focus` say. I didn't test this behavior, I am just flagging this here so people familiar with `FocusTraversalGroup` can evaluate if this is wrong or not.