### PR TITLE
Restart EditableText cursor timer when it moves

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1706,6 +1706,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     _lastKnownRemoteTextEditingValue = value;
 
+    if (_hasInputConnection) {
+      // To keep the cursor from blinking while typing, we want to restart the
+      // cursor timer every time a new character is typed or the cursor moves.
+      _stopCursorTimer(resetCharTicks: false);
+      _startCursorTimer();
+    }
+
     if (value == _value) {
       // This is possible, for example, when the numeric keyboard is input,
       // the engine will notify twice for the same value.
@@ -1729,13 +1736,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       }
 
       _formatAndSetValue(value);
-    }
-
-    if (_hasInputConnection) {
-      // To keep the cursor from blinking while typing, we want to restart the
-      // cursor timer every time a new character is typed.
-      _stopCursorTimer(resetCharTicks: false);
-      _startCursorTimer();
     }
   }
 


### PR DESCRIPTION
## Description

Move the call to reset the cursor timer in EditableText before return statements so that it's reset on any key move.

## Related Issues

#69321 

## Tests

No new tests added. Tests run:

```
% flutter test test/widgets/editable_text_cursor_test.dart
Running "flutter pub get" in flutter...                            563ms
00:15 +23: All tests passed!                                                                                                            

% flutter test test/widgets/editable_text_show_on_screen_test.dart 
Running "flutter pub get" in flutter...                            585ms
00:04 +9: All tests passed!                                                                                                             

% flutter test test/widgets/editable_text_test.dart 
Running "flutter pub get" in flutter...                            581ms
00:10 +146: All tests passed!                                                                                                           
```

One test not run due to test issue (missing main method):
```
% flutter test test/widgets/editable_text_utils.dart 
Running "flutter pub get" in flutter...                            525ms
00:01 +0: loading /Library/Frameworks/flutter/packages/flutter/test/widgets/editable_text_utils.dart                                    /var/folders/4h/fx7mwh115nd3n96lsdg3wc800000gn/T/flutter_tools.B84nb9/flutter_test_listener.dsLund/listener.dart:46:50: Error: Getter not
found: 'main'.
    return () => test_config.testExecutable(test.main);
                                                 ^^^^  
00:01 +0 -1: Some tests failed.                                                         
```

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
