### PR TITLE
AppBar draws its defaults from theme.colorScheme

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -547,7 +547,7 @@ class _AppBarState extends State<AppBar> {
   Widget build(BuildContext context) {
     assert(!widget.primary || debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final ThemeData theme = Theme.of(context)!;
+    final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     final AppBarTheme appBarTheme = AppBarTheme.of(context);
     final ScaffoldState? scaffold = Scaffold.maybeOf(context);
@@ -575,10 +575,10 @@ class _AppBarState extends State<AppBar> {
       ?? overallIconTheme;
     TextStyle? centerStyle = widget.textTheme?.headline6
       ?? appBarTheme.textTheme?.headline6
-      ?? theme.textTheme.headline6?.copyWith(color: foregroundColor);
+      ?? theme.primaryTextTheme.headline6?.copyWith(color: foregroundColor);
     TextStyle? sideStyle = widget.textTheme?.bodyText2
       ?? appBarTheme.textTheme?.bodyText2
-      ?? theme.textTheme.bodyText2?.copyWith(color: foregroundColor);
+      ?? theme.primaryTextTheme.bodyText2?.copyWith(color: foregroundColor);
 
     if (widget.toolbarOpacity != 1.0) {
       final double opacity = const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn).transform(widget.toolbarOpacity);

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -370,8 +370,6 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   ///  * [foregroundColor], which specifies the color for icons and text within
   ///    the app bar.
-  ///  * [brightness], which overrides the overall theme's brightness for
-  ///    this app bar.
   ///  * [Theme.of], which returns the current overall Material theme as
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
@@ -388,14 +386,13 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [Brightness.light], and [ColorScheme.onSurface] if the overall
   /// theme's [brightness] is [Brightness.dark].
   ///
-  /// This color is used to configure [DefaultTextStyle] and [IconTheme]
-  /// widgets.
+  /// This color is used to configure [DefaultTextStyle] that contains
+  /// the app bar's children, and the default [IconTheme] widgets that
+  /// are created if [iconTheme] and [actionsIconTheme] are null.
   ///
   /// See also:
   ///
   ///  * [backgroundColor], which specifies the app bar's background color.
-  ///  * [brightness], which overrides the overall theme's brightness for
-  ///    this app bar.
   ///  * [Theme.of], which returns the current overall Material theme as
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
@@ -404,16 +401,20 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    is light or dark.
   final Color? foregroundColor;
 
-  /// AppBar uses this value to determine the default [foregroundColor] and
-  /// [backgroundColor] as well as the app bar's [SystemUiOverlayStyle].
-  ///
-  /// For [Brightness.dark], [SystemUiOverlayStyle.light] is used and for
+  /// Determines the brightness of the [SystemUiOverlayStyle]: for
+  /// [Brightness.dark], [SystemUiOverlayStyle.light] is used and fo
   /// [Brightness.light], [SystemUiOverlayStyle.dark] is used.
+  ///
+  /// If this value is null then [AppBarTheme.brightness] is used
+  /// and if that's null then overall theme's brightness is used.
+  ///
+  /// The AppBar is built within a `AnnotatedRegion<SystemUiOverlayStyle>`
+  /// which causes [SystemChrome.setSystemUIOverlayStyle] to be called
+  /// automatically.  Apps should not enclose the AppBar with
+  /// their own [AnnotatedRegion].
   ///
   /// See also:
   ///
-  ///  * [AppBar.brightness], which overrides the this value and the overall
-  ///    theme's [ColorScheme.brightness].
   ///  * [Theme.of], which returns the current overall Material theme as
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -376,7 +376,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Color? backgroundColor;
 
@@ -400,12 +400,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Color? foregroundColor;
 
-  /// AppBar uses this value to determine the default [color] and [backgroundColor]
-  /// as well as the app bar's [SystemUiOverlayStyle].
+  /// AppBar uses this value to determine the default [foregroundColor] and
+  /// [backgroundColor] as well as the app bar's [SystemUiOverlayStyle].
   ///
   /// For [Brightness.dark], [SystemUiOverlayStyle.light] is used and for
   /// [Brightness.light], [SystemUiOverlayStyle.dark] is used.
@@ -418,7 +418,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Brightness? brightness;
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -359,46 +359,67 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// zero.
   final ShapeBorder? shape;
 
-  /// The color to use for the app bar's [Material].
+  /// The fill color to use for the app bar's [Material].
   ///
-  /// This property is often set along with [brightness], [iconTheme],
-  /// [textTheme].
-  ///
-  /// If this property is null, then [AppBarTheme.color] of
-  /// [ThemeData.appBarTheme] is used. If that is also null,
-  /// the overall theme's [ColorScheme.primary] is used for light color schemes,
-  /// [ColorScheme.surface] for dark color schemes.
+  /// If null, then the [AppBarTheme.color] is used. If that value is also
+  /// null, then [AppBar] uses the overall theme's [ColorScheme.primary] if the
+  /// overall theme's brightness is [Brightness.light], and [ColorScheme.surface]
+  /// if the overall theme's [brightness] is [Brightness.dark].
   ///
   /// See also:
   ///
-  ///  * [ThemeData.colorScheme], the overall theme's color scheme.
-  ///  * [ColorScheme.brightness], classifies the color scheme as light or dark.
+  ///  * [foregroundColor], which specifies the color for icons and text within
+  ///    the app bar.
+  ///  * [brightness], which overrides the overall theme's brightness for
+  ///    this app bar.
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
   final Color? backgroundColor;
 
-  /// The default color to use for the app bar's text and icons.
+  /// The default color for [Text] and [Icon]s within the app bar.
   ///
-  /// If this property is null, then [AppBarTheme.foregroundColor] of
-  /// [ThemeData.appBarTheme] is used. If that is also null,
-  /// the overall theme's [ColorScheme.onPrimary] is used for light color schemes,
-  /// [ColorScheme.onSurface] for dark color schemes.
+  /// If null, then [AppBarTheme.foregroundColor] is used. If that
+  /// value is also null, then [AppBar] uses the overall theme's
+  /// [ColorScheme.onPrimary] if the overall theme's brightness is
+  /// [Brightness.light], and [ColorScheme.onSurface] if the overall
+  /// theme's [brightness] is [Brightness.dark].
+  ///
+  /// This color is used to configure [DefaultTextStyle] and [IconTheme]
+  /// widgets.
   ///
   /// See also:
   ///
-  ///  * [ThemeData.colorScheme], the overall theme's color scheme.
+  ///  * [backgroundColor], which specifies the app bar's background color.
+  ///  * [brightness], which overrides the overall theme's brightness for
+  ///    this app bar.
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
   final Color? foregroundColor;
 
-  /// The brightness of the app bar's [Material].
+  /// AppBar uses this value to determine the default [color] and [backgroundColor]
+  /// as well as the app bar's [SystemUiOverlayStyle].
   ///
-  /// This property is often set along with [backgroundColor],
-  /// [iconTheme], [textTheme].
-  ///
-  /// If this property is null, then [AppBarTheme.brightness] of
-  /// [ThemeData.appBarTheme] is used. If that is also null, then
-  /// the brightness of the [backgroundColor] is used.
+  /// For [Brightness.dark], [SystemUiOverlayStyle.light] is used and for
+  /// [Brightness.light], [SystemUiOverlayStyle.dark] is used.
   ///
   /// See also:
   ///
-  ///  * [ThemeData.estimateBrightnessForColor], which classifies colors as light or dark.
+  ///  * [AppBar.brightness], which overrides the this value and the overall
+  ///    theme's [ColorScheme.brightness].
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
   final Brightness? brightness;
 
   /// The color, opacity, and size to use for app bar icons. Typically this
@@ -543,7 +564,7 @@ class _AppBarState extends State<AppBar> {
       ?? appBarTheme.color
       ?? (colorScheme.brightness == Brightness.dark ? colorScheme.surface : colorScheme.primary);
     final Color foregroundColor = widget.foregroundColor
-      //?? appBarTheme.foregroundColor
+      ?? appBarTheme.foregroundColor
       ?? (colorScheme.brightness == Brightness.dark ? colorScheme.onSurface : colorScheme.onPrimary);
 
     IconThemeData overallIconTheme = widget.iconTheme

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -57,7 +57,7 @@ class AppBarTheme with Diagnosticable {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Brightness? brightness;
 
@@ -77,7 +77,7 @@ class AppBarTheme with Diagnosticable {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Color? color;
 
@@ -99,7 +99,7 @@ class AppBarTheme with Diagnosticable {
   ///    a [ThemeData].
   ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
   ///    default colors are based on.
-  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///  * [ColorScheme.brightness], which indicates if the overall [Theme]
   ///    is light or dark.
   final Color? foregroundColor;
 

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -33,6 +33,7 @@ class AppBarTheme with Diagnosticable {
   const AppBarTheme({
     this.brightness,
     this.color,
+    this.foregroundColor,
     this.elevation,
     this.shadowColor,
     this.iconTheme,
@@ -42,15 +43,65 @@ class AppBarTheme with Diagnosticable {
     this.titleSpacing,
   });
 
-  /// Default value for [AppBar.brightness].
+  /// AppBar uses this value to determine the default [color] and [backgroundColor]
+  /// as well as the app bar's [SystemUiOverlayStyle].
   ///
-  /// If null, [AppBar] uses [ThemeData.primaryColorBrightness].
+  /// For [Brightness.dark], [SystemUiOverlayStyle.light] is used and for
+  /// [Brightness.light], [SystemUiOverlayStyle.dark] is used.
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.brightness], which overrides the this value and the overall
+  ///    theme's [ColorScheme.brightness].
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
   final Brightness? brightness;
 
-  /// Default value for [AppBar.backgroundColor].
+  /// The app bar's background color.
   ///
-  /// If null, [AppBar] uses [ThemeData.primaryColor].
+  /// If null, [AppBar] uses the overall theme's [ColorScheme.primary] if the
+  /// overall theme's brightness is [Brightness.light], and [ColorScheme.surface]
+  /// if the overall theme's [brightness] is [Brightness.dark].
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.backgroundColor], which specifies the AppBar's background color
+  ///    and overrides the background color defined by this theme.
+  ///  * [foregroundColor], which specifies the color for icons and text within
+  ///    the app bar.
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
   final Color? color;
+
+  /// The default color for [Text] and [Icon]s within the app bar.
+  ///
+  /// If null, [AppBar] uses the overall theme's [ColorScheme.onPrimary] if the
+  /// overall theme's brightness is [Brightness.light], and [ColorScheme.onSurface]
+  /// if the overall theme's [brightness] is [Brightness.dark].
+  ///
+  /// This color is used to configure [DefaultTextStyle] and [IconTheme]
+  /// widgets.
+  ///
+  /// See also:
+  ///
+  ///  * [AppBar.foregroundColor], which specifies the app bar's text and icon
+  ///    colors and overrides the foreground color defined by this theme.
+  ///  * [color], which specifies the app bar's background color.
+  ///  * [Theme.of], which returns the current overall Material theme as
+  ///    a [ThemeData].
+  ///  * [ThemeData.colorScheme], the thirteen colors that most Material widget
+  ///    default colors are based on.
+  ///  * [ThemeData.colorScheme.brightness], which indicates if the overall theme
+  ///    is light or dark.
+  final Color? foregroundColor;
 
   /// Default value for [AppBar.elevation].
   ///
@@ -93,6 +144,7 @@ class AppBarTheme with Diagnosticable {
     IconThemeData? actionsIconTheme,
     Brightness? brightness,
     Color? color,
+    Color? foregroundColor,
     double? elevation,
     Color? shadowColor,
     IconThemeData? iconTheme,
@@ -103,6 +155,7 @@ class AppBarTheme with Diagnosticable {
     return AppBarTheme(
       brightness: brightness ?? this.brightness,
       color: color ?? this.color,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
       elevation: elevation ?? this.elevation,
       shadowColor: shadowColor ?? this.shadowColor,
       iconTheme: iconTheme ?? this.iconTheme,
@@ -128,6 +181,7 @@ class AppBarTheme with Diagnosticable {
     return AppBarTheme(
       brightness: t < 0.5 ? a?.brightness : b?.brightness,
       color: Color.lerp(a?.color, b?.color, t),
+      foregroundColor: Color.lerp(a?.foregroundColor, b?.foregroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
       iconTheme: IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t),
@@ -143,6 +197,7 @@ class AppBarTheme with Diagnosticable {
     return hashValues(
       brightness,
       color,
+      foregroundColor,
       elevation,
       shadowColor,
       iconTheme,
@@ -162,6 +217,7 @@ class AppBarTheme with Diagnosticable {
     return other is AppBarTheme
         && other.brightness == brightness
         && other.color == color
+        && other.foregroundColor == foregroundColor
         && other.elevation == elevation
         && other.shadowColor == shadowColor
         && other.iconTheme == iconTheme
@@ -176,6 +232,7 @@ class AppBarTheme with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(ColorProperty('foregroundColor', foregroundColor, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));
     properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: null));
     properties.add(DiagnosticsProperty<IconThemeData>('iconTheme', iconTheme, defaultValue: null));

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -43,8 +43,8 @@ class AppBarTheme with Diagnosticable {
     this.titleSpacing,
   });
 
-  /// AppBar uses this value to determine the default [color] and [backgroundColor]
-  /// as well as the app bar's [SystemUiOverlayStyle].
+  /// AppBar uses this value to determine the default (background) [color] and
+  /// [foregroundColor] as well as the app bar's [SystemUiOverlayStyle].
   ///
   /// For [Brightness.dark], [SystemUiOverlayStyle.light] is used and for
   /// [Brightness.light], [SystemUiOverlayStyle.dark] is used.

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1769,6 +1769,7 @@ void main() {
     ));
 
     expect(darkTheme.primaryColorBrightness, Brightness.dark);
+    expect(darkTheme.colorScheme.brightness, Brightness.dark);
     expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
       statusBarBrightness: Brightness.dark,
       statusBarIconBrightness: Brightness.light,
@@ -1777,14 +1778,17 @@ void main() {
 
   testWidgets('AppBar draws a dark system bar for a light background', (WidgetTester tester) async {
     final ThemeData lightTheme = ThemeData(primaryColor: Colors.white);
-    await tester.pumpWidget(MaterialApp(
-      theme: lightTheme,
-      home: Scaffold(
-        appBar: AppBar(title: const Text('test')),
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: lightTheme,
+        home: Scaffold(
+          appBar: AppBar(title: const Text('test')),
+        ),
       ),
-    ));
+    );
 
     expect(lightTheme.primaryColorBrightness, Brightness.light);
+    expect(lightTheme.colorScheme.brightness, Brightness.light);
     expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
       statusBarBrightness: Brightness.light,
       statusBarIconBrightness: Brightness.dark,

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -175,7 +175,7 @@ void main() {
           builder: (BuildContext context) {
             // This ThemeData has been localized with ThemeData.localize. The
             // appTheme parameter has not, so its textTheme is incomplete.
-            theme = Theme.of(context)!;
+            theme = Theme.of(context);
             return Scaffold(
               appBar: AppBar(
                 actions: <Widget>[

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -29,7 +29,7 @@ void main() {
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
-    expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.dark);
+    expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.dark.statusBarBrightness);
     expect(widget.color, Colors.blue);
     expect(widget.elevation, 4.0);
     expect(widget.shadowColor, Colors.black);
@@ -77,23 +77,25 @@ void main() {
     const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.lightBlue);
     const TextTheme textTheme = TextTheme(headline6: TextStyle(color: Colors.orange), bodyText2: TextStyle(color: Colors.pink));
 
-    final ThemeData themeData = _themeData().copyWith(appBarTheme: _appBarTheme());
-
-    await tester.pumpWidget(MaterialApp(
-      theme: themeData,
-      home: Scaffold(appBar: AppBar(
-        backgroundColor: color,
-        brightness: brightness,
-        elevation: elevation,
-        shadowColor: shadowColor,
-        iconTheme: iconThemeData,
-        actionsIconTheme: actionsIconThemeData,
-        textTheme: textTheme,
-        actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share), onPressed: () { }),
-        ],
-      )),
-    ));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+        home: Scaffold(
+          appBar: AppBar(
+            backgroundColor: color,
+            brightness: brightness,
+            elevation: elevation,
+            shadowColor: shadowColor,
+            iconTheme: iconThemeData,
+            actionsIconTheme: actionsIconThemeData,
+            textTheme: textTheme,
+            actions: <Widget>[
+              IconButton(icon: const Icon(Icons.share), onPressed: () { }),
+            ],
+          ),
+        ),
+      ),
+    );
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
@@ -116,10 +118,8 @@ void main() {
     const IconThemeData iconThemeData = IconThemeData(color: Colors.green);
     const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.lightBlue);
 
-    final ThemeData themeData = _themeData().copyWith(appBarTheme: _appBarTheme());
-
     await tester.pumpWidget(MaterialApp(
-      theme: themeData,
+      theme: ThemeData.from(colorScheme: const ColorScheme.light()),
       home: Scaffold(appBar: AppBar(
         iconTheme: iconThemeData,
         actionsIconTheme: actionsIconThemeData,
@@ -135,16 +135,20 @@ void main() {
 
   testWidgets('AppBarTheme properties take priority over ThemeData properties', (WidgetTester tester) async {
     final AppBarTheme appBarTheme = _appBarTheme();
-    final ThemeData themeData = _themeData().copyWith(appBarTheme: _appBarTheme());
 
-    await tester.pumpWidget(MaterialApp(
-      theme: themeData,
-      home: Scaffold(appBar: AppBar(
-        actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share), onPressed: () { }),
-        ],
-      )),
-    ));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.from(colorScheme: const ColorScheme.light())
+          .copyWith(appBarTheme: _appBarTheme()),
+        home: Scaffold(
+          appBar: AppBar(
+            actions: <Widget>[
+              IconButton(icon: const Icon(Icons.share), onPressed: () { }),
+            ],
+          ),
+        ),
+      ),
+    );
 
     final Material widget = _getAppBarMaterial(tester);
     final IconTheme iconTheme = _getAppBarIconTheme(tester);
@@ -162,33 +166,80 @@ void main() {
     expect(text.style, appBarTheme.textTheme!.bodyText2);
   });
 
-  testWidgets('ThemeData properties are used when no AppBarTheme is set', (WidgetTester tester) async {
-    final ThemeData themeData = _themeData();
+  testWidgets('ThemeData colorScheme is used when no AppBarTheme is set', (WidgetTester tester) async {
+    late ThemeData theme;
+    Widget buildFrame(ThemeData appTheme) {
+      return MaterialApp(
+        theme: appTheme,
+        home: Builder(
+          builder: (BuildContext context) {
+            // This ThemeData has been localized with ThemeData.localize. The
+            // appTheme parameter has not, so its textTheme is incomplete.
+            theme = Theme.of(context)!;
+            return Scaffold(
+              appBar: AppBar(
+                actions: <Widget>[
+                  IconButton(icon: const Icon(Icons.share), onPressed: () { }),
+                ],
+              ),
+            );
+          },
+        ),
+      );
+    }
 
-    await tester.pumpWidget(MaterialApp(
-      theme: themeData,
-      home: Scaffold(appBar: AppBar(
-        actions: <Widget>[
-          IconButton(icon: const Icon(Icons.share), onPressed: () { }),
-        ],
-      )),
-    ));
+    // AppBar defaults for light themes:
+    // - elevation: 4
+    // - shadow color: black
+    // - background color: ColorScheme.primary
+    // - foreground color: ColorScheme.onPrimary
+    // - actions text: style bodyText2, foreground color
+    // - status bar brightness: dark (based on color scheme brightness)
+    {
+      await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.light())));
 
-    final Material widget = _getAppBarMaterial(tester);
-    final IconTheme iconTheme = _getAppBarIconTheme(tester);
-    final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
-    final RichText actionIconText = _getAppBarIconRichText(tester);
-    final DefaultTextStyle text = _getAppBarText(tester);
+      final Material widget = _getAppBarMaterial(tester);
+      final IconTheme iconTheme = _getAppBarIconTheme(tester);
+      final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+      final RichText actionIconText = _getAppBarIconRichText(tester);
+      final DefaultTextStyle text = _getAppBarText(tester);
 
-    expect(SystemChrome.latestStyle!.statusBarBrightness, themeData.brightness);
-    expect(widget.color, themeData.primaryColor);
-    expect(widget.elevation, 4.0);
-    expect(widget.shadowColor, Colors.black);
-    expect(iconTheme.data, themeData.primaryIconTheme);
-    expect(actionsIconTheme.data, themeData.primaryIconTheme);
-    expect(actionIconText.text.style!.color, themeData.primaryIconTheme.color);
-    // Default value for ThemeData.typography is Typography.material2014()
-    expect(text.style, Typography.material2014().englishLike.bodyText2!.merge(Typography.material2014().white.bodyText2).merge(themeData.primaryTextTheme.bodyText2));
+      expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.dark.statusBarBrightness);
+      expect(widget.color, theme.colorScheme.primary);
+      expect(widget.elevation, 4.0);
+      expect(widget.shadowColor, Colors.black);
+      expect(iconTheme.data.color, theme.colorScheme.onPrimary);
+      expect(actionsIconTheme.data.color, theme.colorScheme.onPrimary);
+      expect(actionIconText.text.style!.color, theme.colorScheme.onPrimary);
+      expect(text.style.compareTo(theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.onPrimary)), RenderComparison.identical);
+    }
+
+    // AppBar defaults for dark themes:
+    // - elevation: 4
+    // - shadow color: black
+    // - background color: ColorScheme.surface
+    // - foreground color: ColorScheme.onSurface
+    // - actions text: style bodyText2, foreground color
+    // - status bar brightness: dark (based on background color)
+    {
+      await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.dark())));
+      await tester.pumpAndSettle(); // Theme change animation
+
+      final Material widget = _getAppBarMaterial(tester);
+      final IconTheme iconTheme = _getAppBarIconTheme(tester);
+      final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+      final RichText actionIconText = _getAppBarIconRichText(tester);
+      final DefaultTextStyle text = _getAppBarText(tester);
+
+      expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
+      expect(widget.color, theme.colorScheme.surface);
+      expect(widget.elevation, 4.0);
+      expect(widget.shadowColor, Colors.black);
+      expect(iconTheme.data.color, theme.colorScheme.onSurface);
+      expect(actionsIconTheme.data.color, theme.colorScheme.onSurface);
+      expect(actionIconText.text.style!.color, theme.colorScheme.onSurface);
+      expect(text.style.compareTo(theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.onSurface)), RenderComparison.identical);
+    }
   });
 
   testWidgets('AppBar uses AppBarTheme.centerTitle when centerTitle is null', (WidgetTester tester) async {
@@ -372,15 +423,6 @@ AppBarTheme _appBarTheme() {
     shadowColor: shadowColor,
     iconTheme: iconThemeData,
     textTheme: textTheme,
-  );
-}
-
-ThemeData _themeData() {
-  return ThemeData(
-    primaryColor: Colors.purple,
-    brightness: Brightness.dark,
-    primaryIconTheme: const IconThemeData(color: Colors.green),
-    primaryTextTheme: const TextTheme(headline6: TextStyle(color: Colors.orange), bodyText2: TextStyle(color: Colors.pink)),
   );
 }
 


### PR DESCRIPTION
Added AppBar.foreground and AppBarTheme.foreground color and changed the way that AppBar computes its default colors and styles. Now:

 - The default backgroundColor, i.e. the fill color for the app bar's Material, is ColorScheme.primary for light themes and ColorScheme.surface for dark themes.
 - The default foregroundColor, i.e. the color for text and icons, is ColorScheme.onPrimary for light themes and ColorScheme.onSurface for dark themes.
 - The default text style for the app bar's title is TextTheme.headline6 in the foreground color.
 - The default text style for the app bar's actions and leading widget is TextTheme.bodyText2 in the foreground color.

Both AppBarTheme and AppBar now document how the theme's brightness relates to the SystemUiOverlayStyle per https://github.com/flutter/flutter/issues/67497.

Fixes https://github.com/flutter/flutter/issues/67921.


