### PR TITLE
Disable web expression evaluation tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_web_test.dart
@@ -57,7 +57,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
  testWithoutContext('flutter run expression evaluation - no native javascript objects in static scope', () async {
     await initProject();
@@ -65,7 +65,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await checkStaticScope(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter run expression evaluation - can handle compilation errors', () async {
     await initProject();
@@ -73,7 +73,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateErrorExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in top level function', () async {
     await initProject();
@@ -81,7 +81,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter run expression evaluation - can evaluate trivial expressions in build method', () async {
     await initProject();
@@ -89,7 +89,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in top level function', () async {
     await initProject();
@@ -97,7 +97,7 @@ void batch1() {
     await breakInTopLevelFunction(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter run expression evaluation - can evaluate complex expressions in build method', () async {
     await initProject();
@@ -105,7 +105,7 @@ void batch1() {
     await breakInBuildMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 }
 
 void batch2() {
@@ -149,7 +149,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await failToEvaluateExpression(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter test expression evaluation - can evaluate trivial expressions in a test', () async {
     await initProject();
@@ -157,7 +157,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateTrivialExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 
   testWithoutContext('flutter test expression evaluation - can evaluate complex expressions in a test', () async {
     await initProject();
@@ -165,7 +165,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  }, skip: platform.isMacOS);
+  }, skip: 'Cannot run on non-web-bot'); // Issue: https://github.com/flutter/flutter/issues/69711
 }
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {


### PR DESCRIPTION
## Description

Temporarily disable web expression evaluation tests,
until we figure out how to disable the tests only on non-web bot.

## Related Issues

https://github.com/flutter/flutter/issues/69711