### PR TITLE
Deprecate build ios-framework --universal

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -67,7 +67,7 @@ Future<void> main() async {
           'build',
           options: <String>[
             'ios-framework',
-            '--xcframework',
+            '--universal',
             '--output=$outputDirectoryName'
           ],
         );
@@ -352,6 +352,7 @@ Future<void> main() async {
           options: <String>[
             'ios-framework',
             '--cocoapods',
+            '--universal',
             '--force', // Allow podspec creation on master.
             '--output=$cocoapodsOutputDirectoryName'
           ],

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -73,16 +73,17 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
               'By default, all build configurations are built.'
       )
       ..addFlag('universal',
-        help: 'Produce universal frameworks that include all valid architectures. '
-              'This is true by default.',
-        defaultsTo: true,
-        negatable: true
+        help: '(Deprecated) Produce universal frameworks that include all valid architectures. '
+              'This option will be removed in a future version of Flutter.',
+        negatable: true,
+        hide: true,
       )
       ..addFlag('xcframework',
-        help: 'Produce xcframeworks that include all valid architectures (Xcode 11 or later).',
+        help: 'Produce xcframeworks that include all valid architectures.',
+        defaultsTo: true,
       )
       ..addFlag('cocoapods',
-        help: 'Produce a Flutter.podspec instead of an engine Flutter.framework (recommended if host app uses CocoaPods).',
+        help: 'Produce a Flutter.podspec instead of an engine Flutter.xcframework (recommended if host app uses CocoaPods).',
       )
       ..addOption('output',
         abbr: 'o',
@@ -151,10 +152,15 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     }
 
     if (!boolArg('universal') && !boolArg('xcframework')) {
-      throwToolExit('--universal or --xcframework is required.');
+      throwToolExit('--xcframework or --universal is required.');
     }
     if (boolArg('xcframework') && globals.xcode.majorVersion < 11) {
       throwToolExit('--xcframework requires Xcode 11.');
+    }
+    if (boolArg('universal')) {
+      globals.printError('--universal has been deprecated to support Apple '
+          'Silicon ARM simulators and will be removed in a future version of '
+          'Flutter. Use --xcframework instead.');
     }
     if (buildInfos.isEmpty) {
       throwToolExit('At least one of "--debug" or "--profile", or "--release" is required.');

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 
@@ -43,7 +42,7 @@ void main() {
       );
 
       when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
-      outputDirectory = globals.fs.systemTempDirectory
+      outputDirectory = memoryFileSystem.systemTempDirectory
           .createTempSync('flutter_build_ios_framework_test_output.')
           .childDirectory('Debug')
         ..createSync();


### PR DESCRIPTION
## Description

Universal (fat) frameworks that support physical devices and simulators aren't possible in an ARM simulator world since the arm64 `iphoneos` and `iphonesimulator` slices can't be `lipo`d together.  Deprecate and hide `--universal` and make `--xcframework` the default.

`--universal` will need to be hard deprecated (removed) when the [ARM simulator Flutter.framework](https://github.com/flutter/flutter/issues/64502) ships.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69718

## Tests

Updated `build_ios_framework_module_test`.