### PR TITLE
[null-safety] fix the snippets

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -186,6 +186,7 @@ class SampleChecker {
   /// Computes the headers needed for each sample file.
   List<Line> get headers {
     return _headers ??= <String>[
+      '// @dart = 2.9',
       '// generated code',
       "import 'dart:async';",
       "import 'dart:convert';",


### PR DESCRIPTION
## Description

All of the snippets need to be updated for null safety. Opt them out to unblock the SDK roller.