### PR TITLE
[flutter_tools] update test platform to use buildInfo instead of mode + additional params

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -23,8 +23,6 @@ import 'package:flutter_tools/src/test/coverage_collector.dart';
 import 'package:flutter_tools/src/test/runner.dart';
 import 'package:flutter_tools/src/test/test_wrapper.dart';
 
-// This was largely inspired by lib/src/commands/test.dart.
-
 const String _kOptionPackages = 'packages';
 const String _kOptionShell = 'shell';
 const String _kOptionTestDirectory = 'test-directory';

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -149,13 +149,11 @@ Future<void> run(List<String> args) async {
       watcher: collector,
       ipv6: false,
       enableObservatory: collector != null,
-      buildMode: BuildMode.debug,
+      buildInfo: BuildInfo.debug,
       precompiledDillFiles: tests,
       concurrency: math.max(1, globals.platform.numberOfProcessors - 2),
       icudtlPath: globals.fs.path.absolute(argResults[_kOptionIcudtl] as String),
       coverageDirectory: coverageDirectory,
-      extraFrontEndOptions: <String>[],
-      buildInfo: BuildInfo.debug,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -253,17 +253,14 @@ class TestCommand extends FlutterCommand {
       disableDds: disableDds,
       ipv6: boolArg('ipv6'),
       machine: machine,
-      buildMode: BuildMode.debug,
-      trackWidgetCreation: boolArg('track-widget-creation'),
+      buildInfo: buildInfo,
       updateGoldens: boolArg('update-goldens'),
       concurrency: jobs,
       buildTestAssets: buildTestAssets,
       flutterProject: flutterProject,
       web: stringArg('platform') == 'chrome',
       randomSeed: stringArg('test-randomize-ordering-seed'),
-      extraFrontEndOptions: buildInfo.extraFrontEndOptions,
       nullAssertions: boolArg(FlutterOptions.kNullAssertions),
-      buildInfo: buildInfo,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -53,8 +53,6 @@ FlutterPlatform installHook({
   int port = 0,
   String precompiledDillPath,
   Map<String, String> precompiledDillFiles,
-  @required BuildMode buildMode,
-  bool trackWidgetCreation = false,
   bool updateGoldens = false,
   bool buildTestAssets = false,
   int observatoryPort,
@@ -63,11 +61,8 @@ FlutterPlatform installHook({
   FlutterProject flutterProject,
   String icudtlPath,
   PlatformPluginRegistration platformPluginRegistration,
-  List<String> extraFrontEndOptions,
-  // Deprecated, use extraFrontEndOptions.
-  List<String> dartExperiments,
   bool nullAssertions = false,
-  BuildInfo buildInfo, // TODO(jonahwilliams): make the default
+  @required BuildInfo buildInfo,
 }) {
   assert(testWrapper != null);
   assert(enableObservatory || (!startPaused && observatoryPort == null));
@@ -94,14 +89,11 @@ FlutterPlatform installHook({
     port: port,
     precompiledDillPath: precompiledDillPath,
     precompiledDillFiles: precompiledDillFiles,
-    buildMode: buildMode,
-    trackWidgetCreation: trackWidgetCreation,
     updateGoldens: updateGoldens,
     buildTestAssets: buildTestAssets,
     projectRootDirectory: projectRootDirectory,
     flutterProject: flutterProject,
     icudtlPath: icudtlPath,
-    extraFrontEndOptions: extraFrontEndOptions,
     nullAssertions: nullAssertions,
     buildInfo: buildInfo,
   );
@@ -240,16 +232,13 @@ class FlutterPlatform extends PlatformPlugin {
     this.port,
     this.precompiledDillPath,
     this.precompiledDillFiles,
-    @required this.buildMode,
-    this.trackWidgetCreation,
     this.updateGoldens,
     this.buildTestAssets,
     this.projectRootDirectory,
     this.flutterProject,
     this.icudtlPath,
     this.nullAssertions = false,
-    this.buildInfo,
-    @required this.extraFrontEndOptions,
+    @required this.buildInfo,
   }) : assert(shellPath != null);
 
   final String shellPath;
@@ -264,14 +253,11 @@ class FlutterPlatform extends PlatformPlugin {
   final int port;
   final String precompiledDillPath;
   final Map<String, String> precompiledDillFiles;
-  final BuildMode buildMode;
-  final bool trackWidgetCreation;
   final bool updateGoldens;
   final bool buildTestAssets;
   final Uri projectRootDirectory;
   final FlutterProject flutterProject;
   final String icudtlPath;
-  final List<String> extraFrontEndOptions;
   final bool nullAssertions;
   final BuildInfo buildInfo;
 
@@ -448,7 +434,7 @@ class FlutterPlatform extends PlatformPlugin {
 
       if (precompiledDillPath == null && precompiledDillFiles == null) {
         // Lazily instantiate compiler so it is built only if it is actually used.
-        compiler ??= TestCompiler(buildInfo ?? BuildInfo(buildMode, '', trackWidgetCreation: trackWidgetCreation, treeShakeIcons: false), flutterProject, extraFrontEndOptions);
+        compiler ??= TestCompiler(buildInfo, flutterProject);
         mainDart = await compiler.compile(globals.fs.file(mainDart).uri);
 
         if (mainDart == null) {

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -67,7 +67,7 @@ class FlutterWebPlatform extends PlatformPlugin {
 
     _testGoldenComparator = TestGoldenComparator(
       shellPath,
-      () => TestCompiler(BuildInfo.debug, flutterProject, <String>[]),
+      () => TestCompiler(BuildInfo.debug, flutterProject),
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -39,8 +39,6 @@ abstract class FlutterTestRunner {
     bool machine = false,
     String precompiledDillPath,
     Map<String, String> precompiledDillFiles,
-    @required BuildMode buildMode,
-    bool trackWidgetCreation = false,
     bool updateGoldens = false,
     TestWatcher watcher,
     @required int concurrency,
@@ -50,9 +48,8 @@ abstract class FlutterTestRunner {
     Directory coverageDirectory,
     bool web = false,
     String randomSeed,
-    @required List<String> extraFrontEndOptions,
     bool nullAssertions = false,
-    BuildInfo buildInfo, // TODO(jonahwilliams): make the default
+    @required BuildInfo buildInfo,
   });
 }
 
@@ -76,8 +73,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     bool machine = false,
     String precompiledDillPath,
     Map<String, String> precompiledDillFiles,
-    @required BuildMode buildMode,
-    bool trackWidgetCreation = false,
     bool updateGoldens = false,
     TestWatcher watcher,
     @required int concurrency,
@@ -87,9 +82,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     Directory coverageDirectory,
     bool web = false,
     String randomSeed,
-    @required List<String> extraFrontEndOptions,
     bool nullAssertions = false,
-    BuildInfo buildInfo // TODO(jonahwilliams): make the default argument
+    @required BuildInfo buildInfo,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -175,14 +169,11 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       serverType: serverType,
       precompiledDillPath: precompiledDillPath,
       precompiledDillFiles: precompiledDillFiles,
-      buildMode: buildMode,
-      trackWidgetCreation: trackWidgetCreation,
       updateGoldens: updateGoldens,
       buildTestAssets: buildTestAssets,
       projectRootDirectory: globals.fs.currentDirectory.uri,
       flutterProject: flutterProject,
       icudtlPath: icudtlPath,
-      extraFrontEndOptions: extraFrontEndOptions,
       nullAssertions: nullAssertions,
       buildInfo: buildInfo,
     );

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -39,7 +39,6 @@ class TestCompiler {
   TestCompiler(
     this.buildInfo,
     this.flutterProject,
-    this.extraFrontEndOptions,
   ) : testFilePath = globals.fs.path.join(
         flutterProject.directory.path,
         getBuildDirectory(),
@@ -68,7 +67,6 @@ class TestCompiler {
   final FlutterProject flutterProject;
   final BuildInfo buildInfo;
   final String testFilePath;
-  final List<String> extraFrontEndOptions;
 
 
   ResidentCompiler compiler;
@@ -111,7 +109,7 @@ class TestCompiler {
       unsafePackageSerialization: false,
       dartDefines: buildInfo.dartDefines,
       packagesPath: globalPackagesPath,
-      extraFrontEndOptions: extraFrontEndOptions,
+      extraFrontEndOptions: buildInfo.extraFrontEndOptions,
       platform: globals.platform,
       testCompilation: true,
     );

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -30,10 +30,9 @@ void main() {
     testUsingContext('ensureConfiguration throws an error if an '
       'explicitObservatoryPort is specified and more than one test file', () async {
       final FlutterPlatform flutterPlatform = FlutterPlatform(
-        buildMode: BuildMode.debug,
+        buildInfo: BuildInfo.debug,
         shellPath: '/',
         explicitObservatoryPort: 1234,
-        extraFrontEndOptions: <String>[],
       );
       flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
 
@@ -46,10 +45,9 @@ void main() {
     testUsingContext('ensureConfiguration throws an error if a precompiled '
       'entrypoint is specified and more that one test file', () {
       final FlutterPlatform flutterPlatform = FlutterPlatform(
-        buildMode: BuildMode.debug,
+        buildInfo: BuildInfo.debug,
         shellPath: '/',
         precompiledDillPath: 'example.dill',
-        extraFrontEndOptions: <String>[],
       );
       flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
 
@@ -170,22 +168,18 @@ void main() {
 
     testUsingContext('installHook creates a FlutterPlatform', () {
       expect(() => installHook(
-        buildMode: BuildMode.debug,
+        buildInfo: BuildInfo.debug,
         shellPath: 'abc',
         enableObservatory: false,
         startPaused: true,
-        extraFrontEndOptions: <String>[],
-        buildInfo: BuildInfo.debug,
       ), throwsAssertionError);
 
       expect(() => installHook(
-        buildMode: BuildMode.debug,
+        buildInfo: BuildInfo.debug,
         shellPath: 'abc',
         enableObservatory: false,
         startPaused: false,
         observatoryPort: 123,
-        extraFrontEndOptions: <String>[],
-        buildInfo: BuildInfo.debug,
       ), throwsAssertionError);
 
       FlutterPlatform capturedPlatform;
@@ -199,15 +193,12 @@ void main() {
         port: 100,
         precompiledDillPath: 'def',
         precompiledDillFiles: expectedPrecompiledDillFiles,
-        buildMode: BuildMode.debug,
-        trackWidgetCreation: true,
+        buildInfo: BuildInfo.debug,
         updateGoldens: true,
         buildTestAssets: true,
         observatoryPort: 200,
         serverType: InternetAddressType.IPv6,
         icudtlPath: 'ghi',
-        extraFrontEndOptions: <String>[],
-        buildInfo: BuildInfo.debug,
         platformPluginRegistration: (FlutterPlatform platform) {
           capturedPlatform = platform;
         });
@@ -223,8 +214,7 @@ void main() {
       expect(flutterPlatform.explicitObservatoryPort, equals(200));
       expect(flutterPlatform.precompiledDillPath, equals('def'));
       expect(flutterPlatform.precompiledDillFiles, expectedPrecompiledDillFiles);
-      expect(flutterPlatform.buildMode, equals(BuildMode.debug));
-      expect(flutterPlatform.trackWidgetCreation, equals(true));
+      expect(flutterPlatform.buildInfo, equals(BuildInfo.debug));
       expect(flutterPlatform.updateGoldens, equals(true));
       expect(flutterPlatform.buildTestAssets, equals(true));
       expect(flutterPlatform.icudtlPath, equals('ghi'));
@@ -247,7 +237,7 @@ class MockHttpServer extends Mock implements HttpServer {}
 // Uses a mock HttpServer. We don't want to bind random ports in our CI hosts.
 class TestFlutterPlatform extends FlutterPlatform {
   TestFlutterPlatform() : super(
-    buildMode: BuildMode.debug,
+    buildInfo: BuildInfo.debug,
     shellPath: '/',
     precompiledDillPath: 'example.dill',
     host: InternetAddress.loopbackIPv6,
@@ -256,7 +246,6 @@ class TestFlutterPlatform extends FlutterPlatform {
     startPaused: false,
     enableObservatory: false,
     buildTestAssets: false,
-    extraFrontEndOptions: <String>[],
     disableDds: true,
   );
 
@@ -270,7 +259,7 @@ class TestFlutterPlatform extends FlutterPlatform {
 // Uses a mock HttpServer. We don't want to bind random ports in our CI hosts.
 class TestObservatoryFlutterPlatform extends FlutterPlatform {
   TestObservatoryFlutterPlatform() : super(
-    buildMode: BuildMode.debug,
+    buildInfo: BuildInfo.debug,
     shellPath: '/',
     precompiledDillPath: 'example.dill',
     host: InternetAddress.loopbackIPv6,
@@ -280,7 +269,6 @@ class TestObservatoryFlutterPlatform extends FlutterPlatform {
     enableObservatory: true,
     explicitObservatoryPort: 1234,
     buildTestAssets: false,
-    extraFrontEndOptions: <String>[],
     disableServiceAuthCodes: false,
     disableDds: false,
   );

--- a/packages/flutter_tools/test/general.shard/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test_compiler_test.dart
@@ -139,7 +139,7 @@ class FakeTestCompiler extends TestCompiler {
     BuildInfo buildInfo,
     FlutterProject flutterProject,
     this.residentCompiler,
-  ) : super(buildInfo, flutterProject, <String>[]);
+  ) : super(buildInfo, flutterProject);
 
   final MockResidentCompiler residentCompiler;
 


### PR DESCRIPTION
## Description

Simplifies flutter test codepaths to consistently use BuildInfo. Will require a minor g3 cleanup