### PR TITLE
Do not fail if average_memory_usage is not recorded

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -669,7 +669,8 @@ class PerfTest {
             if (data['average_gpu_usage'] != null) 'average_gpu_usage',
           ],
           if (measureMemory && !isAndroid) ...<String>[
-            'average_memory_usage',
+            // See https://github.com/flutter/flutter/issues/68888
+            if (data['average_memory_usage'] != null) 'average_memory_usage',
             '90th_percentile_memory_usage',
             '99th_percentile_memory_usage',
           ],


### PR DESCRIPTION
## Description

Same as https://github.com/flutter/flutter/pull/69268 but include `average_memory_usage`.

## Related Issues

https://github.com/flutter/flutter/issues/68888