### PR TITLE
[flutter_tools] support ws scheme in use-existing-app

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -191,11 +191,17 @@ class FlutterDriverService extends DriverService {
     DebuggingOptions debuggingOptions,
     bool ipv6,
   ) async {
-    _vmServiceUri = vmServiceUri.toString();
+    Uri uri;
+    if (vmServiceUri.scheme == 'ws') {
+      uri = vmServiceUri.replace(scheme: 'http', path: vmServiceUri.path.replaceFirst('ws/', ''));
+    } else {
+      uri = vmServiceUri;
+    }
+    _vmServiceUri = uri.toString();
     _device = device;
     try {
       await device.dds.startDartDevelopmentService(
-        vmServiceUri,
+        uri,
         debuggingOptions.ddsPort,
         ipv6,
         debuggingOptions.disableServiceAuthCodes,
@@ -206,7 +212,7 @@ class FlutterDriverService extends DriverService {
       // application, DDS will already be running remotely and this call will fail.
       // This can be ignored to continue to use the existing remote DDS instance.
     }
-    _vmService = await _vmServiceConnector(Uri.parse(_vmServiceUri), device: _device);
+    _vmService = await _vmServiceConnector(uri, device: _device);
     final DeviceLogReader logReader = await device.getLogReader(app: _applicationPackage);
     logReader.logLines.listen(_logger.printStatus);
 

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -280,6 +280,31 @@ void main() {
     await driverService.stop();
   });
 
+  testWithoutContext('Can connect to existing application using ws URI', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
+      getVM,
+      getVM,
+      const FakeVmServiceRequest(
+        method: 'ext.flutter.exit',
+        args: <String, Object>{
+          'isolateId': '1',
+        }
+      )
+    ]);
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
+    final DriverService driverService = setUpDriverService(processManager: processManager, vmService: fakeVmServiceHost.vmService);
+    final FakeDevice device = FakeDevice(LaunchResult.failed());
+
+    await driverService.reuseApplication(
+      Uri.parse('ws://127.0.0.1:63426/1UasC_ihpXY=/ws/'),
+      device,
+      DebuggingOptions.enabled(BuildInfo.debug),
+      false,
+    );
+    await driverService.stop();
+  });
+
+
   testWithoutContext('Does not call flutterExit on device types that do not support it', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
       getVM,
@@ -321,6 +346,9 @@ FlutterDriverService setUpDriverService({
       Object compression,
       Device device,
     }) async {
+      if (httpUri.scheme != 'http') {
+        fail('Expected an HTTP scheme, found $httpUri');
+      }
       return vmService;
     }
   );


### PR DESCRIPTION
## Description

Missed this case when fixing --use-existing-app. Both dds and our own launcher require an http scheme URI, convert the ws scheme if provided back to http.