### PR TITLE
AdoptAWidget: WillPopScope

### DIFF
--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,7 +29,6 @@ import 'routes.dart';
 /// {@tool dartpad --template=stateless_widget_material}
 ///
 /// ```dart
-/// 
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -17,8 +17,6 @@ import 'routes.dart';
 ///
 /// ```dart
 /// bool shouldPop = true;
-/// // ...
-///
 /// @override
 /// Widget build(BuildContext) {
 ///   return WillPopScope (
@@ -26,7 +24,6 @@ import 'routes.dart';
 ///       return shouldPop;
 ///     },
 ///     child: Center(
-///       // ...
 ///     ),
 ///   );
 /// }

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -28,9 +28,6 @@ import 'routes.dart';
 ///
 /// {@tool dartpad --template=stateless_widget_material}
 ///
-/// ``` dart imports
-/// import 'package:flutter/material.dart';
-///
 /// ```dart
 /// In this example a snackbar is shown when back button is pressed. Here 
 /// `false` is returned to prevent the screen from popping. Returning `true` 

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,9 +29,7 @@ import 'routes.dart';
 /// {@tool dartpad --template=stateless_widget_material}
 ///
 /// ```dart
-/// In this example a snackbar is shown when back button is pressed. Here
-/// `false` is returned to prevent the screen from popping. Returning `true`
-/// would pop the screen.
+/// 
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,8 +29,8 @@ import 'routes.dart';
 /// {@tool dartpad --template=stateless_widget_material}
 ///
 /// ```dart
-/// In this example a snackbar is shown when back button is pressed. Here 
-/// `false` is returned to prevent the screen from popping. Returning `true` 
+/// In this example a snackbar is shown when back button is pressed. Here
+/// `false` is returned to prevent the screen from popping. Returning `true`
 /// would pop the screen.
 /// Widget build(BuildContext context) {
 ///   return Scaffold(

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -18,15 +18,18 @@ import 'routes.dart';
 /// ```dart
 /// @override
 /// Widget build(BuildContext) {
-///     return WillPopScope(
-///      onWillPop:_handleBackPress,
-///        child:MyWidget(),
+///     return WillPopScope (
+///      onWillPop: _handleBackPress,
+///        child: MyWidget(),
 ///     );
 /// }
 /// ```
 /// {@end-tool}
 ///
 /// {@tool dartpad --template=stateful_widget}
+///
+/// ``` dart imports
+/// import 'package:flutter/material.dart';
 ///
 /// ```dart
 ///   @override
@@ -37,27 +40,27 @@ import 'routes.dart';
 ///         leading: BackButton(),
 ///       ),
 ///       body: WillPopScope(
-///         child:Center(
+///         child: Center(
 ///         child: Text("Press back button in AppBar"),
 ///       ),
-///         onWillPop:_onBackPressed,
+///         onWillPop: _onBackPressed,
 ///       ),
 ///     );
 ///   }
 ///
-///   Future<bool> _onBackPressed(){
+///   Future<bool> _onBackPressed() {
 ///     return showDialog(
-///     context:context,
-///     builder:(context)=>AlertDialog(
-///       title:Text("Do you really want to exit the app?"),
-///       actions:<Widget>[
+///     context: context,
+///     builder: (context) => AlertDialog(
+///       title: Text("Do you really want to exit the app?"),
+///       actions: <Widget>[
 ///         FlatButton(
-///           child:Text("No"),
-///           onPressed:()=> Navigator.pop(context,false),
+///           child: Text("No"),
+///           onPressed:() => Navigator.pop(context,false),
 ///         ),
 ///         FlatButton(
-///           child:Text("Yes"),
-///           onPressed:()=> Navigator.pop(context,true),
+///           child: Text("Yes"),
+///           onPressed:() => Navigator.pop(context,true),
 ///         ),
 ///       ]
 ///     ),
@@ -72,7 +75,8 @@ import 'routes.dart';
 ///  * [ModalRoute.addScopedWillPopCallback] and [ModalRoute.removeScopedWillPopCallback],
 ///    which this widget uses to register and unregister [onWillPop].
 ///  * [Form], which provides an `onWillPop` callback that enables the form
-///    to veto a [pop] initiated by the app's back button.
+///    to veto a `pop` initiated by the app's back button.
+///
 class WillPopScope extends StatefulWidget {
   /// Creates a widget that registers a callback to veto attempts by the user to
   /// dismiss the enclosing [ModalRoute].
@@ -83,7 +87,7 @@ class WillPopScope extends StatefulWidget {
     required this.child,
     required this.onWillPop,
   })   : assert(child != null),
-         super(key: key);
+        super(key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -58,12 +58,14 @@ import 'routes.dart';
 ///         FlatButton(
 ///           child:Text("Yes"),
 ///           onPressed:()=> Navigator.pop(context,true),
-///         )
+///         ),
 ///       ]
-///     )
+///     ),
 ///    );
 ///   }
 /// ```
+///
+/// {@end-tool}
 ///
 /// See also:
 ///
@@ -81,7 +83,7 @@ class WillPopScope extends StatefulWidget {
     required this.child,
     required this.onWillPop,
   })   : assert(child != null),
-        super(key: key);
+         super(key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -18,20 +18,23 @@ import 'routes.dart';
 /// ```dart
 /// @override
 /// Widget build(BuildContext) {
-///     return WillPopScope (
-///      onWillPop: () async {
+///   return WillPopScope (
+///     onWillPop: () async {
 ///        return shouldPop;
-///      },
-///        child: MyWidget(),
-///     );
+///     },
+///     child: Center(),
+///   );
 /// }
 /// ```
 /// {@end-tool}
 ///
 /// {@tool dartpad --template=stateful_widget_material}
 ///
-/// ```dart
+/// ```dart preamble
 /// bool shouldPop = true;
+/// ```
+///
+/// ```dart
 /// @override
 /// Widget build(BuildContext context) {
 ///   return WillPopScope(

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -19,7 +19,9 @@ import 'routes.dart';
 /// @override
 /// Widget build(BuildContext) {
 ///     return WillPopScope (
-///      onWillPop: _handleBackPress,
+///      onWillPop: () async {
+///        return shouldPop;
+///      },
 ///        child: MyWidget(),
 ///     );
 /// }
@@ -27,23 +29,86 @@ import 'routes.dart';
 /// {@end-tool}
 ///
 /// {@tool dartpad --template=stateless_widget_material}
+/// ```dart imports
+/// import 'package:flutter/material.dart';
+/// ```
+///
+/// ```dart main
+/// void main() => runApp(MyApp());
+/// ```
 ///
 /// ```dart
-/// Widget build(BuildContext context) {
-///   return Scaffold(
-///     appBar: AppBar(
-///       title: Text("WillPopScope demo"),
-///       leading: BackButton(),
-///     ),
-///     body: WillPopScope(
-///         child: Center(child: Text("Press back button in AppBar")),
-///         onWillPop: () async {
-///           ScaffoldMessenger.of(context).showSnackBar(
-///               SnackBar(
-///                 content: Text("Callback fired on pressing back button")));
-///           return false;
-///         }),
-///   );
+/// class MyApp extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return MaterialApp(
+///       initialRoute: '/',
+///       routes: {
+///         '/': (context) => FirstPage(),
+///         '/second_screen': (context) => SecondPage(),
+///       },
+///     );
+///   }
+/// }
+///
+/// class FirstPage extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(
+///         title: Text('WillPopScope demo'),
+///       ),
+///       body: Center(
+///         child: RaisedButton(
+///           child: Text('Go to the second screen'),
+///           onPressed: () {
+///             Navigator.pushNamed(context, '/second_screen');
+///           },
+///         ),
+///       ),
+///     );
+///   }
+/// }
+///
+/// class SecondPage extends StatefulWidget {
+///   SecondPage({Key key, this.title}) : super(key: key);
+///   final String title;
+///   @override
+///   _SecondPageState createState() => _SecondPageState();
+/// }
+///
+/// class _SecondPageState extends State<SecondPage> {
+///   bool shouldPop = true;
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return WillPopScope(
+///       onWillPop: () async => shouldPop,
+///       child: Scaffold(
+///         appBar: AppBar(
+///           title: Text("WillPopScope demo"),
+///           leading: BackButton(),
+///         ),
+///         body: Center(
+///           child: Column(
+///             mainAxisAlignment: MainAxisAlignment.center,
+///             children: <Widget>[
+///               Text(
+///                   "Toggle shouldPop using the button.Press the back button in appbar to see the effect."),
+///               OutlinedButton(
+///                 child: Text('shouldPop: $shouldPop'),
+///                 onPressed: () {
+///                   setState(() {
+///                     shouldPop = !shouldPop;
+///                   });
+///                 },
+///               ),
+///             ],
+///           ),
+///         ),
+///       ),
+///     );
+///   }
 /// }
 /// ```
 ///
@@ -65,8 +130,8 @@ class WillPopScope extends StatefulWidget {
     Key? key,
     required this.child,
     required this.onWillPop,
-  })   : assert(child != null),
-         super(key: key);
+  }) : assert(child != null),
+       super(key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -9,10 +9,68 @@ import 'routes.dart';
 /// Registers a callback to veto attempts by the user to dismiss the enclosing
 /// [ModalRoute].
 ///
+/// {@tool snippet --template=stateful_widget}
+///
+/// Whenever the back button is pressed, you will get a callback at [onWillPop],
+/// which returns a [Future]. If the [Future] returned is true, the screen is
+/// popped and if it is false, the screen is not popped.
+///
+/// ```dart
+/// @override
+/// Widget build(BuildContext) {
+///     return WillPopScope(
+///      onWillPop:_handleBackPress,
+///        child:MyWidget(),
+///     );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// {@tool dartpad --template=stateful_widget}
+///
+/// ```dart
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(
+///         title: Text(widget.title),
+///         leading: BackButton(),
+///       ),
+///       body: WillPopScope(
+///         child:Center(
+///         child: Text("Press back button in AppBar"),
+///       ),
+///         onWillPop:_onBackPressed,
+///       ),
+///     );
+///   }
+///
+///   Future<bool> _onBackPressed(){
+///     return showDialog(
+///     context:context,
+///     builder:(context)=>AlertDialog(
+///       title:Text("Do you really want to exit the app?"),
+///       actions:<Widget>[
+///         FlatButton(
+///           child:Text("No"),
+///           onPressed:()=> Navigator.pop(context,false),
+///         ),
+///         FlatButton(
+///           child:Text("Yes"),
+///           onPressed:()=> Navigator.pop(context,true),
+///         )
+///       ]
+///     )
+///    );
+///   }
+/// ```
+///
 /// See also:
 ///
 ///  * [ModalRoute.addScopedWillPopCallback] and [ModalRoute.removeScopedWillPopCallback],
 ///    which this widget uses to register and unregister [onWillPop].
+///  * [Form], which provides an `onWillPop` callback that enables the form
+///    to veto a [pop] initiated by the app's back button.
 class WillPopScope extends StatefulWidget {
   /// Creates a widget that registers a callback to veto attempts by the user to
   /// dismiss the enclosing [ModalRoute].
@@ -22,8 +80,8 @@ class WillPopScope extends StatefulWidget {
     Key? key,
     required this.child,
     required this.onWillPop,
-  }) : assert(child != null),
-       super(key: key);
+  })   : assert(child != null),
+        super(key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -26,46 +26,31 @@ import 'routes.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget}
+/// {@tool dartpad --template=stateless_widget_material}
 ///
 /// ``` dart imports
 /// import 'package:flutter/material.dart';
 ///
 /// ```dart
-///   @override
-///   Widget build(BuildContext context) {
-///     return Scaffold(
-///       appBar: AppBar(
-///         title: Text(widget.title),
-///         leading: BackButton(),
-///       ),
-///       body: WillPopScope(
-///         child: Center(
-///         child: Text("Press back button in AppBar"),
-///       ),
-///         onWillPop: _onBackPressed,
-///       ),
-///     );
-///   }
-///
-///   Future<bool> _onBackPressed() {
-///     return showDialog(
-///     context: context,
-///     builder: (context) => AlertDialog(
-///       title: Text("Do you really want to exit the app?"),
-///       actions: <Widget>[
-///         FlatButton(
-///           child: Text("No"),
-///           onPressed:() => Navigator.pop(context,false),
-///         ),
-///         FlatButton(
-///           child: Text("Yes"),
-///           onPressed:() => Navigator.pop(context,true),
-///         ),
-///       ]
+/// In this example a snackbar is shown when back button is pressed. Here 
+/// `false` is returned to prevent the screen from popping. Returning `true` 
+/// would pop the screen.
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     appBar: AppBar(
+///       title: Text("WillPopScope demo"),
+///       leading: BackButton(),
 ///     ),
-///    );
-///   }
+///     body: WillPopScope(
+///         child: Center(child: Text("Press back button in AppBar")),
+///         onWillPop: () async {
+///           ScaffoldMessenger.of(context).showSnackBar(
+///               SnackBar(
+///                 content: Text("Callback fired on pressing back button")));
+///           return false;
+///         }),
+///   );
+/// }
 /// ```
 ///
 /// {@end-tool}
@@ -87,7 +72,7 @@ class WillPopScope extends StatefulWidget {
     required this.child,
     required this.onWillPop,
   })   : assert(child != null),
-        super(key: key);
+         super(key: key);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -28,88 +28,31 @@ import 'routes.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
-/// ```dart imports
-/// import 'package:flutter/material.dart';
-/// ```
-///
-/// ```dart main
-/// void main() => runApp(MyApp());
-/// ```
-///
+/// {@tool dartpad --template=stateful_widget_material}
+/// 
 /// ```dart
-/// class MyApp extends StatelessWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     return MaterialApp(
-///       initialRoute: '/',
-///       routes: {
-///         '/': (context) => FirstPage(),
-///         '/second_screen': (context) => SecondPage(),
+/// bool shouldPop = true;
+/// @override
+/// Widget build(BuildContext context) {
+///   return WillPopScope(
+///       onWillPop: () async {
+///         setState(() {
+///           shouldPop = !shouldPop;
+///         });
+///         return shouldPop;
 ///       },
-///     );
-///   }
-/// }
-///
-/// class FirstPage extends StatelessWidget {
-///   @override
-///   Widget build(BuildContext context) {
-///     return Scaffold(
-///       appBar: AppBar(
-///         title: Text('WillPopScope demo'),
-///       ),
-///       body: Center(
-///         child: RaisedButton(
-///           child: Text('Go to the second screen'),
-///           onPressed: () {
-///             Navigator.pushNamed(context, '/second_screen');
-///           },
-///         ),
-///       ),
-///     );
-///   }
-/// }
-///
-/// class SecondPage extends StatefulWidget {
-///   SecondPage({Key key, this.title}) : super(key: key);
-///   final String title;
-///   @override
-///   _SecondPageState createState() => _SecondPageState();
-/// }
-///
-/// class _SecondPageState extends State<SecondPage> {
-///   bool shouldPop = true;
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return WillPopScope(
-///       onWillPop: () async => shouldPop,
 ///       child: Scaffold(
-///         appBar: AppBar(
-///           title: Text("WillPopScope demo"),
-///           leading: BackButton(),
-///         ),
-///         body: Center(
-///           child: Column(
-///             mainAxisAlignment: MainAxisAlignment.center,
-///             children: <Widget>[
-///               Text(
-///                   "Toggle shouldPop using the button.Press the back button in appbar to see the effect."),
-///               OutlinedButton(
-///                 child: Text('shouldPop: $shouldPop'),
-///                 onPressed: () {
-///                   setState(() {
-///                     shouldPop = !shouldPop;
-///                   });
-///                 },
-///               ),
-///             ],
+///           appBar: AppBar(
+///             title: Text("Flutter WillPopScope demp"),
+///             leading: BackButton(),
 ///           ),
+///         body: Center(
+///           child: Text(
+///               "Current value of shouldPop is $shouldPop. Tap on back button in appbar to toggle"),
 ///         ),
 ///       ),
 ///     );
 ///   }
-/// }
 /// ```
 ///
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,7 +29,7 @@ import 'routes.dart';
 /// {@end-tool}
 ///
 /// {@tool dartpad --template=stateful_widget_material}
-/// 
+///
 /// ```dart
 /// bool shouldPop = true;
 /// @override

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -12,52 +12,76 @@ import 'routes.dart';
 /// {@tool snippet --template=stateful_widget}
 ///
 /// Whenever the back button is pressed, you will get a callback at [onWillPop],
-/// which returns a [Future]. If the [Future] returned is true, the screen is
-/// popped and if it is false, the screen is not popped.
+/// which returns a [Future]. If the [Future] returns true, the screen is
+/// popped.
 ///
 /// ```dart
 /// bool shouldPop = true;
+/// // ...
 ///
 /// @override
 /// Widget build(BuildContext) {
 ///   return WillPopScope (
 ///     onWillPop: () async {
-///        return shouldPop;
+///       return shouldPop;
 ///     },
-///     child: Center(),
+///     child: Center(
+///       // ...
+///     ),
 ///   );
 /// }
 /// ```
 /// {@end-tool}
 ///
 /// {@tool dartpad --template=stateful_widget_material}
-///
-/// ```dart preamble
-/// bool shouldPop = true;
-/// ```
-///
 /// ```dart
+/// bool shouldPop = true;
 /// @override
 /// Widget build(BuildContext context) {
 ///   return WillPopScope(
-///       onWillPop: () async {
-///         setState(() {
-///           shouldPop = !shouldPop;
-///         });
-///         return shouldPop;
-///       },
-///       child: Scaffold(
-///           appBar: AppBar(
-///             title: Text("Flutter WillPopScope demp"),
-///             leading: BackButton(),
-///           ),
-///         body: Center(
-///           child: Text(
-///               "Current value of shouldPop is $shouldPop. Tap on back button in appbar to toggle"),
+///     onWillPop: () async {
+///       return shouldPop;
+///     },
+///     child: Scaffold(
+///       appBar: AppBar(
+///         title: Text("Flutter WillPopScope demo"),
+///       ),
+///       body: Center(
+///         child: Wrap(
+///           spacing: 20,
+///           direction: Axis.vertical,
+///           crossAxisAlignment: WrapCrossAlignment.center,
+///           children: [
+///             OutlinedButton(
+///               child: Text('Push'),
+///               onPressed: () {
+///                 Navigator.of(context).push(
+///                   MaterialPageRoute(
+///                     builder: (context) {
+///                       return MyStatefulWidget();
+///                     },
+///                   ),
+///                 );
+///               },
+///             ),
+///             OutlinedButton(
+///               child: Text('Pop'),
+///               onPressed: () {
+///                 setState(
+///                   () {
+///                     shouldPop = !shouldPop;
+///                   },
+///                 );
+///               },
+///             ),
+///             Text("Current value of shouldPop is $shouldPop."
+///                 "Push to a new screen and then tap on the back button in appbar to toggle shouldPop"),
+///           ],
 ///         ),
 ///       ),
-///     );
-///   }
+///     ),
+///   );
+/// }
 /// ```
 ///
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -16,6 +16,8 @@ import 'routes.dart';
 /// popped and if it is false, the screen is not popped.
 ///
 /// ```dart
+/// bool shouldPop = true;
+/// 
 /// @override
 /// Widget build(BuildContext) {
 ///   return WillPopScope (

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -18,13 +18,12 @@ import 'routes.dart';
 /// ```dart
 /// bool shouldPop = true;
 /// @override
-/// Widget build(BuildContext) {
+/// Widget build(BuildContext context) {
 ///   return WillPopScope (
 ///     onWillPop: () async {
 ///       return shouldPop;
 ///     },
-///     child: Center(
-///     ),
+///     child: Text('WillPopScope sample'),
 ///   );
 /// }
 /// ```
@@ -44,10 +43,8 @@ import 'routes.dart';
 ///         title: Text("Flutter WillPopScope demo"),
 ///       ),
 ///       body: Center(
-///         child: Wrap(
-///           spacing: 20,
-///           direction: Axis.vertical,
-///           crossAxisAlignment: WrapCrossAlignment.center,
+///         child: Column(
+///           mainAxisAlignment: MainAxisAlignment.center,
 ///           children: [
 ///             OutlinedButton(
 ///               child: Text('Push'),
@@ -62,7 +59,7 @@ import 'routes.dart';
 ///               },
 ///             ),
 ///             OutlinedButton(
-///               child: Text('Pop'),
+///               child: Text('shouldPop: $shouldPop'),
 ///               onPressed: () {
 ///                 setState(
 ///                   () {
@@ -71,8 +68,10 @@ import 'routes.dart';
 ///                 );
 ///               },
 ///             ),
-///             Text("Current value of shouldPop is $shouldPop."
-///                 "Push to a new screen and then tap on the back button in appbar to toggle shouldPop"),
+///             Text("Push to a new screen, then tap on shouldPop "
+///                 "button to toggle its value. Press the back "
+///                 "button in the appBar to check its behaviour "
+///                 "for different values of shouldPop"),
 ///           ],
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -17,7 +17,7 @@ import 'routes.dart';
 ///
 /// ```dart
 /// bool shouldPop = true;
-/// 
+///
 /// @override
 /// Widget build(BuildContext) {
 ///   return WillPopScope (


### PR DESCRIPTION
## Description

Added a code / dartpad example for WillPopScope. In dartpad example, back press is simulated using BackButton as the leading widget in AppBar.

This pull request is:

- [x] A code/dartpad sample
- [x] More references
- [x] More explanation

## Related Issues

Fixes #69469 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
