### PR TITLE
Print errors in all build modes

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -781,6 +781,7 @@ Future<void> _runWebIntegrationTests() async {
   await _runWebStackTraceTest('profile', 'lib/framework_stack_trace.dart');
   await _runWebStackTraceTest('release', 'lib/framework_stack_trace.dart');
   await _runWebDebugTest('lib/stack_trace.dart');
+  await _runWebDebugTest('lib/framework_stack_trace.dart');
   await _runWebDebugTest('lib/web_directory_loading.dart');
   await _runWebDebugTest('test/test.dart');
   await _runWebDebugTest('lib/null_assert_main.dart', enableNullSafety: true);

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -776,8 +776,10 @@ Future<void> _runWebUnitTests() async {
 }
 
 Future<void> _runWebIntegrationTests() async {
-  await _runWebStackTraceTest('profile');
-  await _runWebStackTraceTest('release');
+  await _runWebStackTraceTest('profile', 'lib/stack_trace.dart');
+  await _runWebStackTraceTest('release', 'lib/stack_trace.dart');
+  await _runWebStackTraceTest('profile', 'lib/framework_stack_trace.dart');
+  await _runWebStackTraceTest('release', 'lib/framework_stack_trace.dart');
   await _runWebDebugTest('lib/stack_trace.dart');
   await _runWebDebugTest('lib/web_directory_loading.dart');
   await _runWebDebugTest('test/test.dart');
@@ -807,7 +809,7 @@ Future<void> _runWebIntegrationTests() async {
   ]);
 }
 
-Future<void> _runWebStackTraceTest(String buildMode) async {
+Future<void> _runWebStackTraceTest(String buildMode, String entrypoint) async {
   final String testAppDirectory = path.join(flutterRoot, 'dev', 'integration_tests', 'web');
   final String appBuildDirectory = path.join(testAppDirectory, 'build', 'web');
 
@@ -824,7 +826,7 @@ Future<void> _runWebStackTraceTest(String buildMode) async {
       'web',
       '--$buildMode',
       '-t',
-      'lib/stack_trace.dart',
+      entrypoint,
     ],
     workingDirectory: testAppDirectory,
     environment: <String, String>{

--- a/dev/integration_tests/web/lib/framework_stack_trace.dart
+++ b/dev/integration_tests/web/lib/framework_stack_trace.dart
@@ -1,0 +1,96 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:meta/dart2js.dart';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+// Tests that the framework prints stack traces in all build modes.
+//
+// Regression test for https://github.com/flutter/flutter/issues/68616.
+//
+// See also `dev/integration_tests/web/lib/stack_trace.dart` that tests the
+// framework's ability to parse stack traces in all build modes.
+void main() async {
+  final StringBuffer errorMessage = StringBuffer();
+  debugPrint = (String message, { int wrapWidth }) {
+    errorMessage.writeln(message);
+  };
+
+  runApp(ThrowingWidget());
+
+  // Let the framework flush error messages.
+  await Future<void>.delayed(Duration.zero);
+
+  final StringBuffer output = StringBuffer();
+  if (_errorMessageFormattedCorrectly(errorMessage.toString())) {
+    output.writeln('--- TEST SUCCEEDED ---');
+  } else  {
+    output.writeln('--- UNEXPECTED ERROR MESSAGE FORMAT ---');
+    output.writeln(errorMessage);
+    output.writeln('--- TEST FAILED ---');
+  }
+
+  print(output);
+  html.HttpRequest.request(
+    '/test-result',
+    method: 'POST',
+    sendData: '$output',
+  );
+}
+
+bool _errorMessageFormattedCorrectly(String errorMessage) {
+  if (!errorMessage.contains('Test error message')) {
+    return false;
+  }
+
+  // In release mode symbols are minified. No sense testing the contents of the stack trace.
+  if (kReleaseMode) {
+    return true;
+  }
+
+  const List<String> expectedFunctions = <String>[
+    'topLevelFunction',
+    'secondLevelFunction',
+    'thirdLevelFunction',
+  ];
+
+  return expectedFunctions.every(errorMessage.contains);
+}
+
+class ThrowingWidget extends StatefulWidget {
+  @override
+  _ThrowingWidgetState createState() => _ThrowingWidgetState();
+}
+
+class _ThrowingWidgetState extends State<ThrowingWidget> {
+  @override
+  void initState() {
+    super.initState();
+    topLevelFunction();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+@noInline
+void topLevelFunction() {
+  secondLevelFunction();
+}
+
+@noInline
+void secondLevelFunction() {
+  thirdLevelFunction();
+}
+
+@noInline
+void thirdLevelFunction() {
+  throw Exception('Test error message');
+}


### PR DESCRIPTION
## Description

Print errors in all build modes. Previously, we'd print the following in profile and release modes:

```
I/flutter (26152): ══╡  ╞══════════════════════════════════════════════════════════════════════════════════════════════
I/flutter (26152): ════════════════════════════════════════════════════════════════════════════════════════════════════
```

This is because we attempted to use the diagnostics tree, which is disabled outside the debug mode.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68616
Fixes https://github.com/flutter/flutter/issues/68696
Fixes https://github.com/flutter/flutter/issues/36221

## Tests

Added an integration test (see `framework_stack_trace.dart`).