### PR TITLE
Build App.framework directly to build directory

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -119,6 +119,12 @@ Future<void> main() async {
           <String>['embed_and_thin'],
           environment: <String, String>{
             'SOURCE_ROOT': flutterProject.iosPath,
+            'BUILT_PRODUCTS_DIR': path.join(
+              flutterProject.rootPath,
+              'build',
+              'ios',
+              'Release-iphoneos',
+            ),
             'TARGET_BUILD_DIR': buildPath,
             'FRAMEWORKS_FOLDER_PATH': 'Runner.app/Frameworks',
             'VERBOSE_SCRIPT_LOGGING': '1',

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -50,7 +50,7 @@ class CleanCommand extends FlutterCommand {
     deleteFile(flutterProject.ios.ephemeralDirectory);
     deleteFile(flutterProject.ios.generatedXcodePropertiesFile);
     deleteFile(flutterProject.ios.generatedEnvironmentVariableExportScript);
-    deleteFile(flutterProject.ios.compiledDartFramework);
+    deleteFile(flutterProject.ios.deprecatedCompiledDartFramework);
 
     deleteFile(flutterProject.linux.ephemeralDirectory);
     deleteFile(flutterProject.macos.ephemeralDirectory);

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -539,7 +539,7 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
     logger.printError('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
     logger.printError('');
     logger.printError('You can temporarily work around this issue by running:');
-    logger.printError('  rm -rf ios/Flutter/App.framework');
+    logger.printError('  flutter clean');
     return;
   }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -682,7 +682,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
     .childDirectory('Flutter')
     .childFile('Generated.xcconfig');
 
-  Directory get compiledDartFramework => _flutterLibRoot
+  /// No longer compiled to this location.
+  ///
+  /// Used only for "flutter clean" to remove old references.
+  Directory get deprecatedCompiledDartFramework => _flutterLibRoot
       .childDirectory('Flutter')
       .childDirectory('App.framework');
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -48,7 +48,7 @@ void main() {
         projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
         projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
-        projectUnderTest.ios.compiledDartFramework.createSync(recursive: true);
+        projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
 
         projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
@@ -68,7 +68,7 @@ void main() {
         expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
-        expect(projectUnderTest.ios.compiledDartFramework.existsSync(), isFalse);
+        expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);
 
         expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/69612 with updated `ios_content_validation_test`.

## Description

Since https://github.com/flutter/flutter/pull/51453 we no longer need to build the App.framework to a known directory like `project/ios/Flutter/App.framework`.  Instead, build the frameworks directly to the build products directory.  For example, `flutter build ios -v --simulator` will build to `/build/ios/Debug-iphonesimulator/App.framework`.

Additionally, this sets us up to no longer need to `lipo` the simulator and non-simulator frameworks together since they will build to different directories.

https://github.com/flutter/flutter/blob/cb67513f29dbf7f41818c9eb8cc42d845e243fca/packages/flutter_tools/lib/src/build_system/targets/ios.dart#L103-L112

When Apple Silicon ships and ARM simulators are supported, this `lipo` will fail since the simulator and real device frameworks will both contain `arm64`.

Also stop copying the `.DS_Store` directories, while we're at it (already done with `Flutter.framework`).  These files shouldn't be copied, and it adds spew during the installation phase:
```
[        ] [ 31%] Copying
/build/ios/iphoneos/Runner.app/Frameworks/App.framework/flutter_assets/assets/navbar/.DS_Store to
device
```

## Related Issues

https://github.com/flutter/flutter/issues/60118

## Tests

Updated `ios_content_validation_test`.  Already many many integration tests that will blow up in the compiled dart code or flutter_assets are missing.