### PR TITLE
Compile snapshot_assembly with sdk root set in Xcode

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -185,6 +185,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     -dTargetFile="${target_path}"                                         \
     -dBuildMode=${build_mode}                                             \
     -dIosArchs="${ARCHS}"                                                 \
+    -dSdkRoot="${SDKROOT}"                                                \
     -dSplitDebugInfo="${SPLIT_DEBUG_INFO}"                                \
     -dTreeShakeIcons="${TREE_SHAKE_ICONS}"                                \
     -dTrackWidgetCreation="${TRACK_WIDGET_CREATION}"                      \

--- a/packages/flutter_tools/lib/src/aot.dart
+++ b/packages/flutter_tools/lib/src/aot.dart
@@ -14,6 +14,7 @@ import 'build_system/targets/ios.dart';
 import 'cache.dart';
 import 'globals.dart' as globals;
 import 'ios/bitcode.dart';
+import 'macos/xcode.dart';
 import 'project.dart';
 
 /// Builds AOT snapshots given a platform, build mode and a path to a Dart
@@ -26,12 +27,13 @@ class AotBuilder {
     @required String mainDartFile,
     bool bitcode = kBitcodeEnabledDefault,
     bool quiet = true,
-    Iterable<DarwinArch> iosBuildArchs = defaultIOSArchs,
+    Iterable<DarwinArch> iosBuildArchs,
     bool reportTimings = false,
   }) async {
     if (platform == null) {
       throwToolExit('No AOT build platform specified');
     }
+    iosBuildArchs ??= defaultIOSArchsForSdk(SdkType.iPhone);
     Target target;
     bool expectSo = false;
     switch (platform) {

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -111,13 +111,13 @@ class AOTSnapshotter {
     @required String mainPath,
     @required String outputPath,
     DarwinArch darwinArch,
+    String sdkRoot,
     List<String> extraGenSnapshotOptions = const <String>[],
     @required bool bitcode,
     @required String splitDebugInfo,
     @required bool dartObfuscation,
     bool quiet = false,
   }) async {
-    // TODO(cbracken): replace IOSArch with TargetPlatform.ios_{armv7,arm64}.
     assert(platform != TargetPlatform.ios || darwinArch != null);
     if (bitcode && platform != TargetPlatform.ios) {
       _logger.printError('Bitcode is only supported for iOS.');
@@ -209,6 +209,7 @@ class AOTSnapshotter {
       final RunResult result = await _buildFramework(
         appleArch: darwinArch,
         isIOS: platform == TargetPlatform.ios,
+        sdkRoot: sdkRoot,
         assemblyPath: assembly,
         outputPath: outputDir.path,
         bitcode: bitcode,
@@ -226,6 +227,7 @@ class AOTSnapshotter {
   Future<RunResult> _buildFramework({
     @required DarwinArch appleArch,
     @required bool isIOS,
+    @required String sdkRoot,
     @required String assemblyPath,
     @required String outputPath,
     @required bool bitcode,
@@ -248,12 +250,10 @@ class AOTSnapshotter {
     const String embedBitcodeArg = '-fembed-bitcode';
     final String assemblyO = _fileSystem.path.join(outputPath, 'snapshot_assembly.o');
     List<String> isysrootArgs;
-    if (isIOS) {
-      final String iPhoneSDKLocation = await _xcode.sdkLocation(SdkType.iPhone);
-      if (iPhoneSDKLocation != null) {
-        isysrootArgs = <String>['-isysroot', iPhoneSDKLocation];
-      }
+    if (sdkRoot != null) {
+      isysrootArgs = <String>['-isysroot', sdkRoot];
     }
+
     final RunResult compileResult = await _xcode.cc(<String>[
       '-arch', targetArch,
       if (isysrootArgs != null) ...isysrootArgs,

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -11,6 +11,7 @@ import 'base/logger.dart';
 import 'base/utils.dart';
 import 'build_system/targets/icon_tree_shaker.dart';
 import 'globals.dart' as globals;
+import 'macos/xcode.dart';
 
 /// Information about a build to be performed or used.
 class BuildInfo {
@@ -472,9 +473,23 @@ enum AndroidArch {
 }
 
 /// The default set of iOS device architectures to build for.
-const List<DarwinArch> defaultIOSArchs = <DarwinArch>[
-  DarwinArch.arm64,
-];
+List<DarwinArch> defaultIOSArchsForSdk(SdkType sdkType) {
+  switch (sdkType) {
+    case SdkType.iPhone:
+      return <DarwinArch>[
+        DarwinArch.armv7,
+        DarwinArch.arm64,
+      ];
+    case SdkType.iPhoneSimulator:
+      return <DarwinArch>[
+        // Apple Silicon ARM simulators not yet supported.
+        DarwinArch.x86_64,
+      ];
+    default:
+      assert(false, 'Unknown SDK type $sdkType');
+      return null;
+  }
+}
 
 String getNameForDarwinArch(DarwinArch arch) {
   switch (arch) {

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -65,6 +65,9 @@ const String kFileSystemRoots = 'FileSystemRoots';
 /// The other supported value is armv7, the 32-bit iOS architecture.
 const String kIosArchs = 'IosArchs';
 
+/// Path to the SDK root to be used as the isysroot.
+const String kSdkRoot = 'SdkRoot';
+
 /// Whether to enable Dart obfuscation and where to save the symbol map.
 const String kDartObfuscation = 'DartObfuscation';
 

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -89,6 +89,7 @@ abstract class AotAssemblyBase extends Target {
         mainPath: environment.buildDir.childFile('app.dill').path,
         outputPath: environment.fileSystem.path.join(buildOutputPath, getNameForDarwinArch(darwinArch)),
         darwinArch: darwinArch,
+        sdkRoot: environment.defines[kSdkRoot],
         bitcode: bitcode,
         quiet: true,
         splitDebugInfo: splitDebugInfo,

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -28,7 +28,7 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
       ..addFlag('quiet', defaultsTo: false)
       ..addMultiOption('ios-arch',
         splitCommas: true,
-        defaultsTo: defaultIOSArchs.map<String>(getNameForDarwinArch),
+        defaultsTo: <String>[getNameForDarwinArch(DarwinArch.arm64)],
         allowed: DarwinArch.values.map<String>(getNameForDarwinArch),
         help: 'iOS architectures to build.',
       )

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -21,6 +21,7 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
+import '../macos/xcode.dart';
 import '../plugins.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
@@ -376,6 +377,7 @@ end
             kExtraFrontEndOptions: buildInfo.extraFrontEndOptions.join(','),
           kIosArchs: <DarwinArch>[DarwinArch.armv7, DarwinArch.arm64]
             .map(getNameForDarwinArch).join(' '),
+          kSdkRoot: await globals.xcode.sdkLocation(SdkType.iPhone),
         },
         artifacts: globals.artifacts,
         fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -586,7 +586,7 @@ class XCDevice {
         if (architecture.startsWith('armv7')) {
           cpuArchitecture = DarwinArch.armv7;
         } else {
-          cpuArchitecture = defaultIOSArchs.first;
+          cpuArchitecture = DarwinArch.arm64;
         }
         _logger.printError(
           'Unknown architecture $architecture, defaulting to '

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 
@@ -43,7 +42,7 @@ void main() {
       );
 
       when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
-      outputDirectory = globals.fs.systemTempDirectory
+      outputDirectory = memoryFileSystem.systemTempDirectory
           .createTempSync('flutter_build_ios_framework_test_output.')
           .childDirectory('Debug')
         ..createSync();

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -24,15 +24,6 @@ const FakeCommand kARMCheckCommand = FakeCommand(
   exitCode: 1,
 );
 
-const FakeCommand kSdkPathCommand = FakeCommand(
-  command: <String>[
-    'xcrun',
-    '--sdk',
-    'iphoneos',
-    '--show-sdk-path'
-  ]
-);
-
 const List<String> kDefaultClang = <String>[
   '-miphoneos-version-min=8.0',
   '-dynamiclib',
@@ -47,7 +38,7 @@ const List<String> kDefaultClang = <String>[
   '-install_name',
   '@rpath/App.framework/App',
   '-isysroot',
-  '',
+  'path/to/sdk',
   '-o',
   'build/foo/App.framework/App',
   'build/foo/snapshot_assembly.o',
@@ -68,7 +59,7 @@ const List<String> kBitcodeClang = <String>[
   '@rpath/App.framework/App',
   '-fembed-bitcode',
   '-isysroot',
-  '',
+  'path/to/sdk',
   '-o',
   'build/foo/App.framework/App',
   'build/foo/snapshot_assembly.o',
@@ -223,6 +214,7 @@ void main() {
       expect(await snapshotter.build(
         platform: TargetPlatform.ios,
         darwinArch: DarwinArch.arm64,
+        sdkRoot: 'path/to/sdk',
         buildMode: BuildMode.debug,
         mainPath: 'main.dill',
         outputPath: outputPath,
@@ -278,7 +270,6 @@ void main() {
         ]
       ));
       processManager.addCommand(kARMCheckCommand);
-      processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
           'xcrun',
@@ -286,7 +277,7 @@ void main() {
           '-arch',
           'armv7',
           '-isysroot',
-          '',
+          'path/to/sdk',
           '-fembed-bitcode',
           '-c',
           'build/foo/snapshot_assembly.S',
@@ -310,6 +301,7 @@ void main() {
         mainPath: 'main.dill',
         outputPath: outputPath,
         darwinArch: DarwinArch.armv7,
+        sdkRoot: 'path/to/sdk',
         bitcode: true,
         splitDebugInfo: null,
         dartObfuscation: false,
@@ -340,7 +332,6 @@ void main() {
         ]
       ));
       processManager.addCommand(kARMCheckCommand);
-      processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
           'xcrun',
@@ -348,7 +339,7 @@ void main() {
           '-arch',
           'armv7',
           '-isysroot',
-          '',
+          'path/to/sdk',
           '-c',
           'build/foo/snapshot_assembly.S',
           '-o',
@@ -371,6 +362,7 @@ void main() {
         mainPath: 'main.dill',
         outputPath: outputPath,
         darwinArch: DarwinArch.armv7,
+        sdkRoot: 'path/to/sdk',
         bitcode: false,
         splitDebugInfo: 'foo',
         dartObfuscation: false,
@@ -399,7 +391,6 @@ void main() {
         ]
       ));
       processManager.addCommand(kARMCheckCommand);
-      processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
           'xcrun',
@@ -407,7 +398,7 @@ void main() {
           '-arch',
           'armv7',
           '-isysroot',
-          '',
+          'path/to/sdk',
           '-c',
           'build/foo/snapshot_assembly.S',
           '-o',
@@ -430,6 +421,7 @@ void main() {
         mainPath: 'main.dill',
         outputPath: outputPath,
         darwinArch: DarwinArch.armv7,
+        sdkRoot: 'path/to/sdk',
         bitcode: false,
         splitDebugInfo: null,
         dartObfuscation: true,
@@ -457,7 +449,6 @@ void main() {
         ]
       ));
       processManager.addCommand(kARMCheckCommand);
-      processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
           'xcrun',
@@ -465,7 +456,7 @@ void main() {
           '-arch',
           'armv7',
           '-isysroot',
-          '',
+          'path/to/sdk',
           '-c',
           'build/foo/snapshot_assembly.S',
           '-o',
@@ -488,6 +479,7 @@ void main() {
         mainPath: 'main.dill',
         outputPath: outputPath,
         darwinArch: DarwinArch.armv7,
+        sdkRoot: 'path/to/sdk',
         bitcode: false,
         splitDebugInfo: null,
         dartObfuscation: false,
@@ -512,7 +504,6 @@ void main() {
         ]
       ));
       processManager.addCommand(kARMCheckCommand);
-      processManager.addCommand(kSdkPathCommand);
       processManager.addCommand(const FakeCommand(
         command: <String>[
           'xcrun',
@@ -520,7 +511,7 @@ void main() {
           '-arch',
           'arm64',
           '-isysroot',
-          '',
+          'path/to/sdk',
           '-c',
           'build/foo/snapshot_assembly.S',
           '-o',
@@ -543,6 +534,7 @@ void main() {
         mainPath: 'main.dill',
         outputPath: outputPath,
         darwinArch: DarwinArch.arm64,
+        sdkRoot: 'path/to/sdk',
         bitcode: false,
         splitDebugInfo: null,
         dartObfuscation: false,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -485,25 +485,13 @@ void main() {
         ],
         exitCode: 1,
       ),
-      const FakeCommand(command: <String>[
-        'xcrun',
-        '--sdk',
-        'iphoneos',
-        '--show-sdk-path',
-      ]),
-      const FakeCommand(command: <String>[
-        'xcrun',
-        '--sdk',
-        'iphoneos',
-        '--show-sdk-path',
-      ]),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',
         '-arch',
         'armv7',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-c',
         '$build/armv7/snapshot_assembly.S',
         '-o',
@@ -515,7 +503,7 @@ void main() {
         '-arch',
         'arm64',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-c',
         '$build/arm64/snapshot_assembly.S',
         '-o',
@@ -539,7 +527,7 @@ void main() {
         '-install_name',
         '@rpath/App.framework/App',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-o',
         '$build/armv7/App.framework/App',
         '$build/armv7/snapshot_assembly.o',
@@ -562,7 +550,7 @@ void main() {
         '-install_name',
         '@rpath/App.framework/App',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',
@@ -577,6 +565,7 @@ void main() {
       ]),
     ]);
     iosEnvironment.defines[kIosArchs] ='armv7 arm64';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
 
     await const AotAssemblyProfile().build(iosEnvironment);
 
@@ -590,6 +579,7 @@ void main() {
   testUsingContext('AotAssemblyProfile with bitcode sends correct argument to snapshotter (one arch)', () async {
     iosEnvironment.defines[kIosArchs] = 'arm64';
     iosEnvironment.defines[kBitcodeFlag] = 'true';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
     final String build = iosEnvironment.buildDir.path;
     processManager.addCommands(<FakeCommand>[
       FakeCommand(command: <String>[
@@ -610,19 +600,13 @@ void main() {
         ],
         exitCode: 1,
       ),
-      const FakeCommand(command: <String>[
-        'xcrun',
-        '--sdk',
-        'iphoneos',
-        '--show-sdk-path',
-      ]),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',
         '-arch',
         'arm64',
         '-isysroot',
-        '',
+        'path/to/sdk',
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-c',
@@ -650,7 +634,7 @@ void main() {
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',
@@ -676,6 +660,7 @@ void main() {
   testUsingContext('AotAssemblyRelease configures gen_snapshot with code size directory', () async {
     iosEnvironment.defines[kCodeSizeDirectory] = 'code_size_1';
     iosEnvironment.defines[kIosArchs] = 'arm64';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
     iosEnvironment.defines[kBitcodeFlag] = 'true';
     final String build = iosEnvironment.buildDir.path;
     processManager.addCommands(<FakeCommand>[
@@ -699,19 +684,13 @@ void main() {
         ],
         exitCode: 1,
       ),
-      const FakeCommand(command: <String>[
-        'xcrun',
-        '--sdk',
-        'iphoneos',
-        '--show-sdk-path',
-      ]),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',
         '-arch',
         'arm64',
         '-isysroot',
-        '',
+        'path/to/sdk',
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-c',
@@ -739,7 +718,7 @@ void main() {
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-isysroot',
-        '',
+        'path/to/sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',


### PR DESCRIPTION
## Description

With the upcoming support for [Apple Silicon ARM simulators](https://github.com/flutter/flutter/issues/69334), App.framework can no longer contain architectures for both `iphoneos` and `iphonesimulator` since they need to be build against different SDKs, but they can no longer be `lipo`d together (`lipo` complains both binaries contain arm64 and fails).

Primarily this is a problem when building the debug stub framework:
https://github.com/flutter/flutter/blob/cb67513f29dbf7f41818c9eb8cc42d845e243fca/packages/flutter_tools/lib/src/build_system/targets/ios.dart#L106-L111

And in `flutter build ios-framework` that smush together plugin frameworks.

1. Output App.framework to different `iphoneos` and `iphonesimulator` directories - done with https://github.com/flutter/flutter/pull/69699.
2. Refactor the build system to take either the `iphoneos` and `iphonesimulator` SDK from Xcode instead of trying to guess from the architectures (to stop assuming x86 == simulator).  Use it for `aot` (this PR).
3. Remove `lipo`ing from debug stub framework step and only use the requested `iphoneos` or `iphonesimulator` SDK, not for both.  Refactor `flutter build ios-framework` as needed (next PR).
4. Deprecate `flutter build ios-framework --universal` - https://github.com/flutter/flutter/pull/69720
5. Deprecate `flutter build aot` - https://github.com/flutter/flutter/issues/49562

This PR actually doesn't change any behavior, but I did steps 2 and 3 at the same time and the patch is too large to easily review.  Some of this will make more sense on the next PR.

## Related Issues

Support https://github.com/flutter/flutter/issues/69334
