### PR TITLE
Show macOS arm64 architecture in doctor and devices list

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -621,6 +621,10 @@ abstract class Device {
   /// The device's platform.
   Future<TargetPlatform> get targetPlatform;
 
+  /// Platform name for display only.
+  Future<String> get targetPlatformDisplayName async =>
+      getNameForTargetPlatform(await targetPlatform);
+
   Future<String> get sdkNameAndVersion;
 
   /// Create a platform-specific [DevFSWriter] for the given [app], or
@@ -749,7 +753,7 @@ abstract class Device {
       table.add(<String>[
         '${device.name} (${device.category})',
         device.id,
-        getNameForTargetPlatform(targetPlatform),
+        await device.targetPlatformDisplayName,
         '${await device.sdkNameAndVersion}$supportIndicator',
       ]);
     }

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -27,6 +27,7 @@ class MacOSDevice extends DesktopDevice {
     @required OperatingSystemUtils operatingSystemUtils,
   }) : _processManager = processManager,
        _logger = logger,
+       _operatingSystemUtils = operatingSystemUtils,
        super(
         'macos',
         platformType: PlatformType.macos,
@@ -39,6 +40,7 @@ class MacOSDevice extends DesktopDevice {
 
   final ProcessManager _processManager;
   final Logger _logger;
+  final OperatingSystemUtils _operatingSystemUtils;
 
   @override
   bool isSupported() => true;
@@ -46,8 +48,19 @@ class MacOSDevice extends DesktopDevice {
   @override
   String get name => 'macOS';
 
+  /// Returns [TargetPlatform.darwin_x64] even on macOS ARM devices.
+  ///
+  /// Build system, artifacts rely on Rosetta to translate to x86_64 on ARM.
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin_x64;
+
+  @override
+  Future<String> get targetPlatformDisplayName async {
+    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+      return 'darwin-arm64';
+    }
+    return super.targetPlatformDisplayName;
+  }
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -604,6 +604,9 @@ void main() {
         when(device.id).thenReturn(id);
         when(device.isLocalEmulator).thenAnswer((_) async => false);
         when(device.sdkNameAndVersion).thenAnswer((_) async => 'Android 46');
+        when(device.targetPlatformDisplayName)
+            .thenAnswer((_) async => 'android');
+
         return device;
       }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -1059,5 +1059,6 @@ class MockDevice extends Mock implements Device {
     when(id).thenReturn('device-id');
     when(isLocalEmulator).thenAnswer((_) => Future<bool>.value(false));
     when(targetPlatform).thenAnswer((_) => Future<TargetPlatform>.value(TargetPlatform.android));
+    when(targetPlatformDisplayName).thenAnswer((_) async => 'android');
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -238,6 +238,8 @@ void main() {
         when(mockDevice.id).thenReturn('mock-id');
         when(mockDevice.name).thenReturn('mock-name');
         when(mockDevice.platformType).thenReturn(PlatformType.android);
+        when(mockDevice.targetPlatformDisplayName)
+            .thenAnswer((Invocation invocation) async => 'mock-platform');
         when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) => Future<String>.value('api-14'));
 
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -166,6 +166,30 @@ void main() {
     expect(device.isSupportedForProject(flutterProject), true);
   });
 
+  testWithoutContext('target platform display name on x86_64', () async {
+    final MacOSDevice device = MacOSDevice(
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.any(),
+      operatingSystemUtils:
+      FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+    );
+
+    expect(await device.targetPlatformDisplayName, 'darwin-x64');
+  });
+
+  testWithoutContext('target platform display name on ARM', () async {
+    final MacOSDevice device = MacOSDevice(
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.any(),
+      operatingSystemUtils:
+          FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+    );
+
+    expect(await device.targetPlatformDisplayName, 'darwin-arm64');
+  });
+
   testUsingContext('isSupportedForProject is false with no host app', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final MacOSDevice device = MacOSDevice(

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -167,24 +167,28 @@ void main() {
   });
 
   testWithoutContext('target platform display name on x86_64', () async {
+    final FakeOperatingSystemUtils fakeOperatingSystemUtils =
+        FakeOperatingSystemUtils();
+    fakeOperatingSystemUtils.hostPlatform = HostPlatform.darwin_x64;
     final MacOSDevice device = MacOSDevice(
       fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.any(),
-      operatingSystemUtils:
-      FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+      operatingSystemUtils: fakeOperatingSystemUtils,
     );
 
     expect(await device.targetPlatformDisplayName, 'darwin-x64');
   });
 
   testWithoutContext('target platform display name on ARM', () async {
+    final FakeOperatingSystemUtils fakeOperatingSystemUtils =
+        FakeOperatingSystemUtils();
+    fakeOperatingSystemUtils.hostPlatform = HostPlatform.darwin_arm;
     final MacOSDevice device = MacOSDevice(
       fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.any(),
-      operatingSystemUtils:
-          FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+      operatingSystemUtils: fakeOperatingSystemUtils,
     );
 
     expect(await device.targetPlatformDisplayName, 'darwin-arm64');

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -291,11 +291,13 @@ class MockSimControl extends Mock implements SimControl {
 }
 
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
+  FakeOperatingSystemUtils({this.hostPlatform = HostPlatform.linux_x64});
+
   @override
   ProcessResult makeExecutable(File file) => null;
 
   @override
-  HostPlatform hostPlatform = HostPlatform.linux_x64;
+  HostPlatform hostPlatform;
 
   @override
   void chmod(FileSystemEntity entity, String mode) { }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -291,13 +291,11 @@ class MockSimControl extends Mock implements SimControl {
 }
 
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
-  FakeOperatingSystemUtils({this.hostPlatform = HostPlatform.linux_x64});
-
   @override
   ProcessResult makeExecutable(File file) => null;
 
   @override
-  HostPlatform hostPlatform;
+  HostPlatform hostPlatform = HostPlatform.linux_x64;
 
   @override
   void chmod(FileSystemEntity entity, String mode) { }


### PR DESCRIPTION
## Description

Add `targetPlatformDisplayName` for `flutter doctor` and `flutter devices` to show when the host is an Apple Silicon macOS ARM machine.

Do not add a more substantive `TargetPlatform.darwin_arm64` change since the artifacts, build system, etc all require `darwin_x64` even on ARM to leverage Rosetta translation.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/65976

## Tests
macos_device_tests