### PR TITLE
[devicelab] mark routing test as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -440,6 +440,7 @@ tasks:
       Verifies that `flutter drive --route` still works. No performance numbers.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   linux_chrome_dev_mode:
     description: >


### PR DESCRIPTION
## Description

This test is actually failing. mark as flaky to unblock the tree - I've brought this up with the framework team.

TBR @yjbanov 
