### PR TITLE
AnimatedPositioned

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1058,6 +1058,43 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
+/// {@tool dartpad --template=stateful_widget_scaffold}
+///
+/// The following example transitions an AnimatedPositioned
+/// between two states. It adjusts the `height`, `width`, and
+/// [Positioned] properties when tapped.
+///
+/// ```dart
+/// bool selected = false;
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   return Stack(
+///     children: [
+///       AnimatedPositioned(
+///         width: selected ? 200.0 : 50.0,
+///         height: selected ? 50.0 : 200.0,
+///         top: selected ? 50.0 : 150.0,
+///         right: 150.0,
+///         duration: Duration(seconds: 2),
+///         curve: Curves.fastOutSlowIn,
+///         child: GestureDetector(
+///           onTap: () {
+///             setState(() {
+///               selected = !selected;
+///             });
+///           },
+///           child: Container(
+///             color: Colors.blue,
+///           ),
+///         ),
+///       ),
+///     ],
+///   );
+/// }
+///```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [AnimatedPositionedDirectional], which adapts to the ambient

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1086,6 +1086,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///           },
 ///           child: Container(
 ///             color: Colors.blue,
+///             child: Text('Tap me to start the animated transition'),
 ///           ),
 ///         ),
 ///       ),


### PR DESCRIPTION
AnimatedPositoned

This wasn't assign in Adopt a Widget, As all Adopt a Widget issue has been assigned already. I looked up for the widget which doesn't have Sample code, turns out AnimatedPositioned doesn't have one.

This pull request is:

- [x] A code sample
- [ ] More references
- [ ] More explanation
