### PR TITLE
Cancel drag or hold when scrolling is disabled.

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -498,7 +498,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       return;
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
-      // Cancel active drag/hold gestures before we dispose the gesture
+      // Cancel active drag/hold activities because we're disposing the gesture
       // recognizers.
       _handleDragCancel();
     } else {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -498,6 +498,9 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       return;
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
+      // Cancel active drag/hold gestures before we dispose the gesture
+      // recognizers.
+      _handleDragCancel();
     } else {
       switch (widget.axis) {
         case Axis.vertical:

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -498,8 +498,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       return;
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
-      // Cancel active drag/hold activities because we're disposing the gesture
-      // recognizers.
+      // Cancel active drag/hold activities because the gesture recognizers will
+      // soon be disposed by our RawGestureDetector.
       _handleDragCancel();
     } else {
       switch (widget.axis) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -498,8 +498,9 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       return;
     if (!canDrag) {
       _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
-      // Cancel active drag/hold activities because the gesture recognizers will
-      // soon be disposed by our RawGestureDetector.
+      // Cancel the active hold/drag (if any) because the gesture recognizers
+      // will soon be disposed by our RawGestureDetector, and we won't be
+      // receiving pointer up events to cancel the hold/drag.
       _handleDragCancel();
     } else {
       switch (widget.axis) {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -369,7 +369,7 @@ void main() {
   });
 
   group('setCanDrag to false with active drag gesture: ', () {
-      Future<void> pumpTestWidget(WidgetTester tester, { required bool canDrag }) {
+    Future<void> pumpTestWidget(WidgetTester tester, { required bool canDrag }) {
       return tester.pumpWidget(
         MaterialApp(
           home: CustomScrollView(

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -369,25 +369,25 @@ void main() {
   });
 
   group('setCanDrag to false with active drag gesture: ', () {
-    Future<void> pumpTestWidget(WidgetTester tester, bool canDrag) async {
-      return await tester.pumpWidget(
+      Future<void> pumpTestWidget(WidgetTester tester, { required bool canDrag }) {
+      return tester.pumpWidget(
         MaterialApp(
           home: CustomScrollView(
             physics: canDrag ? const AlwaysScrollableScrollPhysics() : const NeverScrollableScrollPhysics(),
             slivers: <Widget>[SliverToBoxAdapter(
-                child: SizedBox(
-                  height: 2000,
-                  child: GestureDetector(onTap: () {},),
-                ),
+              child: SizedBox(
+                height: 2000,
+                child: GestureDetector(onTap: () {},),
+              ),
             )],
           ),
         ),
       );
     }
 
-    testWidgets('hold', (WidgetTester tester) async {
+    testWidgets('Hold does not disable user interaction', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/66816.
-      await pumpTestWidget(tester, true);
+      await pumpTestWidget(tester, canDrag: true);
       final RenderIgnorePointer renderIgnorePointer = tester.renderObject<RenderIgnorePointer>(
         find.descendant(of: find.byType(CustomScrollView), matching: find.byType(IgnorePointer)),
       );
@@ -397,16 +397,16 @@ void main() {
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Viewport)));
       expect(renderIgnorePointer.ignoring, false);
 
-      await pumpTestWidget(tester, false);
+      await pumpTestWidget(tester, canDrag: false);
       expect(renderIgnorePointer.ignoring, false);
 
       await gesture.up();
       expect(renderIgnorePointer.ignoring, false);
     });
 
-    testWidgets('drag', (WidgetTester tester) async {
+    testWidgets('Drag disables user interaction when recognized', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/66816.
-      await pumpTestWidget(tester, true);
+      await pumpTestWidget(tester, canDrag: true);
       final RenderIgnorePointer renderIgnorePointer = tester.renderObject<RenderIgnorePointer>(
         find.descendant(of: find.byType(CustomScrollView), matching: find.byType(IgnorePointer)),
       );
@@ -419,15 +419,15 @@ void main() {
       // Starts ignoring when the drag is recognized.
       expect(renderIgnorePointer.ignoring, true);
 
-      await pumpTestWidget(tester, false);
+      await pumpTestWidget(tester, canDrag: false);
       expect(renderIgnorePointer.ignoring, false);
 
       await gesture.up();
       expect(renderIgnorePointer.ignoring, false);
     });
 
-    testWidgets('ballistic', (WidgetTester tester) async {
-      await pumpTestWidget(tester, true);
+    testWidgets('Ballistic disables user interaction until it stops', (WidgetTester tester) async {
+      await pumpTestWidget(tester, canDrag: true);
       final RenderIgnorePointer renderIgnorePointer = tester.renderObject<RenderIgnorePointer>(
         find.descendant(of: find.byType(CustomScrollView), matching: find.byType(IgnorePointer)),
       );


### PR DESCRIPTION
## Description

`Scrollable`s ignore pointer events when some activities (drag, ballistic) are in progress. When a drag is in progress and `setCanDrag(false)` is called before the touch up event, the gesture recognizers will get `disposed` and the drag activity will not end. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66816.

## Tests

I added the following tests:

setCanDrag to false with active ScrollActivity: 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
