### PR TITLE
Dropdown button can have itemHeight less than kMinInteractiveDimension in web

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -845,7 +845,7 @@ class DropdownButton<T> extends StatefulWidget {
        assert(isDense != null),
        assert(isExpanded != null),
        assert(autofocus != null),
-       assert(itemHeight == null || itemHeight >=  kMinInteractiveDimension),
+       assert(itemHeight == null || kIsWeb || itemHeight >=  kMinInteractiveDimension),
        super(key: key);
 
   /// The list of items the user can select.

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2663,4 +2663,31 @@ void main() {
     expect(find.text('first').hitTestable(), findsNothing);
     expect(find.text('second').hitTestable(), findsNothing);
   });
+
+  testWidgets('Dropdown button can have itemHeight less than kMinInteractiveDimension in web', (WidgetTester tester) async  {
+    const String value = 'foo';
+    final UniqueKey itemKey = UniqueKey();
+
+    await tester.pumpWidget(TestApp(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: DropdownButton<String>(
+          value: value,
+          itemHeight: 40,
+          items: <DropdownMenuItem<String>>[
+            DropdownMenuItem<String>(
+              key: itemKey,
+              value: 'foo',
+              child: const Text(value),
+            ),
+          ],
+          isDense: true,
+          onChanged: (_) { },
+          style: const TextStyle(color: Colors.blue),
+        ),
+      ),
+    ));
+
+    expect(tester.takeException(), isNull);
+  }, skip: !kIsWeb);
 }


### PR DESCRIPTION
## Description

Flutter's Material DropdownButton has required minimum item height of kMinInteractiveDimension. It's impossible to set it to lower value, as the widget will crash due to assert(itemHeight == null || itemHeight >= kMinInteractiveDimension)

While this makes some sense on touchscreen devices (to prevent creating areas which would be hard to interact with), it makes absolutely no sense on the web.

## Related Issues

Fixes #69398 

## Tests

I added the following tests:

- Test to check Dropdown button can have itemHeight less than kMinInteractiveDimension in web.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
