### PR TITLE
Remove the flaky flag from post-bdf benchmark

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -550,7 +550,7 @@ tasks:
       Measures the runtime performance of animations after a backdrop filter is removed on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: true
+    flaky: false
 
   complex_layout_scroll_perf_ios__timeline_summary:
     description: >

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -550,7 +550,6 @@ tasks:
       Measures the runtime performance of animations after a backdrop filter is removed on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: false
 
   complex_layout_scroll_perf_ios__timeline_summary:
     description: >


### PR DESCRIPTION
This benchmark has been marked flaky for some time because it was a frequent source of disconnects.

Recently it has had about 30 clean runs in a row, starting with e444b1e3fa6f0478c885565a78498480591cc980, so I am removing the flaky flag.

Fixes https://github.com/flutter/flutter/issues/59238