### PR TITLE
Use runZonedGuarded() instead of deprecated onError.

### DIFF
--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -305,7 +305,7 @@ void main() {
         final FlutterError error = FlutterError('Oops');
         double errorCount = 0;
 
-        runZoned(
+        runZonedGuarded(
           () async {
             mockHelper.refreshCompleter = Completer<void>.sync();
             await tester.pumpWidget(
@@ -371,7 +371,7 @@ void main() {
             )));
             expect(mockHelper.invocations, hasLength(5));
           },
-          onError: (dynamic e) {
+          (Object e, StackTrace stack) {
             expect(e, error);
             expect(errorCount, 0);
             errorCount++;

--- a/packages/flutter_tools/test/general.shard/base/async_guard_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/async_guard_test.dart
@@ -152,7 +152,7 @@ void main() {
 
     final Completer<void> completer = Completer<void>();
     await FakeAsync().run((FakeAsync time) {
-      unawaited(runZoned(() async {
+      unawaited(runZonedGuarded(() async {
         final Future<void> f = asyncGuard<void>(() => delayedThrow(time))
           .catchError((Object e, StackTrace s) {
             caughtByCatchError = true;
@@ -165,7 +165,7 @@ void main() {
         if (!completer.isCompleted) {
           completer.complete(null);
         }
-      }, onError: (Object e, StackTrace s) {
+      }, (Object e, StackTrace s) {
         caughtByZone = true;
         if (!completer.isCompleted) {
           completer.complete(null);
@@ -188,7 +188,7 @@ void main() {
 
     final Completer<void> completer = Completer<void>();
     await FakeAsync().run((FakeAsync time) {
-      unawaited(runZoned(() async {
+      unawaited(runZonedGuarded(() async {
         final Future<void> f = asyncGuard<void>(
           () => delayedThrow(time),
           onError: (Object e, StackTrace s) {
@@ -203,7 +203,7 @@ void main() {
         if (!completer.isCompleted) {
           completer.complete(null);
         }
-      }, onError: (Object e, StackTrace s) {
+      }, (Object e, StackTrace s) {
         caughtByZone = true;
         if (!completer.isCompleted) {
           completer.complete(null);
@@ -226,7 +226,7 @@ void main() {
 
     final Completer<void> completer = Completer<void>();
     await FakeAsync().run((FakeAsync time) {
-      unawaited(runZoned(() async {
+      unawaited(runZonedGuarded(() async {
         final Future<void> f = asyncGuard<void>(
           () => delayedThrow(time),
           onError: (Object e) {
@@ -241,7 +241,7 @@ void main() {
         if (!completer.isCompleted) {
           completer.complete(null);
         }
-      }, onError: (Object e, StackTrace s) {
+      }, (Object e, StackTrace s) {
         caughtByZone = true;
         if (!completer.isCompleted) {
           completer.complete(null);
@@ -265,7 +265,7 @@ void main() {
 
     final Completer<void> completer = Completer<void>();
     await FakeAsync().run((FakeAsync time) {
-      unawaited(runZoned(() async {
+      unawaited(runZonedGuarded(() async {
         final Future<void> f = asyncGuard<void>(
           () => delayedThrow(time),
           onError: (Object e, [StackTrace s]) {
@@ -281,7 +281,7 @@ void main() {
         if (!completer.isCompleted) {
           completer.complete(null);
         }
-      }, onError: (Object e, StackTrace s) {
+      }, (Object e, StackTrace s) {
         caughtByZone = true;
         if (!completer.isCompleted) {
           completer.complete(null);


### PR DESCRIPTION
We are [updating](https://dart-review.googlesource.com/c/sdk/+/169256) Dart analyzer to report deprecation hints in more cases. This uncovered a few places in Flutter.