### PR TITLE
Mark flutter_gallery_sksl_warmup__transition_perf_e2e_ios32 as unflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -228,7 +228,6 @@ tasks:
       with SkSL shader warm-up with e2e.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
-    flaky: true
 
   backdrop_filter_perf__timeline_summary:
     description: >


### PR DESCRIPTION
## Description

Hopefully https://github.com/flutter/flutter/pull/69260 unflaked this for awhile, though it started succeeding again after a reboot before that merged.

Mark as unflaky so it gets proper P1 attention when it starts failing again.

## Related Issues

#69260
https://github.com/flutter/flutter/pull/69259