### PR TITLE
Update dartdoc to 0.36.2

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.36.1
+    "$PUB" global activate dartdoc 0.36.2
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
## Description

This is a patch release primarily to fix an issue where we were tagging libraries and elements with "null safety" even when they were not null safe (dart-lang/dartdoc#2403).

## Related Issues

See release notes for dartdoc at:  https://github.com/dart-lang/dartdoc/releases/tag/v0.36.2

## Tests

Tested manually by running the bot script and spot checking that null safety tags no longer appear on packages that aren't migrated, and by running dartdoc's "compare-flutter-warnings" to make sure no new warnings were introduced.