### PR TITLE
[flutter_tools] enable web integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
@@ -46,7 +46,7 @@ void main() {
         reason: 'After $i steps, debugger should stop at $expectedLine but stopped at $actualLine'
       );
     }
-  }, skip: true); // https://github.com/flutter/flutter/issues/62889
+  });
 
   tearDown(() async {
     await flutter.stop();

--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
@@ -46,7 +46,7 @@ void main() {
         reason: 'After $i steps, debugger should stop at $expectedLine but stopped at $actualLine'
       );
     }
-  });
+  }, skip: platform.isMacOS);
 
   tearDown(() async {
     await flutter.stop();

--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
@@ -149,7 +149,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter test expression evaluation - can evaluate trivial expressions in a test', () async {
     await initProject();
@@ -157,7 +157,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter test expression evaluation - can evaluate complex expressions in a test', () async {
     await initProject();
@@ -165,7 +165,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 }
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {

--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
@@ -57,7 +57,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
  testWithoutContext('flutter run expression evaluation - no native javascript objects in static scope', () async {
     await initProject();
@@ -65,7 +65,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await checkStaticScope(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter run expression evaluation - can handle compilation errors', () async {
     await initProject();
@@ -73,7 +73,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateErrorExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in top level function', () async {
     await initProject();
@@ -81,7 +81,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in build method', () async {
     await initProject();
@@ -89,7 +89,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in top level function', () async {
     await initProject();
@@ -97,7 +97,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in build method', () async {
     await initProject();
@@ -105,7 +105,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 }
 
 void batch2() {
@@ -149,7 +149,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter test expression evaluation - can evaluate trivial expressions in a test', () async {
     await initProject();
@@ -157,7 +157,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 
   testWithoutContext('flutter test expression evaluation - can evaluate complex expressions in a test', () async {
     await initProject();
@@ -165,7 +165,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: 'CI not setup for web tests'); // https://github.com/flutter/flutter/issues/53779
+  });
 }
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {

--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
@@ -57,7 +57,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
  testWithoutContext('flutter run expression evaluation - no native javascript objects in static scope', () async {
     await initProject();
@@ -65,7 +65,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await checkStaticScope(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter run expression evaluation - can handle compilation errors', () async {
     await initProject();
@@ -73,7 +73,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateErrorExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in top level function', () async {
     await initProject();
@@ -81,7 +81,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in build method', () async {
     await initProject();
@@ -89,7 +89,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in top level function', () async {
     await initProject();
@@ -97,7 +97,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in build method', () async {
     await initProject();
@@ -105,7 +105,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: platform.isMacOS);
 }
 
 void batch2() {

--- a/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../src/common.dart';
+import 'test_data/hot_reload_project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  final HotReloadProject project = HotReloadProject();
+  FlutterRunTestDriver flutter;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('hot_reload_test.');
+    await project.setUpIn(tempDir);
+    flutter = FlutterRunTestDriver(tempDir);
+  });
+
+  tearDown(() async {
+    await flutter?.stop();
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('hot restart works without error', () async {
+    await flutter.run(chrome: true);
+    await flutter.hotRestart();
+  });
+
+  testWithoutContext('newly added code executes during hot restart', () async {
+    final Completer<void> completer = Completer<void>();
+    final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
+      print(line);
+      if (line.contains('(((((RELOAD WORKED)))))')) {
+        completer.complete();
+      }
+    });
+    await flutter.run(chrome: true);
+    project.uncommentHotReloadPrint();
+    try {
+      await flutter.hotRestart();
+      await completer.future;
+    } finally {
+      await subscription.cancel();
+    }
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
@@ -30,7 +30,7 @@ void main() {
   testWithoutContext('hot restart works without error', () async {
     await flutter.run(chrome: true);
     await flutter.hotRestart();
-  });
+  }, skip: platform.isMacOS);
 
   testWithoutContext('newly added code executes during hot restart', () async {
     final Completer<void> completer = Completer<void>();
@@ -48,5 +48,5 @@ void main() {
     } finally {
       await subscription.cancel();
     }
-  });
+  }, skip: platform.isMacOS);
 }

--- a/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_web_test.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/common.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import 'test_data/hot_reload_project.dart';

--- a/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
@@ -89,8 +89,8 @@ class WebSteppingProject extends Project {
 
     Future<void> doAsyncStuff() async {
       print("test"); // BREAKPOINT
-      await new Future.value(true); // STEP 1 // STEP 2
-      await new Future.microtask(() => true);
+      await new Future.value(true); // STEP 1
+      await new Future.microtask(() => true); // STEP 2
       await new Future.delayed(const Duration(milliseconds: 1));  // STEP 3
       print("done!"); // STEP 4
     } // STEP 5

--- a/packages/flutter_tools/test/integration.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_run_test.dart
@@ -27,5 +27,5 @@ void main() {
 
   testWithoutContext('flutter run works on web devices with a unary main function', () async {
     await flutter.run(chrome: true);
-  }, skip: 'Web CI skipped');
+  });
 }

--- a/packages/flutter_tools/test/integration.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_run_test.dart
@@ -27,5 +27,5 @@ void main() {
 
   testWithoutContext('flutter run works on web devices with a unary main function', () async {
     await flutter.run(chrome: true);
-  });
+  }, skip: platform.isMacOS);
 }


### PR DESCRIPTION
## Description

Enable web integration tests for LUCI. macOS failures are expected since this bot does not have chrome installed.

To run `pub run test test/integration.shard/...` as normal. These tests use the built flutter tool snapshot, so any changes made to it will require re-snapshotting by removing `bin/cache/flutter_tools.stamp`