### PR TITLE
fix #24469, #67354

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,3 +70,4 @@ YeungKC <flutter@yeungkc.com>
 Nobuhiro Tabuki <japanese.around30@gmail.com>
 nt4f04uNd <nt4f04und@gmail.com>
 Anurag Roy <anuragr9847@gmail.com>
+Andrey Kabylin <andrey@kabylin.ru>

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -27,8 +27,6 @@ import 'transitions.dart';
 // dynamic routeObserver;
 // NavigatorState navigator;
 
-const Color _kTransparent = Color(0x00000000);
-
 /// A route that displays widgets in the [Navigator]'s [Overlay].
 abstract class OverlayRoute<T> extends Route<T> {
   /// Creates a route that knows how to interact with an [Overlay].
@@ -1475,10 +1473,10 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   Widget _buildModalBarrier(BuildContext context) {
     Widget barrier;
     if (barrierColor != null && barrierColor!.alpha != 0 && !offstage) { // changedInternalState is called if barrierColor or offstage updates
-      assert(barrierColor != _kTransparent);
+      assert(barrierColor != barrierColor!.withOpacity(0.0));
       final Animation<Color?> color = animation!.drive(
         ColorTween(
-          begin: _kTransparent,
+          begin: barrierColor!.withOpacity(0.0),
           end: barrierColor, // changedInternalState is called if barrierColor updates
         ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve updates
       );

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1425,6 +1425,69 @@ void main() {
       expect(modalBarrierAnimation.value, Colors.black);
     });
 
+    testWidgets('white barrierColor', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      Navigator.of(context).push<void>(
+                          _TestDialogRouteWithCustomBarrierCurve<void>(
+                            child: const Text('Hello World'),
+                            barrierColor: Colors.white,
+                          )
+                      );
+                    },
+                  ),
+                );
+              }
+          ),
+        ),
+      ));
+
+      final CurveTween _defaultBarrierTween = CurveTween(curve: Curves.ease);
+      int _getExpectedBarrierTweenAlphaValue(double t) {
+        return Color.getAlphaFromOpacity(_defaultBarrierTween.transform(t));
+      }
+
+      await tester.tap(find.text('X'));
+      await tester.pump();
+      final Finder animatedModalBarrier = find.byType(AnimatedModalBarrier);
+      expect(animatedModalBarrier, findsOneWidget);
+
+      Animation<Color?> modalBarrierAnimation;
+      modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
+      expect(modalBarrierAnimation.value, Colors.white.withOpacity(0));
+
+      await tester.pump(const Duration(milliseconds: 25));
+      modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
+      expect(
+        modalBarrierAnimation.value!.alpha,
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1),
+      );
+
+      await tester.pump(const Duration(milliseconds: 25));
+      modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
+      expect(
+        modalBarrierAnimation.value!.alpha,
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1),
+      );
+
+      await tester.pump(const Duration(milliseconds: 25));
+      modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
+      expect(
+        modalBarrierAnimation.value!.alpha,
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1),
+      );
+
+      await tester.pumpAndSettle();
+      modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
+      expect(modalBarrierAnimation.value, Colors.white);
+    });
+
     testWidgets('modal route semantics order', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/46625.
       final SemanticsTester semantics = SemanticsTester(tester);
@@ -1781,6 +1844,7 @@ class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierCurve({
     required Widget child,
     this.barrierLabel,
+    this.barrierColor = Colors.black,
     Curve? barrierCurve,
   }) : _barrierCurve = barrierCurve,
        _child = child;
@@ -1794,7 +1858,7 @@ class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   final String? barrierLabel;
 
   @override
-  Color get barrierColor => Colors.black; // easier value to test against
+  final Color? barrierColor;
 
   @override
   Curve get barrierCurve {


### PR DESCRIPTION
## Description

The reason why is simple - we transited barrier color from `barrierColor` to `0x00000000`, therefore we smoothly transit from black transparent to the `barrierColor`, but this is not desirable behavior. For example, if we would like to use a white barrier color, it will be like this 0x00000000 -> 0xFFFFFFFF, but a desirable transition would be 0x00FFFFFF -> 0xFFFFFFFF.

## Related Issues

This PR fixes #24469, #67354. 
