### PR TITLE
[null-safety] add language version to freeform template

### DIFF
--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -1,4 +1,5 @@
 /// Flutter code sample for {{element}}
+// @dart = 2.9
 
 {{description}}
 


### PR DESCRIPTION
## Description

This template was missed during the last update. Should fix https://github.com/flutter/flutter/issues/69042