### PR TITLE
Adaptive RaisedButton

### DIFF
--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -11,6 +12,8 @@ import 'button_theme.dart';
 import 'material_button.dart';
 import 'theme.dart';
 import 'theme_data.dart';
+
+enum _RaisedButtonType { material, adaptive }
 
 /// A material design "raised button".
 ///
@@ -148,44 +151,130 @@ class RaisedButton extends MaterialButton {
     MaterialTapTargetSize? materialTapTargetSize,
     Duration? animationDuration,
     Widget? child,
-  }) : assert(autofocus != null),
-       assert(elevation == null || elevation >= 0.0),
-       assert(focusElevation == null || focusElevation >= 0.0),
-       assert(hoverElevation == null || hoverElevation >= 0.0),
-       assert(highlightElevation == null || highlightElevation >= 0.0),
-       assert(disabledElevation == null || disabledElevation >= 0.0),
-       assert(clipBehavior != null),
-       super(
-         key: key,
-         onPressed: onPressed,
-         onLongPress: onLongPress,
-         onHighlightChanged: onHighlightChanged,
-         mouseCursor: mouseCursor,
-         textTheme: textTheme,
-         textColor: textColor,
-         disabledTextColor: disabledTextColor,
-         color: color,
-         disabledColor: disabledColor,
-         focusColor: focusColor,
-         hoverColor: hoverColor,
-         highlightColor: highlightColor,
-         splashColor: splashColor,
-         colorBrightness: colorBrightness,
-         elevation: elevation,
-         focusElevation: focusElevation,
-         hoverElevation: hoverElevation,
-         highlightElevation: highlightElevation,
-         disabledElevation: disabledElevation,
-         padding: padding,
-         visualDensity: visualDensity,
-         shape: shape,
-         clipBehavior: clipBehavior,
-         focusNode: focusNode,
-         autofocus: autofocus,
-         materialTapTargetSize: materialTapTargetSize,
-         animationDuration: animationDuration,
-         child: child,
-       );
+  })  : _buttonType = _RaisedButtonType.material,
+        assert(autofocus != null),
+        assert(elevation == null || elevation >= 0.0),
+        assert(focusElevation == null || focusElevation >= 0.0),
+        assert(hoverElevation == null || hoverElevation >= 0.0),
+        assert(highlightElevation == null || highlightElevation >= 0.0),
+        assert(disabledElevation == null || disabledElevation >= 0.0),
+        assert(clipBehavior != null),
+        super(
+          key: key,
+          onPressed: onPressed,
+          onLongPress: onLongPress,
+          onHighlightChanged: onHighlightChanged,
+          mouseCursor: mouseCursor,
+          textTheme: textTheme,
+          textColor: textColor,
+          disabledTextColor: disabledTextColor,
+          color: color,
+          disabledColor: disabledColor,
+          focusColor: focusColor,
+          hoverColor: hoverColor,
+          highlightColor: highlightColor,
+          splashColor: splashColor,
+          colorBrightness: colorBrightness,
+          elevation: elevation,
+          focusElevation: focusElevation,
+          hoverElevation: hoverElevation,
+          highlightElevation: highlightElevation,
+          disabledElevation: disabledElevation,
+          padding: padding,
+          visualDensity: visualDensity,
+          shape: shape,
+          clipBehavior: clipBehavior,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          materialTapTargetSize: materialTapTargetSize,
+          animationDuration: animationDuration,
+          child: child,
+        );
+
+  /// Create an adaptive filled button that displays [CupertinoButton] in iOS.
+  ///
+  /// The [autofocus] and [clipBehavior] arguments must not be null.
+  /// Additionally,  [elevation], [hoverElevation], [focusElevation],
+  /// [highlightElevation], and [disabledElevation] must be non-negative, if
+  /// specified.
+  ///
+  /// The [onLongPress], [onHighlightChanged], [mouseCursor], [textTheme], 
+  /// [textColor], [disabledTextColor], [color], [disabledColor], [focusColor], 
+  /// [hoverColor], [highlightColor], [splashColor], [colorBrightness], 
+  /// [elevation], [focusElevation], [hoverElevation], [highlightElevation], 
+  /// [disabledElevation], [visualDensity], [shape], [clipBehavior], 
+  /// [focusNode], [autofocus], [materialTapTargetSize], and 
+  /// [animationDuration] parameters are ignore in iOS.
+  const RaisedButton.adaptive({
+    Key? key,
+    required VoidCallback? onPressed,
+    VoidCallback? onLongPress,
+    ValueChanged<bool>? onHighlightChanged,
+    MouseCursor? mouseCursor,
+    ButtonTextTheme? textTheme,
+    Color? textColor,
+    Color? disabledTextColor,
+    Color? color,
+    Color? disabledColor,
+    Color? focusColor,
+    Color? hoverColor,
+    Color? highlightColor,
+    Color? splashColor,
+    Brightness? colorBrightness,
+    double? elevation,
+    double? focusElevation,
+    double? hoverElevation,
+    double? highlightElevation,
+    double? disabledElevation,
+    EdgeInsetsGeometry? padding,
+    VisualDensity? visualDensity,
+    ShapeBorder? shape,
+    Clip clipBehavior = Clip.none,
+    FocusNode? focusNode,
+    bool autofocus = false,
+    MaterialTapTargetSize? materialTapTargetSize,
+    Duration? animationDuration,
+    Widget? child,
+  })  : _buttonType = _RaisedButtonType.adaptive,
+        assert(child != null),
+        assert(autofocus != null),
+        assert(elevation == null || elevation >= 0.0),
+        assert(focusElevation == null || focusElevation >= 0.0),
+        assert(hoverElevation == null || hoverElevation >= 0.0),
+        assert(highlightElevation == null || highlightElevation >= 0.0),
+        assert(disabledElevation == null || disabledElevation >= 0.0),
+        assert(clipBehavior != null),
+        super(
+          key: key,
+          onPressed: onPressed,
+          onLongPress: onLongPress,
+          onHighlightChanged: onHighlightChanged,
+          mouseCursor: mouseCursor,
+          textTheme: textTheme,
+          textColor: textColor,
+          disabledTextColor: disabledTextColor,
+          color: color,
+          disabledColor: disabledColor,
+          focusColor: focusColor,
+          hoverColor: hoverColor,
+          highlightColor: highlightColor,
+          splashColor: splashColor,
+          colorBrightness: colorBrightness,
+          elevation: elevation,
+          focusElevation: focusElevation,
+          hoverElevation: hoverElevation,
+          highlightElevation: highlightElevation,
+          disabledElevation: disabledElevation,
+          padding: padding,
+          visualDensity: visualDensity,
+          shape: shape,
+          clipBehavior: clipBehavior,
+          focusNode: focusNode,
+          autofocus: autofocus,
+          materialTapTargetSize: materialTapTargetSize,
+          animationDuration: animationDuration,
+          child: child,
+        );
 
   /// Create a filled button from a pair of widgets that serve as the button's
   /// [icon] and [label].
@@ -225,8 +314,19 @@ class RaisedButton extends MaterialButton {
     required Widget label,
   }) = _RaisedButtonWithIcon;
 
-  @override
-  Widget build(BuildContext context) {
+  final _RaisedButtonType _buttonType;
+
+  Widget _buildCupertinoButton(BuildContext context) {
+    return CupertinoButton.filled(
+        key: key,
+        disabledColor: disabledColor ?? CupertinoColors.quaternarySystemFill,
+        padding: padding,
+        child: child!,
+        onPressed: onPressed,
+      );
+  }
+
+  Widget _buildMaterialButton(BuildContext context) {
     final ThemeData theme = Theme.of(context)!;
     final ButtonThemeData buttonTheme = ButtonTheme.of(context);
     return RawMaterialButton(
@@ -256,6 +356,27 @@ class RaisedButton extends MaterialButton {
       materialTapTargetSize: buttonTheme.getMaterialTapTargetSize(this),
       child: child,
     );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (_buttonType) {
+      case _RaisedButtonType.material:
+        return _buildMaterialButton(context);
+      case _RaisedButtonType.adaptive:
+        final ThemeData theme = Theme.of(context)!;
+        assert(theme.platform != null);
+        switch (theme.platform) {
+          case TargetPlatform.iOS:
+          case TargetPlatform.macOS:
+            return _buildCupertinoButton(context);
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            return _buildMaterialButton(context);
+        }
+    }
   }
 
   @override

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -727,6 +728,54 @@ void main() {
     expect(paddingRect.top, tallerWidget.top - 5);
     expect(paddingRect.bottom, tallerWidget.bottom + 12);
   });
+
+  testWidgets(
+    'Adaptive RaisedButton displays CupertinoButton in iOS',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Material(
+              child: RaisedButton.adaptive(
+                child: Text("Button"),
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoButton), findsOneWidget);
+    }, variant: const TargetPlatformVariant(<TargetPlatform> {
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    })
+  );
+
+  testWidgets(
+    'Adaptive RaisedButton does not display CupertinoButton in non-iOS',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Material(
+              child: RaisedButton.adaptive(
+                child: Text("Button"),
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoButton), findsNothing);
+    }, variant: const TargetPlatformVariant(<TargetPlatform> {
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+    }),
+  );
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
## Description

Adaptive implementation for `RaisedButton` per #33830

![ezgif-1-4dcdd7c0c7cb](https://user-images.githubusercontent.com/11810973/97546524-cd450a80-1989-11eb-8470-690f78b12cbb.gif)


## Tests

Added the following basic tests:
- Adaptive `RaisedButton` displays `CupertinoButton` in iOS
- Adaptive `RaisedButton` does not display `CupertinoButton` in non-iOS

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
