### PR TITLE
SliverWithKeepAliveWidget docs

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -746,6 +746,15 @@ class SliverChildListDelegate extends SliverChildDelegate {
 }
 
 /// A base class for sliver that have [KeepAlive] children.
+///
+/// See also:
+///
+///  * [KeepAlive], which marks whether its child widget should be kept alive.
+///  * [SliverChildBuilderDelegate] and [SliverChildListDelegate], slivers
+///     which make use of the keep alive functionality through the
+///     `addAutomaticKeepAlives` property.
+///  * [SliverGrid] and [SliverList], two sliver widgets that are commonly
+///     wrapped with [KeepAlive] widgets to preserve their sliver child subtrees.
 abstract class SliverWithKeepAliveWidget extends RenderObjectWidget {
   /// Initializes fields for subclasses.
   const SliverWithKeepAliveWidget({


### PR DESCRIPTION
`customer-testing` seems to keep failing on https://github.com/flutter/flutter/pull/69523 with dependency conflicts:
```
|
| ---- Log transcript ----
|
| FINE: Pub 2.12.0-3.0.dev
|
| MSG : Resolving dependencies...
|
| SLVR: fact: flutter_svg is 0.19.1
|
| SLVR: derived: flutter_svg
|
| SLVR: fact: flutter_svg requires Flutter SDK version >=1.24.0-6.0.pre <2.0.0
|
| SLVR: conflict: flutter_svg requires Flutter SDK version >=1.24.0-6.0.pre <2.0.0
|
| SLVR: Version solving took 0:00:00.077470 seconds.
|
|     | Tried 1 solutions.
```

Testing to see if this happens for me as well.