### PR TITLE
[devicelab] do not fail test if CPU measurement is not recorded

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -655,8 +655,9 @@ class PerfTest {
           '90th_percentile_vsync_transitions_missed',
           '99th_percentile_vsync_transitions_missed',
           if (measureCpuGpu && !isAndroid) ...<String>[
-            'average_cpu_usage',
-            'average_gpu_usage',
+            // See https://github.com/flutter/flutter/issues/68888
+            if (data['average_cpu_usage'] != null) 'average_cpu_usage',
+            if (data['average_gpu_usage'] != null) 'average_gpu_usage',
           ],
           if (measureMemory && !isAndroid) ...<String>[
             'average_memory_usage',


### PR DESCRIPTION
## Description

These tests are flaking because CPU measurement seems to not be reliable.

https://github.com/flutter/flutter/issues/68888