### PR TITLE
[flutter_tools] implement safe file copy with multiple fallbacks

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -11,6 +11,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p; // ignore: package_path_import
 import 'package:process/process.dart';
 
+import '../reporting/reporting.dart';
 import 'common.dart' show throwToolExit;
 import 'platform.dart';
 
@@ -302,7 +303,6 @@ class ErrorHandlingFile
     } on FileSystemException {
       // Proceed below
     }
-
     // If the copy failed but both of the above checks passed, copy the bytes
     // directly.
     _runSync(() {
@@ -323,6 +323,9 @@ class ErrorHandlingFile
         sink?.closeSync();
       }
     }, platform: _platform, failureMessage: 'Flutter failed to copy $path to $newPath due to unknown error');
+    // The original copy failed, but the manual copy worked. Report an analytics event to
+    // track this to determine if this code path is actually hit.
+    ErrorHandlingEvent('copy-fallback').send();
     return wrapFile(resultFile);
   }
 

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -306,9 +306,11 @@ class ErrorHandlingFile
     // If the copy failed but both of the above checks passed, copy the bytes
     // directly.
     _runSync(() {
-      final RandomAccessFile source = delegate.openSync(mode: FileMode.read);
-      final RandomAccessFile sink = resultFile.openSync(mode: FileMode.writeOnly);
+      RandomAccessFile source;
+      RandomAccessFile sink;
       try {
+        source = delegate.openSync(mode: FileMode.read);
+        sink = resultFile.openSync(mode: FileMode.writeOnly);
         // 64k is the same sized buffer used by dart:io for `File.openRead`.
         final Uint8List buffer = Uint8List(64 * 1024);
         final int totalBytes = source.lengthSync();
@@ -318,6 +320,9 @@ class ErrorHandlingFile
           sink.writeFromSync(buffer, 0, chunkLength);
           bytes += chunkLength;
         }
+      } catch (err) { // ignore: avoid_catches_without_on_clauses
+        ErrorHandlingFileSystem.deleteIfExists(resultFile, recursive: true);
+        rethrow;
       } finally {
         source?.closeSync();
         sink?.closeSync();

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -796,7 +796,6 @@ https://flutter.dev/docs/development/packages-and-plugins/developing-packages#pl
       logger: globals.logger,
       templateRenderer: globals.templateRenderer,
       templateManifest: templateManifest,
-      pub: pub,
     );
     return template.render(directory, context, overwriteExisting: overwrite);
   }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -14,7 +14,6 @@ import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
 import 'bundle.dart' as bundle;
-import 'dart/pub.dart';
 import 'features.dart';
 import 'flutter_manifest.dart';
 import 'globals.dart' as globals;
@@ -702,7 +701,6 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       templateManifest: null,
       logger: globals.logger,
       templateRenderer: globals.templateRenderer,
-      pub: pub,
     );
     template.render(
       target,
@@ -862,7 +860,6 @@ to migrate your project.
       templateManifest: null,
       logger: globals.logger,
       templateRenderer: globals.templateRenderer,
-      pub: pub,
     );
     template.render(
       target,

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -22,6 +22,7 @@ class UsageEvent {
   final Usage flutterUsage;
 
   void send() {
+    print(flutterUsage);
     flutterUsage.sendEvent(category, parameter, label: label, value: value);
   }
 }
@@ -247,4 +248,9 @@ class CodeSizeEvent extends UsageEvent {
     platform,
     flutterUsage: flutterUsage ?? globals.flutterUsage,
   );
+}
+
+/// An event for tracking the usage of specific error handling fallbacks.
+class ErrorHandlingEvent extends UsageEvent {
+  ErrorHandlingEvent(String parameter) : super('error-handling', parameter, flutterUsage: globals.flutterUsage);
 }

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -22,7 +22,6 @@ class UsageEvent {
   final Usage flutterUsage;
 
   void send() {
-    print(flutterUsage);
     flutterUsage.sendEvent(category, parameter, label: label, value: value);
   }
 }

--- a/packages/flutter_tools/test/template_test.dart
+++ b/packages/flutter_tools/test/template_test.dart
@@ -7,8 +7,6 @@ import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/template.dart';
-import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/template.dart';
 import 'package:mockito/mockito.dart';
 import 'src/common.dart';
@@ -30,30 +28,6 @@ void main() {
 
     expect(() => template.render(mockDirectory, <String, Object>{}),
         throwsToolExit());
-  });
-
-  testWithoutContext('Template.render attempts to read byte from template file before copying', () {
-    final MemoryFileSystem baseFileSystem = MemoryFileSystem.test();
-    baseFileSystem.file('templates/foo.copy.tmpl').createSync(recursive: true);
-    final ConfiguredFileSystem fileSystem = ConfiguredFileSystem(
-      baseFileSystem,
-      entities: <String, FileSystemEntity>{
-        '/templates/foo.copy.tmpl': FakeFile('/templates/foo.copy.tmpl'),
-      },
-    );
-
-    final Template template = Template(
-      fileSystem.directory('templates'),
-      fileSystem.currentDirectory,
-      null,
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      templateRenderer: FakeTemplateRenderer(),
-      templateManifest: null,
-    );
-
-    expect(() => template.render(fileSystem.directory('out'), <String, Object>{}),
-      throwsA(isA<FileSystemException>()));
   });
 
   testWithoutContext('Template.render replaces .img.tmpl files with files from the image source', () {
@@ -82,105 +56,9 @@ void main() {
     expect(destinationImage, exists);
     expect(destinationImage.readAsBytesSync(), equals(sourceImage.readAsBytesSync()));
   });
-
-  testWithoutContext('Template.fromName runs pub get if .packages is missing', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    final MockPub pub = MockPub();
-    when(pub.get(
-      context: PubContext.pubGet,
-      directory: anyNamed('directory'),
-      generateSyntheticPackage: false,
-    )).thenThrow(UnsupportedError(''));
-    Cache.flutterRoot = '/flutter';
-
-    // Attempting to run pub in a test throws.
-    await expectLater(Template.fromName(
-        'app',
-        fileSystem: fileSystem,
-        templateManifest: null,
-        logger: BufferLogger.test(),
-        pub: pub,
-        templateRenderer: FakeTemplateRenderer(),
-      ),
-      throwsUnsupportedError,
-    );
-  });
-
-  testWithoutContext('Template.fromName runs pub get if .packages is missing flutter_template_images', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    final MockPub pub = MockPub();
-    when(pub.get(
-      context: PubContext.pubGet,
-      directory: anyNamed('directory'),
-      generateSyntheticPackage: false,
-    )).thenThrow(UnsupportedError(''));
-
-    Cache.flutterRoot = '/flutter';
-    final File packagesFile = fileSystem.directory(Cache.flutterRoot)
-      .childDirectory('packages')
-      .childDirectory('flutter_tools')
-      .childFile('.packages');
-    packagesFile.createSync(recursive: true);
-
-    // Attempting to run pub in a test throws.
-    await expectLater(
-      Template.fromName(
-        'app',
-        fileSystem: fileSystem,
-        templateManifest: null,
-        logger: BufferLogger.test(),
-        pub: pub,
-        templateRenderer: FakeTemplateRenderer(),
-      ),
-      throwsUnsupportedError,
-    );
-  });
-
-  testWithoutContext('Template.fromName runs pub get if flutter_template_images directory is missing', () async {
-    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    final MockPub pub = MockPub();
-    Cache.flutterRoot = '/flutter';
-    final File packagesFile = fileSystem.directory(Cache.flutterRoot)
-      .childDirectory('packages')
-      .childDirectory('flutter_tools')
-      .childFile('.packages');
-    packagesFile.createSync(recursive: true);
-    packagesFile.writeAsStringSync('\n');
-
-    when(pub.get(
-      context: PubContext.pubGet,
-      directory: anyNamed('directory'),
-      generateSyntheticPackage: false,
-    )).thenAnswer((Invocation invocation) async {
-      // Create valid package entry.
-      packagesFile.writeAsStringSync('flutter_template_images:file:///flutter_template_images');
-    });
-
-    await Template.fromName(
-      'app',
-      fileSystem: fileSystem,
-      templateManifest: null,
-      logger: BufferLogger.test(),
-      templateRenderer: FakeTemplateRenderer(),
-      pub: pub,
-    );
-  });
 }
 
-class MockPub extends Mock implements Pub {}
 class MockDirectory extends Mock implements Directory {}
-
-class FakeFile extends Fake implements File {
-  FakeFile(this.path);
-
-  @override
-  final String path;
-
-  @override
-  int lengthSync() {
-    throw const FileSystemException('', '', OSError('', 5));
-  }
-}
 
 class FakeTemplateRenderer extends TemplateRenderer {
   @override


### PR DESCRIPTION
## Description

The tool observes a large number of unhandled exceptions during the file copy portion of flutter create. it is difficult to tell whether the permission issue is caused by the source/destination, or whether it is due to a bug in dart:io.

To work around this, implement a permission check for both the source and dest files. If either fails, the tool can exit with a more specific message.

If these checks pass, then perform the actual copy. If the copy fails, fallback to manually copying the bytes