### PR TITLE
[gen_l10n] Add base method code comments for improved discoverability

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -207,7 +207,7 @@ String generateMethod(Message message, AppResourceBundle bundle) {
 
 String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
   final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
-  final String templateLocaleTranslationComment = 'In $templateArbLocale, this message translates to "${message.value}"';
+  final String templateLocaleTranslationComment = 'In $templateArbLocale, this message translates to "${message.value}".';
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate
       .replaceAll('@(comment)', comment)

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -207,7 +207,8 @@ String generateMethod(Message message, AppResourceBundle bundle) {
 
 String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
   final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
-  final String templateLocaleTranslationComment = 'In $templateArbLocale, this message translates to "${message.value}".';
+  final String templateLocaleTranslationComment = '''/// In $templateArbLocale, this message translates to:
+  /// **"${message.value}"**''';
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate
       .replaceAll('@(comment)', comment)

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -205,16 +205,19 @@ String generateMethod(Message message, AppResourceBundle bundle) {
     .replaceAll('@(message)', generateMessage());
 }
 
-String generateBaseClassMethod(Message message) {
-  final String comment = message.description ?? 'No description provided in @${message.resourceId}';
+String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
+  final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
+  final String templateLocaleTranslationComment = 'In $templateArbLocale, this message translates to "${message.value}"';
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate
       .replaceAll('@(comment)', comment)
+      .replaceAll('@(templateLocaleTranslationComment)', templateLocaleTranslationComment)
       .replaceAll('@(name)', message.resourceId)
       .replaceAll('@(parameters)', generateMethodParameters(message).join(', '));
   }
   return baseClassGetterTemplate
     .replaceAll('@(comment)', comment)
+    .replaceAll('@(templateLocaleTranslationComment)', templateLocaleTranslationComment)
     .replaceAll('@(name)', message.resourceId);
 }
 
@@ -993,7 +996,7 @@ class LocalizationsGenerator {
     _generatedLocalizationsFile = fileTemplate
       .replaceAll('@(header)', header)
       .replaceAll('@(class)', className)
-      .replaceAll('@(methods)', _allMessages.map(generateBaseClassMethod).join('\n'))
+      .replaceAll('@(methods)', _allMessages.map((Message message) => generateBaseClassMethod(message, _templateArbLocale)).join('\n'))
       .replaceAll('@(importFile)', '$directory/$outputFileName')
       .replaceAll('@(supportedLocales)', supportedLocalesCode.join(',\n    '))
       .replaceAll('@(supportedLanguageCodes)', supportedLanguageCodes.join(', '))

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -207,8 +207,10 @@ String generateMethod(Message message, AppResourceBundle bundle) {
 
 String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
   final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
-  final String templateLocaleTranslationComment = '''/// In $templateArbLocale, this message translates to:
+  final String templateLocaleTranslationComment = '''
+  /// In $templateArbLocale, this message translates to:
   /// **"${message.value}"**''';
+
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate
       .replaceAll('@(comment)', comment)

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -209,7 +209,7 @@ String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
   final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
   final String templateLocaleTranslationComment = '''
   /// In $templateArbLocale, this message translates to:
-  /// **"${message.value}"**''';
+  /// **"${generateString(message.value)}"**''';
 
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -209,7 +209,7 @@ String generateBaseClassMethod(Message message, LocaleInfo templateArbLocale) {
   final String comment = message.description ?? 'No description provided for @${message.resourceId}.';
   final String templateLocaleTranslationComment = '''
   /// In $templateArbLocale, this message translates to:
-  /// **"${generateString(message.value)}"**''';
+  /// **${generateString(message.value)}**''';
 
   if (message.placeholders.isNotEmpty) {
     return baseClassMethodTemplate

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -182,14 +182,14 @@ class @(class) extends @(baseLanguageClassName) {
 const String baseClassGetterTemplate = '''
   /// @(comment)
   ///
-  /// @(templateLocaleTranslationComment)
+  @(templateLocaleTranslationComment)
   String get @(name);
 ''';
 
 const String baseClassMethodTemplate = '''
   /// @(comment)
   ///
-  /// @(templateLocaleTranslationComment)
+  @(templateLocaleTranslationComment)
   String @(name)(@(parameters));
 ''';
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -189,7 +189,7 @@ const String baseClassGetterTemplate = '''
 const String baseClassMethodTemplate = '''
   /// @(comment)
   ///
-  @(templateLocaleTranslationComment)
+@(templateLocaleTranslationComment)
   String @(name)(@(parameters));
 ''';
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -180,12 +180,16 @@ class @(class) extends @(baseLanguageClassName) {
 ''';
 
 const String baseClassGetterTemplate = '''
-  // @(comment)
+  /// @(comment)
+  ///
+  /// @(templateLocaleTranslationComment)
   String get @(name);
 ''';
 
 const String baseClassMethodTemplate = '''
-  // @(comment)
+  /// @(comment)
+  ///
+  /// @(templateLocaleTranslationComment)
   String @(name)(@(parameters));
 ''';
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -182,7 +182,7 @@ class @(class) extends @(baseLanguageClassName) {
 const String baseClassGetterTemplate = '''
   /// @(comment)
   ///
-  @(templateLocaleTranslationComment)
+@(templateLocaleTranslationComment)
   String get @(name);
 ''';
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -29,18 +29,18 @@ const String singleMessageArbFileString = '''
 {
   "title": "Title",
   "@title": {
-    "description": "Title for the application"
+    "description": "Title for the application."
   }
 }''';
 const String twoMessageArbFileString = '''
 {
   "title": "Title",
   "@title": {
-    "description": "Title for the application"
+    "description": "Title for the application."
   },
   "subtitle": "Subtitle",
   "@subtitle": {
-    "description": "Subtitle for the application"
+    "description": "Subtitle for the application."
   }
 }''';
 const String esArbFileName = 'app_es.arb';
@@ -1071,6 +1071,85 @@ void main() {
   });
 
   group('writeOutputFiles', () {
+    test('message without placeholders - should generate code comment with description and template message translation', () {
+      _standardFlutterDirectoryL10nSetup(fs);
+      final LocalizationsGenerator generator = LocalizationsGenerator(fs);
+      try {
+        generator.initialize(
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        );
+        generator.loadResources();
+        generator.writeOutputFiles();
+      } on Exception catch (e) {
+        fail('Generating output files should not fail: $e');
+      }
+
+      final File baseLocalizationsFile = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      );
+      expect(baseLocalizationsFile.existsSync(), isTrue);
+
+      final String baseLocalizationsFileContents = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      ).readAsStringSync();
+      expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
+      expect(baseLocalizationsFileContents, contains('/// In en, this message translates to "Title"'));
+    });
+
+    test('message with placeholders - should generate code comment with description and template message translation', () {
+      final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+        ..createSync(recursive: true);
+      l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(r'''{
+  "price": "The price of this item is: ${price}",
+  "@price": {
+    "description": "The price of an online shopping cart item.",
+    "placeholders": {
+      "price": {
+        "type": "double",
+        "format": "decimalPattern"
+      }
+    }
+  }
+}''');
+      l10nDirectory.childFile(esArbFileName)
+        .writeAsStringSync(r'''{
+  "price": "el precio de este artículo es: ${price}"
+}''');
+
+      final LocalizationsGenerator generator = LocalizationsGenerator(fs);
+      try {
+        generator.initialize(
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        );
+        generator.loadResources();
+        generator.writeOutputFiles();
+      } on Exception catch (e) {
+        final L10nException exception = e as L10nException;
+        print(exception.message);
+        fail('Generating output files should not fail: $e');
+      }
+
+      final File baseLocalizationsFile = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      );
+      expect(baseLocalizationsFile.existsSync(), isTrue);
+
+      final String baseLocalizationsFileContents = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      ).readAsStringSync();
+      expect(baseLocalizationsFileContents, contains('/// The price of an online shopping cart item.'));
+      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to "The price of this item is: ${price}"'''));
+    });
+
     test('should generate a file per language', () {
       const String singleEnCaMessageArbFileString = '''
 {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1099,7 +1099,52 @@ void main() {
       expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
       expect(baseLocalizationsFileContents, contains('''
   /// In en, this message translates to:
-  /// **"Title"**'''));
+  /// **'Title'**'''));
+    });
+
+    test('template message translation handles newline characters', () {
+      final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+        ..createSync(recursive: true);
+      l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(r'''
+{
+  "title": "Title \n of the application",
+  "@title": {
+    "description": "Title for the application."
+  }
+}''');
+      l10nDirectory.childFile(esArbFileName)
+        .writeAsStringSync(singleEsMessageArbFileString);
+
+
+
+      final LocalizationsGenerator generator = LocalizationsGenerator(fs);
+      try {
+        generator.initialize(
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        );
+        generator.loadResources();
+        generator.writeOutputFiles();
+      } on Exception catch (e) {
+        fail('Generating output files should not fail: $e');
+      }
+
+      final File baseLocalizationsFile = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      );
+      expect(baseLocalizationsFile.existsSync(), isTrue);
+
+      final String baseLocalizationsFileContents = fs.file(
+        fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
+      ).readAsStringSync();
+      expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
+      expect(baseLocalizationsFileContents, contains(r'''
+  /// In en, this message translates to:
+  /// **'Title \n of the application'**'''));
     });
 
     test('message with placeholders - should generate code comment with description and template message translation', () {
@@ -1153,7 +1198,7 @@ void main() {
       expect(baseLocalizationsFileContents, contains('/// The price of an online shopping cart item.'));
       expect(baseLocalizationsFileContents, contains(r'''
   /// In en, this message translates to:
-  /// **"The price of this item is: ${price}"**'''));
+  /// **'The price of this item is: \${price}'**'''));
     });
 
     test('should generate a file per language', () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1097,7 +1097,7 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
-      expect(baseLocalizationsFileContents, contains('/// In en, this message translates to "Title"'));
+      expect(baseLocalizationsFileContents, contains('/// In en, this message translates to "Title".'));
     });
 
     test('message with placeholders - should generate code comment with description and template message translation', () {
@@ -1147,7 +1147,7 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// The price of an online shopping cart item.'));
-      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to "The price of this item is: ${price}"'''));
+      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to "The price of this item is: ${price}".'''));
     });
 
     test('should generate a file per language', () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1097,7 +1097,8 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
-      expect(baseLocalizationsFileContents, contains('/// In en, this message translates to "Title".'));
+      expect(baseLocalizationsFileContents, contains('''/// In en, this message translates to:
+  /// **"Title"**'''));
     });
 
     test('message with placeholders - should generate code comment with description and template message translation', () {
@@ -1147,7 +1148,8 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// The price of an online shopping cart item.'));
-      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to "The price of this item is: ${price}".'''));
+      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to:
+  /// **"The price of this item is: ${price}"**'''));
     });
 
     test('should generate a file per language', () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1097,7 +1097,8 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// Title for the application.'));
-      expect(baseLocalizationsFileContents, contains('''/// In en, this message translates to:
+      expect(baseLocalizationsFileContents, contains('''
+  /// In en, this message translates to:
   /// **"Title"**'''));
     });
 
@@ -1105,7 +1106,8 @@ void main() {
       final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
         ..createSync(recursive: true);
       l10nDirectory.childFile(defaultTemplateArbFileName)
-        .writeAsStringSync(r'''{
+        .writeAsStringSync(r'''
+{
   "price": "The price of this item is: ${price}",
   "@price": {
     "description": "The price of an online shopping cart item.",
@@ -1118,7 +1120,8 @@ void main() {
   }
 }''');
       l10nDirectory.childFile(esArbFileName)
-        .writeAsStringSync(r'''{
+        .writeAsStringSync(r'''
+{
   "price": "el precio de este artículo es: ${price}"
 }''');
 
@@ -1148,7 +1151,8 @@ void main() {
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
       ).readAsStringSync();
       expect(baseLocalizationsFileContents, contains('/// The price of an online shopping cart item.'));
-      expect(baseLocalizationsFileContents, contains(r'''/// In en, this message translates to:
+      expect(baseLocalizationsFileContents, contains(r'''
+  /// In en, this message translates to:
   /// **"The price of this item is: ${price}"**'''));
     });
 


### PR DESCRIPTION
## Description

As described in https://github.com/flutter/flutter/issues/67206, it can be difficult to figure out what each method or getter in your generated `Localizations` class means. This PR adds the following to the template:
```
  /// <description of the message, as described in @description. This already exists, but won't show on IDEs because its a double slash comment instead of a triple slash one>
  ///
  /// <In ${template locale}, this message translates to ${message translation in template locale}".>
```

As an example, here's an entry in an arb file:
```
{
  "price": "${priceValue} SAR",
  "@price": {
    "description": "The price of an item in the website's shopping cart.",
    "placeholders": {
      "priceValue": {
        "type": "int",
        "format": "decimalPattern"
      }
    }
  }
}
```
and the corresponding method:
```dart
  /// The price of an item in the website's shopping cart.
  ///
  /// In en, this message translates to: 
  /// **'${priceValue} SAR'**.
  String price(int priceValue);
```

This now also shows on the IDE like this:
![Screen Shot 2020-10-26 at 6 52 49 PM](https://user-images.githubusercontent.com/27032613/97164024-7c33eb80-17bc-11eb-822a-1330798565c7.png)


## Related Issues

Fixes https://github.com/flutter/flutter/issues/67206

## Tests

I added the following tests:

- Tests to ensure that the code comments are generated for both placeholder methods and simple message getters.
