### PR TITLE
Center the AnimatedPositioned code sample

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1058,7 +1058,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold_center}
 ///
 /// The following example transitions an AnimatedPositioned
 /// between two states. It adjusts the `height`, `width`, and
@@ -1069,29 +1069,32 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return Stack(
-///     children: [
-///       AnimatedPositioned(
-///         width: selected ? 200.0 : 50.0,
-///         height: selected ? 50.0 : 200.0,
-///         top: selected ? 50.0 : 150.0,
-///         right: 150.0,
-///         duration: Duration(seconds: 2),
-///         curve: Curves.fastOutSlowIn,
-///         child: GestureDetector(
-///           onTap: () {
-///             setState(() {
-///               selected = !selected;
-///             });
-///           },
-///           child: Container(
-///             color: Colors.blue,
-///             child: Text('Tap me to start the animated transition'),
+///   return Container(
+///     width: 200,
+///     height: 350,
+///     child: Stack(
+///       children: [
+///         AnimatedPositioned(
+///           width: selected ? 200.0 : 50.0,
+///           height: selected ? 50.0 : 200.0,
+///           top: selected ? 50.0 : 150.0,
+///           duration: Duration(seconds: 2),
+///           curve: Curves.fastOutSlowIn,
+///           child: GestureDetector(
+///             onTap: () {
+///               setState(() {
+///                 selected = !selected;
+///               });
+///             },
+///             child: Container(
+///               color: Colors.blue,
+///               child: Text('Tap me'),
+///             ),
 ///           ),
 ///         ),
-///       ),
-///     ],
-///   );
+///       ],
+///     ),
+///   ),
 /// }
 ///```
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1094,7 +1094,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///         ),
 ///       ],
 ///     ),
-///   ),
+///   );
 /// }
 ///```
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1088,7 +1088,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///             },
 ///             child: Container(
 ///               color: Colors.blue,
-///               child: Text('Tap me'),
+///               child: Center(child: Text('Tap me')),
 ///             ),
 ///           ),
 ///         ),


### PR DESCRIPTION
## Description

Fixes centering and text overflow issues with the existing sample when the dartdoc window is too small:

Before
<img width="222" alt="Screen Shot 2020-11-03 at 1 36 23 PM" src="https://user-images.githubusercontent.com/27032613/97952836-a481a280-1dd9-11eb-8900-9b0b720bd50f.png">
<img width="222" alt="Screen Shot 2020-11-03 at 1 36 43 PM" src="https://user-images.githubusercontent.com/27032613/97952838-a51a3900-1dd9-11eb-9c4e-5c5797cdb93b.png">


After
<img width="271" alt="Screen Shot 2020-11-03 at 1 35 34 PM" src="https://user-images.githubusercontent.com/27032613/97952785-7d2ad580-1dd9-11eb-826d-5929b2e46902.png">

<img width="271" alt="Screen Shot 2020-11-03 at 1 35 29 PM" src="https://user-images.githubusercontent.com/27032613/97952789-7dc36c00-1dd9-11eb-9baf-1e9e3dba95f6.png">
