### PR TITLE
Say [APP] instead of [Gallery] in web benchmarks

### DIFF
--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -104,7 +104,7 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
           // `dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart`
           // to print information.
           final String message = await request.readAsString();
-          print('[Gallery] $message');
+          print('[APP] $message');
           return Response.ok('Reported.');
         } else {
           return Response.notFound(


### PR DESCRIPTION
## Description

Not all benchmarks are gallery (in fact, none right now).
