### PR TITLE
[flutter_tools] Make flutter upgrade --verify-only display framework version differences instead of commit hashes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -113,7 +113,6 @@ class UpgradeCommandRunner {
       return;
     } else if (verifyOnly) {
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
-      // TODO(fujino): use a [FlutterVersion] once that class supports arbitrary revisions.
       globals.printStatus('The latest version: ${gitTagVersion.frameworkVersionFor(upstreamRevision)}', emphasis: true);
       globals.printStatus('Your current version: ${flutterVersion.frameworkVersion}\n');
       globals.printStatus('To upgrade now, run "flutter upgrade".');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -113,8 +113,8 @@ class UpgradeCommandRunner {
       return;
     } else if (verifyOnly) {
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
-      globals.printStatus('The latest version: ${upstreamVersion.frameworkVersion}(revision ${upstreamVersion.frameworkRevisionShort})', emphasis: true);
-      globals.printStatus('Your current version: ${flutterVersion.frameworkVersion}(revision ${flutterVersion.frameworkRevisionShort})\n');
+      globals.printStatus('The latest version: ${upstreamVersion.frameworkVersion} (revision ${upstreamVersion.frameworkRevisionShort})', emphasis: true);
+      globals.printStatus('Your current version: ${flutterVersion.frameworkVersion} (revision ${flutterVersion.frameworkRevisionShort})\n');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
       if (flutterVersion.channel == 'stable') {
         globals.printStatus('\nSee the announcement and release notes:');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -152,7 +152,6 @@ class UpgradeCommandRunner {
       );
     }
     recordState(flutterVersion);
-    await upgradeChannel(flutterVersion);
     await attemptReset(upstreamVersion.frameworkRevision);
     if (!testFlow) {
       await flutterUpgradeContinue();

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -114,8 +114,8 @@ class UpgradeCommandRunner {
     } else if (verifyOnly) {
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
       // TODO(fujino): use a [FlutterVersion] once that class supports arbitrary revisions.
-      globals.printStatus('The latest revision: $upstreamRevision', emphasis: true);
-      globals.printStatus('Your current version: ${flutterVersion.frameworkRevision}\n');
+      globals.printStatus('The latest version: ${gitTagVersion.frameworkVersionFor(upstreamRevision)}', emphasis: true);
+      globals.printStatus('Your current version: ${flutterVersion.frameworkVersion}\n');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
       if (flutterVersion.channel == 'stable') {
         globals.printStatus('\nSee the announcement and release notes:');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -112,9 +112,10 @@ class UpgradeCommandRunner {
       globals.printStatus('$flutterVersion');
       return;
     } else if (verifyOnly) {
+      final GitTagVersion upstreamGitTag = GitTagVersion.determine(globals.processUtils, commitRevision: upstreamRevision);
       globals.printStatus('A new version of Flutter is available on channel ${flutterVersion.channel}\n');
-      globals.printStatus('The latest version: ${gitTagVersion.frameworkVersionFor(upstreamRevision)}', emphasis: true);
-      globals.printStatus('Your current version: ${flutterVersion.frameworkVersion}\n');
+      globals.printStatus('The latest version: ${upstreamGitTag.frameworkVersionFor(upstreamRevision)}(revision ${upstreamGitTag.hash}', emphasis: true);
+      globals.printStatus('Your current version: ${flutterVersion.frameworkVersion}(revision ${flutterVersion.frameworkRevisionShort})\n');
       globals.printStatus('To upgrade now, run "flutter upgrade".');
       if (flutterVersion.channel == 'stable') {
         globals.printStatus('\nSee the announcement and release notes:');

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -252,7 +252,7 @@ class UpgradeCommandRunner {
         throwToolExit(errorString);
       }
     }
-    return FlutterVersion(const SystemClock(), workingDirectory, revision);
+    return FlutterVersion(workingDirectory: workingDirectory, frameworkRevision: revision);
   }
 
   /// Attempts a hard reset to the given revision.

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -745,7 +745,7 @@ class GitTagVersion {
       }
     }
     final List<String> tags = _runGit(
-      'git tag --points-at $gitRef, processUtils, workingDirectory).trim().split('\n');
+      'git tag --points-at $gitRef', processUtils, workingDirectory).trim().split('\n');
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -733,7 +733,7 @@ class GitTagVersion {
   /// The git tag that is this version's closest ancestor.
   final String gitTag;
 
-  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false}) {
+  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String commitRevision}) {
     if (fetchTags) {
       final String channel = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
       if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
@@ -743,7 +743,7 @@ class GitTagVersion {
       }
     }
     final List<String> tags = _runGit(
-      'git tag --points-at HEAD', processUtils, workingDirectory).trim().split('\n');
+      'git tag --points-at ${commitRevision ?? 'HEAD'}', processUtils, workingDirectory).trim().split('\n');
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -61,7 +61,7 @@ class FlutterVersion {
     String workingDirectory,
     String frameworkRevision,
   }) : _clock = clock,
-      _workingDirectory = workingDirectory, {
+       _workingDirectory = workingDirectory {
     _frameworkRevision = frameworkRevision ?? _runGit(
       gitLog(<String>['-n', '1', '--pretty=format:%H']).join(' '),
       globals.processUtils,
@@ -73,7 +73,6 @@ class FlutterVersion {
 
   final SystemClock _clock;
   final String _workingDirectory;
-  final String _frameworkRevision;
 
   /// Fetches tags from the upstream Flutter repository and re-calculates the
   /// version.

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -59,19 +59,21 @@ class FlutterVersion {
   FlutterVersion({
     SystemClock clock = const SystemClock(),
     String workingDirectory,
+    String frameworkRevision,
   }) : _clock = clock,
-      _workingDirectory = workingDirectory {
-    _frameworkRevision = _runGit(
+      _workingDirectory = workingDirectory, {
+    _frameworkRevision = frameworkRevision ?? _runGit(
       gitLog(<String>['-n', '1', '--pretty=format:%H']).join(' '),
       globals.processUtils,
       _workingDirectory,
     );
-    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: false, commitHash: _frameworkRevision);
+    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: false, gitRef: _frameworkRevision);
     _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
   final SystemClock _clock;
   final String _workingDirectory;
+  final String _frameworkRevision;
 
   /// Fetches tags from the upstream Flutter repository and re-calculates the
   /// version.
@@ -733,7 +735,7 @@ class GitTagVersion {
   /// The git tag that is this version's closest ancestor.
   final String gitTag;
 
-  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String commitHash}) {
+  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String gitRef = 'HEAD'}) {
     if (fetchTags) {
       final String channel = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
       if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
@@ -743,7 +745,7 @@ class GitTagVersion {
       }
     }
     final List<String> tags = _runGit(
-      'git tag --points-at ${commitHash ?? 'HEAD'}', processUtils, workingDirectory).trim().split('\n');
+      'git tag --points-at $gitRef, processUtils, workingDirectory).trim().split('\n');
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');
@@ -764,7 +766,7 @@ class GitTagVersion {
     // recent tag and number of commits past.
     return parse(
       _runGit(
-        'git describe --match *.*.* --long --tags',
+        'git describe --match *.*.* --long --tags $gitRef',
         processUtils,
         workingDirectory,
       )

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -66,7 +66,7 @@ class FlutterVersion {
       globals.processUtils,
       _workingDirectory,
     );
-    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: false);
+    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: false, commitHash: _frameworkRevision);
     _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
@@ -733,7 +733,7 @@ class GitTagVersion {
   /// The git tag that is this version's closest ancestor.
   final String gitTag;
 
-  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String commitRevision}) {
+  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String commitHash}) {
     if (fetchTags) {
       final String channel = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
       if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
@@ -743,7 +743,7 @@ class GitTagVersion {
       }
     }
     final List<String> tags = _runGit(
-      'git tag --points-at ${commitRevision ?? 'HEAD'}', processUtils, workingDirectory).trim().split('\n');
+      'git tag --points-at ${commitHash ?? 'HEAD'}', processUtils, workingDirectory).trim().split('\n');
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -44,7 +44,7 @@ void main() {
       fakePlatform = FakePlatform()..environment = Map<String, String>.unmodifiable(<String, String>{
         'ENV1': 'irrelevant',
         'ENV2': 'irrelevant',
-      })..version = '1.2.3-dev-4.5';
+      });
     });
 
     testUsingContext('throws on unknown tag, official branch,  noforce', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -101,8 +101,10 @@ void main() {
 
     testUsingContext('Correctly provides upgrade version on verify only', () async {
       const String revision = 'abc123';
+      const String upstreamRevision = 'def456';
       when(flutterVersion.frameworkRevision).thenReturn(revision);
       fakeCommandRunner.alreadyUpToDate = false;
+      fakeCommandRunner.remoteRevision = upstreamRevision;
       final Future<FlutterCommandResult> result = fakeCommandRunner.runCommand(
         force: false,
         continueFlow: false,
@@ -113,8 +115,8 @@ void main() {
       );
       expect(await result, FlutterCommandResult.success());
       expect(testLogger.statusText, contains('A new version of Flutter is available'));
-      expect(testLogger.statusText, contains(fakeCommandRunner.remoteRevision));
-      expect(testLogger.statusText, contains(revision));
+      expect(testLogger.statusText, contains('The latest version: ${gitTagVersion.frameworkVersionFor(fakeCommandRunner.remoteRevision)}'));
+      expect(testLogger.statusText, contains('Your current version: ${flutterVersion.frameworkVersion}'));
       expect(processManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -126,9 +126,9 @@ void main() {
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync('git fetch https://github.com/flutter/flutter.git --tags'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
-        when(processManager.runSync('git tag --points-at HEAD'.split(' '),
+        when(processManager.runSync('git tag --points-at random'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
-        when(processManager.runSync('git describe --match *.*.* --long --tags'.split(' '),
+        when(processManager.runSync('git describe --match *.*.* --long --tags random'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync(FlutterVersion.gitLog('-n 1 --pretty=format:%ad --date=iso'.split(' ')),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -77,11 +77,11 @@ void main() {
         ));
 
         processManager.addCommand(const FakeCommand(
-          command: <String>['git', 'tag', '--points-at', 'HEAD'],
+          command: <String>['git', 'tag', '--points-at', '1234abcd'],
         ));
 
         processManager.addCommand(const FakeCommand(
-          command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+          command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', '1234abcd'],
           stdout: '0.1.2-3-1234abcd',
         ));
 
@@ -563,7 +563,7 @@ void main() {
           stdout: '', // no tag
         ),
         const FakeCommand(
-          command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+          command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
           stdout: '$devTag-$commitsAhead-g$headRevision',
         ),
       ],
@@ -585,7 +585,7 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(105, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(106, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
@@ -611,7 +611,7 @@ void main() {
       environment: anyNamed('environment'),
     ));
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);
@@ -630,7 +630,7 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(106, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
@@ -656,7 +656,7 @@ void main() {
       environment: anyNamed('environment'),
     ));
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);
@@ -683,7 +683,7 @@ void main() {
       <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(111, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
@@ -701,7 +701,7 @@ void main() {
       environment: anyNamed('environment'),
     )).called(1);
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);
@@ -728,7 +728,7 @@ void main() {
       <String>['git', 'tag', '--points-at', 'HEAD'],
     ));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(111, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
@@ -861,12 +861,12 @@ void fakeData(
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(105, 0, '', ''));
   when(pm.runSync(
-    <String>['git', 'tag', '--points-at', 'HEAD'],
+    <String>['git', 'tag', '--points-at', '1234abcd'],
     workingDirectory: anyNamed('workingDirectory'),
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(106, 0, '', ''));
   when(pm.runSync(
-    <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags'],
+    <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', '1234abcd'],
     workingDirectory: anyNamed('workingDirectory'),
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''));

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -419,12 +419,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   List<String> xcrunCommand() => <String>['xcrun'];
 }
 
-class MockFlutterVersion extends Mock implements FlutterVersion {
-  MockFlutterVersion({bool isStable = false, String revision}) {
-    when(frameworkRevision).thenReturn(revision);
-    when(frameworkRevisionShort).thenReturn(revision);
-  }
-}
+class MockFlutterVersion extends Mock implements FlutterVersion {}
 
 class MockClock extends Mock implements SystemClock {}
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -419,7 +419,12 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   List<String> xcrunCommand() => <String>['xcrun'];
 }
 
-class MockFlutterVersion extends Mock implements FlutterVersion {}
+class MockFlutterVersion extends Mock implements FlutterVersion {
+  MockFlutterVersion({bool isStable = false, String revision}) {
+    when(frameworkRevision).thenReturn(revision);
+    when(frameworkRevisionShort).thenReturn(revision);
+  }
+}
 
 class MockClock extends Mock implements SystemClock {}
 


### PR DESCRIPTION
## Description
This PR changes the display message when one runs `flutter upgrade --verify-only`, having an available update; namely, replacing the commit hashes with the framework versions.

## Related Issues
Fixes #69417.

## Tests
I modified:
 - Most tests in `upgrade_test.dart` which use `fetchLatestVersion`.
 - Some tests in `version_test.dart` that run `git tag --points-at` and `git describe...`
 - A test in `flutter_command_runner_test.dart` to check whether Flutter toJson o/p reports the flutter framework version.

## Checklist
Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
Did any tests fail when you ran them? Please read [Handling breaking changes].
- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
