### PR TITLE
Fix dropdown crash

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -154,7 +154,6 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
       dropdownMenuItem.onTap!();
     }
 
-    print('popping');
     Navigator.pop(
       context,
       _DropdownRouteResult<T>(dropdownMenuItem.value),
@@ -1116,7 +1115,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   @override
   void dispose() {
     WidgetsBinding.instance!.removeObserver(this);
-    print('_removeDropdownRoute from dispose');
     _removeDropdownRoute();
     WidgetsBinding.instance!.focusManager.removeHighlightModeListener(_handleFocusHighlightModeChange);
     focusNode!.removeListener(_handleFocusChanged);
@@ -1125,7 +1123,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   }
 
   void _removeDropdownRoute() {
-    print('removing');
     _dropdownRoute?._dismiss();
     _dropdownRoute = null;
     _lastOrientation = null;
@@ -1225,7 +1222,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     );
 
     navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
-      print('_removeDropdownRoute from route future');
       _removeDropdownRoute();
       if (!mounted || newValue == null)
         return;

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -154,6 +154,7 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
       dropdownMenuItem.onTap!();
     }
 
+    print('popping');
     Navigator.pop(
       context,
       _DropdownRouteResult<T>(dropdownMenuItem.value),
@@ -456,7 +457,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   }
 
   void _dismiss() {
-    navigator?.removeRoute(this);
+    if (isActive) {
+      navigator?.removeRoute(this);
+    }
   }
 
   double getItemOffset(int index) {
@@ -1113,6 +1116,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   @override
   void dispose() {
     WidgetsBinding.instance!.removeObserver(this);
+    print('_removeDropdownRoute from dispose');
     _removeDropdownRoute();
     WidgetsBinding.instance!.focusManager.removeHighlightModeListener(_handleFocusHighlightModeChange);
     focusNode!.removeListener(_handleFocusChanged);
@@ -1121,6 +1125,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   }
 
   void _removeDropdownRoute() {
+    print('removing');
     _dropdownRoute?._dismiss();
     _dropdownRoute = null;
     _lastOrientation = null;
@@ -1220,6 +1225,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     );
 
     navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
+      print('_removeDropdownRoute from route future');
       _removeDropdownRoute();
       if (!mounted || newValue == null)
         return;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3056,10 +3056,12 @@ class _RouteEntry extends RouteTransitionRecord {
     final Iterable<OverlayEntry> mountedEntries = route.overlayEntries.where((OverlayEntry e) => e.mounted);
 
     if (mountedEntries.isEmpty) {
+      print('direct dispose');
       route.dispose();
     } else {
       int mounted = mountedEntries.length;
       assert(mounted > 0);
+      print('delaying dispose');
       for (final OverlayEntry entry in mountedEntries) {
         late VoidCallback listener;
         listener = () {
@@ -3068,6 +3070,7 @@ class _RouteEntry extends RouteTransitionRecord {
           mounted--;
           entry.removeListener(listener);
           if (mounted == 0) {
+            print('dispose');
             assert(route.overlayEntries.every((OverlayEntry e) => !e.mounted));
             route.dispose();
           }
@@ -4918,6 +4921,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.removeRoute}
   void removeRoute(Route<dynamic> route) {
+    print('removeROute');
     assert(route != null);
     assert(!_debugLocked);
     assert(() {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3056,12 +3056,10 @@ class _RouteEntry extends RouteTransitionRecord {
     final Iterable<OverlayEntry> mountedEntries = route.overlayEntries.where((OverlayEntry e) => e.mounted);
 
     if (mountedEntries.isEmpty) {
-      print('direct dispose');
       route.dispose();
     } else {
       int mounted = mountedEntries.length;
       assert(mounted > 0);
-      print('delaying dispose');
       for (final OverlayEntry entry in mountedEntries) {
         late VoidCallback listener;
         listener = () {
@@ -3070,7 +3068,6 @@ class _RouteEntry extends RouteTransitionRecord {
           mounted--;
           entry.removeListener(listener);
           if (mounted == 0) {
-            print('dispose');
             assert(route.overlayEntries.every((OverlayEntry e) => !e.mounted));
             route.dispose();
           }
@@ -4921,7 +4918,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.removeRoute}
   void removeRoute(Route<dynamic> route) {
-    print('removeROute');
     assert(route != null);
     assert(!_debugLocked);
     assert(() {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2616,7 +2616,7 @@ void main() {
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
 
-  testWidgets('does not crash when option is selected', (WidgetTester tester) async {
+  testWidgets('does not crash when option is selected without waiting for opening animation to complete', (WidgetTester tester) async {
     // Regression test for b/171846624.
 
     final List<String> options = <String>['first', 'second', 'third'];
@@ -2646,6 +2646,7 @@ void main() {
     expect(find.text('second').hitTestable(), findsNothing);
     expect(find.text('third').hitTestable(), findsNothing);
 
+    // Open dropdown.
     await tester.tap(find.text('first').hitTestable());
     await tester.pump();
 
@@ -2653,10 +2654,12 @@ void main() {
     expect(find.text('first').hitTestable(), findsOneWidget);
     expect(find.text('second').hitTestable(), findsOneWidget);
 
+    // Deliberately not waiting for opening animation to complete!
+
+    // Select an option in dropdown.
     await tester.tap(find.text('third').hitTestable());
     await tester.pump();
     expect(find.text('third').hitTestable(), findsOneWidget);
-
     expect(find.text('first').hitTestable(), findsNothing);
     expect(find.text('second').hitTestable(), findsNothing);
   });

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2615,4 +2615,49 @@ void main() {
     expect(value, equals('two'));
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
+
+  testWidgets('does not crash when option is selected', (WidgetTester tester) async {
+    // Regression test for b/171846624.
+
+    final List<String> options = <String>['first', 'second', 'third'];
+    String? value = options.first;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) => DropdownButton<String>(
+              value: value,
+              items: options.map((String s) => DropdownMenuItem<String>(
+                value: s,
+                child: Text(s),
+              )).toList(),
+              onChanged: (String? v) {
+                setState(() {
+                  value = v;
+                });
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('first').hitTestable(), findsOneWidget);
+    expect(find.text('second').hitTestable(), findsNothing);
+    expect(find.text('third').hitTestable(), findsNothing);
+
+    await tester.tap(find.text('first').hitTestable());
+    await tester.pump();
+
+    expect(find.text('third').hitTestable(), findsOneWidget);
+    expect(find.text('first').hitTestable(), findsOneWidget);
+    expect(find.text('second').hitTestable(), findsOneWidget);
+
+    await tester.tap(find.text('third').hitTestable());
+    await tester.pump();
+    expect(find.text('third').hitTestable(), findsOneWidget);
+
+    expect(find.text('first').hitTestable(), findsNothing);
+    expect(find.text('second').hitTestable(), findsNothing);
+  });
 }


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/68913 changed when routes get disposes (they stay alive a little longer). That revealed a bug in the Dropdown widget, which - in certain edge cases - attempts to remove its dropdown route twice if an option is selected. Prior to https://github.com/flutter/flutter/pull/68913 the second removal was a no-op because the route was already disposed when the second removal was attempted (`Route.navigator` was already nulled out). With https://github.com/flutter/flutter/pull/68913 the route is still alive and crashes when removed again. This PR checks whether the dropdown route is still active before removing it to fix that problem.

The edge case is: Something is selected in the drop down the first frame in which the opened menu renders. At this point, the entrance animation hasn't played yet and when the route is now popped (due to something getting selected) we short-circuit its finalization/disposal because there's no pop animation to wait for (since the entrance animation hasn't started playing).

## Related Issues

b/171846624

## Tests

I added the following tests:

* regression test

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
