### PR TITLE
make stack frame parser handle missing class info

### DIFF
--- a/packages/flutter/lib/src/foundation/stack_frame.dart
+++ b/packages/flutter/lib/src/foundation/stack_frame.dart
@@ -211,7 +211,9 @@ class StackFrame {
     String className = '';
     String method = match.group(2)!.replaceAll('.<anonymous closure>', '');
     if (method.startsWith('new')) {
-      className = method.split(' ')[1];
+      final List<String> methodParts = method.split(' ');
+      // Sometimes a web frame will only read "new" and have no class name.
+      className = methodParts.length > 1 ? method.split(' ')[1] : '<unknown>';
       method = '';
       if (className.contains('.')) {
         final List<String> parts  = className.split('.');

--- a/packages/flutter/test/foundation/stack_frame_test.dart
+++ b/packages/flutter/test/foundation/stack_frame_test.dart
@@ -81,6 +81,24 @@ void main() {
       expect('$e', contains('Got a stack frame from package:stack_trace'));
     }
   });
+
+  test('Can parse web constructor invocation with unknown class name', () {
+    const String stackTraceLine = '#32     new (http://localhost:42191/dart-sdk/lib/async/stream_controller.dart:880:9)';
+    expect(
+      StackFrame.fromStackTraceLine(stackTraceLine),
+      const StackFrame(
+        number: 32,
+        className: '<unknown>',
+        method: '',
+        packageScheme: 'http',
+        package: '<unknown>',
+        packagePath: 'dart-sdk/lib/async/stream_controller.dart',
+        line: 880,
+        column: 9,
+        source: stackTraceLine,
+      ),
+    );
+  });
 }
 
 const String stackString = '''


### PR DESCRIPTION
## Description

On the web sometimes we get a stack trace with missing class information when invoking a constructor, e.g.:

```
#32     new (http://localhost:42191/dart-sdk/lib/async/stream_controller.dart:880:9)
```

This change will report "<unknown>" for the class in this case.

## Tests

I added the following tests: more tests in `stack_frame_test.dart`.
