### PR TITLE
Standardize dartdoc macro names

### DIFF
--- a/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
@@ -26,11 +26,9 @@ class AndroidPlatformView extends StatelessWidget {
   /// A PlatformViewFactory for this type must have been registered.
   final String viewType;
 
-  /// {@template flutter.widgets.platformViews.createdParam}
   /// Callback to invoke after the platform view has been created.
   ///
   /// May be null.
-  /// {@endtemplate}
   final PlatformViewCreatedCallback onPlatformViewCreated;
 
   @override

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -578,7 +578,7 @@ class Curve2DSample {
 /// smoothly from one control point to the next, passing through the control
 /// points.
 ///
-/// {@template flutter.animation.curves.catmull_rom_description}
+/// {@template flutter.animation.CatmullRomSpline}
 /// Unlike most cubic splines, Catmull-Rom splines have the advantage that their
 /// curves pass through the control points given to them. They are cubic
 /// polynomial representations, and, in fact, Catmull-Rom splines can be
@@ -766,7 +766,7 @@ class CatmullRomSpline extends Curve2D {
 /// smoothly from one control point to the next, passing through (0.0, 0.0), the
 /// given points, and then (1.0, 1.0).
 ///
-/// {@macro flutter.animation.curves.catmull_rom_description}
+/// {@macro flutter.animation.CatmullRomSpline}
 ///
 /// This class uses a centripetal Catmull-Rom curve (a [CatmullRomSpline]) as
 /// its internal representation. The term centripetal implies that it won't form

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -226,7 +226,7 @@ class CupertinoApp extends StatefulWidget {
   /// This callback is passed along to the [WidgetsApp] built by this widget.
   final LocaleListResolutionCallback? localeListResolutionCallback;
 
-  /// {@macro flutter.widgets.widgetsApp.localeResolutionCallback}
+  /// {@macro flutter.widgets.LocaleResolutionCallback}
   ///
   /// This callback is passed along to the [WidgetsApp] built by this widget.
   final LocaleResolutionCallback? localeResolutionCallback;

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -235,7 +235,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
        ),
        super(key: key);
 
-  /// {@template flutter.cupertino.navBar.leading}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.leading}
   /// Widget to place at the start of the navigation bar. Normally a back button
   /// for a normal page or a cancel button for full page dialogs.
   ///
@@ -244,7 +244,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Widget? leading;
 
-  /// {@template flutter.cupertino.navBar.automaticallyImplyLeading}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
   /// Controls whether we should try to imply the leading widget if null.
   ///
   /// If true and [leading] is null, automatically try to deduce what the [leading]
@@ -272,7 +272,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// This value cannot be null.
   final bool automaticallyImplyMiddle;
 
-  /// {@template flutter.cupertino.navBar.previousPageTitle}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
   /// Manually specify the previous route's title when automatically implying
   /// the leading back button.
   ///
@@ -293,7 +293,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// has a `title`.
   final Widget? middle;
 
-  /// {@template flutter.cupertino.navBar.trailing}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.trailing}
   /// Widget to place at the end of the navigation bar. Normally additional actions
   /// taken on the page such as a search or edit function.
   /// {@endtemplate}
@@ -302,7 +302,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   // TODO(xster): https://github.com/flutter/flutter/issues/10469 implement
   // support for double row navigation bars.
 
-  /// {@template flutter.cupertino.navBar.backgroundColor}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.backgroundColor}
   /// The background color of the navigation bar. If it contains transparency, the
   /// tab bar will automatically produce a blurring effect to the content
   /// behind it.
@@ -311,7 +311,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Color? backgroundColor;
 
-  /// {@template flutter.cupertino.navBar.brightness}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.brightness}
   /// The brightness of the specified [backgroundColor].
   ///
   /// Setting this value changes the style of the system status bar. Typically
@@ -323,7 +323,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final Brightness? brightness;
 
-  /// {@template flutter.cupertino.navBar.padding}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.padding}
   /// Padding for the contents of the navigation bar.
   ///
   /// If null, the navigation bar will adopt the following defaults:
@@ -338,14 +338,14 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final EdgeInsetsDirectional? padding;
 
-  /// {@template flutter.cupertino.navBar.border}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.border}
   /// The border of the navigation bar. By default renders a single pixel bottom border side.
   ///
   /// If a border is null, the navigation bar will not display a border.
   /// {@endtemplate}
   final Border? border;
 
-  /// {@template flutter.cupertino.navBar.actionsForegroundColor}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.actionsForegroundColor}
   /// Default color used for text and icons of the [leading] and [trailing]
   /// widgets in the navigation bar.
   ///
@@ -360,7 +360,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   )
   final Color? actionsForegroundColor;
 
-  /// {@template flutter.cupertino.navBar.transitionBetweenRoutes}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.transitionBetweenRoutes}
   /// Whether to transition between navigation bars.
   ///
   /// When [transitionBetweenRoutes] is true, this navigation bar will transition
@@ -379,7 +379,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   /// {@endtemplate}
   final bool transitionBetweenRoutes;
 
-  /// {@template flutter.cupertino.navBar.heroTag}
+  /// {@template flutter.cupertino.CupertinoNavigationBar.heroTag}
   /// Tag for the navigation bar's Hero widget if [transitionBetweenRoutes] is true.
   ///
   /// Defaults to a common tag between all [CupertinoNavigationBar] and
@@ -608,12 +608,12 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// ([CupertinoPageRoute.title]) and [automaticallyImplyTitle] must be true.
   final Widget? largeTitle;
 
-  /// {@macro flutter.cupertino.navBar.leading}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.leading}
   ///
   /// This widget is visible in both collapsed and expanded states.
   final Widget? leading;
 
-  /// {@macro flutter.cupertino.navBar.automaticallyImplyLeading}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading}
   final bool automaticallyImplyLeading;
 
   /// Controls whether we should try to imply the [largeTitle] widget if null.
@@ -625,7 +625,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// This value cannot be null.
   final bool automaticallyImplyTitle;
 
-  /// {@macro flutter.cupertino.navBar.previousPageTitle}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
   final String? previousPageTitle;
 
   /// A widget to place in the middle of the static navigation bar instead of
@@ -636,24 +636,24 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// [middle] widget is provided.
   final Widget? middle;
 
-  /// {@macro flutter.cupertino.navBar.trailing}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}
   ///
   /// This widget is visible in both collapsed and expanded states.
   final Widget? trailing;
 
-  /// {@macro flutter.cupertino.navBar.backgroundColor}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.backgroundColor}
   final Color? backgroundColor;
 
-  /// {@macro flutter.cupertino.navBar.brightness}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.brightness}
   final Brightness? brightness;
 
-  /// {@macro flutter.cupertino.navBar.padding}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.padding}
   final EdgeInsetsDirectional? padding;
 
-  /// {@macro flutter.cupertino.navBar.border}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.border}
   final Border? border;
 
-  /// {@macro flutter.cupertino.navBar.actionsForegroundColor}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.actionsForegroundColor}
   ///
   /// The default color for text in the [largeTitle] slot is always black, as per
   /// iOS standard design.
@@ -663,10 +663,10 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   )
   final Color? actionsForegroundColor;
 
-  /// {@macro flutter.cupertino.navBar.transitionBetweenRoutes}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.transitionBetweenRoutes}
   final bool transitionBetweenRoutes;
 
-  /// {@macro flutter.cupertino.navBar.heroTag}
+  /// {@macro flutter.cupertino.CupertinoNavigationBar.heroTag}
   final Object heroTag;
 
   /// True if the navigation bar's background color has no transparency.

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -99,7 +99,7 @@ class CupertinoPicker extends StatefulWidget {
   ///
   /// The [itemBuilder] argument must not be null. The [childCount] argument
   /// reflects the number of children that will be provided by the [itemBuilder].
-  /// {@macro flutter.widgets.wheelList.childCount}
+  /// {@macro flutter.widgets.ListWheelChildBuilderDelegate.childCount}
   ///
   /// The [itemExtent] argument must be non-null and positive.
   ///
@@ -150,13 +150,13 @@ class CupertinoPicker extends StatefulWidget {
   /// wheel list edge fade gradient from rendering of the widget.
   final Color? backgroundColor;
 
-  /// {@macro flutter.rendering.wheelList.offAxisFraction}
+  /// {@macro flutter.rendering.RenderListWheelViewport.offAxisFraction}
   final double offAxisFraction;
 
-  /// {@macro flutter.rendering.wheelList.useMagnifier}
+  /// {@macro flutter.rendering.RenderListWheelViewport.useMagnifier}
   final bool useMagnifier;
 
-  /// {@macro flutter.rendering.wheelList.magnification}
+  /// {@macro flutter.rendering.RenderListWheelViewport.magnification}
   final double magnification;
 
   /// A [FixedExtentScrollController] to read and control the current item, and
@@ -171,7 +171,7 @@ class CupertinoPicker extends StatefulWidget {
   /// height. Must not be null and must be positive.
   final double itemExtent;
 
-  /// {@macro flutter.rendering.wheelList.squeeze}
+  /// {@macro flutter.rendering.RenderListWheelViewport.squeeze}
   ///
   /// Defaults to `1.45` to visually mimic iOS.
   final double squeeze;

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -96,7 +96,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @protected
   Widget buildContent(BuildContext context);
 
-  /// {@template flutter.cupertino.cupertinoRouteTransitionMixin.title}
+  /// {@template flutter.cupertino.CupertinoRouteTransitionMixin.title}
   /// A title string for this route.
   ///
   /// Used to auto-populate [CupertinoNavigationBar] and
@@ -433,13 +433,13 @@ class CupertinoPage<T> extends Page<T> {
   /// The content to be shown in the [Route] created by this page.
   final Widget child;
 
-  /// {@macro flutter.cupertino.cupertinoRouteTransitionMixin.title}
+  /// {@macro flutter.cupertino.CupertinoRouteTransitionMixin.title}
   final String? title;
 
-  /// {@macro flutter.widgets.modalRoute.maintainState}
+  /// {@macro flutter.widgets.ModalRoute.maintainState}
   final bool maintainState;
 
-  /// {@macro flutter.widgets.pageRoute.fullscreenDialog}
+  /// {@macro flutter.widgets.PageRoute.fullscreenDialog}
   final bool fullscreenDialog;
 
   @override

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -106,7 +106,7 @@ class CupertinoSwitch extends StatefulWidget {
   /// Defaults to [CupertinoColors.secondarySystemFill] when null.
   final Color? trackColor;
 
-  /// {@template flutter.cupertino.switch.dragStartBehavior}
+  /// {@template flutter.cupertino.CupertinoSwitch.dragStartBehavior}
   /// Determines the way that drag start behavior is handled.
   ///
   /// If set to [DragStartBehavior.start], the drag behavior used to move the

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -131,7 +131,7 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
 /// field (e.g., by pressing a button on the soft keyboard), the text field
 /// calls the [onSubmitted] callback.
 ///
-/// {@macro flutter.widgets.editableText.complexCharacters}
+/// {@macro flutter.widgets.EditableText.onChanged}
 ///
 /// To control the text that is displayed in the text field, use the
 /// [controller]. For example, to set the initial value of the text field, use
@@ -430,7 +430,7 @@ class CupertinoTextField extends StatefulWidget {
   /// paste and cut will be disabled regardless.
   final ToolbarOptions toolbarOptions;
 
-  /// {@macro flutter.widgets.inputDecorator.textAlignVertical}
+  /// {@macro flutter.material.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.readOnly}
@@ -451,13 +451,13 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
 
-  /// {@macro flutter.services.textInput.smartDashesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartDashesType}
   final SmartDashesType smartDashesType;
 
-  /// {@macro flutter.services.textInput.smartQuotesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
   final SmartQuotesType smartQuotesType;
 
-  /// {@macro flutter.services.textInput.enableSuggestions}
+  /// {@macro flutter.services.TextInputConfiguration.enableSuggestions}
   final bool enableSuggestions;
 
   /// {@macro flutter.widgets.editableText.maxLines}
@@ -579,7 +579,7 @@ class CupertinoTextField extends StatefulWidget {
   final GestureTapCallback? onTap;
 
   /// {@macro flutter.widgets.editableText.autofillHints}
-  /// {@macro flutter.services.autofill.autofillHints}
+  /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
   /// {@macro flutter.material.textfield.restorationId}

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -113,7 +113,7 @@ class CupertinoTheme extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -117,7 +117,7 @@ abstract class BindingBase {
   /// Implementations of this method must call their superclass
   /// implementation.
   ///
-  /// {@macro flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@macro flutter.foundation.BindingBase.registerServiceExtension}
   ///
   /// See also:
   ///
@@ -310,7 +310,7 @@ abstract class BindingBase {
   ///
   /// Calls the `callback` callback when the service extension is called.
   ///
-  /// {@macro flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@macro flutter.foundation.BindingBase.registerServiceExtension}
   @protected
   void registerSignalServiceExtension({
     required String name,
@@ -340,7 +340,7 @@ abstract class BindingBase {
   /// Calls the `setter` callback with the new value when the
   /// service extension method is called with a new value.
   ///
-  /// {@macro flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@macro flutter.foundation.BindingBase.registerServiceExtension}
   @protected
   void registerBoolServiceExtension({
     required String name,
@@ -374,7 +374,7 @@ abstract class BindingBase {
   /// Calls the `setter` callback with the new value when the
   /// service extension method is called with a new value.
   ///
-  /// {@macro flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@macro flutter.foundation.BindingBase.registerServiceExtension}
   @protected
   void registerNumericServiceExtension({
     required String name,
@@ -436,7 +436,7 @@ abstract class BindingBase {
   /// Calls the `setter` callback with the new value when the
   /// service extension method is called with a new value.
   ///
-  /// {@macro flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@macro flutter.foundation.BindingBase.registerServiceExtension}
   @protected
   void registerStringServiceExtension({
     required String name,
@@ -470,7 +470,7 @@ abstract class BindingBase {
   ///
   /// The returned map will be mutated.
   ///
-  /// {@template flutter.foundation.bindingBase.registerServiceExtension}
+  /// {@template flutter.foundation.BindingBase.registerServiceExtension}
   /// A registered service extension can only be activated if the vm-service
   /// is included in the build, which only happens in debug and profile mode.
   /// Although a service extension cannot be used in release mode its code may

--- a/packages/flutter/lib/src/gestures/eager.dart
+++ b/packages/flutter/lib/src/gestures/eager.dart
@@ -15,7 +15,7 @@ import 'recognizer.dart';
 class EagerGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Create an eager gesture recognizer.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   EagerGestureRecognizer({ PointerDeviceKind? kind }) : super(kind: kind);
 
   @override

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -120,7 +120,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
   /// to 1.0 for values of `pressure` that are between `pressureMin` and
   /// `pressureMax`.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   ForcePressGestureRecognizer({
     this.startPressure = 0.4,
     this.peakPressure = 0.85,

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -63,7 +63,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// [dragStartBehavior] must not be null.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   DragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
@@ -502,7 +502,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the vertical axis.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
@@ -543,7 +543,7 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
 class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the horizontal axis.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -114,7 +114,7 @@ class _TapTracker {
 class DoubleTapGestureRecognizer extends GestureRecognizer {
   /// Create a gesture recognizer for double taps.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   DoubleTapGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -61,7 +61,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// The argument is optional and is only used for debug purposes (e.g. in the
   /// [toString] serialization).
   ///
-  /// {@template flutter.gestures.gestureRecognizer.kind}
+  /// {@template flutter.gestures.GestureRecognizer.kind}
   /// It's possible to limit this recognizer to a specific [PointerDeviceKind]
   /// by providing the optional [kind] argument. If [kind] is null,
   /// the recognizer will accept pointer events from all device kinds.
@@ -219,7 +219,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
 abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   /// Initialize the object.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   OneSequenceGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
@@ -385,7 +385,7 @@ enum GestureRecognizerState {
 abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Initializes the [deadline] field during construction of subclasses.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   PrimaryPointerGestureRecognizer({
     this.deadline,
     this.preAcceptSlopTolerance = kTouchSlop,

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -222,7 +222,7 @@ class _LineBetweenPointers{
 class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Create a gesture recognizer for interactions intended for scaling content.
   ///
-  /// {@macro flutter.gestures.gestureRecognizer.kind}
+  /// {@macro flutter.gestures.GestureRecognizer.kind}
   ScaleGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -531,7 +531,7 @@ class MaterialApp extends StatefulWidget {
   /// This callback is passed along to the [WidgetsApp] built by this widget.
   final LocaleListResolutionCallback? localeListResolutionCallback;
 
-  /// {@macro flutter.widgets.widgetsApp.localeResolutionCallback}
+  /// {@macro flutter.widgets.LocaleResolutionCallback}
   ///
   /// This callback is passed along to the [WidgetsApp] built by this widget.
   final LocaleResolutionCallback? localeResolutionCallback;

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -62,7 +62,7 @@ class BottomAppBar extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   ///
   /// Typically this the child will be a [Row], with the first child
   /// being an [IconButton] with the [Icons.menu] icon.
@@ -93,7 +93,7 @@ class BottomAppBar extends StatefulWidget {
   /// be rectangular with no notch.
   final NotchedShape? shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -149,7 +149,7 @@ class BottomSheet extends StatefulWidget {
   /// Defaults to null and falls back to [Material]'s default.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defines the bottom sheet's [Material.clipBehavior].
   ///

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -116,7 +116,7 @@ class RawMaterialButton extends StatefulWidget {
   /// [State.setState] is not allowed).
   final ValueChanged<bool>? onHighlightChanged;
 
-  /// {@template flutter.material.button.mouseCursor}
+  /// {@template flutter.material.RawMaterialButton.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// button.
   ///
@@ -296,7 +296,7 @@ class RawMaterialButton extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -70,7 +70,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// Null by default.
   final ButtonStyle? style;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -155,7 +155,7 @@ class Card extends StatelessWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// If this property is null then [CardTheme.clipBehavior] of
   /// [ThemeData.cardTheme] is used. If that's null then the behavior will be [Clip.none].
@@ -185,7 +185,7 @@ class Card extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   static const double _defaultElevation = 1.0;

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -386,7 +386,7 @@ class CheckboxListTile extends StatelessWidget {
   /// If tristate is false (the default), [value] must not be null.
   final bool tristate;
 
-  /// {@macro flutter.material.ListTile.shape}
+  /// {@macro flutter.material.ListTileTheme.shape}
   final ShapeBorder? shape;
 
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -128,7 +128,7 @@ abstract class ChipAttributes {
   ///  * [MaterialState.pressed].
   OutlinedBorder? get shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior;

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -216,7 +216,7 @@ class DataCell {
   /// text should be provided instead, and [placeholder] should be set
   /// to true.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Whether the [child] is actually a placeholder.
@@ -499,7 +499,7 @@ class DataTable extends StatelessWidget {
   /// translucent color. To set a different color for individual rows, see
   /// [DataRow.color].
   ///
-  /// {@template flutter.material.dataTable.dataRowColorCode}
+  /// {@template flutter.material.DataTable.dataRowColor}
   /// ```dart
   /// DataTable(
   ///   dataRowColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
@@ -547,7 +547,7 @@ class DataTable extends StatelessWidget {
   ///
   /// If null, [DataTableThemeData.headingRowColor] is used.
   ///
-  /// {@template flutter.material.dataTable.headingRowColorCode}
+  /// {@template flutter.material.DataTable.headingRowColor}
   /// ```dart
   /// DataTable(
   ///   headingRowColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -51,7 +51,7 @@ class DataTableThemeData with Diagnosticable {
   final Decoration? decoration;
 
   /// {@macro flutter.material.dataTable.dataRowColor}
-  /// {@macro flutter.material.dataTable.dataRowColorCode}
+  /// {@macro flutter.material.DataTable.dataRowColor}
   final MaterialStateProperty<Color?>? dataRowColor;
 
   /// {@macro flutter.material.dataTable.dataRowHeight}
@@ -61,7 +61,7 @@ class DataTableThemeData with Diagnosticable {
   final TextStyle? dataTextStyle;
 
   /// {@macro flutter.material.dataTable.headingRowColor}
-  /// {@macro flutter.material.dataTable.headingRowColorCode}
+  /// {@macro flutter.material.DataTable.headingRowColor}
   final MaterialStateProperty<Color?>? headingRowColor;
 
   /// {@macro flutter.material.dataTable.headingRowHeight}

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -118,7 +118,7 @@ class Dialog extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   static const RoundedRectangleBorder _defaultDialogShape =

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -158,7 +158,7 @@ class Drawer extends StatelessWidget {
   ///
   /// Typically a [SliverList].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The semantic label of the dialog used by accessibility frameworks to
@@ -255,7 +255,7 @@ class DrawerController extends StatefulWidget {
   /// Optional callback that is called when a [Drawer] is opened or closed.
   final DrawerCallback? drawerCallback;
 
-  /// {@template flutter.material.drawer.dragStartBehavior}
+  /// {@template flutter.material.DrawerController.dragStartBehavior}
   /// Determines the way that drag start behavior is handled.
   ///
   /// If set to [DragStartBehavior.start], the drag behavior used for opening

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -68,7 +68,7 @@ class DrawerHeader extends StatelessWidget {
   /// This widget will be sized to the size of the header. To position the child
   /// precisely, consider using an [Align] or [Center] widget.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -290,7 +290,7 @@ class FloatingActionButton extends StatelessWidget {
   /// If this is set to null, the button will be disabled.
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.material.button.mouseCursor}
+  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
   final MouseCursor? mouseCursor;
 
   /// The z-coordinate at which to place this button relative to its parent.
@@ -381,7 +381,7 @@ class FloatingActionButton extends StatelessWidget {
   /// shape as well.
   final ShapeBorder? shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/grid_tile.dart
+++ b/packages/flutter/lib/src/material/grid_tile.dart
@@ -40,7 +40,7 @@ class GridTile extends StatelessWidget {
 
   /// The widget that fills the tile.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -276,7 +276,7 @@ class IconButton extends StatelessWidget {
   /// If this is set to null, the button will be disabled.
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.material.button.mouseCursor}
+  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
   ///
   /// Defaults to [SystemMouseCursors.click].
   final MouseCursor mouseCursor;

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -187,7 +187,7 @@ class Ink extends StatefulWidget {
 
   /// The [child] contained by the container.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// Empty space to inscribe inside the [decoration]. The [child], if any, is

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -325,7 +325,7 @@ class InkResponse extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// Called when the user taps this part of the material.

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1812,7 +1812,7 @@ class InputDecorator extends StatefulWidget {
   /// How the text in the decoration should be aligned horizontally.
   final TextAlign? textAlign;
 
-  /// {@template flutter.widgets.inputDecorator.textAlignVertical}
+  /// {@template flutter.material.InputDecorator.textAlignVertical}
   /// How the text should be aligned vertically.
   ///
   /// Determines the alignment of the baseline within the available space of

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -96,7 +96,7 @@ class ListTileTheme extends InheritedTheme {
   /// If true then [ListTile]s will have the vertically dense layout.
   final bool dense;
 
-  /// {@template flutter.material.ListTile.shape}
+  /// {@template flutter.material.ListTileTheme.shape}
   /// If specified, [shape] defines the shape of the [ListTile]'s [InkWell] border.
   /// {@endtemplate}
   final ShapeBorder? shape;

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -198,7 +198,7 @@ class Material extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The kind of material to show (e.g., card or canvas). This
@@ -275,7 +275,7 @@ class Material extends StatefulWidget {
   /// If false, the border will be painted behind the [child].
   final bool borderOnForeground;
 
-  /// {@template flutter.widgets.Clip}
+  /// {@template flutter.material.Material.clipBehavior}
   /// The content will be clipped (or not) according to this option.
   ///
   /// See the enum [Clip] for details of all possible options and their common
@@ -706,7 +706,7 @@ class _MaterialInterior extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The border of the widget.
@@ -721,7 +721,7 @@ class _MaterialInterior extends ImplicitlyAnimatedWidget {
   /// If false, the border will be painted behind the child.
   final bool borderOnForeground;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -130,7 +130,7 @@ class MaterialButton extends StatelessWidget {
   /// [State.setState] is not allowed).
   final ValueChanged<bool>? onHighlightChanged;
 
-  /// {@macro flutter.material.button.mouseCursor}
+  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
   final MouseCursor? mouseCursor;
 
   /// Defines the button's base colors, and the defaults for the button's minimum
@@ -352,7 +352,7 @@ class MaterialButton extends StatelessWidget {
   /// [ButtonThemeData.shape].
   final ShapeBorder? shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -46,7 +46,7 @@ class MaterialSlice extends MergeableMaterialItem {
 
   /// The contents of this slice.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -165,10 +165,10 @@ class MaterialPage<T> extends Page<T> {
   /// The content to be shown in the [Route] created by this page.
   final Widget child;
 
-  /// {@macro flutter.widgets.modalRoute.maintainState}
+  /// {@macro flutter.widgets.ModalRoute.maintainState}
   final bool maintainState;
 
-  /// {@macro flutter.widgets.pageRoute.fullscreenDialog}
+  /// {@macro flutter.widgets.PageRoute.fullscreenDialog}
   final bool fullscreenDialog;
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -29,7 +29,7 @@ enum _ActivityIndicatorType { material, adaptive }
 abstract class ProgressIndicator extends StatefulWidget {
   /// Creates a progress indicator.
   ///
-  /// {@template flutter.material.progressIndicator.parameters}
+  /// {@template flutter.material.ProgressIndicator.ProgressIndicator}
   /// The [value] argument can either be null for an indeterminate
   /// progress indicator, or non-null for a determinate progress
   /// indicator.
@@ -80,7 +80,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// environment.
   final Animation<Color?>? valueColor;
 
-  /// {@template flutter.material.progressIndicator.semanticsLabel}
+  /// {@template flutter.progress_indicator.ProgressIndicator.semanticsLabel}
   /// The [SemanticsProperties.label] for this progress indicator.
   ///
   /// This value indicates the purpose of the progress bar, and will be
@@ -92,7 +92,7 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticsLabel;
 
-  /// {@template flutter.material.progressIndicator.semanticsValue}
+  /// {@template flutter.progress_indicator.ProgressIndicator.semanticsValue}
   /// The [SemanticsProperties.value] for this progress indicator.
   ///
   /// This will be used in conjunction with the [semanticsLabel] by
@@ -252,7 +252,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 class LinearProgressIndicator extends ProgressIndicator {
   /// Creates a linear progress indicator.
   ///
-  /// {@macro flutter.material.progressIndicator.parameters}
+  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
   const LinearProgressIndicator({
     Key? key,
     double? value,
@@ -442,7 +442,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 class CircularProgressIndicator extends ProgressIndicator {
   /// Creates a circular progress indicator.
   ///
-  /// {@macro flutter.material.progressIndicator.parameters}
+  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
   const CircularProgressIndicator({
     Key? key,
     double? value,
@@ -468,7 +468,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// The [value], [backgroundColor], [valueColor], [strokeWidth],
   /// [semanticsLabel], and [semanticsValue] will be ignored in iOS.
   ///
-  /// {@macro flutter.material.progressIndicator.parameters}
+  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
   const CircularProgressIndicator.adaptive({
     Key? key,
     double? value,
@@ -689,7 +689,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   /// Rather than creating a refresh progress indicator directly, consider using
   /// a [RefreshIndicator] together with a [Scrollable] widget.
   ///
-  /// {@macro flutter.material.progressIndicator.parameters}
+  /// {@macro flutter.material.ProgressIndicator.ProgressIndicator}
   const RefreshProgressIndicator({
     Key? key,
     double? value,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -146,13 +146,13 @@ class RefreshIndicator extends StatefulWidget {
   /// else for more complicated layouts.
   final ScrollNotificationPredicate notificationPredicate;
 
-  /// {@macro flutter.material.progressIndicator.semanticsLabel}
+  /// {@macro flutter.progress_indicator.ProgressIndicator.semanticsLabel}
   ///
   /// This will be defaulted to [MaterialLocalizations.refreshIndicatorSemanticLabel]
   /// if it is null.
   final String? semanticsLabel;
 
-  /// {@macro flutter.material.progressIndicator.semanticsValue}
+  /// {@macro flutter.progress_indicator.ProgressIndicator.semanticsValue}
   final String? semanticsValue;
 
   /// Defines `strokeWidth` for `RefreshIndicator`.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -105,7 +105,7 @@ class ScaffoldMessenger extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The state from the closest instance of this class that encloses the given
@@ -1747,7 +1747,7 @@ class Scaffold extends StatefulWidget {
   /// [AppBar.primary], is true.
   final bool primary;
 
-  /// {@macro flutter.material.drawer.dragStartBehavior}
+  /// {@macro flutter.material.DrawerController.dragStartBehavior}
   final DragStartBehavior drawerDragStartBehavior;
 
   /// The width of the area within which a horizontal swipe will open the

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -44,7 +44,7 @@ import 'theme.dart';
 /// used to exit the search page.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.editableText.complexCharacters}
+/// {@macro flutter.widgets.EditableText.onChanged}
 ///
 /// See also:
 ///
@@ -90,7 +90,7 @@ Future<T?> showSearch<T>({
 /// for another [showSearch] call.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.editableText.complexCharacters}
+/// {@macro flutter.widgets.EditableText.onChanged}
 abstract class SearchDelegate<T> {
 
   /// Constructor to be called by subclasses which may specify [searchFieldLabel], [keyboardType] and/or

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -31,32 +31,32 @@ import 'theme_data.dart';
 ///
 ///  * [SliderThemeData], which describes the actual configuration of a slider
 ///    theme.
-/// {@template flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@template flutter.material.SliderTheme.sliderComponentShape}
 ///  * [SliderComponentShape], which can be used to create custom shapes for
 ///    the [Slider]'s thumb, overlay, and value indicator and the
 ///    [RangeSlider]'s overlay.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.sliderTrackShape}
+/// {@template flutter.material.SliderTheme.sliderTrackShape}
 ///  * [SliderTrackShape], which can be used to create custom shapes for the
 ///    [Slider]'s track.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.sliderTickMarkShape}
+/// {@template flutter.material.SliderTheme.sliderTickMarkShape}
 ///  * [SliderTickMarkShape], which can be used to create custom shapes for the
 ///    [Slider]'s tick marks.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.rangeSliderThumbShape}
+/// {@template flutter.material.SliderTheme.rangeSliderThumbShape}
 ///  * [RangeSliderThumbShape], which can be used to create custom shapes for
 ///    the [RangeSlider]'s thumb.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
+/// {@template flutter.material.SliderTheme.rangeSliderValueIndicatorShape}
 ///  * [RangeSliderValueIndicatorShape], which can be used to create custom
 ///    shapes for the [RangeSlider]'s value indicator.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.rangeSliderTrackShape}
+/// {@template flutter.material.SliderTheme.rangeSliderTrackShape}
 ///  * [RangeSliderTrackShape], which can be used to create custom shapes for
 ///    the [RangeSlider]'s track.
 /// {@endtemplate}
-/// {@template flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
+/// {@template flutter.material.SliderTheme.rangeSliderTickMarkShape}
 ///  * [RangeSliderTickMarkShape], which can be used to create custom shapes for
 ///    the [RangeSlider]'s tick marks.
 /// {@endtemplate}
@@ -223,13 +223,13 @@ enum Thumb {
 ///  * [Theme] widget, which performs a similar function to [SliderTheme],
 ///    but for overall themes.
 ///  * [ThemeData], which has a default [SliderThemeData].
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
-/// {@macro flutter.material.slider.seeAlso.sliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.sliderTickMarkShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.sliderTrackShape}
+/// {@macro flutter.material.SliderTheme.sliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderThumbShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderValueIndicatorShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTickMarkShape}
 @immutable
 class SliderThemeData with Diagnosticable {
   /// Create a [SliderThemeData] given a set of exact values.
@@ -802,12 +802,12 @@ abstract class SliderComponentShape {
 
   /// Paints the shape, taking into account the state passed to it.
   ///
-  /// {@template flutter.material.slider.shape.argument.context}
+  /// {@template flutter.material.SliderComponentShape.paint.context}
   /// The `context` argument is the same as the one that includes the [Slider]'s
   /// render box.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.slider.shape.argument.center}
+  /// {@template flutter.material.SliderComponentShape.paint.center}
   /// The `center` argument is the offset for where this shape's center should be
   /// painted. This offset is relative to the origin of the [context] canvas.
   /// {@endtemplate}
@@ -816,14 +816,14 @@ abstract class SliderComponentShape {
   /// begins to interact with the slider. It reverses when the user stops interacting
   /// with the slider.
   ///
-  /// {@template flutter.material.slider.shape.argument.enableAnimation}
+  /// {@template flutter.material.SliderComponentShape.paint.enableAnimation}
   /// The `enableAnimation` argument is an animation triggered when the [Slider]
   /// is enabled, and it reverses when the slider is disabled. The [Slider] is
   /// enabled when [Slider.onChanged] is not null.Use this to paint intermediate
   /// frames for this shape when the slider changes enabled state.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.slider.shape.argument.isDiscrete}
+  /// {@template flutter.material.SliderComponentShape.paint.isDiscrete}
   /// The `isDiscrete` argument is true if [Slider.divisions] is non-null. When
   /// true, the slider will render tick marks on top of the track.
   /// {@endtemplate}
@@ -833,12 +833,12 @@ abstract class SliderComponentShape {
   /// should appear. If the `labelPainter` argument is null, then no label was
   /// supplied to the [Slider].
   ///
-  /// {@template flutter.material.slider.shape.argument.parentBox}
+  /// {@template flutter.material.SliderComponentShape.paint.parentBox}
   /// The `parentBox` argument is the [RenderBox] of the [Slider]. Its attributes,
   /// such as size, can be used to assist in painting this shape.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.slider.shape.argument.sliderTheme}
+  /// {@template flutter.material.SliderComponentShape.paint.sliderTheme}
   /// the `sliderTheme` argument is the theme assigned to the [Slider] that this
   /// shape belongs to.
   /// {@endtemplate}
@@ -850,14 +850,14 @@ abstract class SliderComponentShape {
   /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
   /// the slider.
   ///
-  /// {@template flutter.material.slider.shape.argument.textScaleFactor}
+  /// {@template flutter.material.SliderComponentShape.paint.textScaleFactor}
   /// The `textScaleFactor` argument can be used to determine whether the
   /// component should paint larger or smaller, depending on whether
   /// [textScaleFactor] is greater than 1 for larger, and between 0 and 1 for
   /// smaller. It usually comes from [MediaQueryData.textScaleFactor].
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.slider.shape.argument.sizeWithOverflow}
+  /// {@template flutter.material.SliderComponentShape.paint.sizeWithOverflow}
   /// The `sizeWithOverflow` argument can be used to determine the bounds the
   /// drawing of the components that are outside of the regular slider bounds.
   /// It's the size of the box, whose center is aligned with the slider's
@@ -907,8 +907,8 @@ abstract class SliderComponentShape {
 ///
 ///  * [RoundSliderTickMarkShape], which is the default [Slider]'s tick mark
 ///    shape that paints a solid circle.
-/// {@macro flutter.material.slider.seeAlso.sliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.sliderTrackShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class SliderTickMarkShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -918,9 +918,9 @@ abstract class SliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@template flutter.material.slider.shape.argument.isEnabled}
+  /// {@template flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
   /// The `isEnabled` argument is false when [Slider.onChanged] is null and true
   /// otherwise. When true, the slider will respond to input.
   /// {@endtemplate}
@@ -931,17 +931,17 @@ abstract class SliderTickMarkShape {
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.slider.shape.argument.context}
+  /// {@macro flutter.material.SliderComponentShape.paint.context}
   ///
-  /// {@macro flutter.material.slider.shape.argument.center}
+  /// {@macro flutter.material.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.slider.shape.argument.parentBox}
+  /// {@macro flutter.material.SliderComponentShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.argument.enableAnimation}
+  /// {@macro flutter.material.SliderComponentShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.slider.shape.argument.isEnabled}
+  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
   /// The `textDirection` argument can be used to determine how the tick marks
   /// are painting depending on whether they are on an active track segment or
@@ -983,8 +983,8 @@ abstract class SliderTickMarkShape {
 ///
 ///  * [RoundedRectSliderTrackShape] for the default [Slider]'s track shape that
 ///    paints a stadium-like track.
-/// {@macro flutter.material.slider.seeAlso.sliderTickMarkShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.sliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class SliderTrackShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1001,11 +1001,11 @@ abstract class SliderTrackShape {
   /// The `offset` argument is relative to the caller's bounding box. It can be used to
   /// convert gesture coordinates from global to slider-relative coordinates.
   ///
-  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.argument.isEnabled}
+  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.slider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.SliderComponentShape.paint.isDiscrete}
   Rect getPreferredRect({
     required RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -1016,30 +1016,30 @@ abstract class SliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.slider.shape.argument.context}
+  /// {@macro flutter.material.SliderComponentShape.paint.context}
   ///
   /// The `offset` argument the offset of the origin of the `parentBox` to the
   /// origin of its `context` canvas. This shape must be painted relative to
   /// this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.slider.shape.argument.parentBox}
+  /// {@macro flutter.material.SliderComponentShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.slider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.SliderComponentShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.slider.shape.argument.enableAnimation}
+  /// {@macro flutter.material.SliderComponentShape.paint.enableAnimation}
   ///
   /// The `thumbCenter` argument is the offset of the center of the thumb
   /// relative to the origin of the [PaintingContext.canvas]. It can be used as
   /// the point that divides the track into 2 segments.
   ///
-  /// {@macro flutter.material.slider.shape.argument.isEnabled}
+  /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.slider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.SliderComponentShape.paint.isDiscrete}
   ///
   /// The `textDirection` argument can be used to determine how the track
   /// segments are painted depending on whether they are active or not.
   ///
-  /// {@template flutter.material.slider.trackSegment}
+  /// {@template flutter.material.SliderTrackShape.paint.trackSegment}
   /// The track segment between the start of the slider and the thumb is the
   /// active track segment. The track segment between the thumb and the end of the
   /// slider is the inactive track segment. In [TextDirection.ltr], the start of
@@ -1065,10 +1065,10 @@ abstract class SliderTrackShape {
 ///
 ///  * [RoundRangeSliderThumbShape] for the default [RangeSlider]'s thumb shape
 ///    that paints a solid circle.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderValueIndicatorShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class RangeSliderThumbShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1076,12 +1076,12 @@ abstract class RangeSliderThumbShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@template flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   /// The `isDiscrete` argument is true if [RangeSlider.divisions] is non-null.
   /// When true, the slider will render tick marks on top of the track.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@template flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   /// The `isEnabled` argument is false when [RangeSlider.onChanged] is null and
   /// true otherwise. When true, the slider will respond to input.
   /// {@endtemplate}
@@ -1089,19 +1089,19 @@ abstract class RangeSliderThumbShape {
 
   /// Paints the thumb shape based on the state passed to it.
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.context}
+  /// {@template flutter.material.RangeSliderThumbShape.paint.context}
   /// The `context` argument represents the [RangeSlider]'s render box.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.slider.shape.argument.center}
+  /// {@macro flutter.material.SliderComponentShape.paint.center}
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.activationAnimation}
+  /// {@template flutter.material.RangeSliderThumbShape.paint.activationAnimation}
   /// The `activationAnimation` argument is an animation triggered when the user
   /// begins to interact with the [RangeSlider]. It reverses when the user stops
   /// interacting with the slider.
   /// {@endtemplate}
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.enableAnimation}
+  /// {@template flutter.material.RangeSliderThumbShape.paint.enableAnimation}
   /// The `enableAnimation` argument is an animation triggered when the
   /// [RangeSlider] is enabled, and it reverses when the slider is disabled. The
   /// [RangeSlider] is enabled when [RangeSlider.onChanged] is not null. Use
@@ -1109,15 +1109,15 @@ abstract class RangeSliderThumbShape {
   /// enabled state.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
   /// If the `isOnTop` argument is true, this thumb is painted on top of the
   /// other slider thumb because this thumb is the one that was most recently
   /// selected.
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@template flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   /// The `sliderTheme` argument is the theme assigned to the [RangeSlider] that
   /// this shape belongs to.
   /// {@endtemplate}
@@ -1126,7 +1126,7 @@ abstract class RangeSliderThumbShape {
   /// of either slider thumb should be changed, such as drawing different
   /// shapes for the left and right thumb.
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.thumb}
+  /// {@template flutter.material.RangeSliderThumbShape.paint.thumb}
   /// The `thumb` argument is the specifier for which of the two thumbs this
   /// method should paint (start or end).
   /// {@endtemplate}
@@ -1155,10 +1155,10 @@ abstract class RangeSliderThumbShape {
 ///
 ///  * [PaddleRangeSliderValueIndicatorShape] for the default [RangeSlider]'s
 ///    value indicator shape that paints a custom path with text in it.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderThumbShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class RangeSliderValueIndicatorShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1166,14 +1166,14 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Returns the preferred size of the shape, based on the given conditions.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `labelPainter` argument helps determine the width of the shape. It is
   /// variable width because it is derived from a formatted string.
   ///
-  /// {@macro flutter.material.slider.shape.argument.textScaleFactor}
+  /// {@macro flutter.material.SliderComponentShape.paint.textScaleFactor}
   Size getPreferredSize(
     bool isEnabled,
     bool isDiscrete, {
@@ -1198,31 +1198,31 @@ abstract class RangeSliderValueIndicatorShape {
 
   /// Paints the value indicator shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.context}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.context}
   ///
-  /// {@macro flutter.material.slider.shape.argument.center}
+  /// {@macro flutter.material.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.activationAnimation}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.activationAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `isOnTop` argument is the top-most value indicator between the two value
   /// indicators, which is always the indicator for the most recently selected thumb. In
   /// the default case, this is used to paint a stroke around the top indicator
   /// for better visibility between the two indicators.
   ///
-  /// {@macro flutter.material.slider.shape.argument.textScaleFactor}
+  /// {@macro flutter.material.SliderComponentShape.paint.textScaleFactor}
   ///
-  /// {@macro flutter.material.slider.shape.argument.sizeWithOverflow}
+  /// {@macro flutter.material.SliderComponentShape.paint.sizeWithOverflow}
   ///
-  /// {@template flutter.material.rangeSlider.shape.argument.parentBox}
+  /// {@template flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
   /// The `parentBox` argument is the [RenderBox] of the [RangeSlider]. Its
   /// attributes, such as size, can be used to assist in painting this shape.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   ///
   /// The `textDirection` argument can be used to determine how any extra text
   /// or graphics, besides the text painted by the [labelPainter] should be
@@ -1232,7 +1232,7 @@ abstract class RangeSliderValueIndicatorShape {
   /// The `value` argument is the current parametric value (from 0.0 to 1.0) of
   /// the slider.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.thumb}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.thumb}
   void paint(
     PaintingContext context,
     Offset center, {
@@ -1260,10 +1260,10 @@ abstract class RangeSliderValueIndicatorShape {
 ///
 ///  * [RoundRangeSliderTickMarkShape] for the default [RangeSlider]'s tick mark
 ///    shape that paints a solid circle.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderThumbShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderValueIndicatorShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class RangeSliderTickMarkShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1273,9 +1273,9 @@ abstract class RangeSliderTickMarkShape {
   ///
   /// It is used to help position the tick marks within the slider.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   Size getPreferredSize({
     required SliderThemeData sliderTheme,
     bool isEnabled,
@@ -1283,22 +1283,22 @@ abstract class RangeSliderTickMarkShape {
 
   /// Paints the slider track.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.context}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.context}
   ///
-  /// {@macro flutter.material.slider.shape.argument.center}
+  /// {@macro flutter.material.SliderComponentShape.paint.center}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.parentBox}
+  /// {@macro flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
   /// The `textDirection` argument can be used to determine how the tick marks
   /// are painted depending on whether they are on an active track segment or not.
   ///
-  /// {@template flutter.material.rangeSlider.trackSegment}
+  /// {@template flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
   /// The track segment between the two thumbs is the active track segment. The
   /// track segments between the thumb and each end of the slider are the inactive
   /// track segments. In [TextDirection.ltr], the start of the slider is on the
@@ -1330,10 +1330,10 @@ abstract class RangeSliderTickMarkShape {
 ///
 ///  * [RoundedRectRangeSliderTrackShape] for the default [RangeSlider]'s track
 ///    shape that paints a stadium-like track.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderThumbShape}
-/// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
-/// {@macro flutter.material.slider.seeAlso.sliderComponentShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTickMarkShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderThumbShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderValueIndicatorShape}
+/// {@macro flutter.material.SliderTheme.sliderComponentShape}
 abstract class RangeSliderTrackShape {
   /// This abstract const constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
@@ -1353,11 +1353,11 @@ abstract class RangeSliderTrackShape {
   /// used to convert gesture coordinates from global to slider-relative
   /// coordinates.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   Rect getPreferredRect({
     required RenderBox parentBox,
     Offset offset = Offset.zero,
@@ -1368,17 +1368,17 @@ abstract class RangeSliderTrackShape {
 
   /// Paints the track shape based on the state passed to it.
   ///
-  /// {@macro flutter.material.slider.shape.argument.context}
+  /// {@macro flutter.material.SliderComponentShape.paint.context}
   ///
   /// The `offset` argument is the offset of the origin of the `parentBox` to
   /// the origin of its `context` canvas. This shape must be painted relative
   /// to this offset. See [PaintingContextCallback].
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.parentBox}
+  /// {@macro flutter.material.RangeSliderValueIndicatorShape.paint.parentBox}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.sliderTheme}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.sliderTheme}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.enableAnimation}
+  /// {@macro flutter.material.RangeSliderThumbShape.paint.enableAnimation}
   ///
   /// The `startThumbCenter` argument is the offset of the center of the start
   /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
@@ -1388,15 +1388,15 @@ abstract class RangeSliderTrackShape {
   /// thumb relative to the origin of the [PaintingContext.canvas]. It can be
   /// used as one point that divides the track between inactive and active.
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isEnabled}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled}
   ///
-  /// {@macro flutter.material.rangeSlider.shape.argument.isDiscrete}
+  /// {@macro flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete}
   ///
   /// The `textDirection` argument can be used to determine how the track
   /// segments are painted depending on whether they are on an active track
   /// segment or not.
   ///
-  /// {@macro flutter.material.rangeSlider.trackSegment}
+  /// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
   void paint(
     PaintingContext context,
     Offset offset, {
@@ -1473,7 +1473,7 @@ abstract class BaseSliderTrackShape {
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.slider.trackSegment}
+/// {@macro flutter.material.SliderTrackShape.paint.trackSegment}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the rectangular slider track shape.]
 /// (https://flutter.github.io/assets-for-api-docs/assets/material/rectangular_slider_track_shape.png)
@@ -1483,7 +1483,7 @@ abstract class BaseSliderTrackShape {
 ///  * [Slider], for the component that is meant to display this shape.
 ///  * [SliderThemeData], where an instance of this class is set to inform the
 ///    slider of the visual details of the its track.
-/// {@macro flutter.material.slider.seeAlso.sliderTrackShape}
+/// {@macro flutter.material.SliderTheme.sliderTrackShape}
 ///  * [RoundedRectSliderTrackShape], for a similar track with rounded edges.
 class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackShape {
   /// Creates a slider track that draws 2 rectangles.
@@ -1579,7 +1579,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.slider.trackSegment}
+/// {@macro flutter.material.SliderTrackShape.paint.trackSegment}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the rounded rect slider track shape.]
 /// (https://flutter.github.io/assets-for-api-docs/assets/material/rounded_rect_slider_track_shape.png)
@@ -1589,7 +1589,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///  * [Slider], for the component that is meant to display this shape.
 ///  * [SliderThemeData], where an instance of this class is set to inform the
 ///    slider of the visual details of the its track.
-/// {@macro flutter.material.slider.seeAlso.sliderTrackShape}
+/// {@macro flutter.material.SliderTheme.sliderTrackShape}
 ///  * [RectangularSliderTrackShape], for a similar track with sharp edges.
 class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackShape {
   /// Create a slider track that draws two rectangles with rounded outer edges.
@@ -1694,7 +1694,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.rangeSlider.trackSegment}
+/// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the rectangular range slider track shape.]
 /// (https://flutter.github.io/assets-for-api-docs/assets/material/rectangular_range_slider_track_shape.png)
@@ -1704,7 +1704,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///  * [RangeSlider], for the component that is meant to display this shape.
 ///  * [SliderThemeData], where an instance of this class is set to inform the
 ///    slider of the visual details of the its track.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
 ///  * [RoundedRectRangeSliderTrackShape], for a similar track with rounded
 ///    edges.
 class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
@@ -1822,7 +1822,7 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
 ///   [SliderThemeData.disabledActiveTrackColor],
 ///   [SliderThemeData.disabledInactiveTrackColor].
 ///
-/// {@macro flutter.material.rangeSlider.trackSegment}
+/// {@macro flutter.material.RangeSliderTickMarkShape.paint.trackSegment}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the rounded rect range slider track shape.]
 /// (https://flutter.github.io/assets-for-api-docs/assets/material/rounded_rect_range_slider_track_shape.png)
@@ -1832,7 +1832,7 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
 ///  * [RangeSlider], for the component that is meant to display this shape.
 ///  * [SliderThemeData], where an instance of this class is set to inform the
 ///    slider of the visual details of the its track.
-/// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
+/// {@macro flutter.material.SliderTheme.rangeSliderTrackShape}
 ///  * [RectangularRangeSliderTrackShape], for a similar track with sharp edges.
 class RoundedRectRangeSliderTrackShape extends RangeSliderTrackShape {
   /// Create a slider track with rounded outer edges.

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -209,7 +209,7 @@ class Switch extends StatefulWidget {
 
   final _SwitchType _switchType;
 
-  /// {@macro flutter.cupertino.switch.dragStartBehavior}
+  /// {@macro flutter.cupertino.CupertinoSwitch.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
   /// The cursor for a mouse pointer when it enters or is hovering over the

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -444,7 +444,7 @@ class SwitchListTile extends StatelessWidget {
   /// By default, the value of `controlAffinity` is [ListTileControlAffinity.platform].
   final ListTileControlAffinity controlAffinity;
 
-  /// {@macro flutter.material.ListTile.shape}
+  /// {@macro flutter.material.ListTileTheme.shape}
   final ShapeBorder? shape;
 
   /// If non-null, defines the background color when [SwitchListTile.selected] is true.

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -395,7 +395,7 @@ class DefaultTabController extends StatefulWidget {
   ///
   /// Typically a [Scaffold] whose [AppBar] includes a [TabBar].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The closest instance of this class that encloses the given context.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -260,7 +260,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// [TextEditingController] using [TextEditingController.text].
 ///
   /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.editableText.complexCharacters}
+/// {@macro flutter.widgets.EditableText.onChanged}
 ///
 /// In the live Dartpad example above, try typing the emoji 👨‍👩‍👦
 /// into the field and submitting. Because the example code measures the length
@@ -622,7 +622,7 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textAlign}
   final TextAlign textAlign;
 
-  /// {@macro flutter.widgets.inputDecorator.textAlignVertical}
+  /// {@macro flutter.material.InputDecorator.textAlignVertical}
   final TextAlignVertical? textAlignVertical;
 
   /// {@macro flutter.widgets.editableText.textDirection}
@@ -640,13 +640,13 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
 
-  /// {@macro flutter.services.textInput.smartDashesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartDashesType}
   final SmartDashesType smartDashesType;
 
-  /// {@macro flutter.services.textInput.smartQuotesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
   final SmartQuotesType smartQuotesType;
 
-  /// {@macro flutter.services.textInput.enableSuggestions}
+  /// {@macro flutter.services.TextInputConfiguration.enableSuggestions}
   final bool enableSuggestions;
 
   /// {@macro flutter.widgets.editableText.maxLines}
@@ -880,7 +880,7 @@ class TextField extends StatefulWidget {
   final ScrollController? scrollController;
 
   /// {@macro flutter.widgets.editableText.autofillHints}
-  /// {@macro flutter.services.autofill.autofillHints}
+  /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
   /// {@template flutter.material.textfield.restorationId}

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -62,7 +62,7 @@ class Theme extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   static final ThemeData _kFallbackTheme = ThemeData.fallback();
@@ -240,7 +240,7 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -221,7 +221,7 @@ class ToggleButtons extends StatelessWidget {
   /// When the callback is null, all toggle buttons will be disabled.
   final void Function(int index)? onPressed;
 
-  /// {@macro flutter.material.button.mouseCursor}
+  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
   final MouseCursor? mouseCursor;
 
   /// The [TextStyle] to apply to any text in these toggle buttons.
@@ -734,7 +734,7 @@ class _ToggleButton extends StatelessWidget {
   /// If this is null, the button will be disabled, see [enabled].
   final VoidCallback? onPressed;
 
-  /// {@macro flutter.material.button.mouseCursor}
+  /// {@macro flutter.material.RawMaterialButton.mouseCursor}
   final MouseCursor? mouseCursor;
 
   /// The width and color of the button's leading side border.

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -115,7 +115,7 @@ class Tooltip extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// Specifies the tooltip's shape and background color.

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -59,7 +59,7 @@ import 'image_provider.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@template flutter.painting.boxDecoration.clip}
+/// {@template flutter.painting.BoxDecoration.clip}
 /// The [shape] or the [borderRadius] won't clip the children of the
 /// decorated [Container]. If the clip is required, insert a clip widget
 /// (e.g., [ClipRect], [ClipRRect], [ClipPath]) as the child of the [Container].
@@ -167,7 +167,7 @@ class BoxDecoration extends Decoration {
   /// Applies only to boxes with rectangular shapes; ignored if [shape] is not
   /// [BoxShape.rectangle].
   ///
-  /// {@macro flutter.painting.boxDecoration.clip}
+  /// {@macro flutter.painting.BoxDecoration.clip}
   final BorderRadiusGeometry? borderRadius;
 
   /// A list of shadows cast by this box behind the box.
@@ -208,7 +208,7 @@ class BoxDecoration extends Decoration {
   /// [BoxShape.circle] and [RoundedRectangleBorder] instead of
   /// [BoxShape.rectangle].
   ///
-  /// {@macro flutter.painting.boxDecoration.clip}
+  /// {@macro flutter.painting.BoxDecoration.clip}
   final BoxShape shape;
 
   @override

--- a/packages/flutter/lib/src/painting/box_fit.dart
+++ b/packages/flutter/lib/src/painting/box_fit.dart
@@ -29,7 +29,7 @@ enum BoxFit {
 
   /// As small as possible while still covering the entire target box.
   ///
-  /// {@template clip_with_box_fit}
+  /// {@template flutter.painting.BoxFit.cover}
   /// To actually clip the content, use `clipBehavior: Clip.hardEdge` alongside
   /// this in a [FittedBox].
   /// {@endtemplate}
@@ -40,7 +40,7 @@ enum BoxFit {
   /// Make sure the full width of the source is shown, regardless of
   /// whether this means the source overflows the target box vertically.
   ///
-  /// {@macro clip_with_box_fit}
+  /// {@macro flutter.painting.BoxFit.cover}
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_fitWidth.png)
   fitWidth,
@@ -48,7 +48,7 @@ enum BoxFit {
   /// Make sure the full height of the source is shown, regardless of
   /// whether this means the source overflows the target box horizontally.
   ///
-  /// {@macro clip_with_box_fit}
+  /// {@macro flutter.painting.BoxFit.cover}
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_fitHeight.png)
   fitHeight,
@@ -58,7 +58,7 @@ enum BoxFit {
   ///
   /// The source image is not resized.
   ///
-  /// {@macro clip_with_box_fit}
+  /// {@macro flutter.painting.BoxFit.cover}
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_none.png)
   none,

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -143,7 +143,7 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     _animation.curve = value;
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1155,7 +1155,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     markNeedsLayout();
   }
 
-  /// {@template flutter.rendering.editable.paintCursorOnTop}
+  /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
   /// If the cursor should be painted on top of the text or underneath it.
   ///
   /// By default, the cursor should be painted on top for iOS platforms and
@@ -1170,7 +1170,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     markNeedsLayout();
   }
 
-  /// {@template flutter.rendering.editable.cursorOffset}
+  /// {@template flutter.rendering.RenderEditable.cursorOffset}
   /// The offset that is used, in pixels, when painting the cursor on screen.
   ///
   /// By default, the cursor position should be set to an offset of
@@ -1362,7 +1362,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   double get _caretMargin => _kCaretGap + cursorWidth;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;
@@ -1818,7 +1818,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Move selection to the location of the last tap down.
   ///
-  /// {@template flutter.rendering.editable.select}
+  /// {@template flutter.rendering.RenderEditable.selectPosition}
   /// This method is mainly used to translate user inputs in global positions
   /// into a [TextSelection]. When used in conjunction with a [EditableText],
   /// the selection change is fed back into [TextEditingController.selection].
@@ -1861,7 +1861,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Select a word around the location of the last tap down.
   ///
-  /// {@macro flutter.rendering.editable.select}
+  /// {@macro flutter.rendering.RenderEditable.selectPosition}
   void selectWord({ required SelectionChangedCause cause }) {
     selectWordsInRange(from: _lastTapDownPosition!, cause: cause);
   }
@@ -1871,7 +1871,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// The first and last endpoints of the selection will always be at the
   /// beginning and end of a word respectively.
   ///
-  /// {@macro flutter.rendering.editable.select}
+  /// {@macro flutter.rendering.RenderEditable.selectPosition}
   void selectWordsInRange({ required Offset from, Offset? to, required SelectionChangedCause cause }) {
     assert(cause != null);
     assert(from != null);
@@ -1896,7 +1896,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Move the selection to the beginning or end of a word.
   ///
-  /// {@macro flutter.rendering.editable.select}
+  /// {@macro flutter.rendering.RenderEditable.selectPosition}
   void selectWordEdge({ required SelectionChangedCause cause }) {
     assert(cause != null);
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -487,7 +487,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   // are treated as not overflowing.
   bool get _hasOverflow => _overflow! > precisionErrorTolerance;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -225,7 +225,7 @@ class RenderFlow extends RenderBox
     }
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -286,7 +286,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// ## About layer annotations
   ///
-  /// {@template flutter.rendering.layer.findAnnotations.aboutAnnotations}
+  /// {@template flutter.rendering.Layer.findAnnotations.aboutAnnotations}
   /// An annotation is an optional object of any type that can be carried with a
   /// layer. An annotation can be found at a location as long as the owner layer
   /// contains the location and is walked to.
@@ -344,7 +344,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// ## About layer annotations
   ///
-  /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
+  /// {@macro flutter.rendering.Layer.findAnnotations.aboutAnnotations}
   ///
   /// See also:
   ///
@@ -370,7 +370,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// ## About layer annotations
   ///
-  /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
+  /// {@macro flutter.rendering.Layer.findAnnotations.aboutAnnotations}
   ///
   /// See also:
   ///
@@ -403,7 +403,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// ## About layer annotations
   ///
-  /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
+  /// {@macro flutter.rendering.Layer.findAnnotations.aboutAnnotations}
   ///
   /// See also:
   ///
@@ -601,7 +601,7 @@ class TextureLayer extends Layer {
   /// un-freezes it when it is certain that a frame with the new size is ready.
   final bool freeze;
 
-  /// {@macro FilterQuality}
+  /// {@macro flutter.widgets.Texture.filterQuality}
   final ui.FilterQuality filterQuality;
 
   @override
@@ -1246,7 +1246,7 @@ class ClipRectLayer extends ContainerLayer {
     }
   }
 
-  /// {@template flutter.clipper.clipBehavior}
+  /// {@template flutter.rendering.ClipRectLayer.clipBehavior}
   /// Controls how to clip.
   ///
   /// Must not be set to null or [Clip.none].
@@ -1334,7 +1334,7 @@ class ClipRRectLayer extends ContainerLayer {
     }
   }
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.antiAlias].
   Clip get clipBehavior => _clipBehavior;
@@ -1418,7 +1418,7 @@ class ClipPathLayer extends ContainerLayer {
     }
   }
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.antiAlias].
   Clip get clipBehavior => _clipBehavior;
@@ -1911,7 +1911,7 @@ class PhysicalModelLayer extends ContainerLayer {
     return clipPath!.transform(matrix.storage);
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   Clip get clipBehavior => _clipBehavior;
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
@@ -2074,7 +2074,7 @@ class LeaderLayer extends ContainerLayer {
   /// pipeline.
   Offset offset;
 
-  /// {@macro flutter.leaderFollower.alwaysNeedsAddToScene}
+  /// {@macro flutter.rendering.FollowerLayer.alwaysNeedsAddToScene}
   @override
   bool get alwaysNeedsAddToScene => true;
 
@@ -2361,7 +2361,7 @@ class FollowerLayer extends ContainerLayer {
     _inverseDirty = true;
   }
 
-  /// {@template flutter.leaderFollower.alwaysNeedsAddToScene}
+  /// {@template flutter.rendering.FollowerLayer.alwaysNeedsAddToScene}
   /// This disables retained rendering.
   ///
   /// A [FollowerLayer] copies changes from a [LeaderLayer] that could be anywhere
@@ -2439,7 +2439,7 @@ class FollowerLayer extends ContainerLayer {
 /// of this layer's children, respecting their opacity. Then it adds this
 /// layer's annotation if all of the following restrictions are met:
 ///
-/// {@template flutter.rendering.annotatedRegionLayer.restrictions}
+/// {@template flutter.rendering.AnnotatedRegionLayer.restrictions}
 /// * The target type must be identical to the annotated type `T`.
 /// * If [size] is provided, the target position must be contained within the
 ///   rectangle formed by [size] and [offset].
@@ -2515,7 +2515,7 @@ class AnnotatedRegionLayer<T extends Object> extends ContainerLayer {
   /// return, this method then adds this layer's annotation if all of the
   /// following restrictions are met:
   ///
-  /// {@macro flutter.rendering.annotatedRegionLayer.restrictions}
+  /// {@macro flutter.rendering.AnnotatedRegionLayer.restrictions}
   ///
   /// This search process respects `onlyFirst`, meaning that when `onlyFirst` is
   /// true, the search will stop when it finds the first annotation from the

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -235,7 +235,7 @@ class RenderListWheelViewport
     markNeedsLayout();
   }
 
-  /// {@template flutter.rendering.wheelList.diameterRatio}
+  /// {@template flutter.rendering.RenderListWheelViewport.diameterRatio}
   /// A ratio between the diameter of the cylinder and the viewport's size
   /// in the main axis.
   ///
@@ -278,7 +278,7 @@ class RenderListWheelViewport
     markNeedsSemanticsUpdate();
   }
 
-  /// {@template flutter.rendering.wheelList.perspective}
+  /// {@template flutter.rendering.RenderListWheelViewport.perspective}
   /// Perspective of the cylindrical projection.
   ///
   /// A number between 0 and 0.01 where 0 means looking at the cylinder from
@@ -308,7 +308,7 @@ class RenderListWheelViewport
     markNeedsSemanticsUpdate();
   }
 
-  /// {@template flutter.rendering.wheelList.offAxisFraction}
+  /// {@template flutter.rendering.RenderListWheelViewport.offAxisFraction}
   /// How much the wheel is horizontally off-center, as a fraction of its width.
 
   /// This property creates the visual effect of looking at a vertical wheel from
@@ -343,7 +343,7 @@ class RenderListWheelViewport
     markNeedsPaint();
   }
 
-  /// {@template flutter.rendering.wheelList.useMagnifier}
+  /// {@template flutter.rendering.RenderListWheelViewport.useMagnifier}
   /// Whether to use the magnifier for the center item of the wheel.
   /// {@endtemplate}
   bool get useMagnifier => _useMagnifier;
@@ -355,7 +355,7 @@ class RenderListWheelViewport
     _useMagnifier = value;
     markNeedsPaint();
   }
-  /// {@template flutter.rendering.wheelList.magnification}
+  /// {@template flutter.rendering.RenderListWheelViewport.magnification}
   /// The zoomed-in rate of the magnifier, if it is used.
   ///
   /// The default value is 1.0, which will not change anything.
@@ -376,7 +376,7 @@ class RenderListWheelViewport
     markNeedsPaint();
   }
 
-  /// {@template flutter.rendering.wheelList.overAndUnderCenterOpacity}
+  /// {@template flutter.rendering.RenderListWheelViewport.overAndUnderCenterOpacity}
   /// The opacity value that will be applied to the wheel that appears below and
   /// above the magnifier.
   ///
@@ -395,7 +395,7 @@ class RenderListWheelViewport
     markNeedsPaint();
   }
 
-  /// {@template flutter.rendering.wheelList.itemExtent}
+  /// {@template flutter.rendering.RenderListWheelViewport.itemExtent}
   /// The size of the children along the main axis. Children [RenderBox]es will
   /// be given the [BoxConstraints] of this exact size.
   ///
@@ -413,7 +413,7 @@ class RenderListWheelViewport
   }
 
 
-  /// {@template flutter.rendering.wheelList.squeeze}
+  /// {@template flutter.rendering.RenderListWheelViewport.squeeze}
   /// The angular compactness of the children on the wheel.
   ///
   /// This denotes a ratio of the number of children on the wheel vs the number
@@ -445,7 +445,7 @@ class RenderListWheelViewport
     markNeedsSemanticsUpdate();
   }
 
-  /// {@template flutter.rendering.wheelList.renderChildrenOutsideViewport}
+  /// {@template flutter.rendering.RenderListWheelViewport.renderChildrenOutsideViewport}
   /// Whether to paint children inside the viewport only.
   ///
   /// If false, every child will be painted. However the [Scrollable] is still
@@ -470,7 +470,7 @@ class RenderListWheelViewport
     markNeedsSemanticsUpdate();
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -365,7 +365,7 @@ class PaintingContext extends ClipContext {
   /// object, rather than reusing an existing layer, satisfies that
   /// requirement.)
   ///
-  /// {@template flutter.rendering.object.pushLayer.offset}
+  /// {@template flutter.rendering.PaintingContext.pushLayer.offset}
   /// The `offset` is the offset to pass to the `painter`. In particular, it is
   /// not an offset applied to the layer itself. Layers conceptually by default
   /// have no position or size, though they can transform their contents. For
@@ -407,7 +407,7 @@ class PaintingContext extends ClipContext {
 
   /// Clip further painting using a rectangle.
   ///
-  /// {@template flutter.rendering.object.needsCompositing}
+  /// {@template flutter.rendering.PaintingContext.pushClipRect.needsCompositing}
   /// The `needsCompositing` argument specifies whether the child needs
   /// compositing. Typically this matches the value of
   /// [RenderObject.needsCompositing] for the caller. If false, this method
@@ -419,7 +419,7 @@ class PaintingContext extends ClipContext {
   /// way to apply the layer effect than actually creating a layer.
   /// {@endtemplate}
   ///
-  /// {@template flutter.rendering.object.pushClipLayer.offset}
+  /// {@template flutter.rendering.PaintingContext.pushClipRect.offset}
   /// The `offset` argument is the offset from the origin of the canvas'
   /// coordinate system to the origin of the caller's coordinate system.
   /// {@endtemplate}
@@ -433,7 +433,7 @@ class PaintingContext extends ClipContext {
   ///
   /// The `clipBehavior` argument controls how the rectangle is clipped.
   ///
-  /// {@template flutter.rendering.object.oldLayer}
+  /// {@template flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   /// For the `oldLayer` argument, specify the layer created in the previous
   /// frame. This gives the engine more information for performance
   /// optimizations. Typically this is the value of [RenderObject.layer] that a
@@ -459,9 +459,9 @@ class PaintingContext extends ClipContext {
 
   /// Clip further painting using a rounded rectangle.
   ///
-  /// {@macro flutter.rendering.object.needsCompositing}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.needsCompositing}
   ///
-  /// {@macro flutter.rendering.object.pushClipLayer.offset}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.offset}
   ///
   /// The `bounds` argument is used to specify the region of the canvas (in the
   /// caller's coordinate system) into which `painter` will paint.
@@ -475,7 +475,7 @@ class PaintingContext extends ClipContext {
   ///
   /// The `clipBehavior` argument controls how the rounded rectangle is clipped.
   ///
-  /// {@macro flutter.rendering.object.oldLayer}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   ClipRRectLayer? pushClipRRect(bool needsCompositing, Offset offset, Rect bounds, RRect clipRRect, PaintingContextCallback painter, { Clip clipBehavior = Clip.antiAlias, ClipRRectLayer? oldLayer }) {
     assert(clipBehavior != null);
     final Rect offsetBounds = bounds.shift(offset);
@@ -495,9 +495,9 @@ class PaintingContext extends ClipContext {
 
   /// Clip further painting using a path.
   ///
-  /// {@macro flutter.rendering.object.needsCompositing}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.needsCompositing}
   ///
-  /// {@macro flutter.rendering.object.pushClipLayer.offset}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.offset}
   ///
   /// The `bounds` argument is used to specify the region of the canvas (in the
   /// caller's coordinate system) into which `painter` will paint.
@@ -511,7 +511,7 @@ class PaintingContext extends ClipContext {
   ///
   /// The `clipBehavior` argument controls how the path is clipped.
   ///
-  /// {@macro flutter.rendering.object.oldLayer}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   ClipPathLayer? pushClipPath(bool needsCompositing, Offset offset, Rect bounds, Path clipPath, PaintingContextCallback painter, { Clip clipBehavior = Clip.antiAlias, ClipPathLayer? oldLayer }) {
     assert(clipBehavior != null);
     final Rect offsetBounds = bounds.shift(offset);
@@ -531,7 +531,7 @@ class PaintingContext extends ClipContext {
 
   /// Blend further painting with a color filter.
   ///
-  /// {@macro flutter.rendering.object.pushLayer.offset}
+  /// {@macro flutter.rendering.PaintingContext.pushLayer.offset}
   ///
   /// The `colorFilter` argument is the [ColorFilter] value to use when blending
   /// the painting done by `painter`.
@@ -539,7 +539,7 @@ class PaintingContext extends ClipContext {
   /// The `painter` callback will be called while the `colorFilter` is applied.
   /// It is called synchronously during the call to [pushColorFilter].
   ///
-  /// {@macro flutter.rendering.object.oldLayer}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   ///
   /// A [RenderObject] that uses this function is very likely to require its
   /// [RenderObject.alwaysNeedsCompositing] property to return true. That informs
@@ -555,7 +555,7 @@ class PaintingContext extends ClipContext {
 
   /// Transform further painting using a matrix.
   ///
-  /// {@macro flutter.rendering.object.needsCompositing}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.needsCompositing}
   ///
   /// The `offset` argument is the offset to pass to `painter` and the offset to
   /// the origin used by `transform`.
@@ -567,7 +567,7 @@ class PaintingContext extends ClipContext {
   /// The `painter` callback will be called while the `transform` is applied. It
   /// is called synchronously during the call to [pushTransform].
   ///
-  /// {@macro flutter.rendering.object.oldLayer}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   TransformLayer? pushTransform(bool needsCompositing, Offset offset, Matrix4 transform, PaintingContextCallback painter, { TransformLayer? oldLayer }) {
     final Matrix4 effectiveTransform = Matrix4.translationValues(offset.dx, offset.dy, 0.0)
       ..multiply(transform)..translate(-offset.dx, -offset.dy);
@@ -603,7 +603,7 @@ class PaintingContext extends ClipContext {
   /// The `painter` callback will be called while the `alpha` is applied. It
   /// is called synchronously during the call to [pushOpacity].
   ///
-  /// {@macro flutter.rendering.object.oldLayer}
+  /// {@macro flutter.rendering.PaintingContext.pushClipRect.oldLayer}
   ///
   /// A [RenderObject] that uses this function is very likely to require its
   /// [RenderObject.alwaysNeedsCompositing] property to return true. That informs

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -59,12 +59,12 @@ Set<Type> _factoriesTypeSet<T>(Set<Factory<T>> factories) {
 /// [RenderAndroidView] is responsible for sizing, displaying and passing touch events to an
 /// Android [View](https://developer.android.com/reference/android/view/View).
 ///
-/// {@template flutter.rendering.platformView.layout}
+/// {@template flutter.rendering.RenderAndroidView.layout}
 /// The render object's layout behavior is to fill all available space, the parent of this object must
 /// provide bounded layout constraints.
 /// {@endtemplate}
 ///
-/// {@template flutter.rendering.platformView.gestures}
+/// {@template flutter.rendering.RenderAndroidView.gestures}
 /// The render object participates in Flutter's gesture arenas, and dispatches touch events to the
 /// platform view iff it won the arena. Specific gestures that should be dispatched to the platform
 /// view can be specified with factories in the `gestureRecognizers` constructor parameter or
@@ -118,7 +118,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     _viewController.addOnPlatformViewCreatedListener(_onPlatformViewCreated);
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;
@@ -136,7 +136,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     markNeedsSemanticsUpdate();
   }
 
-  /// {@template flutter.rendering.platformView.updateGestureRecognizers}
+  /// {@template flutter.rendering.RenderAndroidView.updateGestureRecognizers}
   /// Updates which gestures should be forwarded to the platform view.
   ///
   /// Gesture recognizers created by factories in this set participate in the gesture arena for each
@@ -247,7 +247,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
 
 /// A render object for an iOS UIKit UIView.
 ///
-/// {@template flutter.rendering.platformView.preview}
+/// {@template flutter.rendering.RenderUiKitView}
 /// Embedding UIViews is still preview-quality. To enable the preview for an iOS app add a boolean
 /// field with the key 'io.flutter.embedded_views_preview' and the value set to 'YES' to the
 /// application's Info.plist file. A list of open issued with embedding UIViews is available on
@@ -259,9 +259,9 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
 ///
 /// UIViews are added as sub views of the FlutterView and are composited by Quartz.
 ///
-/// {@macro flutter.rendering.platformView.layout}
+/// {@macro flutter.rendering.RenderAndroidView.layout}
 ///
-/// {@macro flutter.rendering.platformView.gestures}
+/// {@macro flutter.rendering.RenderAndroidView.gestures}
 ///
 /// See also:
 ///
@@ -304,7 +304,7 @@ class RenderUiKitView extends RenderBox {
   // any newly arriving events there's nothing we need to invalidate.
   PlatformViewHitTestBehavior hitTestBehavior;
 
-  /// {@macro flutter.rendering.platformView.updateGestureRecognizers}
+  /// {@macro flutter.rendering.RenderAndroidView.updateGestureRecognizers}
   void updateGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {
     assert(gestureRecognizers != null);
     assert(
@@ -633,7 +633,7 @@ class PlatformViewRenderBox extends RenderBox with _PlatformViewGestureMixin {
     }
   }
 
-  /// {@macro  flutter.rendering.platformView.updateGestureRecognizers}
+  /// {@macro  flutter.rendering.RenderAndroidView.updateGestureRecognizers}
   ///
   /// Any active gesture arena the `PlatformView` participates in is rejected when the
   /// set of gesture recognizers is changed.
@@ -691,7 +691,7 @@ mixin _PlatformViewGestureMixin on RenderBox implements MouseTrackerAnnotation {
 
   _HandlePointerEvent? _handlePointerEvent;
 
-  /// {@macro  flutter.rendering.platformView.updateGestureRecognizers}
+  /// {@macro  flutter.rendering.RenderAndroidView.updateGestureRecognizers}
   ///
   /// Any active gesture arena the `PlatformView` participates in is rejected when the
   /// set of gesture recognizers is changed.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2440,7 +2440,7 @@ class RenderFittedBox extends RenderProxyBox {
   bool? _hasVisualOverflow;
   Matrix4? _transform;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior => _clipBehavior;
@@ -4986,7 +4986,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// The anchor point on the linked [RenderLeaderLayer] that [followerAnchor]
   /// will line up with.
   ///
-  /// {@template flutter.rendering.followerLayer.anchor}
+  /// {@template flutter.rendering.RenderFollowerLayer.leaderAnchor}
   /// For example, when [leaderAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this [RenderFollowerLayer] will be top left aligned
   /// with the linked [RenderLeaderLayer]. When [leaderAnchor] is
@@ -5010,7 +5010,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   /// The anchor point on this [RenderFollowerLayer] that will line up with
   /// [followerAnchor] on the linked [RenderLeaderLayer].
   ///
-  /// {@macro flutter.rendering.followerLayer.anchor}
+  /// {@macro flutter.rendering.RenderFollowerLayer.leaderAnchor}
   ///
   /// Defaults to [Alignment.topLeft].
   Alignment get followerAnchor => _followerAnchor;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -653,7 +653,7 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
   Rect _overflowChildRect = Rect.zero;
   bool _isOverflowing = false;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -18,7 +18,7 @@ import 'sliver.dart';
 /// of its child. Any incoming [SliverConstraints.overlap] is ignored and not
 /// passed on to the child.
 ///
-/// {@template flutter.rendering.sliverPadding.limitation}
+/// {@template flutter.rendering.RenderSliverEdgeInsetsPadding}
 /// Applying padding in the main extent of the viewport to slivers that have scroll effects is likely to have
 /// undesired effects. For example, For example, wrapping a [SliverPersistentHeader] with
 /// `pinned:true` will cause only the appbar to stay pinned while the padding will scroll away.
@@ -307,7 +307,7 @@ abstract class RenderSliverEdgeInsetsPadding extends RenderSliver with RenderObj
 /// its child. Any incoming [SliverConstraints.overlap] is ignored and not
 /// passed on to the child.
 ///
-/// {@macro flutter.rendering.sliverPadding.limitation}
+/// {@macro flutter.rendering.RenderSliverEdgeInsetsPadding}
 class RenderSliverPadding extends RenderSliverEdgeInsetsPadding {
   /// Creates a render object that insets its child in a viewport.
   ///

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -48,7 +48,7 @@ class OverScrollHeaderStretchConfiguration {
   final AsyncCallback? onStretchTrigger;
 }
 
-/// {@template flutter.rendering.persistentHeader.showOnScreenConfiguration}
+/// {@template flutter.rendering.PersistentHeaderShowOnScreenConfiguration}
 /// Specifies how a pinned header or a floating header should react to
 /// [RenderObject.showOnScreen] calls.
 /// {@endtemplate}
@@ -593,7 +593,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   ///    and snapped into view via the corresponding parameters.
   FloatingHeaderSnapConfiguration? snapConfiguration;
 
-  /// {@macro flutter.rendering.persistentHeader.showOnScreenConfiguration}
+  /// {@macro flutter.rendering.PersistentHeaderShowOnScreenConfiguration}
   ///
   /// If set to null, the persistent header will delegate the `showOnScreen` call
   /// to it's parent [RenderObject].

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -420,7 +420,7 @@ class RenderStack extends RenderBox
     }
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/texture.dart
+++ b/packages/flutter/lib/src/rendering/texture.dart
@@ -54,7 +54,7 @@ class TextureBox extends RenderBox {
     }
   }
 
-  /// {@macro FilterQuality}
+  /// {@macro flutter.widgets.Texture.filterQuality}
   FilterQuality get filterQuality => _filterQuality;
   FilterQuality _filterQuality;
   set filterQuality(FilterQuality value) {

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -285,7 +285,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   // pair of independent setters. Changing that would allow a more
   // rational API and would let us make the getter non-nullable.
 
-  /// {@template flutter.rendering.viewport.cacheExtent}
+  /// {@template flutter.rendering.RenderViewportBase.cacheExtent}
   /// The viewport has an area before and after the visible area to cache items
   /// that are about to become visible when the user scrolls.
   ///
@@ -330,7 +330,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// expressed in pixels.
   double? _calculatedCacheExtent;
 
-  /// {@template flutter.rendering.viewport.cacheExtentStyle}
+  /// {@template flutter.rendering.RenderViewportBase.cacheExtentStyle}
   /// Controls how the [cacheExtent] is interpreted.
   ///
   /// If set to [CacheExtentStyle.pixel], the [cacheExtent] will be
@@ -356,7 +356,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     markNeedsLayout();
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -331,7 +331,7 @@ class RenderWrap extends RenderBox
     }
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -647,7 +647,7 @@ class AutofillConfiguration {
   ///
   /// Must not be null or empty.
   ///
-  /// {@template flutter.services.autofill.autofillHints}
+  /// {@template flutter.services.AutofillConfiguration.autofillHints}
   /// For the best results, hint strings need to be understood by the platform's
   /// autofill service. The common values of hint strings can be found in
   /// [AutofillHints], as well as their availability on different platforms.
@@ -728,7 +728,7 @@ abstract class AutofillClient {
 
 /// An ordered group within which [AutofillClient]s are logically connected.
 ///
-/// {@template flutter.services.autofill.AutofillScope}
+/// {@template flutter.services.AutofillScope}
 /// [AutofillClient]s within the same [AutofillScope] are isolated from other
 /// input fields during autofill. That is, when an autofillable [TextInputClient]
 /// gains focus, only the [AutofillClient]s within the same [AutofillScope] will

--- a/packages/flutter/lib/src/services/raw_keyboard_ios.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_ios.dart
@@ -259,7 +259,7 @@ class RawKeyEventDataIos extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether the CAPS
   /// LOCK modifier key is on.
   ///
-  /// {@template flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@template flutter.services.RawKeyEventDataIos.modifierCapsLock}
   /// Use this value if you need to decode the [modifiers] field yourself, but
   /// it's much easier to use [isModifierPressed] if you just want to know if
   /// a modifier is pressed.
@@ -269,91 +269,91 @@ class RawKeyEventDataIos extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// SHIFT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierShift = 0x20000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierLeftShift = 0x02;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierRightShift = 0x04;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// CTRL modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierControl = 0x40000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierLeftControl = 0x01;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierRightControl = 0x2000;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// ALT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierOption = 0x80000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierLeftOption = 0x20;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierRightOption = 0x40;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierCommand = 0x100000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierLeftCommand = 0x08;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierRightCommand = 0x10;
 
   /// This mask is used to check the [modifiers] field to test whether any key in
   /// the numeric keypad is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierNumericPad = 0x200000;
 
   /// This mask is used to check the [modifiers] field to test whether the
   /// HELP modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierHelp = 0x400000;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// FUNCTION modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataIOS.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataIos.modifierCapsLock}
   static const int modifierFunction = 0x800000;
 
   /// Used to retrieve only the device-independent modifier flags, allowing

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -171,7 +171,7 @@ class GLFWKeyHelper with KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the CAPS LOCK modifier key is on.
   ///
-  /// {@template flutter.services.glfwKeyHelper.modifiers}
+  /// {@template flutter.services.GLFWKeyHelper.modifierCapsLock}
   /// Use this value if you need to decode the [RawKeyEventDataLinux.modifiers]
   /// field yourself, but it's much easier to use [isModifierPressed] if you
   /// just want to know if a modifier is pressed. This is especially true on
@@ -183,32 +183,32 @@ class GLFWKeyHelper with KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the SHIFT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.glfwKeyHelper.modifiers}
+  /// {@macro flutter.services.GLFWKeyHelper.modifierCapsLock}
   static const int modifierShift = 0x0001;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the CTRL modifier keys is pressed.
   ///
-  /// {@macro flutter.services.glfwKeyHelper.modifiers}
+  /// {@macro flutter.services.GLFWKeyHelper.modifierCapsLock}
   static const int modifierControl = 0x0002;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the ALT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.glfwKeyHelper.modifiers}
+  /// {@macro flutter.services.GLFWKeyHelper.modifierCapsLock}
   static const int modifierAlt = 0x0004;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the Meta(SUPER) modifier keys is pressed.
   ///
-  /// {@macro flutter.services.glfwKeyHelper.modifiers}
+  /// {@macro flutter.services.GLFWKeyHelper.modifierCapsLock}
   static const int modifierMeta = 0x0008;
 
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether any key in the numeric keypad is pressed.
   ///
-  /// {@macro flutter.services.glfwKeyHelper.modifiers}
+  /// {@macro flutter.services.GLFWKeyHelper.modifierCapsLock}
   static const int modifierNumericPad = 0x0020;
 
   int _mergeModifiers({required int modifiers, required int keyCode, required bool isDown}) {
@@ -308,7 +308,7 @@ class GtkKeyHelper with KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the SHIFT modifier keys is pressed.
   ///
-  /// {@template flutter.services.gtkKeyHelper.modifiers}
+  /// {@template flutter.services.GtkKeyHelper.modifierShift}
   /// Use this value if you need to decode the [RawKeyEventDataLinux.modifiers] field yourself, but
   /// it's much easier to use [isModifierPressed] if you just want to know if a
   /// modifier is pressed. This is especially true on GTK, since its modifiers
@@ -319,32 +319,32 @@ class GtkKeyHelper with KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the CAPS LOCK modifier key is on.
   ///
-  /// {@macro flutter.services.gtkKeyHelper.modifiers}
+  /// {@macro flutter.services.GtkKeyHelper.modifierShift}
   static const int modifierCapsLock = 1 << 1;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the CTRL modifier keys is pressed.
   ///
-  /// {@macro flutter.services.gtkKeyHelper.modifiers}
+  /// {@macro flutter.services.GtkKeyHelper.modifierShift}
   static const int modifierControl = 1 << 2;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the first modifier key is pressed (usually mapped to alt).
   ///
-  /// {@macro flutter.services.gtkKeyHelper.modifiers}
+  /// {@macro flutter.services.GtkKeyHelper.modifierShift}
   static const int modifierMod1 = 1 << 3;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the second modifier key is pressed (assumed to be mapped to
   /// num lock).
   ///
-  /// {@macro flutter.services.gtkKeyHelper.modifiers}
+  /// {@macro flutter.services.GtkKeyHelper.modifierShift}
   static const int modifierMod2 = 1 << 4;
 
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the Meta(SUPER) modifier keys is pressed.
   ///
-  /// {@macro flutter.services.gtkKeyHelper.modifiers}
+  /// {@macro flutter.services.GtkKeyHelper.modifierShift}
   static const int modifierMeta = 1 << 28;
 
   int _mergeModifiers({required int modifiers, required int keyCode, required bool isDown}) {

--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -245,7 +245,7 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether the CAPS
   /// LOCK modifier key is on.
   ///
-  /// {@template flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@template flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   /// Use this value if you need to decode the [modifiers] field yourself, but
   /// it's much easier to use [isModifierPressed] if you just want to know if
   /// a modifier is pressed.
@@ -255,91 +255,91 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// SHIFT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierShift = 0x20000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierLeftShift = 0x02;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierRightShift = 0x04;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// CTRL modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierControl = 0x40000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierLeftControl = 0x01;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierRightControl = 0x2000;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// ALT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierOption = 0x80000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierLeftOption = 0x20;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierRightOption = 0x40;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierCommand = 0x100000;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierLeftCommand = 0x08;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// CMD modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierRightCommand = 0x10;
 
   /// This mask is used to check the [modifiers] field to test whether any key in
   /// the numeric keypad is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierNumericPad = 0x200000;
 
   /// This mask is used to check the [modifiers] field to test whether the
   /// HELP modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierHelp = 0x400000;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// FUNCTION modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataMacOs.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataMacOs.modifierCapsLock}
   static const int modifierFunction = 0x800000;
 
   /// Used to retrieve only the device-independent modifier flags, allowing

--- a/packages/flutter/lib/src/services/raw_keyboard_windows.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_windows.dart
@@ -202,7 +202,7 @@ class RawKeyEventDataWindows extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// SHIFT modifier keys is pressed.
   ///
-  /// {@template flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@template flutter.services.RawKeyEventDataWindows.modifierShift}
   /// Use this value if you need to decode the [modifiers] field yourself, but
   /// it's much easier to use [isModifierPressed] if you just want to know if
   /// a modifier is pressed.
@@ -212,78 +212,78 @@ class RawKeyEventDataWindows extends RawKeyEventData {
   /// This mask is used to check the [modifiers] field to test whether the left
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierLeftShift = 1 << 1;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// SHIFT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierRightShift = 1 << 2;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// CTRL modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierControl = 1 << 3;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierLeftControl = 1 << 4;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// CTRL modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierRightControl = 1 << 5;
 
   /// This mask is used to check the [modifiers] field to test whether one of the
   /// ALT modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierAlt = 1 << 6;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierLeftAlt = 1 << 7;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// ALT modifier key is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierRightAlt = 1 << 8;
 
   /// This mask is used to check the [modifiers] field to test whether the left
   /// WIN modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierLeftMeta = 1 << 9;
 
   /// This mask is used to check the [modifiers] field to test whether the right
   /// WIN modifier keys is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierRightMeta = 1 << 10;
 
   /// This mask is used to check the [modifiers] field to test whether the CAPS LOCK key
   /// is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierCaps = 1 << 11;
 
   /// This mask is used to check the [modifiers] field to test whether the NUM LOCK key
   /// is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierNumLock = 1 << 12;
 
     /// This mask is used to check the [modifiers] field to test whether the SCROLL LOCK key
   /// is pressed.
   ///
-  /// {@macro flutter.services.rawKeyEventDataWindows.modifiers}
+  /// {@macro flutter.services.RawKeyEventDataWindows.modifierShift}
   static const int modifierScrollLock = 1 << 13;
 }

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -439,7 +439,7 @@ class RestorationBucket {
   /// Creates an empty [RestorationBucket] to be provided to [adoptChild] to add
   /// it to the bucket hierarchy.
   ///
-  /// {@template flutter.services.restoration.bucketcreation}
+  /// {@template flutter.services.RestorationBucket.empty.bucketCreation}
   /// Instantiating a bucket directly is rare, most buckets are created by
   /// claiming a child from a parent via [claimChild]. If no parent bucket is
   /// available, [RestorationManager.rootBucket] may be used as a parent.
@@ -478,7 +478,7 @@ class RestorationBucket {
   /// }
   /// ```
   ///
-  /// {@macro flutter.services.restoration.bucketcreation}
+  /// {@macro flutter.services.RestorationBucket.empty.bucketCreation}
   ///
   /// The `manager` argument must not be null.
   RestorationBucket.root({
@@ -501,7 +501,7 @@ class RestorationBucket {
   /// data stored under the given ID. In that case, create an empty bucket (via
   /// [RestorationBucket.empty] and have the parent adopt it via [adoptChild].
   ///
-  /// {@macro flutter.services.restoration.bucketcreation}
+  /// {@macro flutter.services.RestorationBucket.empty.bucketCreation}
   ///
   /// The `restorationId` and `parent` argument must not be null.
   RestorationBucket.child({

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -26,7 +26,7 @@ import 'text_input.dart';
 /// implement the [formatEditUpdate] method.
 ///
 /// ## Handling emojis and other complex characters
-/// {@macro flutter.widgets.editableText.complexCharacters}
+/// {@macro flutter.widgets.EditableText.onChanged}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -495,7 +495,7 @@ class TextInputConfiguration {
   /// Android and web, setting [autofillConfiguration] to null disables autofill.
   final AutofillConfiguration? autofillConfiguration;
 
-  /// {@template flutter.services.textInput.smartDashesType}
+  /// {@template flutter.services.TextInputConfiguration.smartDashesType}
   /// Whether to allow the platform to automatically format dashes.
   ///
   /// This flag only affects iOS versions 11 and above. It sets
@@ -520,7 +520,7 @@ class TextInputConfiguration {
   /// {@endtemplate}
   final SmartDashesType smartDashesType;
 
-  /// {@template flutter.services.textInput.smartQuotesType}
+  /// {@template flutter.services.TextInputConfiguration.smartQuotesType}
   /// Whether to allow the platform to automatically format quotes.
   ///
   /// This flag only affects iOS. It sets
@@ -545,7 +545,7 @@ class TextInputConfiguration {
   /// {@endtemplate}
   final SmartQuotesType smartQuotesType;
 
-  /// {@template flutter.services.textInput.enableSuggestions}
+  /// {@template flutter.services.TextInputConfiguration.enableSuggestions}
   /// Whether to show input suggestions as the user types.
   ///
   /// This flag only affects Android. On iOS, suggestions are tied directly to
@@ -1377,7 +1377,7 @@ class TextInput {
   /// automatically when they are disposed. The default behavior can be
   /// overridden in [AutofillGroup.onDisposeAction].
   ///
-  /// {@template flutter.services.autofill.autofillContext}
+  /// {@template flutter.services.TextInput.finishAutofillContext}
   /// An autofill context is a collection of input fields that live in the
   /// platform's text input plugin. The platform is encouraged to save the user
   /// input stored in the current autofill context before the context is

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -147,7 +147,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
   /// leaks, use of the [ActionListener] widget to register and unregister your
   /// listener appropriately is highly recommended.
   ///
-  /// {@template flutter.widgets.actions.multipleAdds}
+  /// {@template flutter.widgets.Action.addActionListener}
   /// If a listener had been added twice, and is removed once during an
   /// iteration (i.e. in response to a notification), it will still be called
   /// again. If, on the other hand, it is removed as many times as it was
@@ -174,7 +174,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
   /// memory leaks, use of the [ActionListener] widget to register and
   /// unregister your listener appropriately is highly recommended.
   ///
-  /// {@macro flutter.widgets.actions.multipleAdds}
+  /// {@macro flutter.widgets.Action.addActionListener}
   @mustCallSuper
   void removeActionListener(ActionListenerCallback listener) => _listeners.remove(listener);
 
@@ -266,7 +266,7 @@ class ActionListener extends StatefulWidget {
   /// Must not be null.
   final Action<Intent> action;
 
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -464,7 +464,7 @@ class Actions extends StatefulWidget {
   /// {@endtemplate}
   final Map<Type, Action<Intent>> actions;
 
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   // Visits the Actions widget ancestors of the given element using
@@ -999,7 +999,7 @@ class FocusableActionDetector extends StatefulWidget {
 
   /// The child widget for this [FocusableActionDetector] widget.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -103,7 +103,7 @@ class AnimatedSize extends SingleChildRenderObjectWidget {
   /// The [TickerProvider] for this widget.
   final TickerProvider vsync;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -49,7 +49,7 @@ export 'dart:ui' show Locale;
 ///    is recommended over [LocaleResolutionCallback].
 typedef LocaleListResolutionCallback = Locale? Function(List<Locale>? locales, Iterable<Locale> supportedLocales);
 
-/// {@template flutter.widgets.widgetsApp.localeResolutionCallback}
+/// {@template flutter.widgets.LocaleResolutionCallback}
 /// The signature of [WidgetsApp.localeResolutionCallback].
 ///
 /// It is recommended to provide a [LocaleListResolutionCallback] instead of a

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -28,7 +28,7 @@ enum AutofillContextAction {
 /// [AutofillClient]s that share the same closest [AutofillGroup] ancestor must
 /// be built together, and they be will be autofilled together.
 ///
-/// {@macro flutter.services.autofill.AutofillScope}
+/// {@macro flutter.services.AutofillScope}
 ///
 /// The [AutofillGroup] widget only knows about [AutofillClient]s registered to
 /// it using the [AutofillGroupState.register] API. Typically, [AutofillGroup]
@@ -41,7 +41,7 @@ enum AutofillContextAction {
 /// widget) can be used to clean up the current autofill context when the
 /// current autofill context is no longer relevant.
 ///
-/// {@macro flutter.services.autofill.autofillContext}
+/// {@macro flutter.services.TextInput.finishAutofillContext}
 ///
 /// By default, [onDisposeAction] is set to [AutofillContextAction.commit], in
 /// which case when any of the topmost [AutofillGroup]s is being disposed, the
@@ -158,7 +158,7 @@ class AutofillGroup extends StatefulWidget {
 
   /// Returns the closest [AutofillGroupState] which encloses the given context.
   ///
-  /// {@macro flutter.widgets.autofill.AutofillGroupState}
+  /// {@macro flutter.widgets.AutofillGroupState}
   ///
   /// See also:
   ///
@@ -169,14 +169,14 @@ class AutofillGroup extends StatefulWidget {
     return scope?._scope;
   }
 
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The [AutofillContextAction] to be run when this [AutofillGroup] is the
   /// topmost [AutofillGroup] and it's being disposed, in order to clean up the
   /// current autofill context.
   ///
-  /// {@macro flutter.services.autofill.autofillContext}
+  /// {@macro flutter.services.TextInput.finishAutofillContext}
   ///
   /// Defaults to [AutofillContextAction.commit], which prompts the platform to
   /// save the user input and destroy the current autofill context. No action
@@ -189,7 +189,7 @@ class AutofillGroup extends StatefulWidget {
 
 /// State associated with an [AutofillGroup] widget.
 ///
-/// {@template flutter.widgets.autofill.AutofillGroupState}
+/// {@template flutter.widgets.AutofillGroupState}
 /// An [AutofillGroupState] can be used to register an [AutofillClient] when it
 /// enters this [AutofillGroup] (for example, when an [EditableText] is mounted or
 /// reparented onto the [AutofillGroup]'s subtree), and unregister an

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -33,7 +33,7 @@ class AutomaticKeepAlive extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override

--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -256,7 +256,7 @@ class Banner extends StatelessWidget {
 
   /// The widget to show behind the banner.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The message to show in the banner.
@@ -338,7 +338,7 @@ class CheckedModeBanner extends StatelessWidget {
 
   /// The widget to show behind the banner.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -624,7 +624,7 @@ class ClipRect extends SingleChildRenderObjectWidget {
   /// If non-null, determines which clip to use.
   final CustomClipper<Rect>? clipper;
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -699,7 +699,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   /// If non-null, determines which clip to use.
   final CustomClipper<RRect>? clipper;
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.antiAlias].
   final Clip clipBehavior;
@@ -763,7 +763,7 @@ class ClipOval extends SingleChildRenderObjectWidget {
   /// object) instead.
   final CustomClipper<Rect>? clipper;
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.antiAlias].
   final Clip clipBehavior;
@@ -864,7 +864,7 @@ class ClipPath extends SingleChildRenderObjectWidget {
   /// efficient way of obtaining that effect.
   final CustomClipper<Path>? clipper;
 
-  /// {@macro flutter.clipper.clipBehavior}
+  /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
   /// Defaults to [Clip.antiAlias].
   final Clip clipBehavior;
@@ -935,7 +935,7 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
   /// The type of shape.
   final BoxShape shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1034,7 +1034,7 @@ class PhysicalShape extends SingleChildRenderObjectWidget {
   /// shape for use with this widget.
   final CustomClipper<Path> clipper;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -1411,7 +1411,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// The anchor point on the linked [CompositedTransformTarget] that
   /// [followerAnchor] will line up with.
   ///
-  /// {@template flutter.widgets.followerLayer.anchor}
+  /// {@template flutter.widgets.CompositedTransformFollower.targetAnchor}
   /// For example, when [targetAnchor] and [followerAnchor] are both
   /// [Alignment.topLeft], this widget will be top left aligned with the linked
   /// [CompositedTransformTarget]. When [targetAnchor] is
@@ -1427,7 +1427,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// The anchor point on this widget that will line up with [followerAnchor] on
   /// the linked [CompositedTransformTarget].
   ///
-  /// {@macro flutter.widgets.followerLayer.anchor}
+  /// {@macro flutter.widgets.CompositedTransformFollower.targetAnchor}
   ///
   /// Defaults to [Alignment.topLeft].
   final Alignment followerAnchor;
@@ -1502,7 +1502,7 @@ class FittedBox extends SingleChildRenderObjectWidget {
   ///    relative to text direction.
   final AlignmentGeometry alignment;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -2343,7 +2343,7 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
   /// will be retained.
   final Axis? constrainedAxis;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -3064,7 +3064,7 @@ class SliverToBoxAdapter extends SingleChildRenderObjectWidget {
 /// is a basic sliver that insets another sliver by applying padding on each
 /// side.
 ///
-/// {@macro flutter.rendering.sliverPadding.limitation}
+/// {@macro flutter.rendering.RenderSliverEdgeInsetsPadding}
 ///
 /// See also:
 ///
@@ -3395,7 +3395,7 @@ class Stack extends MultiChildRenderObjectWidget {
   )
   final Overflow overflow;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -3860,7 +3860,7 @@ class PositionedDirectional extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -4068,7 +4068,7 @@ class Flex extends MultiChildRenderObjectWidget {
   /// way for the framework to know the correct baseline _a priori_.
   final TextBaseline? textBaseline;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -4958,7 +4958,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// [verticalDirection] must not be null.
   final VerticalDirection verticalDirection;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
@@ -5197,7 +5197,7 @@ class Flow extends MultiChildRenderObjectWidget {
   /// The delegate that controls the transformation matrices of the children.
   final FlowDelegate delegate;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;
@@ -6070,7 +6070,7 @@ class MouseRegion extends StatefulWidget {
   /// is unmounted while being hovered by a pointer, the [onExit] of the widget
   /// callback will never called. For more details, see [onExit].
   ///
-  /// {@template flutter.mouseRegion.triggerTime}
+  /// {@template flutter.widgets.MouseRegion.onEnter.triggerTime}
   /// The time that this callback is triggered is always between frames: either
   /// during the post-frame callbacks, or during the callback of a pointer
   /// event.
@@ -6262,7 +6262,7 @@ class MouseRegion extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@macro flutter.mouseRegion.triggerTime}
+  /// {@macro flutter.widgets.MouseRegion.onEnter.triggerTime}
   ///
   /// See also:
   ///
@@ -6301,7 +6301,7 @@ class MouseRegion extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -7168,7 +7168,7 @@ class KeyedSubtree extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Wrap each item in a KeyedSubtree whose key is based on the item's existing key or

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -698,7 +698,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
 
   /// Whether the Flutter engine has rasterized the first frame.
   ///
-  /// {@macro flutter.frame_rasterized_vs_presented}
+  /// {@macro flutter.flutter_driver.WaitUntilFirstFrameRasterized}
   ///
   /// See also:
   ///
@@ -709,7 +709,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   /// A future that completes when the Flutter engine has rasterized the first
   /// frame.
   ///
-  /// {@macro flutter.frame_rasterized_vs_presented}
+  /// {@macro flutter.flutter_driver.WaitUntilFirstFrameRasterized}
   ///
   /// See also:
   ///
@@ -1080,7 +1080,7 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The [RenderObject] that is the parent of the [Element] created by this widget.

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -290,7 +290,7 @@ class Container extends StatelessWidget {
   /// the parent provides unbounded constraints, in which case the container
   /// will attempt to be as small as possible.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// Align the [child] within the container.

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -102,7 +102,7 @@ class Dismissible extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// A widget that is stacked behind the child. If secondaryBackground is also

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -159,7 +159,7 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// To limit the number of simultaneous drags on multitouch devices, see
   /// [maxSimultaneousDrags].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The widget to display instead of [child] when one or more drags are under way.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -610,13 +610,13 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   final bool autocorrect;
 
-  /// {@macro flutter.services.textInput.smartDashesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartDashesType}
   final SmartDashesType smartDashesType;
 
-  /// {@macro flutter.services.textInput.smartQuotesType}
+  /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
   final SmartQuotesType smartQuotesType;
 
-  /// {@macro flutter.services.textInput.enableSuggestions}
+  /// {@macro flutter.services.TextInputConfiguration.enableSuggestions}
   final bool enableSuggestions;
 
   /// The text style to use for the editable text.
@@ -974,7 +974,7 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   ///
   /// ## Handling emojis and other complex characters
-  /// {@template flutter.widgets.editableText.complexCharacters}
+  /// {@template flutter.widgets.EditableText.onChanged}
   /// It's important to always use
   /// [characters](https://pub.dev/packages/characters) when dealing with user
   /// input text that may contain complex characters. This will ensure that
@@ -1105,7 +1105,7 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   final SelectionChangedCallback? onSelectionChanged;
 
-  /// {@macro flutter.widgets.textSelection.onSelectionHandleTapped}
+  /// {@macro flutter.widgets.TextSelectionOverlay.onSelectionHandleTapped}
   final VoidCallback? onSelectionHandleTapped;
 
   /// {@template flutter.widgets.editableText.inputFormatters}
@@ -1168,10 +1168,10 @@ class EditableText extends StatefulWidget {
   /// animate on Android platforms.
   final bool cursorOpacityAnimates;
 
-  ///{@macro flutter.rendering.editable.cursorOffset}
+  ///{@macro flutter.rendering.RenderEditable.cursorOffset}
   final Offset? cursorOffset;
 
-  ///{@macro flutter.rendering.editable.paintCursorOnTop}
+  ///{@macro flutter.rendering.RenderEditable.paintCursorAboveText}
   final bool paintCursorAboveText;
 
   /// Controls how tall the selection highlight boxes are computed to be.
@@ -1282,10 +1282,10 @@ class EditableText extends StatefulWidget {
   ///   compatible [keyboardType]. Empirically, [TextInputType.name] works well
   ///   with many autofill hints that are predefined on iOS.
   /// {@endtemplate}
-  /// {@macro flutter.services.autofill.autofillHints}
+  /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -222,7 +222,7 @@ enum UnfocusDisposition {
 /// To see the focus tree in the debug console, call [debugDumpFocusTree]. To
 /// get the focus tree as a string, call [debugDescribeFocusTree].
 ///
-/// {@template flutter.widgets.focus_manager.focus.lifecycle}
+/// {@template flutter.widgets.FocusNode.lifecycle}
 /// ## Lifecycle
 ///
 /// There are several actors involved in the lifecycle of a
@@ -265,7 +265,7 @@ enum UnfocusDisposition {
 /// call [dispose] when the node is done being used.
 /// {@endtemplate}
 ///
-/// {@template flutter.widgets.focus_manager.focus.keyEvents}
+/// {@template flutter.widgets.FocusNode.keyEvents}
 /// ## Key Event Propagation
 ///
 /// The [FocusManager] receives key events from [RawKeyboard] and will pass them
@@ -572,7 +572,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// Called if this focus node receives a key event while focused (i.e. when
   /// [hasFocus] returns true).
   ///
-  /// {@macro flutter.widgets.focus_manager.focus.keyEvents}
+  /// {@macro flutter.widgets.FocusNode.keyEvents}
   FocusOnKeyCallback? get onKey => _onKey;
   FocusOnKeyCallback? _onKey;
 
@@ -1205,8 +1205,8 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
 /// as the [focusedChild] of this node, adopting if it isn't already part of the
 /// focus tree.
 ///
-/// {@macro flutter.widgets.focus_manager.focus.lifecycle}
-/// {@macro flutter.widgets.focus_manager.focus.keyEvents}
+/// {@macro flutter.widgets.FocusNode.lifecycle}
+/// {@macro flutter.widgets.FocusNode.keyEvents}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -303,7 +303,7 @@ class Focus extends StatefulWidget {
 
   /// The child widget of this [Focus].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Handler for keys pressed when this object or one of its children has
@@ -1023,7 +1023,7 @@ class ExcludeFocus extends StatelessWidget {
 
   /// The child widget of this [ExcludeFocus].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1107,7 +1107,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
 
 /// Base class for all sort orders for [OrderedTraversalPolicy] traversal.
 ///
-/// {@template flutter.widgets.focusorder.comparable}
+/// {@template flutter.widgets.FocusOrder.comparable}
 /// Only orders of the same type are comparable. If a set of widgets in the same
 /// [FocusTraversalGroup] contains orders that are not comparable with each
 /// other, it will assert, since the ordering between such keys is undefined. To
@@ -1173,7 +1173,7 @@ abstract class FocusOrder with Diagnosticable implements Comparable<FocusOrder> 
 /// to a widget subtree that is using a [OrderedTraversalPolicy] to define the
 /// order in which widgets should be traversed with the keyboard.
 ///
-/// {@macro flutter.widgets.focusorder.comparable}
+/// {@macro flutter.widgets.FocusOrder.comparable}
 ///
 /// See also:
 ///
@@ -1211,7 +1211,7 @@ class NumericFocusOrder extends FocusOrder {
 /// This sorts strings using Dart's default string comparison, which is not
 /// locale specific.
 ///
-/// {@macro flutter.widgets.focusorder.comparable}
+/// {@macro flutter.widgets.FocusOrder.comparable}
 ///
 /// See also:
 ///
@@ -1254,7 +1254,7 @@ class _OrderedFocusInfo {
 /// A [FocusTraversalPolicy] that orders nodes by an explicit order that resides
 /// in the nearest [FocusTraversalOrder] widget ancestor.
 ///
-/// {@macro flutter.widgets.focusorder.comparable}
+/// {@macro flutter.widgets.FocusOrder.comparable}
 ///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
 /// This sample shows how to assign a traversal order to a widget. In the
@@ -1387,7 +1387,7 @@ class OrderedTraversalPolicy extends FocusTraversalPolicy with DirectionalFocusT
 /// An inherited widget that describes the order in which its child subtree
 /// should be traversed.
 ///
-/// {@macro flutter.widgets.focusorder.comparable}
+/// {@macro flutter.widgets.FocusOrder.comparable}
 ///
 /// The order for a widget is determined by the [FocusOrder] returned by
 /// [FocusTraversalOrder.of] for a particular context.
@@ -1679,7 +1679,7 @@ class FocusTraversalGroup extends StatefulWidget {
 
   /// The child widget of this [FocusTraversalGroup].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Returns the focus policy set by the [FocusTraversalGroup] that most

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -113,7 +113,7 @@ class Form extends StatefulWidget {
   ///
   /// This is the root of the widget hierarchy that contains this form.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Enables the form to veto attempts by the user to dismiss the [ModalRoute]
@@ -137,7 +137,7 @@ class Form extends StatefulWidget {
   /// Used to enable/disable form fields auto validation and update their error
   /// text.
   ///
-  /// {@macro flutter.widgets.form.autovalidateMode}
+  /// {@macro flutter.widgets.FormField.autovalidateMode}
   final AutovalidateMode autovalidateMode;
 
   /// Used to enable/disable form fields auto validation and update their error
@@ -380,7 +380,7 @@ class FormField<T> extends StatefulWidget {
   /// Used to enable/disable this form field auto validation and update its
   /// error text.
   ///
-  /// {@template flutter.widgets.form.autovalidateMode}
+  /// {@template flutter.widgets.FormField.autovalidateMode}
   /// If [AutovalidateMode.onUserInteraction] this form field will only
   /// auto-validate after its content changes, if [AutovalidateMode.always] it
   /// will auto validate even without user interaction and

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1118,7 +1118,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// location at which this object was inserted into the tree (i.e., [context])
   /// or on the widget used to configure this object (i.e., [widget]).
   ///
-  /// {@template flutter.widgets.subscriptions}
+  /// {@template flutter.widgets.State.initState}
   /// If a [State]'s [build] method depends on an object that can itself
   /// change state, for example a [ChangeNotifier] or [Stream], or some
   /// other object to which one can subscribe to receive notifications, then
@@ -1160,7 +1160,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// The framework always calls [build] after calling [didUpdateWidget], which
   /// means any calls to [setState] in [didUpdateWidget] are redundant.
   ///
-  /// {@macro flutter.widgets.subscriptions}
+  /// {@macro flutter.widgets.State.initState}
   ///
   /// If you override this, make sure your method starts with a call to
   /// super.didUpdateWidget(oldWidget).
@@ -1168,7 +1168,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   @protected
   void didUpdateWidget(covariant T oldWidget) { }
 
-  /// {@macro flutter.widgets.reassemble}
+  /// {@macro flutter.widgets.Element.reassemble}
   ///
   /// In addition to this method being invoked, it is guaranteed that the
   /// [build] method will be invoked when a reassemble is signaled. Most
@@ -1328,7 +1328,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// Subclasses should override this method to release any resources retained
   /// by this object (e.g., stop any active animations).
   ///
-  /// {@macro flutter.widgets.subscriptions}
+  /// {@macro flutter.widgets.State.initState}
   ///
   /// If you override this, make sure to end your method with a call to
   /// super.dispose().
@@ -1506,7 +1506,7 @@ abstract class ProxyWidget extends Widget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@template flutter.widgets.child}
+  /// {@template flutter.widgets.ProxyWidget.child}
   /// This widget can only have one child. To lay out multiple children, let this
   /// widget's child be a widget such as [Row], [Column], or [Stack], which have a
   /// `children` property, and then provide the children to that widget.
@@ -1888,7 +1888,7 @@ abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -3120,7 +3120,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   BuildOwner? get owner => _owner;
   BuildOwner? _owner;
 
-  /// {@template flutter.widgets.reassemble}
+  /// {@template flutter.widgets.Element.reassemble}
   /// Called whenever the application is reassembled during debugging, for
   /// example during hot reload.
   ///
@@ -5865,7 +5865,7 @@ abstract class RenderObjectElement extends Element {
 
   /// Insert the given child into [renderObject] at the given slot.
   ///
-  /// {@macro flutter.widgets.slots}
+  /// {@macro flutter.widgets.RenderObjectElement.insertRenderObjectChild}
   ///
   /// ## Deprecation
   ///
@@ -5912,7 +5912,7 @@ abstract class RenderObjectElement extends Element {
 
   /// Insert the given child into [renderObject] at the given slot.
   ///
-  /// {@template flutter.widgets.slots}
+  /// {@template flutter.widgets.RenderObjectElement.insertRenderObjectChild}
   /// The semantics of `slot` are determined by this element. For example, if
   /// this element has a single child, the slot should always be null. If this
   /// element has a list of children, the previous sibling element wrapped in an
@@ -5927,7 +5927,7 @@ abstract class RenderObjectElement extends Element {
   ///
   /// The given child is guaranteed to have [renderObject] as its parent.
   ///
-  /// {@macro flutter.widgets.slots}
+  /// {@macro flutter.widgets.RenderObjectElement.insertRenderObjectChild}
   ///
   /// This method is only ever called if [updateChild] can end up being called
   /// with an existing [Element] child and a `slot` that differs from the slot
@@ -5987,7 +5987,7 @@ abstract class RenderObjectElement extends Element {
   ///
   /// The given child is guaranteed to have [renderObject] as its parent.
   ///
-  /// {@macro flutter.widgets.slots}
+  /// {@macro flutter.widgets.RenderObjectElement.insertRenderObjectChild}
   ///
   /// This method is only ever called if [updateChild] can end up being called
   /// with an existing [Element] child and a `slot` that differs from the slot

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -297,7 +297,7 @@ class GestureDetector extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// A pointer that might cause a tap with a primary button has contacted the
@@ -991,7 +991,7 @@ class RawGestureDetector extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The gestures that this widget will attempt to recognize.

--- a/packages/flutter/lib/src/widgets/grid_paper.dart
+++ b/packages/flutter/lib/src/widgets/grid_paper.dart
@@ -102,7 +102,7 @@ class GridPaper extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -193,7 +193,7 @@ class Hero extends StatefulWidget {
   /// Changes in scale and aspect ratio work well in hero animations, changes
   /// in layout or composition do not.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Optional override to supply a widget that's shown during the hero's flight.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -726,7 +726,7 @@ class Image extends StatefulWidget {
   /// be passed as the `child` argument to the [loadingBuilder]. For example,
   /// consider the following builders used in conjunction:
   ///
-  /// {@template flutter.widgets.image.chainedBuildersExample}
+  /// {@template flutter.widgets.Image.frameBuilder.chainedBuildersExample}
   /// ```dart
   /// Image(
   ///   ...
@@ -818,7 +818,7 @@ class Image extends StatefulWidget {
   /// builder will contain the _result_ of the [frameBuilder]. For example,
   /// consider the following builders used in conjunction:
   ///
-  /// {@macro flutter.widgets.image.chainedBuildersExample}
+  /// {@macro flutter.widgets.Image.frameBuilder.chainedBuildersExample}
   ///
   /// {@tool dartpad --template=stateless_widget_material}
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -317,7 +317,7 @@ typedef TweenConstructor<T extends Object> = Tween<T> Function(T targetValue);
 
 /// Signature for callbacks passed to [ImplicitlyAnimatedWidgetState.forEachTween].
 ///
-/// {@template flutter.widgets.implicit_animations.tweenVisitorArguments}
+/// {@template flutter.widgets.TweenVisitor.arguments}
 /// The `tween` argument should contain the current tween value. This will
 /// initially be null when the state is first initialized.
 ///
@@ -448,7 +448,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   /// result back into the member variable. The arguments to `visitor` are as
   /// follows:
   ///
-  /// {@macro flutter.widgets.implicit_animations.tweenVisitorArguments}
+  /// {@macro flutter.widgets.TweenVisitor.arguments}
   ///
   /// ### When this method will be called
   ///
@@ -664,7 +664,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   /// the parent provides unbounded constraints, in which case the container
   /// will attempt to be as small as possible.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// Align the [child] within the container.
@@ -840,7 +840,7 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -974,7 +974,7 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// If non-null, sets its height to the child's height multiplied by this factor.
@@ -1108,7 +1108,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The offset of the child's left edge from the left of the stack.
@@ -1243,7 +1243,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The offset of the child's start edge from the start of the stack.
@@ -1404,7 +1404,7 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The target opacity.
@@ -1640,7 +1640,7 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The target text style.
@@ -1772,7 +1772,7 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The type of shape.
@@ -1780,7 +1780,7 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
   /// This property is not animated.
   final BoxShape shape;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -243,7 +243,7 @@ class InteractiveViewer extends StatefulWidget {
   /// At the time this is called, the [TransformationController] will have
   /// already been updated to reflect the change caused by the interaction.
   ///
-  /// {@template flutter.widgets.interactiveViewer.onInteraction}
+  /// {@template flutter.widgets.InteractiveViewer.onInteractionEnd}
   /// Will be called even if the interaction is disabled with
   /// [panEnabled] or [scaleEnabled].
   ///
@@ -265,7 +265,7 @@ class InteractiveViewer extends StatefulWidget {
   /// At the time this is called, the [TransformationController] will not have
   /// changed due to this interaction.
   ///
-  /// {@macro flutter.widgets.interactiveViewer.onInteraction}
+  /// {@macro flutter.widgets.InteractiveViewer.onInteractionEnd}
   ///
   /// The coordinates provided in the details' `focalPoint` and
   /// `localFocalPoint` are normal Flutter event coordinates, not
@@ -284,7 +284,7 @@ class InteractiveViewer extends StatefulWidget {
   /// At the time this is called, the [TransformationController] will have
   /// already been updated to reflect the change caused by the interaction.
   ///
-  /// {@macro flutter.widgets.interactiveViewer.onInteraction}
+  /// {@macro flutter.widgets.InteractiveViewer.onInteractionEnd}
   ///
   /// The coordinates provided in the details' `focalPoint` and
   /// `localFocalPoint` are normal Flutter event coordinates, not

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -18,7 +18,7 @@ typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstrain
 /// adhere to. This is useful when the parent constrains the child's size and layout,
 /// and doesn't depend on the child's intrinsic size.
 ///
-/// {@template flutter.widgets.layoutBuilder.builderFunctionInvocation}
+/// {@template flutter.widgets.ConstrainedLayoutBuilder}
 /// The [builder] function is called in the following situations:
 ///
 /// * The first time the widget is laid out.
@@ -235,7 +235,7 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
 /// the child's intrinsic size. The [LayoutBuilder]'s final size will match its
 /// child's size.
 ///
-/// {@macro flutter.widgets.layoutBuilder.builderFunctionInvocation}
+/// {@macro flutter.widgets.ConstrainedLayoutBuilder}
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=IYDVcriKjsw}
 ///

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -165,7 +165,7 @@ class ListWheelChildBuilderDelegate extends ListWheelChildDelegate {
   /// Called lazily to build children.
   final NullableIndexedWidgetBuilder builder;
 
-  /// {@template flutter.widgets.wheelList.childCount}
+  /// {@template flutter.widgets.ListWheelChildBuilderDelegate.childCount}
   /// If non-null, [childCount] is the maximum number of children that can be
   /// provided, and children are available from 0 to [childCount] - 1.
   ///
@@ -673,29 +673,29 @@ class ListWheelScrollView extends StatefulWidget {
   /// Defaults to matching platform conventions.
   final ScrollPhysics? physics;
 
-  /// {@macro flutter.rendering.wheelList.diameterRatio}
+  /// {@macro flutter.rendering.RenderListWheelViewport.diameterRatio}
   final double diameterRatio;
 
-  /// {@macro flutter.rendering.wheelList.perspective}
+  /// {@macro flutter.rendering.RenderListWheelViewport.perspective}
   final double perspective;
 
-  /// {@macro flutter.rendering.wheelList.offAxisFraction}
+  /// {@macro flutter.rendering.RenderListWheelViewport.offAxisFraction}
   final double offAxisFraction;
 
-  /// {@macro flutter.rendering.wheelList.useMagnifier}
+  /// {@macro flutter.rendering.RenderListWheelViewport.useMagnifier}
   final bool useMagnifier;
 
-  /// {@macro flutter.rendering.wheelList.magnification}
+  /// {@macro flutter.rendering.RenderListWheelViewport.magnification}
   final double magnification;
 
-  /// {@macro flutter.rendering.wheelList.overAndUnderCenterOpacity}
+  /// {@macro flutter.rendering.RenderListWheelViewport.overAndUnderCenterOpacity}
   final double overAndUnderCenterOpacity;
 
   /// Size of each child in the main axis. Must not be null and must be
   /// positive.
   final double itemExtent;
 
-  /// {@macro flutter.rendering.wheelList.squeeze}
+  /// {@macro flutter.rendering.RenderListWheelViewport.squeeze}
   ///
   /// Defaults to 1.
   final double squeeze;
@@ -703,13 +703,13 @@ class ListWheelScrollView extends StatefulWidget {
   /// On optional listener that's called when the centered item changes.
   final ValueChanged<int>? onSelectedItemChanged;
 
-  /// {@macro flutter.rendering.wheelList.renderChildrenOutsideViewport}
+  /// {@macro flutter.rendering.RenderListWheelViewport.renderChildrenOutsideViewport}
   final bool renderChildrenOutsideViewport;
 
   /// A delegate that helps lazily instantiating child.
   final ListWheelChildDelegate childDelegate;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -1002,33 +1002,33 @@ class ListWheelViewport extends RenderObjectWidget {
        ),
        super(key: key);
 
-  /// {@macro flutter.rendering.wheelList.diameterRatio}
+  /// {@macro flutter.rendering.RenderListWheelViewport.diameterRatio}
   final double diameterRatio;
 
-  /// {@macro flutter.rendering.wheelList.perspective}
+  /// {@macro flutter.rendering.RenderListWheelViewport.perspective}
   final double perspective;
 
-  /// {@macro flutter.rendering.wheelList.offAxisFraction}
+  /// {@macro flutter.rendering.RenderListWheelViewport.offAxisFraction}
   final double offAxisFraction;
 
-  /// {@macro flutter.rendering.wheelList.useMagnifier}
+  /// {@macro flutter.rendering.RenderListWheelViewport.useMagnifier}
   final bool useMagnifier;
 
-  /// {@macro flutter.rendering.wheelList.magnification}
+  /// {@macro flutter.rendering.RenderListWheelViewport.magnification}
   final double magnification;
 
-  /// {@macro flutter.rendering.wheelList.overAndUnderCenterOpacity}
+  /// {@macro flutter.rendering.RenderListWheelViewport.overAndUnderCenterOpacity}
   final double overAndUnderCenterOpacity;
 
-  /// {@macro flutter.rendering.wheelList.itemExtent}
+  /// {@macro flutter.rendering.RenderListWheelViewport.itemExtent}
   final double itemExtent;
 
-  /// {@macro flutter.rendering.wheelList.squeeze}
+  /// {@macro flutter.rendering.RenderListWheelViewport.squeeze}
   ///
   /// Defaults to 1.
   final double squeeze;
 
-  /// {@macro flutter.rendering.wheelList.renderChildrenOutsideViewport}
+  /// {@macro flutter.rendering.RenderListWheelViewport.renderChildrenOutsideViewport}
   final bool renderChildrenOutsideViewport;
 
   /// [ViewportOffset] object describing the content that should be visible
@@ -1038,7 +1038,7 @@ class ListWheelViewport extends RenderObjectWidget {
   /// A delegate that lazily instantiates children.
   final ListWheelChildDelegate childDelegate;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -405,7 +405,7 @@ class Localizations extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// The locale of the Localizations widget for the widget tree that

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1627,7 +1627,7 @@ class Navigator extends StatefulWidget {
   /// provided,
   /// {@endtemplate}
   ///
-  /// {@template flutter.widgets.navigator.pushNamed.arguments}
+  /// {@template flutter.widgets.Navigator.pushNamed}
   /// The provided `arguments` are passed to the pushed route via
   /// [RouteSettings.arguments]. Any object can be passed as `arguments` (e.g. a
   /// [String], [int], or an instance of a custom `MyRouteArguments` class).
@@ -1716,7 +1716,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.pushNamed}
   ///
-  /// {@template flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@template flutter.widgets.Navigator.restorablePushNamed.arguments}
   /// The provided `arguments` are passed to the pushed route via
   /// [RouteSettings.arguments]. Any object that is serializable via the
   /// [StandardMessageCodec] can be passed as `arguments`. Often, a Map is used
@@ -1726,7 +1726,7 @@ class Navigator extends StatefulWidget {
   /// [Navigator.onUnknownRoute] to construct the route.
   /// {@endtemplate}
   ///
-  /// {@template flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@template flutter.widgets.Navigator.restorablePushNamed.returnValue}
   /// The method returns an opaque ID for the pushed route that can be used by
   /// the [RestorableRouteFuture] to gain access to the actual [Route] object
   /// added to the navigator and its return value. You can ignore the return
@@ -1796,7 +1796,7 @@ class Navigator extends StatefulWidget {
   /// be provided.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -1835,9 +1835,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.pushReplacementNamed}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -1890,7 +1890,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@endtemplate}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -1928,9 +1928,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.popAndPushNamed}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -1994,7 +1994,7 @@ class Navigator extends StatefulWidget {
   /// must be provided.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -2033,9 +2033,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.pushNamedAndRemoveUntil}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -2106,7 +2106,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.push}
   ///
-  /// {@template flutter.widgets.navigator.restorablePush.arguments}
+  /// {@template flutter.widgets.Navigator.restorablePush}
   /// The method takes a _static_ [RestorableRouteBuilder] as argument, which
   /// must instantiate and return a new [Route] object that will be added to
   /// the navigator. The provided `arguments` object is passed to the
@@ -2117,7 +2117,7 @@ class Navigator extends StatefulWidget {
   /// passed as `arguments`. Often, a Map is used to pass key-value pairs.
   /// {@endtemplate}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -2210,9 +2210,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.pushReplacement}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -2315,9 +2315,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.pushAndRemoveUntil}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -2402,9 +2402,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.replace}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   @optionalTypeArgs
   static String restorableReplace<T extends Object?>(BuildContext context, { required Route<dynamic> oldRoute, required RestorableRouteBuilder<T> newRouteBuilder, Object? arguments }) {
     return Navigator.of(context)!.restorableReplace<T>(oldRoute: oldRoute, newRouteBuilder: newRouteBuilder, arguments: arguments);
@@ -2458,9 +2458,9 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.navigator.replaceRouteBelow}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   @optionalTypeArgs
   static String restorableReplaceRouteBelow<T extends Object?>(BuildContext context, { required Route<dynamic> anchorRoute, required RestorableRouteBuilder<T> newRouteBuilder, Object? arguments }) {
     return Navigator.of(context)!.restorableReplaceRouteBelow<T>(anchorRoute: anchorRoute, newRouteBuilder: newRouteBuilder, arguments: arguments);
@@ -4014,7 +4014,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushNamed}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -4045,9 +4045,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushNamed}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -4081,7 +4081,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushReplacementNamed}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -4115,9 +4115,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushReplacementNamed}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -4151,7 +4151,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.popAndPushNamed}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -4185,9 +4185,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.popAndPushNamed}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -4214,7 +4214,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushNamedAndRemoveUntil}
   ///
-  /// {@macro flutter.widgets.navigator.pushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.pushNamed}
   ///
   /// {@tool snippet}
   ///
@@ -4247,9 +4247,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushNamedAndRemoveUntil}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.arguments}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool snippet}
   ///
@@ -4319,9 +4319,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.push}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -4457,9 +4457,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushReplacement}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -4563,9 +4563,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.pushAndRemoveUntil}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
   /// {@tool dartpad --template=stateful_widget_material}
   ///
@@ -4661,9 +4661,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.replace}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   @optionalTypeArgs
   String restorableReplace<T extends Object?>({ required Route<dynamic> oldRoute, required RestorableRouteBuilder<T> newRouteBuilder, Object? arguments }) {
     assert(oldRoute != null);
@@ -4733,9 +4733,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.navigator.replaceRouteBelow}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePush.arguments}
+  /// {@macro flutter.widgets.Navigator.restorablePush}
   ///
-  /// {@macro flutter.widgets.navigator.restorablePushNamed.returnValue}
+  /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   @optionalTypeArgs
   String restorableReplaceRouteBelow<T extends Object?>({ required Route<dynamic> anchorRoute, required RestorableRouteBuilder<T> newRouteBuilder, Object? arguments }) {
     assert(anchorRoute != null);

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -452,7 +452,7 @@ class NestedScrollView extends StatefulWidget {
   /// is expected to float. This cannot be null.
   final bool floatHeaderSlivers;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -104,7 +104,7 @@ class NotificationListener<T extends Notification> extends StatelessWidget {
   ///
   /// This is not necessarily the widget that dispatched the notification.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Called when a notification of the appropriate type arrives at this

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -213,7 +213,7 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   ///    text and text-direction-sensitive render objects.
   final TextDirection? textDirection;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -262,7 +262,7 @@ class Overlay extends StatefulWidget {
   /// To remove an entry from an [Overlay], use [OverlayEntry.remove].
   final List<OverlayEntry> initialEntries;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   final Clip clipBehavior;
@@ -639,7 +639,7 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
     }
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -250,7 +250,7 @@ class PageStorage extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The page storage bucket to use for this subtree.

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -593,7 +593,7 @@ class PageView extends StatefulWidget {
   /// the [children] list will not be mutated after it has been passed in here.
   /// See the documentation at [SliverChildListDelegate.children] for more details.
   ///
-  /// {@template flutter.widgets.pageView.allowImplicitScrolling}
+  /// {@template flutter.widgets.PageView.allowImplicitScrolling}
   /// The [allowImplicitScrolling] parameter must not be null. If true, the
   /// [PageView] will participate in accessibility scrolling more like a
   /// [ListView], where implicit scroll actions will move to the next page
@@ -635,7 +635,7 @@ class PageView extends StatefulWidget {
   /// you are planning to change child order at a later time, consider using
   /// [PageView] or [PageView.custom].
   ///
-  /// {@macro flutter.widgets.pageView.allowImplicitScrolling}
+  /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
   PageView.builder({
     Key? key,
     this.scrollDirection = Axis.horizontal,
@@ -737,7 +737,7 @@ class PageView extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@macro flutter.widgets.pageView.allowImplicitScrolling}
+  /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
   PageView.custom({
     Key? key,
     this.scrollDirection = Axis.horizontal,
@@ -824,7 +824,7 @@ class PageView extends StatefulWidget {
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -15,7 +15,7 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     this.fullscreenDialog = false,
   }) : super(settings: settings);
 
-  /// {@template flutter.widgets.pageRoute.fullscreenDialog}
+  /// {@template flutter.widgets.PageRoute.fullscreenDialog}
   /// Whether this page route is a full-screen dialog.
   ///
   /// In Material and Cupertino, being fullscreen has the effects of making

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -23,12 +23,12 @@ import 'framework.dart';
 /// The embedded Android view is painted just like any other Flutter widget and transformations
 /// apply to it as well.
 ///
-/// {@template flutter.widgets.platformViews.layout}
+/// {@template flutter.widgets.AndroidView.layout}
 /// The widget fills all available space, the parent of this object must provide bounded layout
 /// constraints.
 /// {@endtemplate}
 ///
-/// {@template flutter.widgets.platformViews.gestures}
+/// {@template flutter.widgets.AndroidView.gestures}
 /// The widget participates in Flutter's gesture arenas, and dispatches touch events to the
 /// platform view iff it won the arena. Specific gestures that should be dispatched to the platform
 /// view can be specified in the `gestureRecognizers` constructor parameter. If
@@ -47,7 +47,7 @@ import 'framework.dart';
 ///   }
 /// ```
 ///
-/// {@template flutter.widgets.platformViews.lifetime}
+/// {@template flutter.widgets.AndroidView.lifetime}
 /// The platform view's lifetime is the same as the lifetime of the [State] object for this widget.
 /// When the [State] is disposed the platform view (and auxiliary resources) are lazily
 /// released (some resources are immediately released and some by platform garbage collector).
@@ -58,7 +58,7 @@ import 'framework.dart';
 class AndroidView extends StatefulWidget {
   /// Creates a widget that embeds an Android view.
   ///
-  /// {@template flutter.widgets.platformViews.constructorParams}
+  /// {@template flutter.widgets.AndroidView.constructorArgs}
   /// The `viewType` and `hitTestBehavior` parameters must not be null.
   /// If `creationParams` is not null then `creationParamsCodec` must not be null.
   /// {@endtemplate}
@@ -88,21 +88,21 @@ class AndroidView extends StatefulWidget {
   ///  * [AndroidView] for an example of registering a platform view factory.
   final String viewType;
 
-  /// {@template flutter.widgets.platformViews.createdParam}
+  /// {@template flutter.widgets.AndroidView.onPlatformViewCreated}
   /// Callback to invoke after the platform view has been created.
   ///
   /// May be null.
   /// {@endtemplate}
   final PlatformViewCreatedCallback? onPlatformViewCreated;
 
-  /// {@template flutter.widgets.platformViews.hittestParam}
+  /// {@template flutter.widgets.AndroidView.hitTestBehavior}
   /// How this widget should behave during hit testing.
   ///
   /// This defaults to [PlatformViewHitTestBehavior.opaque].
   /// {@endtemplate}
   final PlatformViewHitTestBehavior hitTestBehavior;
 
-  /// {@template flutter.widgets.platformViews.directionParam}
+  /// {@template flutter.widgets.AndroidView.layoutDirection}
   /// The text direction to use for the embedded view.
   ///
   /// If this is null, the ambient [Directionality] is used instead.
@@ -111,7 +111,7 @@ class AndroidView extends StatefulWidget {
 
   /// Which gestures should be forwarded to the Android view.
   ///
-  /// {@template flutter.widgets.platformViews.gestureRecognizersDescHead}
+  /// {@template flutter.widgets.AndroidView.gestureRecognizers.descHead}
   /// The gesture recognizers built by factories in this set participate in the gesture arena for
   /// each pointer that was put down on the widget. If any of these recognizers win the
   /// gesture arena, the entire pointer event sequence starting from the pointer down event
@@ -154,7 +154,7 @@ class AndroidView extends StatefulWidget {
   /// )
   /// ```
   ///
-  /// {@template flutter.widgets.platformViews.gestureRecognizersDescFoot}
+  /// {@template flutter.widgets.AndroidView.gestureRecognizers.descFoot}
   /// A platform view can be configured to consume all pointers that were put down in its bounds
   /// by passing a factory for an [EagerGestureRecognizer] in [gestureRecognizers].
   /// [EagerGestureRecognizer] is a special gesture recognizer that immediately claims the gesture
@@ -183,7 +183,7 @@ class AndroidView extends StatefulWidget {
   /// This must not be null if [creationParams] is not null.
   final MessageCodec<dynamic>? creationParamsCodec;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge], and must not be null.
   final Clip clipBehavior;
@@ -196,16 +196,16 @@ class AndroidView extends StatefulWidget {
 // TODO(ychris): remove the documentation for conic path not supported once https://github.com/flutter/flutter/issues/35062 is resolved.
 /// Embeds an iOS view in the Widget hierarchy.
 ///
-/// {@macro flutter.rendering.platformView.preview}
+/// {@macro flutter.rendering.RenderUiKitView}
 ///
 /// Embedding iOS views is an expensive operation and should be avoided when a Flutter
 /// equivalent is possible.
 ///
-/// {@macro flutter.widgets.platformViews.layout}
+/// {@macro flutter.widgets.AndroidView.layout}
 ///
-/// {@macro flutter.widgets.platformViews.gestures}
+/// {@macro flutter.widgets.AndroidView.gestures}
 ///
-/// {@macro flutter.widgets.platformViews.lifetime}
+/// {@macro flutter.widgets.AndroidView.lifetime}
 ///
 /// Construction of UIViews is done asynchronously, before the UIView is ready this widget paints
 /// nothing while maintaining the same layout constraints.
@@ -215,7 +215,7 @@ class AndroidView extends StatefulWidget {
 class UiKitView extends StatefulWidget {
   /// Creates a widget that embeds an iOS view.
   ///
-  /// {@macro flutter.widgets.platformViews.constructorParams}
+  /// {@macro flutter.widgets.AndroidView.constructorArgs}
   const UiKitView({
     Key? key,
     required this.viewType,
@@ -236,13 +236,13 @@ class UiKitView extends StatefulWidget {
   /// A PlatformViewFactory for this type must have been registered.
   final String viewType;
 
-  /// {@macro flutter.widgets.platformViews.createdParam}
+  /// {@macro flutter.widgets.AndroidView.onPlatformViewCreated}
   final PlatformViewCreatedCallback? onPlatformViewCreated;
 
-  /// {@macro flutter.widgets.platformViews.hittestParam}
+  /// {@macro flutter.widgets.AndroidView.hitTestBehavior}
   final PlatformViewHitTestBehavior hitTestBehavior;
 
-  /// {@macro flutter.widgets.platformViews.directionParam}
+  /// {@macro flutter.widgets.AndroidView.layoutDirection}
   final TextDirection? layoutDirection;
 
   /// Passed as the `arguments` argument of [-\[FlutterPlatformViewFactory createWithFrame:viewIdentifier:arguments:\]](/objcdoc/Protocols/FlutterPlatformViewFactory.html#/c:objc(pl)FlutterPlatformViewFactory(im)createWithFrame:viewIdentifier:arguments:)
@@ -260,7 +260,7 @@ class UiKitView extends StatefulWidget {
 
   /// Which gestures should be forwarded to the UIKit view.
   ///
-  /// {@macro flutter.widgets.platformViews.gestureRecognizersDescHead}
+  /// {@macro flutter.widgets.AndroidView.gestureRecognizers.descHead}
   ///
   /// For example, with the following setup vertical drags will not be dispatched to the UIKit
   /// view as the vertical drag gesture is claimed by the parent [GestureDetector].
@@ -295,7 +295,7 @@ class UiKitView extends StatefulWidget {
   /// )
   /// ```
   ///
-  /// {@macro flutter.widgets.platformViews.gestureRecognizersDescFoot}
+  /// {@macro flutter.widgets.AndroidView.gestureRecognizers.descFoot}
   // We use OneSequenceGestureRecognizers as they support gesture arena teams.
   // TODO(amirh): get a list of GestureRecognizers here.
   // https://github.com/flutter/flutter/issues/20953
@@ -317,7 +317,7 @@ class UiKitView extends StatefulWidget {
 /// transformations apply to it as well. This widget should only be used in
 /// Flutter Web.
 ///
-/// {@macro flutter.widgets.platformViews.layout}
+/// {@macro flutter.widgets.AndroidView.layout}
 ///
 /// Due to security restrictions with cross-origin `<iframe>` elements, Flutter
 /// cannot dispatch pointer events to an HTML view. If an `<iframe>` is the
@@ -337,7 +337,7 @@ class UiKitView extends StatefulWidget {
 /// Make sure that your HTML views are sized no larger than necessary, or you
 /// may cause difficulty for users trying to enable accessibility.
 ///
-/// {@macro flutter.widgets.platformViews.lifetime}
+/// {@macro flutter.widgets.AndroidView.lifetime}
 class HtmlElementView extends StatelessWidget {
   /// Creates a platform view for Flutter Web.
   ///
@@ -772,7 +772,7 @@ typedef CreatePlatformViewCallback = PlatformViewController Function(PlatformVie
 /// Provides common functionality for embedding a platform view (e.g an android.view.View on Android)
 /// with the Flutter framework.
 ///
-/// {@macro flutter.widgets.platformViews.lifetime}
+/// {@macro flutter.widgets.AndroidView.lifetime}
 ///
 /// To implement a new platform view widget, return this widget in the `build` method.
 /// For example:
@@ -951,7 +951,7 @@ class PlatformViewSurface extends LeafRenderObjectWidget {
 
   /// Which gestures should be forwarded to the PlatformView.
   ///
-  /// {@macro flutter.widgets.platformViews.gestureRecognizersDescHead}
+  /// {@macro flutter.widgets.AndroidView.gestureRecognizers.descHead}
   ///
   /// For example, with the following setup vertical drags will not be dispatched to the platform view
   /// as the vertical drag gesture is claimed by the parent [GestureDetector].
@@ -984,13 +984,13 @@ class PlatformViewSurface extends LeafRenderObjectWidget {
   /// )
   /// ```
   ///
-  /// {@macro flutter.widgets.platformViews.gestureRecognizersDescFoot}
+  /// {@macro flutter.widgets.AndroidView.gestureRecognizers.descFoot}
   // We use OneSequenceGestureRecognizers as they support gesture arena teams.
   // TODO(amirh): get a list of GestureRecognizers here.
   // https://github.com/flutter/flutter/issues/20953
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
-  /// {@macro flutter.widgets.platformViews.hittestParam}
+  /// {@macro flutter.widgets.AndroidView.hitTestBehavior}
   final PlatformViewHitTestBehavior hitTestBehavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -50,7 +50,7 @@ class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -62,7 +62,7 @@ class RawKeyboardListener extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -14,7 +14,7 @@ export 'package:flutter/services.dart' show RestorationBucket;
 /// Creates a new scope for restoration IDs used by descendant widgets to claim
 /// [RestorationBucket]s.
 ///
-/// {@template flutter.widgets.restoration.scope}
+/// {@template flutter.widgets.RestorationScope}
 /// A restoration scope inserts a [RestorationBucket] into the widget tree,
 /// which descendant widgets can access via [RestorationScope.of]. It is
 /// uncommon for descendants to directly store data in this bucket. Instead,
@@ -80,7 +80,7 @@ class RestorationScope extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The restoration ID used by this widget to obtain a child bucket from the
@@ -119,7 +119,7 @@ class _RestorationScopeState extends State<RestorationScope> with RestorationMix
 /// Inserts a provided [RestorationBucket] into the widget tree and makes it
 /// available to descendants via [RestorationScope.of].
 ///
-/// {@macro flutter.widgets.restoration.scope}
+/// {@macro flutter.widgets.RestorationScope}
 ///
 /// If [bucket] is null, no restoration bucket is made available to descendant
 /// widgets ([RestorationScope.of] invoked from a descendant will return null).
@@ -230,7 +230,7 @@ class RootRestorationScope extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The restoration ID used to identify the child bucket that this widget

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -187,7 +187,7 @@ class _RestorablePrimitiveValue<T extends Object> extends RestorableValue<T> {
 
 /// A [RestorableProperty] that knows how to store and restore a [num].
 ///
-/// {@template flutter.widgets.restoration.primitivevalue}
+/// {@template flutter.widgets.RestorableNum}
 /// The current [value] of this property is stored in the restoration data.
 /// During state restoration the property is restored to the value it had when
 /// the restoration data it is getting restored from was collected.
@@ -202,7 +202,7 @@ class _RestorablePrimitiveValue<T extends Object> extends RestorableValue<T> {
 class RestorableNum<T extends num> extends _RestorablePrimitiveValue<T> {
   /// Creates a [RestorableNum].
   ///
-  /// {@template flutter.widgets.restoration.primitivevalue.constructor}
+  /// {@template flutter.widgets.RestorableNum.constructor}
   /// If no restoration data is available to restore the value in this property
   /// from, the property will be initialized with the provided `defaultValue`.
   /// {@endtemplate}
@@ -211,41 +211,41 @@ class RestorableNum<T extends num> extends _RestorablePrimitiveValue<T> {
 
 /// A [RestorableProperty] that knows how to store and restore a [double].
 ///
-/// {@macro flutter.widgets.restoration.primitivevalue}
+/// {@macro flutter.widgets.RestorableNum}
 class RestorableDouble extends RestorableNum<double> {
   /// Creates a [RestorableDouble].
   ///
-  /// {@macro flutter.widgets.restoration.primitivevalue.constructor}
+  /// {@macro flutter.widgets.RestorableNum.constructor}
   RestorableDouble(double defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore an [int].
 ///
-/// {@macro flutter.widgets.restoration.primitivevalue}
+/// {@macro flutter.widgets.RestorableNum}
 class RestorableInt extends RestorableNum<int> {
   /// Creates a [RestorableInt].
   ///
-  /// {@macro flutter.widgets.restoration.primitivevalue.constructor}
+  /// {@macro flutter.widgets.RestorableNum.constructor}
   RestorableInt(int defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore a [String].
 ///
-/// {@macro flutter.widgets.restoration.primitivevalue}
+/// {@macro flutter.widgets.RestorableNum}
 class RestorableString extends _RestorablePrimitiveValue<String> {
   /// Creates a [RestorableString].
   ///
-  /// {@macro flutter.widgets.restoration.primitivevalue.constructor}
+  /// {@macro flutter.widgets.RestorableNum.constructor}
   RestorableString(String defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore a [bool].
 ///
-/// {@macro flutter.widgets.restoration.primitivevalue}
+/// {@macro flutter.widgets.RestorableNum}
 class RestorableBool extends _RestorablePrimitiveValue<bool> {
   /// Creates a [RestorableBool].
   ///
-  /// {@macro flutter.widgets.restoration.primitivevalue.constructor}
+  /// {@macro flutter.widgets.RestorableNum.constructor}
   RestorableBool(bool defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -93,7 +93,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   Future<T?> get completed => _transitionCompleter.future;
   final Completer<T?> _transitionCompleter = Completer<T?>();
 
-  /// {@template flutter.widgets.transitionRoute.transitionDuration}
+  /// {@template flutter.widgets.TransitionRoute.transitionDuration}
   /// The duration the transition going forwards.
   ///
   /// See also:
@@ -103,7 +103,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// {@endtemplate}
   Duration get transitionDuration;
 
-  /// {@template flutter.widgets.transitionRoute.reverseTransitionDuration}
+  /// {@template flutter.widgets.TransitionRoute.reverseTransitionDuration}
   /// The duration the transition going in reverse.
   ///
   /// By default, the reverse transition duration is set to the value of
@@ -111,7 +111,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// {@endtemplate}
   Duration get reverseTransitionDuration => transitionDuration;
 
-  /// {@template flutter.widgets.transitionRoute.opaque}
+  /// {@template flutter.widgets.TransitionRoute.opaque}
   /// Whether the route obscures previous routes when the transition is complete.
   ///
   /// When an opaque route's entrance transition is complete, the routes behind
@@ -1099,7 +1099,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   // The API for subclasses to override - used by this class
 
-  /// {@template flutter.widgets.modalRoute.barrierDismissible}
+  /// {@template flutter.widgets.ModalRoute.barrierDismissible}
   /// Whether you can dismiss this route by tapping the modal barrier.
   ///
   /// The modal barrier is the scrim that is rendered behind each route, which
@@ -1140,7 +1140,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// has no effect.
   bool get semanticsDismissible => true;
 
-  /// {@template flutter.widgets.modalRoute.barrierColor}
+  /// {@template flutter.widgets.ModalRoute.barrierColor}
   /// The color to use for the modal barrier. If this is null, the barrier will
   /// be transparent.
   ///
@@ -1183,7 +1183,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [ModalBarrier], the widget that implements this feature.
   Color? get barrierColor;
 
-  /// {@template flutter.widgets.modalRoute.barrierLabel}
+  /// {@template flutter.widgets.ModalRoute.barrierLabel}
   /// The semantic label used for a dismissible barrier.
   ///
   /// If the barrier is dismissible, this label will be read out if
@@ -1234,7 +1234,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [AnimatedModalBarrier], the widget that implements this feature.
   Curve get barrierCurve => Curves.ease;
 
-  /// {@template flutter.widgets.modalRoute.maintainState}
+  /// {@template flutter.widgets.ModalRoute.maintainState}
   /// Whether the route should remain in memory when it is inactive.
   ///
   /// If this is true, then the route is maintained, so that any futures it is

--- a/packages/flutter/lib/src/widgets/safe_area.dart
+++ b/packages/flutter/lib/src/widgets/safe_area.dart
@@ -89,7 +89,7 @@ class SafeArea extends StatelessWidget {
   /// The padding on the [MediaQuery] for the [child] will be suitably adjusted
   /// to zero out any sides that were avoided by this widget.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -237,7 +237,7 @@ abstract class ScrollView extends StatelessWidget {
   /// the viewport.
   final double anchor;
 
-  /// {@macro flutter.rendering.viewport.cacheExtent}
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   final double? cacheExtent;
 
   /// The number of children that will contribute semantic information.
@@ -265,7 +265,7 @@ abstract class ScrollView extends StatelessWidget {
   /// {@macro flutter.widgets.scrollable.restorationId}
   final String? restorationId;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -880,7 +880,7 @@ typedef ScrollIncrementCalculator = double Function(ScrollIncrementDetails detai
 /// This is used to configure a [ScrollIncrementDetails] object to pass to a
 /// [ScrollIncrementCalculator] function on a [Scrollable].
 ///
-/// {@template flutter.widgets.scrollable.scroll_increment_type.intent}
+/// {@template flutter.widgets.ScrollIncrementType.intent}
 /// This indicates the *intent* of the scroll, not necessarily the size. Not all
 /// scrollable areas will have the concept of a "line" or "page", but they can
 /// respond to the different standard key bindings that cause scrolling, which
@@ -924,7 +924,7 @@ class ScrollIncrementDetails {
 
   /// The type of scroll this is (e.g. line, page, etc.).
   ///
-  /// {@macro flutter.widgets.scrollable.scroll_increment_type.intent}
+  /// {@macro flutter.widgets.ScrollIncrementType.intent}
   final ScrollIncrementType type;
 
   /// The current metrics of the scrollable that is being scrolled.

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -38,7 +38,7 @@ class SemanticsDebugger extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The [TextStyle] to use when rendering semantics labels.

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -425,7 +425,7 @@ class Shortcuts extends StatefulWidget {
 
   /// The child widget for this [Shortcuts] widget.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The debug label that is printed for this node when logged.

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -287,13 +287,13 @@ class SingleChildScrollView extends StatelessWidget {
 
   /// The widget that scrolls.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -413,7 +413,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     markNeedsLayout();
   }
 
-  /// {@macro flutter.rendering.viewport.cacheExtent}
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   double get cacheExtent => _cacheExtent;
   double _cacheExtent;
   set cacheExtent(double value) {
@@ -424,7 +424,7 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     markNeedsLayout();
   }
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none], and must not be null.
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -46,7 +46,7 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 /// of the existing subclasses that provide adaptors to builder callbacks or
 /// explicit child lists.
 ///
-/// {@template flutter.widgets.sliverChildDelegate.lifecycle}
+/// {@template flutter.widgets.SliverChildDelegate.lifecycle}
 /// ## Child elements' lifecycle
 ///
 /// ### Creation
@@ -771,7 +771,7 @@ abstract class SliverMultiBoxAdaptorWidget extends SliverWithKeepAliveWidget {
   }) : assert(delegate != null),
        super(key: key);
 
-  /// {@template flutter.widgets.sliverMultiBoxAdaptor.delegate}
+  /// {@template flutter.widgets.SliverMultiBoxAdaptorWidget.delegate}
   /// The delegate that provides the children for this widget.
   ///
   /// The children are constructed lazily using this delegate to avoid creating
@@ -842,7 +842,7 @@ abstract class SliverMultiBoxAdaptorWidget extends SliverWithKeepAliveWidget {
 /// [SliverFixedExtentList] does not need to perform layout on its children to
 /// obtain their extent in the main axis and is therefore more efficient.
 ///
-/// {@macro flutter.widgets.sliverChildDelegate.lifecycle}
+/// {@macro flutter.widgets.SliverChildDelegate.lifecycle}
 ///
 /// See also:
 ///
@@ -904,7 +904,7 @@ class SliverList extends SliverMultiBoxAdaptorWidget {
 /// ```
 /// {@end-tool}
 ///
-/// {@macro flutter.widgets.sliverChildDelegate.lifecycle}
+/// {@macro flutter.widgets.SliverChildDelegate.lifecycle}
 ///
 /// See also:
 ///
@@ -977,7 +977,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
 /// ```
 /// {@end-tool}
 ///
-/// {@macro flutter.widgets.sliverChildDelegate.lifecycle}
+/// {@macro flutter.widgets.SliverChildDelegate.lifecycle}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -56,7 +56,7 @@ class SliverFillViewport extends StatelessWidget {
   /// effect. Defaults to true.
   final bool padEnds;
 
-  /// {@macro flutter.widgets.sliverMultiBoxAdaptor.delegate}
+  /// {@macro flutter.widgets.SliverMultiBoxAdaptorWidget.delegate}
   final SliverChildDelegate delegate;
 
   @override

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -19,7 +19,7 @@ typedef SliverLayoutWidgetBuilder = Widget Function(BuildContext context, Sliver
 /// The [SliverLayoutBuilder]'s final [SliverGeometry] will match the [SliverGeometry]
 /// of its child.
 ///
-/// {@macro flutter.widgets.layoutBuilder.builderFunctionInvocation}
+/// {@macro flutter.widgets.ConstrainedLayoutBuilder}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -356,7 +356,7 @@ class TextSelectionOverlay {
   ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
   final DragStartBehavior dragStartBehavior;
 
-  /// {@template flutter.widgets.textSelection.onSelectionHandleTapped}
+  /// {@template flutter.widgets.TextSelectionOverlay.onSelectionHandleTapped}
   /// A callback that's invoked when a selection handle is tapped.
   ///
   /// Both regular taps and long presses invoke this callback, but a drag

--- a/packages/flutter/lib/src/widgets/texture.dart
+++ b/packages/flutter/lib/src/widgets/texture.dart
@@ -45,7 +45,7 @@ class Texture extends LeafRenderObjectWidget {
   /// The identity of the backend texture.
   final int textureId;
 
-  /// {@template FilterQuality}
+  /// {@template flutter.widgets.Texture.filterQuality}
   /// The quality of sampling the texture and rendering it on screen.
   ///
   /// When the texture is scaled, a default [FilterQuality.low] is used for a higher quality but slower

--- a/packages/flutter/lib/src/widgets/ticker_provider.dart
+++ b/packages/flutter/lib/src/widgets/ticker_provider.dart
@@ -41,7 +41,7 @@ class TickerMode extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Whether tickers in the given subtree should be enabled or disabled.

--- a/packages/flutter/lib/src/widgets/title.dart
+++ b/packages/flutter/lib/src/widgets/title.dart
@@ -35,7 +35,7 @@ class Title extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -291,7 +291,7 @@ class SlideTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -394,7 +394,7 @@ class ScaleTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -494,7 +494,7 @@ class RotationTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -627,7 +627,7 @@ class SizeTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
   @override
@@ -988,7 +988,7 @@ class PositionedTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -1107,7 +1107,7 @@ class RelativePositionedTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -1232,7 +1232,7 @@ class DecoratedBoxTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -1293,7 +1293,7 @@ class AlignTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override
@@ -1398,7 +1398,7 @@ class DefaultTextStyleTransition extends AnimatedWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   @override

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -118,17 +118,17 @@ class Viewport extends MultiChildRenderObjectWidget {
   /// The [center] must be the key of a child of the viewport.
   final Key? center;
 
-  /// {@macro flutter.rendering.viewport.cacheExtent}
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   ///
   /// See also:
   ///
   ///  * [cacheExtentStyle], which controls the units of the [cacheExtent].
   final double? cacheExtent;
 
-  /// {@macro flutter.rendering.viewport.cacheExtentStyle}
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
   final CacheExtentStyle cacheExtentStyle;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
@@ -322,7 +322,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   /// Typically a [ScrollPosition].
   final ViewportOffset offset;
 
-  /// {@macro flutter.widgets.Clip}
+  /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -88,7 +88,7 @@ class Visibility extends StatelessWidget {
 
   /// The widget to show or hide, as controlled by [visible].
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// The widget to use when the child is not [visible], assuming that none of

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1544,7 +1544,7 @@ mixin WidgetInspectorService {
   /// object that `diagnosticsNodeId` references only including children that
   /// were created directly by user code.
   ///
-  /// {@template widgets.inspector.trackCreation}
+  /// {@template flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
   /// Requires [Widget] creation locations which are only available for debug
   /// mode builds when the `--track-widget-creation` flag is enabled on the call
   /// to the `flutter` tool. This flag is enabled by default in debug builds.
@@ -1830,7 +1830,7 @@ mixin WidgetInspectorService {
 
   /// Returns whether [Widget] creation locations are available.
   ///
-  /// {@macro widgets.inspector.trackCreation}
+  /// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
   bool isWidgetCreationTracked() {
     _widgetCreationTracked ??= _WidgetForTypeTests() is _HasCreationLocation;
     return _widgetCreationTracked!;
@@ -2761,7 +2761,7 @@ const TextStyle _messageStyle = TextStyle(
 /// Interface for classes that track the source code location the their
 /// constructor was called from.
 ///
-/// {@macro widgets.inspector.trackCreation}
+/// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 // ignore: unused_element
 abstract class _HasCreationLocation {
   _Location get _location;
@@ -2894,7 +2894,7 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
 ///
 /// This always returns false if it is not called in debug mode.
 ///
-/// {@macro widgets.inspector.trackCreation}
+/// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 ///
 /// Currently is local creation locations are only available for
 /// [Widget] and [Element].
@@ -2914,7 +2914,7 @@ bool debugIsLocalCreationLocation(Object object) {
 ///
 /// ex: "file:///path/to/main.dart:4:3"
 ///
-/// {@macro widgets.inspector.trackCreation}
+/// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 ///
 /// Currently creation locations are only available for [Widget] and [Element].
 String? _describeCreationLocation(Object object) {
@@ -2924,7 +2924,7 @@ String? _describeCreationLocation(Object object) {
 
 /// Returns the creation location of an object if one is available.
 ///
-/// {@macro widgets.inspector.trackCreation}
+/// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 ///
 /// Currently creation locations are only available for [Widget] and [Element].
 _Location? _getCreationLocation(Object? object) {

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -27,7 +27,7 @@ class WillPopScope extends StatefulWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// {@macro flutter.widgets.child}
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
   /// Called to veto attempts by the user to dismiss the enclosing [ModalRoute].

--- a/packages/flutter_driver/lib/src/common/wait.dart
+++ b/packages/flutter_driver/lib/src/common/wait.dart
@@ -89,7 +89,7 @@ class WaitUntilNoPendingFrame extends Command {
 /// A Flutter Driver command that waits until the Flutter engine rasterizes the
 /// first frame.
 ///
-/// {@template flutter.frame_rasterized_vs_presented}
+/// {@template flutter.flutter_driver.WaitUntilFirstFrameRasterized}
 /// Usually, the time that a frame is rasterized is very close to the time that
 /// it gets presented on the display. Specifically, rasterization is the last
 /// expensive phase of a frame that's still in Flutter's control.

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1268,7 +1268,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 /// These values are set on the binding's
 /// [LiveTestWidgetsFlutterBinding.framePolicy] property.
 ///
-/// {@template flutter.flutter_test.frame_policy}
+/// {@template flutter.flutter_test.LiveTestWidgetsFlutterBindingFramePolicy}
 /// The default is [LiveTestWidgetsFlutterBindingFramePolicy.fadePointers].
 /// Setting this to anything other than
 /// [LiveTestWidgetsFlutterBindingFramePolicy.onlyPumps] results in pumping
@@ -1417,7 +1417,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// system requests during an asynchronous pause (as would normally happen
   /// when running an application with [WidgetsFlutterBinding]).
   ///
-  /// {@macro flutter.flutter_test.frame_policy}
+  /// {@macro flutter.flutter_test.LiveTestWidgetsFlutterBindingFramePolicy}
   ///
   /// See [LiveTestWidgetsFlutterBindingFramePolicy].
   LiveTestWidgetsFlutterBindingFramePolicy framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fadePointers;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -302,7 +302,7 @@ abstract class WidgetController {
   /// If the middle of the widget is not exposed, this might send
   /// events to another object.
   ///
-  /// {@template flutter.flutter_test.fling}
+  /// {@template flutter.flutter_test.WidgetController.fling}
   /// This can pump frames.
   ///
   /// Exactly 50 pointer events are synthesized.
@@ -358,7 +358,7 @@ abstract class WidgetController {
   /// Attempts a fling gesture starting from the given location, moving the
   /// given distance, reaching the given speed.
   ///
-  /// {@macro flutter.flutter_test.fling}
+  /// {@macro flutter.flutter_test.WidgetController.fling}
   ///
   /// A fling is essentially a drag that ends at a particular speed. If you
   /// just want to drag and end without a fling, use [dragFrom].
@@ -476,7 +476,7 @@ abstract class WidgetController {
   /// The operation happens at once. If you want the drag to last for a period
   /// of time, consider using [timedDrag].
   ///
-  /// {@template flutter.flutter_test.drag}
+  /// {@template flutter.flutter_test.WidgetController.drag}
   /// By default, if the x or y component of offset is greater than
   /// [kDragSlopDefault], the gesture is broken up into two separate moves
   /// calls. Changing `touchSlopX` or `touchSlopY` will change the minimum
@@ -521,7 +521,7 @@ abstract class WidgetController {
   /// The operation happens at once. If you want the drag to last for a period
   /// of time, consider using [timedDragFrom].
   ///
-  /// {@macro flutter.flutter_test.drag}
+  /// {@macro flutter.flutter_test.WidgetController.drag}
   Future<void> dragFrom(
     Offset startLocation,
     Offset offset, {
@@ -613,7 +613,7 @@ abstract class WidgetController {
   /// [fling] or ballistic animation, depending on the speed from
   /// `offset/duration`.
   ///
-  /// {@template flutter.flutter_test.timeddrag}
+  /// {@template flutter.flutter_test.WidgetController.timedDrag}
   /// The move events are sent at a given `frequency` in Hz (or events per
   /// second). It defaults to 60Hz.
   ///
@@ -647,7 +647,7 @@ abstract class WidgetController {
   /// [flingFrom] or ballistic animation, depending on the speed from
   /// `offset/duration`.
   ///
-  /// {@macro flutter.flutter_test.timeddrag}
+  /// {@macro flutter.flutter_test.WidgetController.timedDrag}
   Future<void> timedDragFrom(
     Offset startLocation,
     Offset offset,

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -214,7 +214,7 @@ test_package.TypeMatcher<T> isInstanceOf<T>() => isA<T>();
 
 /// Asserts that two [double]s are equal, within some tolerated error.
 ///
-/// {@template flutter.flutter_test.moreOrLessEquals.epsilon}
+/// {@template flutter.flutter_test.moreOrLessEquals}
 /// Two values are considered equal if the difference between them is within
 /// [precisionErrorTolerance] of the larger one. This is an arbitrary value
 /// which can be adjusted using the `epsilon` argument. This matcher is intended
@@ -237,7 +237,7 @@ Matcher moreOrLessEquals(double value, { double epsilon = precisionErrorToleranc
 
 /// Asserts that two [Rect]s are equal, within some tolerated error.
 ///
-/// {@macro flutter.flutter_test.moreOrLessEquals.epsilon}
+/// {@macro flutter.flutter_test.moreOrLessEquals}
 ///
 /// See also:
 ///
@@ -251,7 +251,7 @@ Matcher rectMoreOrLessEquals(Rect value, { double epsilon = precisionErrorTolera
 
 /// Asserts that two [Offset]s are equal, within some tolerated error.
 ///
-/// {@macro flutter.flutter_test.moreOrLessEquals.epsilon}
+/// {@macro flutter.flutter_test.moreOrLessEquals}
 ///
 /// See also:
 ///


### PR DESCRIPTION
## Description

This standardizes the dartdoc template macro names to roughly follow the convention:

`flutter.library.Class.member[.optionalDescription]`

Where there was no need for a description, I didn't add one.

Some (about 1/4) of the macros were already in this form, but standardizing the rest (which were in various forms) resulted in the following transforms:

<details>
<pre>
flutter.animation.curves.catmull_rom_description => flutter.animation.CatmullRomSpline
flutter.cupertino.navBar.actionsForegroundColor => flutter.cupertino.CupertinoNavigationBar.actionsForegroundColor
flutter.cupertino.navBar.automaticallyImplyLeading => flutter.cupertino.CupertinoNavigationBar.automaticallyImplyLeading
flutter.cupertino.navBar.backgroundColor => flutter.cupertino.CupertinoNavigationBar.backgroundColor
flutter.cupertino.navBar.border => flutter.cupertino.CupertinoNavigationBar.border
flutter.cupertino.navBar.brightness => flutter.cupertino.CupertinoNavigationBar.brightness
flutter.cupertino.navBar.heroTag => flutter.cupertino.CupertinoNavigationBar.heroTag
flutter.cupertino.navBar.leading => flutter.cupertino.CupertinoNavigationBar.leading
flutter.cupertino.navBar.padding => flutter.cupertino.CupertinoNavigationBar.padding
flutter.cupertino.navBar.previousPageTitle => flutter.cupertino.CupertinoNavigationBar.previousPageTitle
flutter.cupertino.navBar.trailing => flutter.cupertino.CupertinoNavigationBar.trailing
flutter.cupertino.navBar.transitionBetweenRoutes => flutter.cupertino.CupertinoNavigationBar.transitionBetweenRoutes
flutter.cupertino.cupertinoRouteTransitionMixin.title => flutter.cupertino.CupertinoRouteTransitionMixin.title
flutter.cupertino.switch.dragStartBehavior => flutter.cupertino.CupertinoSwitch.dragStartBehavior
flutter.frame_rasterized_vs_presented => flutter.flutter_driver.WaitUntilFirstFrameRasterized
flutter.flutter_test.frame_policy => flutter.flutter_test.LiveTestWidgetsFlutterBindingFramePolicy
flutter.flutter_test.moreOrLessEquals.epsilon => flutter.flutter_test.moreOrLessEquals
flutter.flutter_test.drag => flutter.flutter_test.WidgetController.drag
flutter.flutter_test.fling => flutter.flutter_test.WidgetController.fling
flutter.flutter_test.timeddrag => flutter.flutter_test.WidgetController.timedDrag
flutter.foundation.bindingBase.registerServiceExtension => flutter.foundation.BindingBase.registerServiceExtension
flutter.gestures.gestureRecognizer.kind => flutter.gestures.GestureRecognizer.kind
flutter.material.dataTable.dataRowColorCode => flutter.material.DataTable.dataRowColor
flutter.material.dataTable.headingRowColorCode => flutter.material.DataTable.headingRowColor
flutter.material.drawer.dragStartBehavior => flutter.material.DrawerController.dragStartBehavior
flutter.widgets.inputDecorator.textAlignVertical => flutter.material.InputDecorator.textAlignVertical
flutter.material.ListTile.shape => flutter.material.ListTileTheme.shape
flutter.widgets.Clip => flutter.material.Material.clipBehavior
flutter.material.progressIndicator.parameters => flutter.material.ProgressIndicator.ProgressIndicator
flutter.material.rangeSlider.shape.argument.isDiscrete => flutter.material.RangeSliderThumbShape.getPreferredSize.isDiscrete
flutter.material.rangeSlider.shape.argument.isEnabled => flutter.material.RangeSliderThumbShape.getPreferredSize.isEnabled
flutter.material.rangeSlider.shape.argument.activationAnimation => flutter.material.RangeSliderThumbShape.paint.activationAnimation
flutter.material.rangeSlider.shape.argument.context => flutter.material.RangeSliderThumbShape.paint.context
flutter.material.rangeSlider.shape.argument.enableAnimation => flutter.material.RangeSliderThumbShape.paint.enableAnimation
flutter.material.rangeSlider.shape.argument.sliderTheme => flutter.material.RangeSliderThumbShape.paint.sliderTheme
flutter.material.rangeSlider.shape.argument.thumb => flutter.material.RangeSliderThumbShape.paint.thumb
flutter.material.rangeSlider.trackSegment => flutter.material.RangeSliderTickMarkShape.paint.trackSegment
flutter.material.rangeSlider.shape.argument.parentBox => flutter.material.RangeSliderValueIndicatorShape.paint.parentBox
flutter.material.button.mouseCursor => flutter.material.RawMaterialButton.mouseCursor
flutter.material.slider.shape.argument.center => flutter.material.SliderComponentShape.paint.center
flutter.material.slider.shape.argument.context => flutter.material.SliderComponentShape.paint.context
flutter.material.slider.shape.argument.enableAnimation => flutter.material.SliderComponentShape.paint.enableAnimation
flutter.material.slider.shape.argument.isDiscrete => flutter.material.SliderComponentShape.paint.isDiscrete
flutter.material.slider.shape.argument.parentBox => flutter.material.SliderComponentShape.paint.parentBox
flutter.material.slider.shape.argument.sizeWithOverflow => flutter.material.SliderComponentShape.paint.sizeWithOverflow
flutter.material.slider.shape.argument.sliderTheme => flutter.material.SliderComponentShape.paint.sliderTheme
flutter.material.slider.shape.argument.textScaleFactor => flutter.material.SliderComponentShape.paint.textScaleFactor
flutter.material.slider.seeAlso.rangeSliderThumbShape => flutter.material.SliderTheme.rangeSliderThumbShape
flutter.material.slider.seeAlso.rangeSliderTickMarkShape => flutter.material.SliderTheme.rangeSliderTickMarkShape
flutter.material.slider.seeAlso.rangeSliderTrackShape => flutter.material.SliderTheme.rangeSliderTrackShape
flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape => flutter.material.SliderTheme.rangeSliderValueIndicatorShape
flutter.material.slider.seeAlso.sliderComponentShape => flutter.material.SliderTheme.sliderComponentShape
flutter.material.slider.seeAlso.sliderTickMarkShape => flutter.material.SliderTheme.sliderTickMarkShape
flutter.material.slider.seeAlso.sliderTrackShape => flutter.material.SliderTheme.sliderTrackShape
flutter.material.slider.shape.argument.isEnabled => flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled
flutter.material.slider.trackSegment => flutter.material.SliderTrackShape.paint.trackSegment
flutter.painting.boxDecoration.clip => flutter.painting.BoxDecoration.clip
clip_with_box_fit => flutter.painting.BoxFit.cover
flutter.material.progressIndicator.semanticsLabel => flutter.progress_indicator.ProgressIndicator.semanticsLabel
flutter.material.progressIndicator.semanticsValue => flutter.progress_indicator.ProgressIndicator.semanticsValue
flutter.rendering.annotatedRegionLayer.restrictions => flutter.rendering.AnnotatedRegionLayer.restrictions
flutter.clipper.clipBehavior => flutter.rendering.ClipRectLayer.clipBehavior
flutter.leaderFollower.alwaysNeedsAddToScene => flutter.rendering.FollowerLayer.alwaysNeedsAddToScene
flutter.rendering.layer.findAnnotations.aboutAnnotations => flutter.rendering.Layer.findAnnotations.aboutAnnotations
flutter.rendering.object.needsCompositing => flutter.rendering.PaintingContext.pushClipRect.needsCompositing
flutter.rendering.object.pushClipLayer.offset => flutter.rendering.PaintingContext.pushClipRect.offset
flutter.rendering.object.oldLayer => flutter.rendering.PaintingContext.pushClipRect.oldLayer
flutter.rendering.object.pushLayer.offset => flutter.rendering.PaintingContext.pushLayer.offset
flutter.rendering.persistentHeader.showOnScreenConfiguration => flutter.rendering.PersistentHeaderShowOnScreenConfiguration
flutter.rendering.platformView.gestures => flutter.rendering.RenderAndroidView.gestures
flutter.rendering.platformView.layout => flutter.rendering.RenderAndroidView.layout
flutter.rendering.platformView.updateGestureRecognizers => flutter.rendering.RenderAndroidView.updateGestureRecognizers
flutter.rendering.editable.cursorOffset => flutter.rendering.RenderEditable.cursorOffset
flutter.rendering.editable.paintCursorOnTop => flutter.rendering.RenderEditable.paintCursorAboveText
flutter.rendering.editable.select => flutter.rendering.RenderEditable.selectPosition
flutter.rendering.followerLayer.anchor => flutter.rendering.RenderFollowerLayer.leaderAnchor
flutter.rendering.wheelList.diameterRatio => flutter.rendering.RenderListWheelViewport.diameterRatio
flutter.rendering.wheelList.itemExtent => flutter.rendering.RenderListWheelViewport.itemExtent
flutter.rendering.wheelList.magnification => flutter.rendering.RenderListWheelViewport.magnification
flutter.rendering.wheelList.offAxisFraction => flutter.rendering.RenderListWheelViewport.offAxisFraction
flutter.rendering.wheelList.overAndUnderCenterOpacity => flutter.rendering.RenderListWheelViewport.overAndUnderCenterOpacity
flutter.rendering.wheelList.perspective => flutter.rendering.RenderListWheelViewport.perspective
flutter.rendering.wheelList.renderChildrenOutsideViewport => flutter.rendering.RenderListWheelViewport.renderChildrenOutsideViewport
flutter.rendering.wheelList.squeeze => flutter.rendering.RenderListWheelViewport.squeeze
flutter.rendering.wheelList.useMagnifier => flutter.rendering.RenderListWheelViewport.useMagnifier
flutter.rendering.sliverPadding.limitation => flutter.rendering.RenderSliverEdgeInsetsPadding
flutter.rendering.platformView.preview => flutter.rendering.RenderUiKitView
flutter.rendering.viewport.cacheExtent => flutter.rendering.RenderViewportBase.cacheExtent
flutter.rendering.viewport.cacheExtentStyle => flutter.rendering.RenderViewportBase.cacheExtentStyle
flutter.services.autofill.autofillHints => flutter.services.AutofillConfiguration.autofillHints
flutter.services.autofill.AutofillScope => flutter.services.AutofillScope
flutter.services.glfwKeyHelper.modifiers => flutter.services.GLFWKeyHelper.modifierCapsLock
flutter.services.gtkKeyHelper.modifiers => flutter.services.GtkKeyHelper.modifierShift
flutter.services.rawKeyEventDataIOS.modifiers => flutter.services.RawKeyEventDataIos.modifierCapsLock
flutter.services.rawKeyEventDataMacOs.modifiers => flutter.services.RawKeyEventDataMacOs.modifierCapsLock
flutter.services.rawKeyEventDataWindows.modifiers => flutter.services.RawKeyEventDataWindows.modifierShift
flutter.services.restoration.bucketcreation => flutter.services.RestorationBucket.empty.bucketCreation
flutter.services.autofill.autofillContext => flutter.services.TextInput.finishAutofillContext
flutter.services.textInput.enableSuggestions => flutter.services.TextInputConfiguration.enableSuggestions
flutter.services.textInput.smartDashesType => flutter.services.TextInputConfiguration.smartDashesType
flutter.services.textInput.smartQuotesType => flutter.services.TextInputConfiguration.smartQuotesType
flutter.widgets.actions.multipleAdds => flutter.widgets.Action.addActionListener
flutter.widgets.platformViews.constructorParams => flutter.widgets.AndroidView.constructorArgs
flutter.widgets.platformViews.gestureRecognizersDescFoot => flutter.widgets.AndroidView.gestureRecognizers.descFoot
flutter.widgets.platformViews.gestureRecognizersDescHead => flutter.widgets.AndroidView.gestureRecognizers.descHead
flutter.widgets.platformViews.gestures => flutter.widgets.AndroidView.gestures
flutter.widgets.platformViews.hittestParam => flutter.widgets.AndroidView.hitTestBehavior
flutter.widgets.platformViews.layout => flutter.widgets.AndroidView.layout
flutter.widgets.platformViews.directionParam => flutter.widgets.AndroidView.layoutDirection
flutter.widgets.platformViews.lifetime => flutter.widgets.AndroidView.lifetime
flutter.widgets.platformViews.createdParam => flutter.widgets.AndroidView.onPlatformViewCreated
flutter.widgets.autofill.AutofillGroupState => flutter.widgets.AutofillGroupState
flutter.widgets.followerLayer.anchor => flutter.widgets.CompositedTransformFollower.targetAnchor
flutter.widgets.layoutBuilder.builderFunctionInvocation => flutter.widgets.ConstrainedLayoutBuilder
flutter.widgets.editableText.complexCharacters => flutter.widgets.EditableText.onChanged
flutter.widgets.reassemble => flutter.widgets.Element.reassemble
flutter.widgets.focus_manager.focus.keyEvents => flutter.widgets.FocusNode.keyEvents
flutter.widgets.focus_manager.focus.lifecycle => flutter.widgets.FocusNode.lifecycle
flutter.widgets.focusorder.comparable => flutter.widgets.FocusOrder.comparable
flutter.widgets.form.autovalidateMode => flutter.widgets.FormField.autovalidateMode
flutter.widgets.image.chainedBuildersExample => flutter.widgets.Image.frameBuilder.chainedBuildersExample
flutter.widgets.interactiveViewer.onInteraction => flutter.widgets.InteractiveViewer.onInteractionEnd
flutter.widgets.wheelList.childCount => flutter.widgets.ListWheelChildBuilderDelegate.childCount
flutter.widgets.widgetsApp.localeResolutionCallback => flutter.widgets.LocaleResolutionCallback
flutter.widgets.modalRoute.barrierColor => flutter.widgets.ModalRoute.barrierColor
flutter.widgets.modalRoute.barrierDismissible => flutter.widgets.ModalRoute.barrierDismissible
flutter.widgets.modalRoute.barrierLabel => flutter.widgets.ModalRoute.barrierLabel
flutter.widgets.modalRoute.maintainState => flutter.widgets.ModalRoute.maintainState
flutter.mouseRegion.triggerTime => flutter.widgets.MouseRegion.onEnter.triggerTime
flutter.widgets.navigator.pushNamed.arguments => flutter.widgets.Navigator.pushNamed
flutter.widgets.navigator.restorablePush.arguments => flutter.widgets.Navigator.restorablePush
flutter.widgets.navigator.restorablePushNamed.arguments => flutter.widgets.Navigator.restorablePushNamed.arguments
flutter.widgets.navigator.restorablePushNamed.returnValue => flutter.widgets.Navigator.restorablePushNamed.returnValue
flutter.widgets.pageRoute.fullscreenDialog => flutter.widgets.PageRoute.fullscreenDialog
flutter.widgets.pageView.allowImplicitScrolling => flutter.widgets.PageView.allowImplicitScrolling
flutter.widgets.child => flutter.widgets.ProxyWidget.child
flutter.widgets.slots => flutter.widgets.RenderObjectElement.insertRenderObjectChild
flutter.widgets.restoration.primitivevalue => flutter.widgets.RestorableNum
flutter.widgets.restoration.primitivevalue.constructor => flutter.widgets.RestorableNum.constructorArgs
flutter.widgets.restoration.scope => flutter.widgets.RestorationScope
flutter.widgets.scrollable.scroll_increment_type.intent => flutter.widgets.ScrollIncrementType.intent
flutter.widgets.sliverChildDelegate.lifecycle => flutter.widgets.SliverChildDelegate.lifecycle
flutter.widgets.sliverMultiBoxAdaptor.delegate => flutter.widgets.SliverMultiBoxAdaptorWidget.delegate
flutter.widgets.subscriptions => flutter.widgets.State.initState
flutter.widgets.textSelection.onSelectionHandleTapped => flutter.widgets.TextSelectionOverlay.onSelectionHandleTapped
FilterQuality => flutter.widgets.Texture.filterQuality
flutter.widgets.transitionRoute.opaque => flutter.widgets.TransitionRoute.opaque
flutter.widgets.transitionRoute.reverseTransitionDuration => flutter.widgets.TransitionRoute.reverseTransitionDuration
flutter.widgets.transitionRoute.transitionDuration => flutter.widgets.TransitionRoute.transitionDuration
flutter.widgets.implicit_animations.tweenVisitorArguments => flutter.widgets.TweenVisitor.arguments
widgets.inspector.trackCreation => flutter.widgets.WidgetInspectorService.getChildrenSummaryTree
</pre>
</details>

I think `flutter.widgets.child => flutter.widgets.ProxyWidget.child` is kind of dubious, since it's a pretty core thing to `Widget`, and kind of a detail that it's defined in `ProxyWidget`, but at least you do know where the template resides if you wanted to change it, and makes it easy to find.

The slider and range slider changes also might be a step back, but they contain the same information, just in the more standard form.

[And, no, I didn't audit all of the templates by hand: I used a hacked version of dartdoc to print out the canonical names of the symbols each of the templates was attached to, and then (by hand) fixed up the ones that all mapped to the same one by adding their descriptions back in, and made a quick script to do the substitutions in place, verifying first that none of the new names already existed.]

## Related Issues

- https://github.com/flutter/flutter/issues/69252

## Tests

- This is a "docs only" only change, so no tests.
