### PR TITLE
enable web_long_running_tests shard

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -133,6 +133,12 @@
          "flaky": false
       },
       {
+         "name": "Linux web_long_running_tests",
+         "repo": "flutter",
+         "task_name": "linux_web_long_running_tests",
+         "flaky": false
+      },
+      {
          "name":"Linux web_e2e_test",
          "repo":"flutter",
          "task_name":"linux_web_e2e_test",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -154,6 +154,13 @@
          "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_tools/", "packages/flutter_web_plugins/", "bin/"]
       },
       {
+         "name": "Linux web_long_running_tests",
+         "repo":"flutter",
+         "task_name":"web_long_running_tests",
+         "enabled":true,
+         "run_if":["dev/", "packages/", "bin/"]
+      },
+      {
         "name":"Linux web_e2e_test",
         "repo":"flutter",
         "task_name":"linux_web_e2e_test",


### PR DESCRIPTION
## Description

Enable web_long_running_tests shard. The `led` runs are successful:

- https://ci.chromium.org/p/flutter/builders/try/Linux%20SDK%20Drone/91634?
- https://ci.chromium.org/p/flutter/builders/try/Linux%20SDK%20Drone/91635?
- https://ci.chromium.org/p/flutter/builders/try/Linux%20SDK%20Drone/91642?

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69028
