### PR TITLE
Make the launch background drawable compatible with older Android API levels

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/main/res/drawable-v21/launch_background.xml
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
+    <item android:drawable="?android:colorBackground" />
 
     <!-- You can insert your own image assets here -->
     <!-- <item>

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -21,6 +21,7 @@
         "templates/app/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl",
         "templates/app/android.tmpl/app/src/main/AndroidManifest.xml.tmpl",
         "templates/app/android.tmpl/app/src/main/res/drawable/launch_background.xml",
+        "templates/app/android.tmpl/app/src/main/res/drawable-v21/launch_background.xml",
         "templates/app/android.tmpl/app/src/main/res/mipmap-hdpi/ic_launcher.png",
         "templates/app/android.tmpl/app/src/main/res/mipmap-mdpi/ic_launcher.png",
         "templates/app/android.tmpl/app/src/main/res/mipmap-xhdpi/ic_launcher.png",


### PR DESCRIPTION
The https://github.com/flutter/flutter/pull/65182 change introduced a
drawable with a reference to a theme attribute.  Loading this requires
a Resources.getDrawable API introduced in API level 21.
