### PR TITLE
[flutter_tools] do not reload sources if no sources changed

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -953,7 +953,7 @@ class HotRunner extends ResidentRunner {
       fullRestart: false,
       reason: reason,
       overallTimeInMs: reloadInMs,
-      finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int,
+      finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int ?? 0,
       syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int ?? 0,
       syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int ?? 0,
       syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int ?? 0,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -819,64 +819,20 @@ class HotRunner extends ResidentRunner {
       return OperationResult(1, 'DevFS synchronization failed');
     }
     String reloadMessage = 'Reloaded 0 libraries';
-    Map<String, Object> firstReloadDetails;
+    final Map<String, Object> firstReloadDetails = <String, Object>{};
     if (updatedDevFS.invalidatedSourcesCount > 0) {
-      final Stopwatch vmReloadTimer = Stopwatch()..start();
-      const String entryPath = 'main.dart.incremental.dill';
-      final List<Future<DeviceReloadReport>> allReportsFutures = <Future<DeviceReloadReport>>[];
-
-      for (final FlutterDevice device in flutterDevices) {
-        final List<Future<vm_service.ReloadReport>> reportFutures = await _reloadDeviceSources(
-          device,
-          entryPath,
-          pause: pause,
-        );
-        allReportsFutures.add(Future.wait(reportFutures).then(
-          (List<vm_service.ReloadReport> reports) async {
-            // TODO(aam): Investigate why we are validating only first reload report,
-            // which seems to be current behavior
-            final vm_service.ReloadReport firstReport = reports.first;
-            // Don't print errors because they will be printed further down when
-            // `validateReloadReport` is called again.
-            await device.updateReloadStatus(
-              validateReloadReport(firstReport, printErrors: false),
-            );
-            return DeviceReloadReport(device, reports);
-          },
-        ));
+      final OperationResult result = await _reloadSourcesHelper(
+        pause,
+        firstReloadDetails,
+        targetPlatform,
+        sdkName,
+        emulator,
+        reason,
+      );
+      if (result.code != 0) {
+        return result;
       }
-      final List<DeviceReloadReport> reports = await Future.wait(allReportsFutures);
-      for (final DeviceReloadReport report in reports) {
-        final vm_service.ReloadReport reloadReport = report.reports[0];
-        if (!validateReloadReport(reloadReport)) {
-          // Reload failed.
-          HotEvent('reload-reject',
-            targetPlatform: targetPlatform,
-            sdkName: sdkName,
-            emulator: emulator,
-            fullRestart: false,
-            reason: reason,
-            nullSafety: usageNullSafety,
-            fastReassemble: null,
-          ).send();
-          // Reset devFS lastCompileTime to ensure the file will still be marked
-          // as dirty on subsequent reloads.
-          _resetDevFSCompileTime();
-          final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
-          return OperationResult(1, 'Reload rejected: ${contents.notices.join("\n")}');
-        }
-        // Collect stats only from the first device. If/when run -d all is
-        // refactored, we'll probably need to send one hot reload/restart event
-        // per device to analytics.
-        firstReloadDetails ??= castStringKeyedMap(reloadReport.json['details']);
-        final int loadedLibraryCount = reloadReport.json['details']['loadedLibraryCount'] as int;
-        final int finalLibraryCount = reloadReport.json['details']['finalLibraryCount'] as int;
-        globals.printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
-        reloadMessage = 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries';
-      }
-
-      // Record time it took for the VM to reload the sources.
-      _addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
+      reloadMessage = result.message;
     }
 
     final Stopwatch reassembleTimer = Stopwatch()..start();
@@ -997,18 +953,10 @@ class HotRunner extends ResidentRunner {
       fullRestart: false,
       reason: reason,
       overallTimeInMs: reloadInMs,
-      finalLibraryCount: firstReloadDetails != null
-        ? firstReloadDetails['finalLibraryCount'] as int
-        : null,
-      syncedLibraryCount: firstReloadDetails != null
-        ? firstReloadDetails['receivedLibraryCount'] as int
-        : null,
-      syncedClassesCount: firstReloadDetails != null
-        ? firstReloadDetails['receivedClassesCount'] as int
-        : null,
-      syncedProceduresCount: firstReloadDetails != null
-        ? firstReloadDetails['receivedProceduresCount'] as int
-        : null,
+      finalLibraryCount: firstReloadDetails['finalLibraryCount'] as int,
+      syncedLibraryCount: firstReloadDetails['receivedLibraryCount'] as int ?? 0,
+      syncedClassesCount: firstReloadDetails['receivedClassesCount'] as int ?? 0,
+      syncedProceduresCount: firstReloadDetails['receivedProceduresCount'] as int ?? 0,
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: devFSTimer.elapsed.inMilliseconds,
@@ -1031,6 +979,70 @@ class HotRunner extends ResidentRunner {
       failedReassemble ? 1 : OperationResult.ok.code,
       reloadMessage,
     );
+  }
+
+  Future<OperationResult> _reloadSourcesHelper(
+    bool pause,
+    Map<String, dynamic> firstReloadDetails,
+    String targetPlatform,
+    String sdkName,
+    bool emulator,
+    String reason,
+  ) async {
+    final Stopwatch vmReloadTimer = Stopwatch()..start();
+    const String entryPath = 'main.dart.incremental.dill';
+    final List<Future<DeviceReloadReport>> allReportsFutures = <Future<DeviceReloadReport>>[];
+
+    for (final FlutterDevice device in flutterDevices) {
+      final List<Future<vm_service.ReloadReport>> reportFutures = await _reloadDeviceSources(
+        device,
+        entryPath,
+        pause: pause,
+      );
+      allReportsFutures.add(Future.wait(reportFutures).then(
+        (List<vm_service.ReloadReport> reports) async {
+          // TODO(aam): Investigate why we are validating only first reload report,
+          // which seems to be current behavior
+          final vm_service.ReloadReport firstReport = reports.first;
+          // Don't print errors because they will be printed further down when
+          // `validateReloadReport` is called again.
+          await device.updateReloadStatus(
+            validateReloadReport(firstReport, printErrors: false),
+          );
+          return DeviceReloadReport(device, reports);
+        },
+      ));
+    }
+    final List<DeviceReloadReport> reports = await Future.wait(allReportsFutures);
+    final vm_service.ReloadReport reloadReport = reports.first.reports[0];
+    if (!validateReloadReport(reloadReport)) {
+      // Reload failed.
+      HotEvent('reload-reject',
+        targetPlatform: targetPlatform,
+        sdkName: sdkName,
+        emulator: emulator,
+        fullRestart: false,
+        reason: reason,
+        nullSafety: usageNullSafety,
+        fastReassemble: null,
+      ).send();
+      // Reset devFS lastCompileTime to ensure the file will still be marked
+      // as dirty on subsequent reloads.
+      _resetDevFSCompileTime();
+      final ReloadReportContents contents = ReloadReportContents.fromReloadReport(reloadReport);
+      return OperationResult(1, 'Reload rejected: ${contents.notices.join("\n")}');
+    }
+    // Collect stats only from the first device. If/when run -d all is
+    // refactored, we'll probably need to send one hot reload/restart event
+    // per device to analytics.
+    firstReloadDetails.addAll(castStringKeyedMap(reloadReport.json['details']));
+    final int loadedLibraryCount = reloadReport.json['details']['loadedLibraryCount'] as int;
+    final int finalLibraryCount = reloadReport.json['details']['finalLibraryCount'] as int;
+    globals.printTrace('reloaded $loadedLibraryCount of $finalLibraryCount libraries');
+    // reloadMessage = 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries';
+    // Record time it took for the VM to reload the sources.
+    _addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
+    return OperationResult(0, 'Reloaded $loadedLibraryCount of $finalLibraryCount libraries');
   }
 
   String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind) {

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -652,6 +652,72 @@ void main() {
     Usage: () => MockUsage(),
   }));
 
+  testUsingContext('ResidentRunner does not reload sources if no sources changed', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+     listViews,
+      listViews,
+      setAssetBundlePath,
+      listViews,
+      FakeVmServiceRequest(
+        method: 'getIsolate',
+        args: <String, Object>{
+          'isolateId': '1',
+        },
+        jsonResponse: fakeUnpausedIsolate.toJson(),
+      ),
+      FakeVmServiceRequest(
+        method: 'ext.flutter.reassemble',
+        args: <String, Object>{
+          'isolateId': fakeUnpausedIsolate.id,
+        },
+      ),
+    ]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+    );
+    when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
+      return 'Example';
+    });
+    when(mockDevice.targetPlatform).thenAnswer((Invocation invocation) async {
+      return TargetPlatform.android_arm;
+    });
+    when(mockDevice.isLocalEmulator).thenAnswer((Invocation invocation) async {
+      return false;
+    });
+    final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
+    final Completer<void> onAppStart = Completer<void>.sync();
+    unawaited(residentRunner.attach(
+      appStartedCompleter: onAppStart,
+      connectionInfoCompleter: onConnectionInfo,
+    ));
+    await onAppStart.future;
+    when(mockFlutterDevice.updateDevFS(
+      mainUri: anyNamed('mainUri'),
+      target: anyNamed('target'),
+      bundle: anyNamed('bundle'),
+      firstBuildTime: anyNamed('firstBuildTime'),
+      bundleFirstUpload: anyNamed('bundleFirstUpload'),
+      bundleDirty: anyNamed('bundleDirty'),
+      fullRestart: anyNamed('fullRestart'),
+      projectRootPath: anyNamed('projectRootPath'),
+      pathToReload: anyNamed('pathToReload'),
+      invalidatedFiles: anyNamed('invalidatedFiles'),
+      dillOutputPath: anyNamed('dillOutputPath'),
+      packageConfig: anyNamed('packageConfig'),
+    )).thenAnswer((Invocation _) async {
+      return UpdateFSReport(success: true, invalidatedSourcesCount: 0);
+    });
+
+    final OperationResult result = await residentRunner.restart(fullRestart: false);
+
+    expect(result.code, 0);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  }));
+
   testUsingContext('ResidentRunner reports error with missing entrypoint file', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,


### PR DESCRIPTION
## Description

If no source files were changed by a hot reload, do not send the reload sources RPC. This slightly speeds up the no-op reloads and gives users a faster way to force a re-render.