### PR TITLE
Make WidgetsLocalizations.of non-nullable

### DIFF
--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -255,7 +255,7 @@ abstract class CupertinoLocalizations {
   /// CupertinoLocalizations.of(context).anteMeridiemAbbreviation;
   /// ```
   static CupertinoLocalizations of(BuildContext context) {
-    debugCheckHasCupertinoLocalizations(context);
+    assert(debugCheckHasCupertinoLocalizations(context));
     return Localizations.of<CupertinoLocalizations>(context, CupertinoLocalizations)!;
   }
 }

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -506,7 +506,7 @@ abstract class MaterialLocalizations {
   /// tooltip: MaterialLocalizations.of(context).backButtonTooltip,
   /// ```
   static MaterialLocalizations of(BuildContext context) {
-    debugCheckHasMaterialLocalizations(context);
+    assert(debugCheckHasMaterialLocalizations(context));
     return Localizations.of<MaterialLocalizations>(context, MaterialLocalizations)!;
   }
 }

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
 import 'framework.dart';
+import 'localizations.dart';
 import 'media_query.dart';
 import 'table.dart';
 
@@ -336,6 +337,44 @@ bool debugAssertAllWidgetVarsUnset(String reason) {
         debugProfileBuildsEnabled ||
         debugHighlightDeprecatedWidgets) {
       throw FlutterError(reason);
+    }
+    return true;
+  }());
+  return true;
+}
+
+/// Asserts that the given context has a [Localizations] ancestor that contains
+/// a [WidgetsLocalizations] delegate.
+///
+/// To call this function, use the following pattern, typically in the
+/// relevant Widget's build method:
+///
+/// ```dart
+/// assert(debugCheckHasWidgetsLocalizations(context));
+/// ```
+///
+/// Does nothing if asserts are disabled. Always returns true.
+bool debugCheckHasWidgetsLocalizations(BuildContext context) {
+  assert(() {
+    if (Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations) == null) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('No WidgetsLocalizations found.'),
+        ErrorDescription(
+          '${context.widget.runtimeType} widgets require WidgetsLocalizations '
+          'to be provided by a Localizations widget ancestor.'
+        ),
+        ErrorDescription(
+          'The widgets library uses Localizations to generate messages, '
+          'labels, and abbreviations.'
+        ),
+        ErrorHint(
+          'To introduce a WidgetsLocalizations, either use a '
+          'WidgetsApp at the root of your application to include them '
+          'automatically, or add a Localization widget with a '
+          'WidgetsLocalizations delegate.'
+        ),
+        ...context.describeMissingAncestor(expectedAncestorType: WidgetsLocalizations)
+      ]);
     }
     return true;
   }());

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -322,27 +322,6 @@ void debugWidgetBuilderValue(Widget widget, Widget? built) {
   }());
 }
 
-/// Returns true if none of the widget library debug variables have been changed.
-///
-/// This function is used by the test framework to ensure that debug variables
-/// haven't been inadvertently changed.
-///
-/// See [the widgets library](widgets/widgets-library.html) for a complete list.
-bool debugAssertAllWidgetVarsUnset(String reason) {
-  assert(() {
-    if (debugPrintRebuildDirtyWidgets ||
-        debugPrintBuildScope ||
-        debugPrintScheduleBuildForStacks ||
-        debugPrintGlobalKeyedWidgetLifecycle ||
-        debugProfileBuildsEnabled ||
-        debugHighlightDeprecatedWidgets) {
-      throw FlutterError(reason);
-    }
-    return true;
-  }());
-  return true;
-}
-
 /// Asserts that the given context has a [Localizations] ancestor that contains
 /// a [WidgetsLocalizations] delegate.
 ///
@@ -375,6 +354,27 @@ bool debugCheckHasWidgetsLocalizations(BuildContext context) {
         ),
         ...context.describeMissingAncestor(expectedAncestorType: WidgetsLocalizations)
       ]);
+    }
+    return true;
+  }());
+  return true;
+}
+
+/// Returns true if none of the widget library debug variables have been changed.
+///
+/// This function is used by the test framework to ensure that debug variables
+/// haven't been inadvertently changed.
+///
+/// See [the widgets library](widgets/widgets-library.html) for a complete list.
+bool debugAssertAllWidgetVarsUnset(String reason) {
+  assert(() {
+    if (debugPrintRebuildDirtyWidgets ||
+        debugPrintBuildScope ||
+        debugPrintScheduleBuildForStacks ||
+        debugPrintGlobalKeyedWidgetLifecycle ||
+        debugProfileBuildsEnabled ||
+        debugHighlightDeprecatedWidgets) {
+      throw FlutterError(reason);
     }
     return true;
   }());

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -165,7 +165,7 @@ abstract class WidgetsLocalizations {
   /// textDirection: WidgetsLocalizations.of(context).textDirection,
   /// ```
   static WidgetsLocalizations of(BuildContext context) {
-    debugCheckHasWidgetsLocalizations(context);
+    assert(debugCheckHasWidgetsLocalizations(context));
     return Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations)!;
   }
 }

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'container.dart';
+import 'debug.dart';
 import 'framework.dart';
 
 // Examples can assume:
@@ -155,7 +156,7 @@ abstract class WidgetsLocalizations {
   /// that encloses the given context.
   ///
   /// This method is just a convenient shorthand for:
-  /// `Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations)`.
+  /// `Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations)!`.
   ///
   /// References to the localized resources defined by this class are typically
   /// written in terms of this method. For example:
@@ -163,8 +164,9 @@ abstract class WidgetsLocalizations {
   /// ```dart
   /// textDirection: WidgetsLocalizations.of(context).textDirection,
   /// ```
-  static WidgetsLocalizations? of(BuildContext context) {
-    return Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations);
+  static WidgetsLocalizations of(BuildContext context) {
+    debugCheckHasWidgetsLocalizations(context);
+    return Localizations.of<WidgetsLocalizations>(context, WidgetsLocalizations)!;
   }
 }
 

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -215,25 +215,7 @@ void main() {
     }
   });
 
-  test('debugAssertAllWidgetVarsUnset', () {
-    debugHighlightDeprecatedWidgets = true;
-    late FlutterError error;
-    try {
-      debugAssertAllWidgetVarsUnset('The value of a widget debug variable was changed by the test.');
-    } on FlutterError catch (e) {
-      error = e;
-    } finally {
-      expect(error, isNotNull);
-      expect(error.diagnostics.length, 1);
-      expect(
-        error.toStringDeep(),
-        'FlutterError\n'
-        '   The value of a widget debug variable was changed by the test.\n',
-      );
-    }
-  });
-
-  testWidgets('debugCheckHasCupertinoLocalizations throws', (WidgetTester tester) async {
+  testWidgets('debugCheckHasWidgetsLocalizations throws', (WidgetTester tester) async {
     final GlobalKey noLocalizationsAvailable = GlobalKey();
     final GlobalKey localizationsAvailable = GlobalKey();
 
@@ -252,11 +234,29 @@ void main() {
     );
 
     expect(() => debugCheckHasWidgetsLocalizations(noLocalizationsAvailable.currentContext!), throwsA(isAssertionError.having(
-          (AssertionError e) => e.message,
+      (AssertionError e) => e.message,
       'message',
       contains('No WidgetsLocalizations found'),
     )));
 
     expect(debugCheckHasWidgetsLocalizations(localizationsAvailable.currentContext!), isTrue);
+  });
+
+  test('debugAssertAllWidgetVarsUnset', () {
+    debugHighlightDeprecatedWidgets = true;
+    late FlutterError error;
+    try {
+      debugAssertAllWidgetVarsUnset('The value of a widget debug variable was changed by the test.');
+    } on FlutterError catch (e) {
+      error = e;
+    } finally {
+      expect(error, isNotNull);
+      expect(error.diagnostics.length, 1);
+      expect(
+        error.toStringDeep(),
+        'FlutterError\n'
+        '   The value of a widget debug variable was changed by the test.\n',
+      );
+    }
   });
 }

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -232,4 +232,31 @@ void main() {
       );
     }
   });
+
+  testWidgets('debugCheckHasCupertinoLocalizations throws', (WidgetTester tester) async {
+    final GlobalKey noLocalizationsAvailable = GlobalKey();
+    final GlobalKey localizationsAvailable = GlobalKey();
+
+    await tester.pumpWidget(
+      Container(
+        key: noLocalizationsAvailable,
+        child: WidgetsApp(
+          builder: (BuildContext context, Widget? child) {
+            return Container(
+              key: localizationsAvailable,
+            );
+          },
+          color: const Color(0xFF4CAF50),
+        ),
+      ),
+    );
+
+    expect(() => debugCheckHasWidgetsLocalizations(noLocalizationsAvailable.currentContext!), throwsA(isAssertionError.having(
+          (AssertionError e) => e.message,
+      'message',
+      contains('No WidgetsLocalizations found'),
+    )));
+
+    expect(debugCheckHasWidgetsLocalizations(localizationsAvailable.currentContext!), isTrue);
+  });
 }


### PR DESCRIPTION
## Description

Follow-up to https://github.com/flutter/flutter/pull/68807. Turns out, I forgot the `WidgetsLocalizations`. This gives them the same non-null treatment as Material/CupertinoLocalizations.

## Related Issues

n/a

## Tests

I added the following tests:

n/a, refactoring

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
