### PR TITLE
start and stop chromedriver once per sub-shard; do not wait for it to quit

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -157,7 +157,7 @@
          "name": "Linux web_long_running_tests",
          "repo":"flutter",
          "task_name":"web_long_running_tests",
-         "enabled":false,
+         "enabled":true,
          "run_if":["dev/", "packages/", "bin/"]
       },
       {


### PR DESCRIPTION
## Description

Start one shared instance of chromedriver and quit it at the end. This removes the need to check for driver connection at the end of the test, which seems to be leaving sockets that are not fully closed.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69421
