### PR TITLE
UnconstrainedBox overflow indicator should not shown when overflowing but [clipBehavior] is not [Clip.none]

### DIFF
--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -715,17 +715,17 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
     if (clipBehavior == Clip.none) {
       _clipRectLayer = null;
       super.paint(context, offset);
+
+      // Display the overflow indicator.
+      assert(() {
+        paintOverflowIndicator(context, offset, _overflowContainerRect, _overflowChildRect);
+        return true;
+      }());
     } else {
       // We have overflow and the clipBehavior isn't none. Clip it.
       _clipRectLayer = context.pushClipRect(needsCompositing, offset, Offset.zero & size, super.paint,
           clipBehavior: clipBehavior, oldLayer:_clipRectLayer);
     }
-
-    // Display the overflow indicator.
-    assert(() {
-      paintOverflowIndicator(context, offset, _overflowContainerRect, _overflowChildRect);
-      return true;
-    }());
   }
 
   ClipRectLayer? _clipRectLayer;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2291,9 +2291,9 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 /// If the box cannot expand enough to accommodate the entire child, the
 /// child will be clipped.
 ///
-/// In debug mode, if the child overflows the container, a warning will be
-/// printed on the console, and black and yellow striped areas will appear where
-/// the overflow occurs.
+/// In debug mode, if the child overflows the container and the [clipBehavior]
+/// is [Clip.none], a warning will be printed on the console, and black and
+/// yellow striped areas will appear where the overflow occurs.
 ///
 /// See also:
 ///

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -344,6 +344,23 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
+  testWidgets('overflow indicator is not shown when overflowing but [clipBehavior] is not [Clip.none]', (WidgetTester tester) async {
+    const UnconstrainedBox box = UnconstrainedBox(
+      clipBehavior: Clip.hardEdge,
+      child: SizedBox(width: 200.0, height: 200.0),
+    );
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          height: 100.0,
+          child: box,
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
   group('ColoredBox', () {
     late _MockCanvas mockCanvas;
     late _MockPaintingContext mockContext;


### PR DESCRIPTION
## Description

Currently, I am using a `UnconstrainedBox` to prevent parent constraints and clip the overflows, but there is an assert at debug mode.

From #55977, `UnconstrainedBox` widget can specify `clipBehavior`, So when the user specifies that the `clipBehavior` is not `[Clip.none]`, it is more reasonable to not display the overflow indicator.

@liyuqian Hi, also waiting for your opinions :)


## Tests

I added the following tests:

See files.