### PR TITLE
Revert "Build App.framework directly to build directory"

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -179,7 +179,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     ${flutter_engine_flag}                                                \
     ${local_engine_flag}                                                  \
     assemble                                                              \
-    --output="${BUILT_PRODUCTS_DIR}/"                                     \
+    --output="${derived_dir}/"                                            \
     ${performance_measurement_option}                                     \
     -dTargetPlatform=ios                                                  \
     -dTargetFile="${target_path}"                                         \
@@ -287,23 +287,25 @@ EmbedFlutterFrameworks() {
     project_path="${FLUTTER_APPLICATION_PATH}"
   fi
 
+  # Prefer the hidden .ios folder, but fallback to a visible ios folder if .ios
+  # doesn't exist.
+  local flutter_ios_out_folder="${project_path}/.ios/Flutter"
+  local flutter_ios_engine_folder="${project_path}/.ios/Flutter/engine"
+  if [[ ! -d ${flutter_ios_out_folder} ]]; then
+    flutter_ios_out_folder="${project_path}/ios/Flutter"
+    flutter_ios_engine_folder="${project_path}/ios/Flutter"
+  fi
+
+  AssertExists "${flutter_ios_out_folder}"
+
   # Embed App.framework from Flutter into the app (after creating the Frameworks directory
   # if it doesn't already exist).
   local xcode_frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
   RunCommand mkdir -p -- "${xcode_frameworks_dir}"
-  RunCommand rsync -av --delete --filter "- .DS_Store/" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
+  RunCommand rsync -av --delete "${flutter_ios_out_folder}/App.framework" "${xcode_frameworks_dir}"
 
   # Embed the actual Flutter.framework that the Flutter app expects to run against,
   # which could be a local build or an arch/type specific build.
-
-  # Prefer the hidden .ios folder, but fallback to a visible ios folder if .ios
-  # doesn't exist.
-  local flutter_ios_engine_folder="${project_path}/.ios/Flutter/engine"
-  if [[ ! -d ${flutter_ios_engine_folder} ]]; then
-    flutter_ios_engine_folder="${project_path}/ios/Flutter"
-  fi
-
-  AssertExists "${flutter_ios_engine_folder}"
 
   # Copy Xcode behavior and don't copy over headers or modules.
   RunCommand rsync -av --delete --filter "- .DS_Store/" --filter "- Headers/" --filter "- Modules/" "${flutter_ios_engine_folder}/Flutter.framework" "${xcode_frameworks_dir}/"

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -50,7 +50,7 @@ class CleanCommand extends FlutterCommand {
     deleteFile(flutterProject.ios.ephemeralDirectory);
     deleteFile(flutterProject.ios.generatedXcodePropertiesFile);
     deleteFile(flutterProject.ios.generatedEnvironmentVariableExportScript);
-    deleteFile(flutterProject.ios.deprecatedCompiledDartFramework);
+    deleteFile(flutterProject.ios.compiledDartFramework);
 
     deleteFile(flutterProject.linux.ephemeralDirectory);
     deleteFile(flutterProject.macos.ephemeralDirectory);

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -539,7 +539,7 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
     logger.printError('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
     logger.printError('');
     logger.printError('You can temporarily work around this issue by running:');
-    logger.printError('  flutter clean');
+    logger.printError('  rm -rf ios/Flutter/App.framework');
     return;
   }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -682,10 +682,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
     .childDirectory('Flutter')
     .childFile('Generated.xcconfig');
 
-  /// No longer compiled to this location.
-  ///
-  /// Used only for "flutter clean" to remove old references.
-  Directory get deprecatedCompiledDartFramework => _flutterLibRoot
+  Directory get compiledDartFramework => _flutterLibRoot
       .childDirectory('Flutter')
       .childDirectory('App.framework');
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -48,7 +48,7 @@ void main() {
         projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
         projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
-        projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
+        projectUnderTest.ios.compiledDartFramework.createSync(recursive: true);
 
         projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
@@ -68,7 +68,7 @@ void main() {
         expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
-        expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);
+        expect(projectUnderTest.ios.compiledDartFramework.existsSync(), isFalse);
 
         expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);


### PR DESCRIPTION
Reverts flutter/flutter#69612

Failing ios_content_validation test:

```
════════════════════════╡ ••• Xcode backend script ••• ╞════════════════════════

2020-11-02T19:21:23.317623: 
Executing: /Users/flutter/.cocoon/flutter/packages/flutter_tools/bin/xcode_backend.sh embed_and_thin in /Users/flutter/.cocoon/flutter/dev/devicelab with environment {SOURCE_ROOT: /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/ios, TARGET_BUILD_DIR: /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos, FRAMEWORKS_FOLDER_PATH: Runner.app/Frameworks, VERBOSE_SCRIPT_LOGGING: 1, FLUTTER_BUILD_MODE: release, ACTION: install}
2020-11-02T19:21:23.325129: stdout: ♦ mkdir -p -- /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos/Runner.app/Frameworks
2020-11-02T19:21:23.329468: stdout: ♦ rsync -av --delete --filter - .DS_Store/ /App.framework /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos/Runner.app/Frameworks
2020-11-02T19:21:23.334435: stdout: building file list ... done
stderr: rsync: link_stat "/App.framework" failed: No such file or directory (2)
stdout: 
stdout: sent 29 bytes  received 20 bytes  98.00 bytes/sec
stdout: total size is 0  speedup is 0.00
stderr: rsync error: some files could not be transferred (code 23) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-52.200.1/rsync/main.c(996) [sender=2.6.9]
"/Users/flutter/.cocoon/flutter/packages/flutter_tools/bin/xcode_backend.sh" exit code: 23
2020-11-02T19:21:23.664907: 
════════════════════════╡ ••• Xcode backend script ••• ╞════════════════════════

2020-11-02T19:21:23.317623: 
Executing: /Users/flutter/.cocoon/flutter/packages/flutter_tools/bin/xcode_backend.sh embed_and_thin in /Users/flutter/.cocoon/flutter/dev/devicelab with environment {SOURCE_ROOT: /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/ios, TARGET_BUILD_DIR: /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos, FRAMEWORKS_FOLDER_PATH: Runner.app/Frameworks, VERBOSE_SCRIPT_LOGGING: 1, FLUTTER_BUILD_MODE: release, ACTION: install}
2020-11-02T19:21:23.325129: stdout: ♦ mkdir -p -- /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos/Runner.app/Frameworks
2020-11-02T19:21:23.329468: stdout: ♦ rsync -av --delete --filter - .DS_Store/ /App.framework /var/folders/td/jlh092g928l86qfb9gs3dfvc0000gn/T/flutter_devicelab_gradle_plugin_test.U3lQ2v/hello/build/ios/iphoneos/Runner.app/Frameworks
2020-11-02T19:21:23.334435: stdout: building file list ... done
stderr: rsync: link_stat "/App.framework" failed: No such file or directory (2)
stdout: 
stdout: sent 29 bytes  received 20 bytes  98.00 bytes/sec
stdout: total size is 0  speedup is 0.00
stderr: rsync error: some files could not be transferred (code 23) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-52.200.1/rsync/main.c(996) [sender=2.6.9]
"/Users/flutter/.cocoon/flutter/packages/flutter_tools/bin/xcode_backend.sh" exit code: 23
2020-11-02T19:21:23.664907: 

```

[ios_content_validation_test_b770883_2 (2).log](https://github.com/flutter/flutter/files/5479246/ios_content_validation_test_b770883_2.2.log)


TBR @jmagman 