### PR TITLE
Support targeting physical iOS devices on Apple Silicon 

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -329,7 +329,7 @@ abstract class IOSApp extends ApplicationPackage {
   }
 
   static Future<IOSApp> fromIosProject(IosProject project, BuildInfo buildInfo) {
-    if (getCurrentHostPlatform() != HostPlatform.darwin_x64) {
+    if (!globals.platform.isMacOS) {
       return null;
     }
     if (!project.exists) {

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -253,10 +253,11 @@ class _PosixUtils extends OperatingSystemUtils {
           _processUtils.runSync(<String>['sw_vers', '-productName']),
           _processUtils.runSync(<String>['sw_vers', '-productVersion']),
           _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
+          _processUtils.runSync(<String>['uname', '-m']),
         ];
         if (results.every((RunResult result) => result.exitCode == 0)) {
           _name = '${results[0].stdout.trim()} ${results[1].stdout
-              .trim()} ${results[2].stdout.trim()}';
+              .trim()} ${results[2].stdout.trim()} ${results[3].stdout.trim()}';
         }
       }
       _name ??= super.name;

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
+import '../build_info.dart';
 import '../globals.dart' as globals;
 import 'common.dart';
 import 'file_system.dart';
@@ -24,6 +25,13 @@ abstract class OperatingSystemUtils {
   }) {
     if (platform.isWindows) {
       return _WindowsUtils(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
+    } else if (platform.isMacOS) {
+      return _MacOSUtils(
         fileSystem: fileSystem,
         logger: logger,
         platform: platform,
@@ -113,6 +121,8 @@ abstract class OperatingSystemUtils {
     final String osName = _platform.operatingSystem;
     return osNames.containsKey(osName) ? osNames[osName] : osName;
   }
+
+  HostPlatform get hostPlatform;
 
   List<File> _which(String execName, { bool all = false });
 
@@ -243,30 +253,63 @@ class _PosixUtils extends OperatingSystemUtils {
     return _fileSystem.file(path);
   }
 
+  @override
+  String get pathVarSeparator => ':';
+
+  @override
+  HostPlatform hostPlatform = HostPlatform.linux_x64;
+}
+
+class _MacOSUtils extends _PosixUtils {
+  _MacOSUtils({
+    @required FileSystem fileSystem,
+    @required Logger logger,
+    @required Platform platform,
+    @required ProcessManager processManager,
+  }) : super(
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        );
+
   String _name;
 
   @override
   String get name {
     if (_name == null) {
-      if (_platform.isMacOS) {
-        final List<RunResult> results = <RunResult>[
-          _processUtils.runSync(<String>['sw_vers', '-productName']),
-          _processUtils.runSync(<String>['sw_vers', '-productVersion']),
-          _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
-          _processUtils.runSync(<String>['uname', '-m']),
-        ];
-        if (results.every((RunResult result) => result.exitCode == 0)) {
-          _name = '${results[0].stdout.trim()} ${results[1].stdout
-              .trim()} ${results[2].stdout.trim()} ${results[3].stdout.trim()}';
-        }
+      final List<RunResult> results = <RunResult>[
+        _processUtils.runSync(<String>['sw_vers', '-productName']),
+        _processUtils.runSync(<String>['sw_vers', '-productVersion']),
+        _processUtils.runSync(<String>['sw_vers', '-buildVersion']),
+      ];
+      if (results.every((RunResult result) => result.exitCode == 0)) {
+        _name =
+            '${results[0].stdout.trim()} ${results[1].stdout.trim()} ${results[2].stdout.trim()} ${getNameForHostPlatform(hostPlatform)}';
       }
       _name ??= super.name;
     }
     return _name;
   }
 
+  HostPlatform _hostPlatform;
+
+  // On ARM returns arm64, even when this process is running in Rosetta.
   @override
-  String get pathVarSeparator => ':';
+  HostPlatform get hostPlatform {
+    if (_hostPlatform == null) {
+      final RunResult arm64Check =
+          _processUtils.runSync(<String>['sysctl', 'hw.optional.arm64']);
+      // hw.optional.arm64 is unavailable on < macOS 11 and exits with 1, assume x86 on failure.
+      // On arm64 stdout is "sysctl hw.optional.arm64: 1"
+      if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
+        _hostPlatform = HostPlatform.darwin_arm;
+      } else {
+        _hostPlatform = HostPlatform.darwin_x64;
+      }
+    }
+    return _hostPlatform;
+  }
 }
 
 class _WindowsUtils extends OperatingSystemUtils {
@@ -281,6 +324,9 @@ class _WindowsUtils extends OperatingSystemUtils {
     platform: platform,
     processManager: processManager,
   );
+
+  @override
+  HostPlatform hostPlatform = HostPlatform.windows_x64;
 
   @override
   void makeExecutable(File file) {}

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -300,8 +300,8 @@ class _MacOSUtils extends _PosixUtils {
     if (_hostPlatform == null) {
       final RunResult arm64Check =
           _processUtils.runSync(<String>['sysctl', 'hw.optional.arm64']);
-      // hw.optional.arm64 is unavailable on < macOS 11 and exits with 1, assume x86 on failure.
       // On arm64 stdout is "sysctl hw.optional.arm64: 1"
+      // On x86 hw.optional.arm64 is unavailable and exits with 1.
       if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
         _hostPlatform = HostPlatform.darwin_arm;
       } else {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -394,6 +394,7 @@ bool isEmulatorBuildMode(BuildMode mode) {
 
 enum HostPlatform {
   darwin_x64,
+  darwin_arm,
   linux_x64,
   windows_x64,
 }
@@ -402,6 +403,8 @@ String getNameForHostPlatform(HostPlatform platform) {
   switch (platform) {
     case HostPlatform.darwin_x64:
       return 'darwin-x64';
+    case HostPlatform.darwin_arm:
+      return 'darwin-arm';
     case HostPlatform.linux_x64:
       return 'linux-x64';
     case HostPlatform.windows_x64:
@@ -414,6 +417,7 @@ String getNameForHostPlatform(HostPlatform platform) {
 enum TargetPlatform {
   android,
   ios,
+  // darwin_arm64 not yet supported, macOS desktop targets run in Rosetta as x86.
   darwin_x64,
   linux_x64,
   windows_x64,

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -236,14 +236,15 @@ class DebugUniveralFramework extends Target {
       throw Exception('Failed to create App.framework.');
     }
     final List<String> lipoCommand = <String>[
-      'xcrun',
+      ...globals.xcode.xcrunCommand(),
       'lipo',
       '-create',
       iphoneFile.path,
       simulatorFile.path,
       '-output',
-      lipoOutputFile.path
+      lipoOutputFile.path,
     ];
+
     final RunResult lipoResult = await processUtils.run(
       lipoCommand,
     );

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -318,7 +318,7 @@ end
 
         // Remove simulator architecture in profile and release mode.
         final List<String> lipoCommand = <String>[
-          'xcrun',
+          ...globals.xcode.xcrunCommand(),
           'lipo',
           fatFlutterFrameworkBinary.path,
           '-remove',
@@ -425,7 +425,7 @@ end
           'bitcode' : 'marker'; // In release, force bitcode embedding without archiving.
 
       List<String> pluginsBuildCommand = <String>[
-        'xcrun',
+        ...globals.xcode.xcrunCommand(),
         'xcodebuild',
         '-alltargets',
         '-sdk',
@@ -451,7 +451,7 @@ end
 
       if (mode == BuildMode.debug) {
         pluginsBuildCommand = <String>[
-          'xcrun',
+          ...globals.xcode.xcrunCommand(),
           'xcodebuild',
           '-alltargets',
           '-sdk',
@@ -503,7 +503,7 @@ end
               modeDirectory.childDirectory(podFrameworkName),
             );
             final List<String> lipoCommand = <String>[
-              'xcrun',
+              ...globals.xcode.xcrunCommand(),
               'lipo',
               '-create',
               globals.fs.path.join(podProduct.path, binaryName),
@@ -532,7 +532,7 @@ end
 
           if (boolArg('xcframework')) {
             final List<String> xcframeworkCommand = <String>[
-              'xcrun',
+              ...globals.xcode.xcrunCommand(),
               'xcodebuild',
               '-create-xcframework',
               '-framework',
@@ -616,7 +616,7 @@ end
 
       // Create iOS framework.
       List<String> lipoCommand = <String>[
-        'xcrun',
+        ...globals.xcode.xcrunCommand(),
         'lipo',
         fatFlutterFrameworkBinary.path,
         '-remove',
@@ -642,7 +642,7 @@ end
       globals.fsUtils.copyDirectorySync(fatFramework, simulatorFlutterFrameworkDirectory);
 
       lipoCommand = <String>[
-        'xcrun',
+        ...globals.xcode.xcrunCommand(),
         'lipo',
         fatFlutterFrameworkBinary.path,
         '-thin',
@@ -663,7 +663,7 @@ end
 
       // Create XCFramework from iOS and simulator frameworks.
       final List<String> xcframeworkCommand = <String>[
-        'xcrun',
+        ...globals.xcode.xcrunCommand(),
         'xcodebuild',
         '-create-xcframework',
         '-framework', armFlutterFrameworkDirectory.path,
@@ -696,7 +696,7 @@ end
     // Simulator is only supported in Debug mode.
     // "Fat" framework here must only contain arm.
     final List<String> xcframeworkCommand = <String>[
-      'xcrun',
+      ...globals.xcode.xcrunCommand(),
       'xcodebuild',
       '-create-xcframework',
       '-framework', fatFramework.path,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -193,10 +193,10 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   final List<String> buildCommands = <String>[
-    '/usr/bin/env',
-    'xcrun',
+    ...globals.xcode.xcrunCommand(),
     'xcodebuild',
-    '-configuration', configuration,
+    '-configuration',
+    configuration,
   ];
 
   if (globals.logger.isVerbose) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -25,7 +25,6 @@ import '../protocol_discovery.dart';
 import 'mac.dart';
 import 'plist_parser.dart';
 
-const String _xcrunPath = '/usr/bin/xcrun';
 const String iosSimulatorId = 'apple_ios_simulator';
 
 class IOSSimulators extends PollingDeviceDiscovery {
@@ -51,8 +50,12 @@ class IOSSimulatorUtils {
     @required Xcode xcode,
     @required Logger logger,
     @required ProcessManager processManager,
-  }) : _simControl = SimControl(logger: logger, processManager: processManager),
-      _xcode = xcode;
+  })  : _simControl = SimControl(
+          logger: logger,
+          processManager: processManager,
+          xcode: xcode,
+        ),
+        _xcode = xcode;
 
   final SimControl _simControl;
   final Xcode _xcode;
@@ -80,11 +83,14 @@ class SimControl {
   SimControl({
     @required Logger logger,
     @required ProcessManager processManager,
-  }) : _logger = logger,
-       _processUtils = ProcessUtils(processManager: processManager, logger: logger);
+    @required Xcode xcode,
+  })  : _logger = logger,
+        _xcode = xcode,
+        _processUtils = ProcessUtils(processManager: processManager, logger: logger);
 
   final Logger _logger;
   final ProcessUtils _processUtils;
+  final Xcode _xcode;
 
   /// Runs `simctl list --json` and returns the JSON of the corresponding
   /// [section].
@@ -106,7 +112,13 @@ class SimControl {
     //   },
     //   "pairs": { ... },
 
-    final List<String> command = <String>[_xcrunPath, 'simctl', 'list', '--json', section.name];
+    final List<String> command = <String>[
+      ..._xcode.xcrunCommand(),
+      'simctl',
+      'list',
+      '--json',
+      section.name,
+    ];
     _logger.printTrace(command.join(' '));
     final RunResult results = await _processUtils.run(command);
     if (results.exitCode != 0) {
@@ -155,7 +167,7 @@ class SimControl {
 
   Future<bool> isInstalled(String deviceId, String appId) {
     return _processUtils.exitsHappy(<String>[
-      _xcrunPath,
+      ..._xcode.xcrunCommand(),
       'simctl',
       'get_app_container',
       deviceId,
@@ -167,7 +179,13 @@ class SimControl {
     RunResult result;
     try {
       result = await _processUtils.run(
-        <String>[_xcrunPath, 'simctl', 'install', deviceId, appPath],
+        <String>[
+          ..._xcode.xcrunCommand(),
+          'simctl',
+          'install',
+          deviceId,
+          appPath,
+        ],
         throwOnError: true,
       );
     } on ProcessException catch (exception) {
@@ -180,7 +198,13 @@ class SimControl {
     RunResult result;
     try {
       result = await _processUtils.run(
-        <String>[_xcrunPath, 'simctl', 'uninstall', deviceId, appId],
+        <String>[
+          ..._xcode.xcrunCommand(),
+          'simctl',
+          'uninstall',
+          deviceId,
+          appId,
+        ],
         throwOnError: true,
       );
     } on ProcessException catch (exception) {
@@ -194,7 +218,7 @@ class SimControl {
     try {
       result = await _processUtils.run(
         <String>[
-          _xcrunPath,
+          ..._xcode.xcrunCommand(),
           'simctl',
           'launch',
           deviceId,
@@ -212,7 +236,14 @@ class SimControl {
   Future<void> takeScreenshot(String deviceId, String outputPath) async {
     try {
       await _processUtils.run(
-        <String>[_xcrunPath, 'simctl', 'io', deviceId, 'screenshot', outputPath],
+        <String>[
+          ..._xcode.xcrunCommand(),
+          'simctl',
+          'io',
+          deviceId,
+          'screenshot',
+          outputPath,
+        ],
         throwOnError: true,
       );
     } on ProcessException catch (exception) {
@@ -315,8 +346,6 @@ class IOSSimulator extends Device {
 
   Map<ApplicationPackage, _IOSSimulatorLogReader> _logReaders;
   _IOSSimulatorDevicePortForwarder _portForwarder;
-
-  String get xcrunPath => globals.fs.path.join('/usr', 'bin', 'xcrun');
 
   @override
   Future<bool> isAppInstalled(
@@ -632,7 +661,16 @@ Future<Process> launchDeviceUnifiedLogging (IOSSimulator device, String appName)
   ]);
 
   return processUtils.start(<String>[
-    _xcrunPath, 'simctl', 'spawn', device.id, 'log', 'stream', '--style', 'json', '--predicate', predicate,
+    ...globals.xcode.xcrunCommand(),
+    'simctl',
+    'spawn',
+    device.id,
+    'log',
+    'stream',
+    '--style',
+    'json',
+    '--predicate',
+    predicate,
   ]);
 }
 

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -174,7 +174,7 @@ class Xcode {
   /// tools and properties.
   ///
   /// Returns `xcrun` on x86 macOS.
-  /// Returns `/usr/bin/arch -arm64 xcrun` on ARM macOS to force Xcode commands
+  /// Returns `/usr/bin/arch -arm64e xcrun` on ARM macOS to force Xcode commands
   /// to run outside the x86 Rosetta translation, which may cause crashes.
   List<String> xcrunCommand() {
     final List<String> xcrunCommand = <String>[];
@@ -182,7 +182,7 @@ class Xcode {
       // Force Xcode commands to run outside Rosetta.
       xcrunCommand.addAll(<String>[
         '/usr/bin/arch',
-        '-arm64',
+        '-arm64e',
       ]);
     }
     xcrunCommand.add('xcrun');

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -17,6 +17,14 @@ import 'package:mockito/mockito.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 
+const FakeCommand kARMCheckCommand = FakeCommand(
+  command: <String>[
+    'sysctl',
+    'hw.optional.arm64',
+  ],
+  exitCode: 1,
+);
+
 const FakeCommand kSdkPathCommand = FakeCommand(
   command: <String>[
     'xcrun',
@@ -265,6 +273,7 @@ void main() {
           'main.dill',
         ]
       ));
+      processManager.addCommand(kARMCheckCommand);
       processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -327,6 +336,7 @@ void main() {
           'main.dill',
         ]
       ));
+      processManager.addCommand(kARMCheckCommand);
       processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -386,6 +396,7 @@ void main() {
           'main.dill',
         ]
       ));
+      processManager.addCommand(kARMCheckCommand);
       processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -444,6 +455,7 @@ void main() {
           'main.dill',
         ]
       ));
+      processManager.addCommand(kARMCheckCommand);
       processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -499,6 +511,7 @@ void main() {
           'main.dill',
         ]
       ));
+      processManager.addCommand(kARMCheckCommand);
       processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -95,6 +95,29 @@ void main() {
     });
   });
 
+  testWithoutContext('macos name', () async {
+    when(mockProcessManager.runSync(
+      <String>['sw_vers', '-productName'],
+    )).thenReturn(ProcessResult(0, 0, 'product', ''));
+    when(mockProcessManager.runSync(
+      <String>['sw_vers', '-productVersion'],
+    )).thenReturn(ProcessResult(0, 0, 'version', ''));
+    when(mockProcessManager.runSync(
+      <String>['sw_vers', '-buildVersion'],
+    )).thenReturn(ProcessResult(0, 0, 'build', ''));
+    when(mockProcessManager.runSync(
+      <String>['uname', '-m'],
+    )).thenReturn(ProcessResult(0, 0, 'arch', ''));
+    final MockFileSystem fileSystem = MockFileSystem();
+    final OperatingSystemUtils utils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'macos'),
+      processManager: mockProcessManager,
+    );
+    expect(utils.name, 'product version build arch');
+  });
+
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
     when(mockProcessManager.runSync(

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -6,10 +6,10 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -22,9 +22,11 @@ const String kPath2 = '/another/bin/$kExecutable';
 
 void main() {
   MockProcessManager mockProcessManager;
+  FakeProcessManager fakeProcessManager;
 
   setUp(() {
     mockProcessManager = MockProcessManager();
+    fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
   });
 
   OperatingSystemUtils createOSUtils(Platform platform) {
@@ -32,28 +34,50 @@ void main() {
       fileSystem: MemoryFileSystem(),
       logger: BufferLogger.test(),
       platform: platform,
-      processManager: mockProcessManager,
+      processManager: fakeProcessManager,
     );
   }
 
   group('which on POSIX', () {
     testWithoutContext('returns null when executable does not exist', () async {
-      when(mockProcessManager.runSync(<String>['which', kExecutable]))
-          .thenReturn(ProcessResult(0, 1, null, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            kExecutable,
+          ],
+          exitCode: 1,
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       expect(utils.which(kExecutable), isNull);
     });
 
     testWithoutContext('returns exactly one result', () async {
-      when(mockProcessManager.runSync(<String>['which', 'foo']))
-          .thenReturn(ProcessResult(0, 0, kPath1, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            'foo',
+          ],
+          stdout: kPath1,
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       expect(utils.which(kExecutable).path, kPath1);
     });
 
     testWithoutContext('returns all results for whichAll', () async {
-      when(mockProcessManager.runSync(<String>['which', '-a', kExecutable]))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'which',
+            '-a',
+            kExecutable,
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'linux'));
       final List<File> result = utils.whichAll(kExecutable);
       expect(result, hasLength(2));
@@ -66,27 +90,55 @@ void main() {
     testWithoutContext('throws tool exit if where throws an argument error', () async {
       when(mockProcessManager.runSync(<String>['where', kExecutable]))
           .thenThrow(ArgumentError('Cannot find executable for where'));
-      final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'windows'),
+        processManager: mockProcessManager,
+      );
 
       expect(() => utils.which(kExecutable), throwsA(isA<ToolExit>()));
     });
+
     testWithoutContext('returns null when executable does not exist', () async {
-      when(mockProcessManager.runSync(<String>['where', kExecutable]))
-          .thenReturn(ProcessResult(0, 1, null, null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            kExecutable,
+          ],
+          exitCode: 1,
+        ),
+      );
+
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       expect(utils.which(kExecutable), isNull);
     });
 
     testWithoutContext('returns exactly one result', () async {
-      when(mockProcessManager.runSync(<String>['where', 'foo']))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            'foo',
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       expect(utils.which(kExecutable).path, kPath1);
     });
 
     testWithoutContext('returns all results for whichAll', () async {
-      when(mockProcessManager.runSync(<String>['where', kExecutable]))
-          .thenReturn(ProcessResult(0, 0, '$kPath1\n$kPath2', null));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'where',
+            kExecutable,
+          ],
+          stdout: '$kPath1\n$kPath2',
+        ),
+      );
       final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
       final List<File> result = utils.whichAll(kExecutable);
       expect(result, hasLength(2));
@@ -95,34 +147,162 @@ void main() {
     });
   });
 
-  testWithoutContext('macos name', () async {
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-productName'],
-    )).thenReturn(ProcessResult(0, 0, 'product', ''));
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-productVersion'],
-    )).thenReturn(ProcessResult(0, 0, 'version', ''));
-    when(mockProcessManager.runSync(
-      <String>['sw_vers', '-buildVersion'],
-    )).thenReturn(ProcessResult(0, 0, 'build', ''));
-    when(mockProcessManager.runSync(
-      <String>['uname', '-m'],
-    )).thenReturn(ProcessResult(0, 0, 'arch', ''));
-    final MockFileSystem fileSystem = MockFileSystem();
-    final OperatingSystemUtils utils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'macos'),
-      processManager: mockProcessManager,
-    );
-    expect(utils.name, 'product version build arch');
+  group('host platform', () {
+    testWithoutContext('unknown defaults to Linux', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'fuchsia'));
+      expect(utils.hostPlatform, HostPlatform.linux_x64);
+    });
+
+    testWithoutContext('Windows', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      expect(utils.hostPlatform, HostPlatform.windows_x64);
+    });
+
+    testWithoutContext('Linux', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'linux'));
+      expect(utils.hostPlatform, HostPlatform.linux_x64);
+    });
+
+    testWithoutContext('macOS ARM', () async {
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            'sysctl',
+            'hw.optional.arm64',
+          ],
+          stdout: 'hw.optional.arm64: 1',
+        ),
+      );
+
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_arm);
+    });
+
+    testWithoutContext('macOS 11 x86', () async {
+      fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'sysctl',
+              'hw.optional.arm64',
+            ],
+            stdout: 'hw.optional.arm64: 0',
+          ),
+          );
+
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
+    });
+
+    testWithoutContext('macOS 10 x86', () async {
+      fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'sysctl',
+              'hw.optional.arm64',
+            ],
+            exitCode: 1,
+          ),
+          );
+
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.hostPlatform, HostPlatform.darwin_x64);
+    });
+
+    testWithoutContext('macOS ARM name', () async {
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-productName',
+          ],
+          stdout: 'product',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-productVersion',
+          ],
+          stdout: 'version',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-buildVersion',
+          ],
+          stdout: 'build',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sysctl',
+            'hw.optional.arm64',
+          ],
+          stdout: 'hw.optional.arm64: 1',
+        ),
+      ]);
+
+      final OperatingSystemUtils utils =
+          createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.name, 'product version build darwin-arm');
+    });
+
+    testWithoutContext('macOS x86 name', () async {
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-productName',
+          ],
+          stdout: 'product',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-productVersion',
+          ],
+          stdout: 'version',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sw_vers',
+            '-buildVersion',
+          ],
+          stdout: 'build',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'sysctl',
+            'hw.optional.arm64',
+          ],
+          exitCode: 1,
+        ),
+      ]);
+
+      final OperatingSystemUtils utils =
+          createOSUtils(FakePlatform(operatingSystem: 'macos'));
+      expect(utils.name, 'product version build darwin-x64');
+    });
   });
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {
     const String exceptionMessage = 'Something really bad happened.';
-    when(mockProcessManager.runSync(
-      <String>['unzip', '-o', '-q', null, '-d', null],
-    )).thenReturn(ProcessResult(0, 1, '', exceptionMessage));
+
+    fakeProcessManager.addCommand(
+      const FakeCommand(command: <String>[
+        'unzip',
+        '-o',
+        '-q',
+        null,
+        '-d',
+        null,
+      ], exitCode: 1, stderr: exceptionMessage),
+    );
+
     final MockFileSystem fileSystem = MockFileSystem();
     final MockFile mockFile = MockFile();
     final MockDirectory mockDirectory = MockDirectory();
@@ -134,7 +314,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(operatingSystem: 'linux'),
-      processManager: mockProcessManager,
+      processManager: fakeProcessManager,
     );
 
     expect(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -457,6 +457,13 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        exitCode: 1,
+      ),
       const FakeCommand(command: <String>[
         'xcrun',
         '--sdk',
@@ -575,6 +582,13 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        exitCode: 1,
+      ),
       const FakeCommand(command: <String>[
         'xcrun',
         '--sdk',
@@ -657,6 +671,13 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        exitCode: 1,
+      ),
       const FakeCommand(command: <String>[
         'xcrun',
         '--sdk',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -72,6 +72,13 @@ void main() {
     environment.defines[kIosArchs] = 'arm64';
     processManager.addCommands(<FakeCommand>[
       // Create iphone stub.
+      const FakeCommand(
+        command: <String>[
+          'sysctl',
+          'hw.optional.arm64',
+        ],
+        exitCode: 1,
+      ),
       const FakeCommand(command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path']),
       FakeCommand(command: <String>[
         'xcrun',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -37,7 +37,6 @@ List<String> _xattrArgs(FlutterProject flutterProject) {
 }
 
 const List<String> kRunReleaseArgs = <String>[
-  '/usr/bin/env',
   'xcrun',
   'xcodebuild',
   '-configuration',
@@ -94,6 +93,7 @@ void main() {
       );
       mockXcode = MockXcode();
       when(mockXcode.isVersionSatisfactory).thenReturn(true);
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
       fileSystem.file('foo/.packages')
         ..createSync(recursive: true)
         ..writeAsStringSync('\n');

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -87,6 +87,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     }, testOn: 'posix');
   });
 
@@ -129,6 +130,7 @@ void main() {
       FileSystemUtils: () => fsUtils,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     }, testOn: 'posix');
 
     testUsingContext('respects IOS_SIMULATOR_LOG_FILE_PATH', () {
@@ -145,6 +147,7 @@ void main() {
       FileSystemUtils: () => fsUtils,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
   });
 
@@ -265,6 +268,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('Apple Watch is unsupported', () {
@@ -278,6 +282,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPad 2 is supported', () {
@@ -291,6 +296,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPad Retina is supported', () {
@@ -304,6 +310,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPhone 5 is supported', () {
@@ -317,6 +324,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPhone 5s is supported', () {
@@ -330,6 +338,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPhone SE is supported', () {
@@ -343,6 +352,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPhone 7 Plus is supported', () {
@@ -356,6 +366,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('iPhone X is supported', () {
@@ -369,6 +380,7 @@ void main() {
       Platform: () => osx,
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
   });
 
@@ -391,7 +403,11 @@ void main() {
         Future<ProcessResult>.value(ProcessResult(2, 0, '', ''))
       );
       // Test a real one. Screenshot doesn't require instance states.
-      final SimControl simControl = SimControl(processManager: mockProcessManager, logger: mockLogger);
+      final SimControl simControl = SimControl(
+        processManager: mockProcessManager,
+        logger: mockLogger,
+        xcode: mockXcode,
+      );
       // Doesn't matter what the device is.
       deviceUnderTest = IOSSimulator(
         'x',
@@ -399,6 +415,7 @@ void main() {
         simControl: simControl,
         xcode: mockXcode,
       );
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
     });
 
     testWithoutContext(
@@ -421,7 +438,7 @@ void main() {
         await deviceUnderTest.takeScreenshot(mockFile);
         verify(mockProcessManager.run(
           <String>[
-            '/usr/bin/xcrun',
+            'xcrun',
             'simctl',
             'io',
             'x',
@@ -446,6 +463,7 @@ void main() {
         .thenAnswer((Invocation invocation) => Future<Process>.value(MockProcess()));
       mockSimControl = MockSimControl();
       mockXcode = MockXcode();
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
     });
 
     testUsingContext('syslog uses tail', () async {
@@ -469,7 +487,8 @@ void main() {
       FileSystemUtils: () => FileSystemUtils(
         fileSystem: fileSystem,
         platform: macosPlatform,
-      )
+      ),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('unified logging with app name', () async {
@@ -491,7 +510,7 @@ void main() {
 
       final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
       expect(command, <String>[
-        '/usr/bin/xcrun',
+        'xcrun',
         'simctl',
         'spawn',
         'x',
@@ -506,6 +525,7 @@ void main() {
       overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       FileSystem: () => fileSystem,
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('unified logging without app name', () async {
@@ -526,7 +546,7 @@ void main() {
 
       final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
       expect(command, <String>[
-        '/usr/bin/xcrun',
+        'xcrun',
         'simctl',
         'spawn',
         'x',
@@ -541,6 +561,7 @@ void main() {
       overrides: <Type, Generator>{
         ProcessManager: () => mockProcessManager,
         FileSystem: () => fileSystem,
+        Xcode: () => mockXcode,
       });
   });
 
@@ -555,6 +576,7 @@ void main() {
       mockIosProject = MockIosProject();
       mockSimControl = MockSimControl();
       mockXcode = MockXcode();
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
     });
 
     group('syslog', () {
@@ -594,6 +616,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
         Platform: () => osx,
+        Xcode: () => mockXcode,
       });
 
       testUsingContext('simulator can output `)`', () async {
@@ -630,6 +653,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
         Platform: () => osx,
+        Xcode: () => mockXcode,
       });
 
       testUsingContext('multiline messages', () async {
@@ -682,6 +706,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
         Platform: () => osx,
+        Xcode: () => mockXcode,
       });
     });
 
@@ -694,7 +719,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           'AND NOT(eventMessage CONTAINS " libxpc.dylib ")';
         fakeProcessManager.addCommand(const FakeCommand(
             command:  <String>[
-              '/usr/bin/xcrun',
+              'xcrun',
               'simctl',
               'spawn',
               '123456',
@@ -740,6 +765,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
+        Xcode: () => mockXcode,
       });
     });
   });
@@ -791,11 +817,13 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         return ProcessResult(mockPid, 0, validSimControlOutput, '');
       });
 
+      mockXcode = MockXcode();
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
       simControl = SimControl(
         logger: mockLogger,
         processManager: mockProcessManager,
+        xcode: mockXcode,
       );
-      mockXcode = MockXcode();
     });
 
     testWithoutContext('getDevices succeeds', () async {
@@ -848,7 +876,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
     testWithoutContext('.install() handles exceptions', () async {
       when(mockProcessManager.run(
-        <String>['/usr/bin/xcrun', 'simctl', 'install', deviceId, appId],
+        <String>['xcrun', 'simctl', 'install', deviceId, appId],
         environment: anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory'),
       )).thenThrow(const ProcessException('xcrun', <String>[]));
@@ -860,7 +888,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
     testWithoutContext('.uninstall() handles exceptions', () async {
       when(mockProcessManager.run(
-        <String>['/usr/bin/xcrun', 'simctl', 'uninstall', deviceId, appId],
+        <String>['xcrun', 'simctl', 'uninstall', deviceId, appId],
         environment: anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory'),
       )).thenThrow(const ProcessException('xcrun', <String>[]));
@@ -872,7 +900,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
     testWithoutContext('.launch() handles exceptions', () async {
       when(mockProcessManager.run(
-        <String>['/usr/bin/xcrun', 'simctl', 'launch', deviceId, appId],
+        <String>['xcrun', 'simctl', 'launch', deviceId, appId],
         environment: anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory'),
       )).thenThrow(const ProcessException('xcrun', <String>[]));
@@ -890,6 +918,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
     setUp(() {
       simControl = MockSimControl();
       mockXcode = MockXcode();
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
     });
 
     testUsingContext("startApp uses compiled app's Info.plist to find CFBundleIdentifier", () async {
@@ -914,6 +943,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       PlistParser: () => MockPlistUtils(),
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
   });
 
@@ -947,6 +977,7 @@ flutter:
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
 
@@ -965,6 +996,7 @@ flutter:
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
 
     testUsingContext('is false with no host app and no module', () async {
@@ -981,6 +1013,7 @@ flutter:
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
+      Xcode: () => mockXcode,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -265,7 +265,7 @@ void main() {
 
           expect(xcode.xcrunCommand(), <String>[
             '/usr/bin/arch',
-            '-arm64',
+            '-arm64e',
             'xcrun',
           ]);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -43,7 +43,7 @@ void main() {
       setUp(() {
         xcode = Xcode(
           logger: logger,
-          platform: MockPlatform(),
+          platform: FakePlatform(operatingSystem: 'macos'),
           fileSystem: MemoryFileSystem.test(),
           processManager: processManager,
           xcodeProjectInterpreter: MockXcodeProjectInterpreter(),
@@ -61,8 +61,10 @@ void main() {
       });
 
       testWithoutContext('eulaSigned is false when clang is not installed', () {
-        when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-          .thenThrow(const ProcessException('/usr/bin/xcrun', <String>['clang']));
+        when(processManager.runSync(<String>['sysctl', 'hw.optional.arm64']))
+            .thenReturn(ProcessResult(123, 1, '', ''));
+        when(processManager.runSync(<String>['xcrun', 'clang']))
+          .thenThrow(const ProcessException('xcrun', <String>['clang']));
 
         expect(xcode.eulaSigned, isFalse);
       });
@@ -83,22 +85,11 @@ void main() {
           cache: MockCache(),
           iproxy: IProxy.test(logger: logger, processManager: processManager),
         );
-      });
-
-      testWithoutContext("xcrun can't find xcdevice", () {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-          .thenThrow(const ProcessException('xcrun', <String>['--find', 'xcdevice']));
-        expect(xcdevice.isInstalled, false);
-        verify(processManager.runSync(any)).called(1);
+        when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
       });
 
       testWithoutContext('available devices xcdevice fails', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
         when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
           .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
@@ -108,9 +99,6 @@ void main() {
 
       testWithoutContext('diagnostics xcdevice fails', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
         when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
           .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
@@ -128,209 +116,269 @@ void main() {
     });
 
     group('Xcode', () {
-      Xcode xcode;
       MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
-      MockPlatform platform;
 
       setUp(() {
         mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-        platform = MockPlatform();
-        xcode = Xcode(
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
+        final Xcode xcode = Xcode(
           logger: logger,
-          platform: platform,
+          platform: FakePlatform(operatingSystem: 'windows'),
           fileSystem: MemoryFileSystem.test(),
           processManager: fakeProcessManager,
           xcodeProjectInterpreter: mockXcodeProjectInterpreter,
         );
-      });
-
-      testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
-        const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcode-select', '--print-path'],
-          stdout: xcodePath,
-        ));
-
-        expect(xcode.xcodeSelectPath, xcodePath);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isVersionSatisfactory, isFalse);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
-
-        expect(xcode.isVersionSatisfactory, isFalse);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isVersionSatisfactory, isTrue);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isVersionSatisfactory, isTrue);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isVersionSatisfactory, isTrue);
-      });
-
-      testWithoutContext('xcodeVersionSatisfactory is true when patch version exceeds minimum', () {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(1);
-
-        expect(xcode.isVersionSatisfactory, isTrue);
-      });
-
-      testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
-        when(platform.isMacOS).thenReturn(false);
 
         expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
       });
 
-      testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
-        when(platform.isMacOS).thenReturn(true);
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcode-select', '--print-path'],
-          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
-        ));
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+      group('macOS', () {
+        Xcode xcode;
+        FakePlatform platform;
 
-        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
+        setUp(() {
+          mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+          platform = FakePlatform(operatingSystem: 'macos');
+          xcode = Xcode(
+            logger: logger,
+            platform: platform,
+            fileSystem: MemoryFileSystem.test(),
+            processManager: fakeProcessManager,
+            xcodeProjectInterpreter: mockXcodeProjectInterpreter,
+          );
+        });
 
-      testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
-        when(platform.isMacOS).thenReturn(true);
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcode-select', '--print-path'],
-          exitCode: 127,
-          stderr: 'ERROR',
-        ));
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
-        when(platform.isMacOS).thenReturn(true);
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcode-select', '--print-path'],
-          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
-        ));
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
-        when(platform.isMacOS).thenReturn(true);
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcode-select', '--print-path'],
-          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
-        ));
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-        when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
-
-        expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcrun', 'clang'],
-          exitCode: 1,
-          stderr: 'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.',
-        ));
-
-        expect(xcode.eulaSigned, isFalse);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
-        fakeProcessManager.addCommand(const FakeCommand(
-          command: <String>['/usr/bin/xcrun', 'clang'],
-          exitCode: 1,
-          stderr: 'clang: error: no input files',
-        ));
-
-        expect(xcode.eulaSigned, isTrue);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-      });
-
-      testWithoutContext('SDK name', () {
-        expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
-        expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
-        expect(getNameForSdk(SdkType.macOS), 'macosx');
-      });
-
-      group('SDK location', () {
-        const String sdkroot = 'Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk';
-
-        testWithoutContext('--show-sdk-path iphoneos', () async {
+        testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
+          const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
-            stdout: sdkroot,
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            stdout: xcodePath,
           ));
 
-          expect(await xcode.sdkLocation(SdkType.iPhone), sdkroot);
+          expect(xcode.xcodeSelectPath, xcodePath);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         });
 
-        testWithoutContext('--show-sdk-path macosx', () async {
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
-            stdout: sdkroot,
-          ));
+        testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
 
-          expect(await xcode.sdkLocation(SdkType.macOS), sdkroot);
+          expect(xcode.isVersionSatisfactory, isFalse);
+        });
+
+        testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+
+          expect(xcode.isVersionSatisfactory, isFalse);
+        });
+
+        testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+
+          expect(xcode.isVersionSatisfactory, isTrue);
+        });
+
+        testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+
+          expect(xcode.isVersionSatisfactory, isTrue);
+        });
+
+        testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+
+          expect(xcode.isVersionSatisfactory, isTrue);
+        });
+
+        testWithoutContext('xcodeVersionSatisfactory is true when patch version exceeds minimum', () {
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(1);
+
+          expect(xcode.isVersionSatisfactory, isTrue);
+        });
+
+        testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+          ));
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+
+          expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         });
 
-        testWithoutContext('--show-sdk-path fails', () async {
+        testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
-            exitCode: 1,
-            stderr: 'xcrun: error:',
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            exitCode: 127,
+            stderr: 'ERROR',
           ));
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
 
-          expect(() async => await xcode.sdkLocation(SdkType.iPhone),
-            throwsToolExit(message: 'Could not find SDK location'));
+          expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+          ));
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+
+          expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('xcrun runs natively on arm64', () {
+          fakeProcessManager.addCommands(const <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'sysctl',
+                'hw.optional.arm64',
+              ],
+              stdout: 'hw.optional.arm64: 1',
+            ),
+          ]);
+
+          expect(xcode.xcrunCommand(), <String>[
+            '/usr/bin/arch',
+            '-arm64',
+            'xcrun',
+          ]);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+          ));
+          when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+
+          expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
+          fakeProcessManager.addCommands(const <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'sysctl',
+                'hw.optional.arm64',
+              ],
+              exitCode: 1,
+            ),
+            FakeCommand(
+              command: <String>['xcrun', 'clang'],
+              exitCode: 1,
+              stderr:
+                  'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.',
+            ),
+          ]);
+
+          expect(xcode.eulaSigned, isFalse);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
+          fakeProcessManager.addCommands(
+            const <FakeCommand>[
+              FakeCommand(
+                command: <String>[
+                  'sysctl',
+                  'hw.optional.arm64',
+                ],
+                exitCode: 1,
+              ),
+              FakeCommand(
+                command: <String>['xcrun', 'clang'],
+                exitCode: 1,
+                stderr: 'clang: error: no input files',
+              ),
+            ],
+          );
+          expect(xcode.eulaSigned, isTrue);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('SDK name', () {
+          expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
+          expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
+          expect(getNameForSdk(SdkType.macOS), 'macosx');
+        });
+
+        group('SDK location', () {
+          setUp(() {
+            fakeProcessManager.addCommand(
+              const FakeCommand(
+                command: <String>[
+                  'sysctl',
+                  'hw.optional.arm64',
+                ],
+                exitCode: 1,
+              ),
+            );
+          });
+
+          const String sdkroot = 'Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk';
+
+          testWithoutContext('--show-sdk-path iphoneos', () async {
+            fakeProcessManager.addCommand(const FakeCommand(
+              command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+              stdout: sdkroot,
+            ));
+
+            expect(await xcode.sdkLocation(SdkType.iPhone), sdkroot);
+            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          });
+
+          testWithoutContext('--show-sdk-path macosx', () async {
+            fakeProcessManager.addCommand(const FakeCommand(
+              command: <String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
+              stdout: sdkroot,
+            ));
+
+            expect(await xcode.sdkLocation(SdkType.macOS), sdkroot);
+            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          });
+
+          testWithoutContext('--show-sdk-path fails', () async {
+            fakeProcessManager.addCommand(const FakeCommand(
+              command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+              exitCode: 1,
+              stderr: 'xcrun: error:',
+            ));
+
+            expect(() async => await xcode.sdkLocation(SdkType.iPhone),
+              throwsToolExit(message: 'Could not find SDK location'));
+            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          });
         });
       });
     });
@@ -354,23 +402,13 @@ void main() {
           cache: mockCache,
           iproxy: IProxy.test(logger: logger, processManager: fakeProcessManager),
         );
+        when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
       });
 
       group('installed', () {
         testWithoutContext('Xcode not installed', () {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
           expect(xcdevice.isInstalled, false);
-        });
-
-        testWithoutContext('is installed', () {
-          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
-
-          expect(xcdevice.isInstalled, true);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         });
       });
 
@@ -384,10 +422,6 @@ void main() {
 
         testUsingContext('relays events', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           fakeProcessManager.addCommand(const FakeCommand(
             command: <String>[
@@ -446,10 +480,6 @@ void main() {
 
         testUsingContext('returns devices', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           const String devicesOutput = '''
 [
@@ -570,10 +600,6 @@ void main() {
 
         testWithoutContext('uses timeout', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           fakeProcessManager.addCommand(const FakeCommand(
             command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '20'],
@@ -585,10 +611,6 @@ void main() {
 
         testUsingContext('ignores "Preparing debugger support for iPhone" error', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           const String devicesOutput = '''
 [
@@ -629,10 +651,6 @@ void main() {
 
         testUsingContext('handles unknown architectures', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           const String devicesOutput = '''
 [
@@ -688,10 +706,6 @@ void main() {
 
         testUsingContext('uses cache', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           const String devicesOutput = '''
 [
@@ -729,10 +743,6 @@ void main() {
 
         testUsingContext('returns error message', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-          fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', '--find', 'xcdevice'],
-            stdout: '/path/to/xcdevice',
-          ));
 
           const String devicesOutput = '''
 [
@@ -842,6 +852,5 @@ void main() {
 class MockXcode extends Mock implements Xcode {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
-class MockPlatform extends Mock implements Platform {}
 class MockArtifacts extends Mock implements Artifacts {}
 class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/build_runner/mustache_template.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -293,6 +294,9 @@ class MockSimControl extends Mock implements SimControl {
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
   @override
   ProcessResult makeExecutable(File file) => null;
+
+  @override
+  HostPlatform hostPlatform = HostPlatform.linux_x64;
 
   @override
   void chmod(FileSystemEntity entity, String mode) { }


### PR DESCRIPTION
## Description
Stable hotfix PR.
`flutter run` works against physical iOS and Android devices.  Also works from Xcode.

Does not work on:
- iOS simulators (missing engine architecture)
- iOS apps with plugins (https://github.com/CocoaPods/CocoaPods/issues/9907)
- Android emulators ([b/162290052](https://b.corp.google.com/issues/162290052) can't launch)

## Related Issues
https://github.com/flutter/flutter/issues/60118

Pull requests applied (with some merge conflicts resolved):
https://github.com/flutter/flutter/pull/65978
https://github.com/flutter/flutter/pull/67970
https://github.com/flutter/flutter/pull/68050
https://github.com/flutter/flutter/pull/68855