### PR TITLE
Decrease device discovery timeout from 10 to 5 seconds

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -636,7 +636,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   Future<List<String>> discoverDevices() async {
     final List<dynamic> results = json.decode(await eval(
       path.join(flutterDirectory.path, 'bin', 'flutter'),
-      <String>['devices', '--machine', '--suppress-analytics', '--device-timeout', '10'],
+      <String>['devices', '--machine', '--suppress-analytics', '--device-timeout', '5'],
     )) as List<dynamic>;
 
     // [

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -434,7 +434,7 @@ Future<String> eval(
 
 List<String> flutterCommandArgs(String command, List<String> options) {
   // Commands support the --device-timeout flag.
-  final List<String> supportedDeviceTimeoutCommands = <String>[
+  final Set<String> supportedDeviceTimeoutCommands = <String>{
     'attach',
     'devices',
     'drive',
@@ -442,7 +442,7 @@ List<String> flutterCommandArgs(String command, List<String> options) {
     'logs',
     'run',
     'screenshot',
-  ];
+  };
   return <String>[
     command,
     if (deviceOperatingSystem == DeviceOperatingSystem.ios && supportedDeviceTimeoutCommands.contains(command))

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -448,7 +448,7 @@ List<String> flutterCommandArgs(String command, List<String> options) {
     if (deviceOperatingSystem == DeviceOperatingSystem.ios && supportedDeviceTimeoutCommands.contains(command))
       ...<String>[
         '--device-timeout',
-        '10',
+        '5',
       ],
     if (localEngine != null) ...<String>['--local-engine', localEngine],
     if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -771,7 +771,7 @@ class PerfTestWithSkSL extends PerfTest {
         'run',
         if (deviceOperatingSystem == DeviceOperatingSystem.ios)
           ...<String>[
-            '--device-timeout', '10',
+            '--device-timeout', '5',
           ],
         '--verbose',
         '--verbose-system-logs',


### PR DESCRIPTION
## Description

Hitting the 30 seconds test timeout, reduce device discover time.
```
2020-10-28T18:52:26.356414: stdout: [+15695 ms] 00:30 [32m+0[0m[31m -1[0m: post_backdrop_filter_perf [1m[31m[E][0m[0m
2020-10-28T18:52:26.356636: stdout: [        ]   TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
```

## Related Issues

https://github.com/flutter/flutter/pull/69260