### PR TITLE
AdoptAWidget: SnackBar

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -175,7 +175,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///             label: "Action",
 ///             onPressed: () {
 ///               // Code to execute.
-///             }
+///             },
 ///           ),
 ///         ),
 ///       );

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -157,7 +157,91 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///
 /// A SnackBar with an action will not time out when TalkBack or VoiceOver are
 /// enabled. This is controlled by [AccessibilityFeatures.accessibleNavigation].
-///
+/// 
+/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// 
+/// Here is an example of a [SnackBar] with an [action] button implemented using
+/// [SnackBarAction].
+/// 
+/// ```dart preamble
+/// class _ShowSnackBarButton extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return ElevatedButton(
+///       child: Text("Show Snackbar"),
+///       onPressed: () {
+///         Scaffold.of(context).showSnackBar(
+///           SnackBar(
+///             content: Text("Awesome Snackbar!"),
+///             action: SnackBarAction(
+///               label: "Action",
+///               onPressed: () {
+///                 // Code to execute 
+///               }
+///             ),
+///           ),
+///         );
+///       },
+///     );
+///   }
+/// }
+/// ```
+/// 
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return _ShowSnackBarButton();
+/// }
+/// ```
+/// {@end-tool}
+/// 
+/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// 
+/// Here is an example of a customized [SnackBar]. It utilizes
+/// [behavior], [shape], [padding], [width] to customize the location and 
+/// appearance.
+/// 
+/// ```dart preamble
+/// SnackBar _customSnackBar() {
+///   return SnackBar(
+///     action: SnackBarAction(
+///       label: "Action",
+///       onPressed: () {
+///         // Code to execute.
+///       },
+///     ),
+///     content: Text("Awesome SnackBar!"),
+///     width: 280.0, //Width of the SnackBar.
+///     padding: EdgeInsets.symmetric(
+///       horizontal: 8.0), // Inner padding for SnackBar content.
+///     behavior: SnackBarBehavior.floating,
+///     shape: RoundedRectangleBorder(
+///         borderRadius: BorderRadius.circular(10.0),
+///     ),
+///   );
+/// }
+/// 
+/// class _ShowSnackBarButton extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return ElevatedButton(
+///       child: Text("Show Snackbar"),
+///       onPressed: () {
+///         Scaffold.of(context).showSnackBar(
+///           _customSnackBar(),
+///         );
+///       },
+///     );
+///   }
+/// }
+/// ```
+/// 
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return _ShowSnackBarButton();
+/// }
+/// ```
+/// {@end-tool}
+/// 
 /// See also:
 ///
 ///  * [ScaffoldMessenger.of], to obtain the current [ScaffoldMessengerState],

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -206,7 +206,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///           ),
 ///           content: Text("Awesome SnackBar!"),
 ///           duration: Duration(milliseconds: 1500),
-///           width: 280.0, //Width of the SnackBar.
+///           width: 280.0, // Width of the SnackBar.
 ///           padding: EdgeInsets.symmetric(
 ///             horizontal: 8.0), // Inner padding for SnackBar content.
 ///           behavior: SnackBarBehavior.floating,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -163,33 +163,24 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// Here is an example of a [SnackBar] with an [action] button implemented using
 /// [SnackBarAction].
 ///
-/// ```dart preamble
-/// class _ShowSnackBarButton extends StatelessWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     return ElevatedButton(
-///       child: Text("Show Snackbar"),
-///       onPressed: () {
-///         Scaffold.of(context).showSnackBar(
-///           SnackBar(
-///             content: Text("Awesome Snackbar!"),
-///             action: SnackBarAction(
-///               label: "Action",
-///               onPressed: () {
-///                 // Code to execute
-///               }
-///             ),
-///           ),
-///         );
-///       },
-///     );
-///   }
-/// }
-/// ```
-///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return _ShowSnackBarButton();
+///   return ElevatedButton(
+///     child: Text("Show Snackbar"),
+///     onPressed: () {
+///       ScaffoldMessenger.of(context).showSnackBar(
+///         SnackBar(
+///           content: Text("Awesome Snackbar!"),
+///           action: SnackBarAction(
+///             label: "Action",
+///             onPressed: () {
+///               // Code to execute.
+///             }
+///           ),
+///         ),
+///       );
+///     },
+///   );
 /// }
 /// ```
 /// {@end-tool}
@@ -197,47 +188,35 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
 ///
 /// Here is an example of a customized [SnackBar]. It utilizes
-/// [behavior], [shape], [padding], [width] to customize the location and
-/// appearance.
-///
-/// ```dart preamble
-/// SnackBar _customSnackBar() {
-///   return SnackBar(
-///     action: SnackBarAction(
-///       label: "Action",
-///       onPressed: () {
-///         // Code to execute.
-///       },
-///     ),
-///     content: Text("Awesome SnackBar!"),
-///     width: 280.0, //Width of the SnackBar.
-///     padding: EdgeInsets.symmetric(
-///       horizontal: 8.0), // Inner padding for SnackBar content.
-///     behavior: SnackBarBehavior.floating,
-///     shape: RoundedRectangleBorder(
-///         borderRadius: BorderRadius.circular(10.0),
-///     ),
-///   );
-/// }
-///
-/// class _ShowSnackBarButton extends StatelessWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     return ElevatedButton(
-///       child: Text("Show Snackbar"),
-///       onPressed: () {
-///         Scaffold.of(context).showSnackBar(
-///           _customSnackBar(),
-///         );
-///       },
-///     );
-///   }
-/// }
-/// ```
+/// [behavior], [shape], [padding], [width], and [duration] to customize the
+/// location, appearance, and the duration for which the [SnackBar] is visible.
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return _ShowSnackBarButton();
+///   return ElevatedButton(
+///     child: Text("Show Snackbar"),
+///     onPressed: () {
+///       ScaffoldMessenger.of(context).showSnackBar(
+///         SnackBar(
+///           action: SnackBarAction(
+///             label: "Action",
+///             onPressed: () {
+///               // Code to execute.
+///             },
+///           ),
+///           content: Text("Awesome SnackBar!"),
+///           duration: Duration(milliseconds: 1500),
+///           width: 280.0, //Width of the SnackBar.
+///           padding: EdgeInsets.symmetric(
+///             horizontal: 8.0), // Inner padding for SnackBar content.
+///           behavior: SnackBarBehavior.floating,
+///           shape: RoundedRectangleBorder(
+///             borderRadius: BorderRadius.circular(10.0),
+///           ),
+///         ),
+///       );
+///     },
+///   );
 /// }
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -157,12 +157,12 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///
 /// A SnackBar with an action will not time out when TalkBack or VoiceOver are
 /// enabled. This is controlled by [AccessibilityFeatures.accessibleNavigation].
-/// 
+///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
-/// 
+///
 /// Here is an example of a [SnackBar] with an [action] button implemented using
 /// [SnackBarAction].
-/// 
+///
 /// ```dart preamble
 /// class _ShowSnackBarButton extends StatelessWidget {
 ///   @override
@@ -176,7 +176,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///             action: SnackBarAction(
 ///               label: "Action",
 ///               onPressed: () {
-///                 // Code to execute 
+///                 // Code to execute
 ///               }
 ///             ),
 ///           ),
@@ -186,20 +186,20 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///   }
 /// }
 /// ```
-/// 
+///
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return _ShowSnackBarButton();
 /// }
 /// ```
 /// {@end-tool}
-/// 
+///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
-/// 
+///
 /// Here is an example of a customized [SnackBar]. It utilizes
-/// [behavior], [shape], [padding], [width] to customize the location and 
+/// [behavior], [shape], [padding], [width] to customize the location and
 /// appearance.
-/// 
+///
 /// ```dart preamble
 /// SnackBar _customSnackBar() {
 ///   return SnackBar(
@@ -219,7 +219,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///     ),
 ///   );
 /// }
-/// 
+///
 /// class _ShowSnackBarButton extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -234,14 +234,14 @@ class _SnackBarActionState extends State<SnackBarAction> {
 ///   }
 /// }
 /// ```
-/// 
+///
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return _ShowSnackBarButton();
 /// }
 /// ```
 /// {@end-tool}
-/// 
+///
 /// See also:
 ///
 ///  * [ScaffoldMessenger.of], to obtain the current [ScaffoldMessengerState],


### PR DESCRIPTION
## Description

Adds two dartpad samples for SnackBar documentation:
1. Simple SnackBar usage with an action button.
2. Custom SnackBar using behavior, shape, padding and width.

This pull request is:
- [x] A code sample
- [ ] More references
- [ ] More explanation

## Related Issues

Closes #69490 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
