### PR TITLE
[flutter_tools] conditionally invoke pub run test for drive scripts based on presence of dependency

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
@@ -15,6 +14,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../build_info.dart';
+import '../dart/package_map.dart';
 import '../device.dart';
 import '../drive/drive_service.dart';
 import '../globals.dart' as globals;

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -4,7 +4,9 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config_types.dart';
 
 import '../android/android_device.dart';
 import '../application_package.dart';
@@ -178,7 +180,12 @@ class DriveCommand extends RunCommandBase {
       logger: _logger,
       processUtils: globals.processUtils,
       dartSdkPath: globals.artifacts.getArtifactPath(Artifact.engineDartBinary),
-   );
+    );
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+      globals.fs.file('.packages'),
+      logger: _logger,
+      throwOnError: false,
+    ) ?? PackageConfig.empty;
     final DriverService driverService = _flutterDriverFactory.createDriverService(web);
     final BuildInfo buildInfo = getBuildInfo();
     final DebuggingOptions debuggingOptions = createDebuggingOptions();
@@ -220,6 +227,7 @@ class DriveCommand extends RunCommandBase {
       testFile,
       stringsArg('test-arguments'),
       <String, String>{},
+      packageConfig,
       chromeBinary: stringArg('chrome-binary'),
       headless: boolArg('headless'),
       browserDimension: stringArg('browser-dimension').split(','),

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -5,6 +5,7 @@
 import 'package:dds/dds.dart' as dds;
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config_types.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../application_package.dart';
@@ -77,7 +78,8 @@ abstract class DriverService {
   Future<int> startTest(
     String testFile,
     List<String> arguments,
-    Map<String, String> environment, {
+    Map<String, String> environment,
+    PackageConfig packageConfig, {
     bool headless,
     String chromeBinary,
     String browserName,
@@ -218,7 +220,8 @@ class FlutterDriverService extends DriverService {
   Future<int> startTest(
     String testFile,
     List<String> arguments,
-    Map<String, String> environment, {
+    Map<String, String> environment,
+    PackageConfig packageConfig, {
     bool headless,
     String chromeBinary,
     String browserName,
@@ -226,14 +229,14 @@ class FlutterDriverService extends DriverService {
     int driverPort,
     List<String> browserDimension,
   }) async {
+    // Check if package:test is available. If not, fall back to invoking
+    // the test script directly.
     return _processUtils.stream(<String>[
       _dartSdkPath,
-      'pub',
-      'run',
-      'test',
-      ...arguments,
-      testFile,
-      '-rexpanded',
+      if (packageConfig['test'] != null)
+        ...<String>['pub', 'run', 'test', ...arguments, testFile, '-rexpanded']
+      else
+        ...<String>[...arguments, testFile, '-rexpanded'],
     ], environment: <String, String>{
       'VM_SERVICE_URL': _vmServiceUri,
       ...environment,

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -230,7 +230,9 @@ class FlutterDriverService extends DriverService {
     List<String> browserDimension,
   }) async {
     // Check if package:test is available. If not, fall back to invoking
-    // the test script directly.
+    // the test script directly. `pub run test` is strictly better because
+    // in the even that a socket or something similar is left open, the
+    // test runner will correctly shutdown the VM instead of hanging forever.
     return _processUtils.stream(<String>[
       _dartSdkPath,
       if (packageConfig['test'] != null)

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
 import 'package:webdriver/async_io.dart' as async_io;
 
 import '../base/common.dart';
@@ -82,7 +83,7 @@ class WebDriverService extends DriverService {
   }
 
   @override
-  Future<int> startTest(String testFile, List<String> arguments, Map<String, String> environment, {
+  Future<int> startTest(String testFile, List<String> arguments, Map<String, String> environment, PackageConfig packageConfig, {
     bool headless,
     String chromeBinary,
     String browserName,


### PR DESCRIPTION

## Description

The migration to package:vm_service in flutter driver also updated the test script to run through pub run test. This broke some of the plugins CI: https://github.com/flutter/flutter/pull/69126#issuecomment-718220274

Conditionally call pub run test if the package itself has that dependency, otherwise fallback to `dart testfile`