### PR TITLE
Methods in build_ios_framework for universal and XCFrameworks

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -338,7 +338,7 @@ end
       status.stop();
     }
 
-    await _produceXCFramework(buildInfo, fatFlutterFrameworkCopy);
+    await _produceXCFrameworkFromUniversal(buildInfo, fatFlutterFrameworkCopy);
   }
 
   Future<void> _produceAppFramework(BuildInfo buildInfo, Directory modeDirectory) async {
@@ -397,7 +397,7 @@ end
     }
 
     final Directory destinationAppFrameworkDirectory = modeDirectory.childDirectory(appFrameworkName);
-    await _produceXCFramework(buildInfo, destinationAppFrameworkDirectory);
+    await _produceXCFrameworkFromUniversal(buildInfo, destinationAppFrameworkDirectory);
   }
 
   Future<void> _producePlugins(
@@ -494,69 +494,17 @@ end
             continue;
           }
           final String binaryName = globals.fs.path.basenameWithoutExtension(podFrameworkName);
-          if (boolArg('universal')) {
-            globals.fsUtils.copyDirectorySync(
-              podProduct as Directory,
-              modeDirectory.childDirectory(podFrameworkName),
-            );
-            final List<String> lipoCommand = <String>[
-              ...globals.xcode.xcrunCommand(),
-              'lipo',
-              '-create',
-              globals.fs.path.join(podProduct.path, binaryName),
-              if (mode == BuildMode.debug)
-                simulatorBuildConfiguration
-                  .childDirectory(binaryName)
+
+          final List<Directory> frameworks = <Directory>[
+            podProduct as Directory,
+            if (mode == BuildMode.debug)
+              simulatorBuildConfiguration
+                  .childDirectory(builtProduct.basename)
                   .childDirectory(podFrameworkName)
-                  .childFile(binaryName)
-                  .path,
-              '-output',
-              modeDirectory.childDirectory(podFrameworkName).childFile(binaryName).path
-            ];
+          ];
 
-            final RunResult pluginsLipoResult = await globals.processUtils.run(
-              lipoCommand,
-              workingDirectory: outputDirectory.path,
-              allowReentrantFlutter: false,
-            );
-
-            if (pluginsLipoResult.exitCode != 0) {
-              throwToolExit(
-                'Unable to create universal $binaryName.framework: ${buildPluginsResult.stderr}',
-              );
-            }
-          }
-
-          if (boolArg('xcframework')) {
-            final List<String> xcframeworkCommand = <String>[
-              ...globals.xcode.xcrunCommand(),
-              'xcodebuild',
-              '-create-xcframework',
-              '-framework',
-              podProduct.path,
-              if (mode == BuildMode.debug)
-                '-framework',
-              if (mode == BuildMode.debug)
-                simulatorBuildConfiguration
-                  .childDirectory(binaryName)
-                  .childDirectory(podFrameworkName)
-                  .path,
-              '-output',
-              modeDirectory.childFile('$binaryName.xcframework').path
-            ];
-
-            final RunResult xcframeworkResult = await globals.processUtils.run(
-              xcframeworkCommand,
-              workingDirectory: outputDirectory.path,
-              allowReentrantFlutter: false,
-            );
-
-            if (xcframeworkResult.exitCode != 0) {
-              throwToolExit(
-                'Unable to create $binaryName.xcframework: ${xcframeworkResult.stderr}',
-              );
-            }
-          }
+          await _produceUniversalFramework(frameworks, binaryName, modeDirectory);
+          await _produceXCFramework(frameworks, binaryName, modeDirectory);
         }
       }
     } finally {
@@ -564,7 +512,7 @@ end
     }
   }
 
-  Future<void> _produceXCFramework(BuildInfo buildInfo, Directory fatFramework) async {
+  Future<void> _produceXCFrameworkFromUniversal(BuildInfo buildInfo, Directory fatFramework) async {
     if (boolArg('xcframework')) {
       final String frameworkBinaryName = globals.fs.path.basenameWithoutExtension(
           fatFramework.basename);
@@ -576,7 +524,9 @@ end
         if (buildInfo.mode == BuildMode.debug) {
           await _produceDebugXCFramework(fatFramework, frameworkBinaryName);
         } else {
-          await _produceNonDebugXCFramework(buildInfo, fatFramework, frameworkBinaryName);
+          await _produceXCFramework(
+              <Directory>[fatFramework], frameworkBinaryName,
+              fatFramework.parent);
         }
       } finally {
         status.stop();
@@ -658,15 +608,34 @@ end
       }
 
       // Create XCFramework from iOS and simulator frameworks.
+      await _produceXCFramework(
+        <Directory>[
+          armFlutterFrameworkDirectory,
+          simulatorFlutterFrameworkDirectory
+        ],
+        frameworkBinaryName,
+        fatFramework.parent,
+      );
+    } finally {
+      temporaryOutput.deleteSync(recursive: true);
+    }
+  }
+
+  Future<void> _produceXCFramework(Iterable<Directory> frameworks,
+      String frameworkBinaryName, Directory outputDirectory) async {
+    if (!boolArg('xcframework')) {
+      return;
+    }
       final List<String> xcframeworkCommand = <String>[
         ...globals.xcode.xcrunCommand(),
         'xcodebuild',
         '-create-xcframework',
-        '-framework', armFlutterFrameworkDirectory.path,
-        '-framework', simulatorFlutterFrameworkDirectory.path,
-        '-output', fatFramework.parent
-            .childFile('$frameworkBinaryName.xcframework')
-            .path
+        for (Directory framework in frameworks) ...<String>[
+          '-framework',
+          framework.path
+        ],
+        '-output',
+        outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path
       ];
 
       final RunResult xcframeworkResult = await globals.processUtils.run(
@@ -676,39 +645,48 @@ end
 
       if (xcframeworkResult.exitCode != 0) {
         throwToolExit(
-          'Unable to create XCFramework: ${xcframeworkResult.stderr}',
-        );
+            'Unable to create $frameworkBinaryName.xcframework: ${xcframeworkResult.stderr}');
       }
-    } finally {
-      temporaryOutput.deleteSync(recursive: true);
-    }
   }
 
-  Future<void> _produceNonDebugXCFramework(
-    BuildInfo buildInfo,
-    Directory fatFramework,
-    String frameworkBinaryName,
-  ) async {
-    // Simulator is only supported in Debug mode.
-    // "Fat" framework here must only contain arm.
-    final List<String> xcframeworkCommand = <String>[
+  Future<void> _produceUniversalFramework(Iterable<Directory> frameworks,
+      String frameworkBinaryName, Directory outputDirectory) async {
+    if (!boolArg('universal')) {
+      return;
+    }
+    final Directory outputFrameworkDirectory = outputDirectory
+        .childDirectory('$frameworkBinaryName.framework');
+
+    // Copy the first framework over completely to get headers, resources, etc.
+    globals.fsUtils.copyDirectorySync(
+      frameworks.first,
+      outputFrameworkDirectory,
+    );
+
+    // Recreate the framework binary by lipo'ing the framework binaries together.
+    final List<String> lipoCommand = <String>[
       ...globals.xcode.xcrunCommand(),
-      'xcodebuild',
-      '-create-xcframework',
-      '-framework', fatFramework.path,
-      '-output', fatFramework.parent
-          .childFile('$frameworkBinaryName.xcframework')
-          .path
+      'lipo',
+      '-create',
+      for (Directory framework in frameworks) ...<String>[
+        framework
+            .childFile(frameworkBinaryName)
+            .path
+      ],
+      '-output',
+      outputFrameworkDirectory.childFile(frameworkBinaryName).path
     ];
 
-    final RunResult xcframeworkResult = await globals.processUtils.run(
-      xcframeworkCommand,
+    final RunResult lipoResult = await globals.processUtils.run(
+      lipoCommand,
+      workingDirectory: outputDirectory.path,
       allowReentrantFlutter: false,
     );
 
-    if (xcframeworkResult.exitCode != 0) {
+    if (lipoResult.exitCode != 0) {
       throwToolExit(
-          'Unable to create XCFramework: ${xcframeworkResult.stderr}');
+          'Unable to create $frameworkBinaryName.framework: ${lipoResult
+              .stderr}');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -626,27 +626,27 @@ end
     if (!boolArg('xcframework')) {
       return;
     }
-      final List<String> xcframeworkCommand = <String>[
-        ...globals.xcode.xcrunCommand(),
-        'xcodebuild',
-        '-create-xcframework',
-        for (Directory framework in frameworks) ...<String>[
-          '-framework',
-          framework.path
-        ],
-        '-output',
-        outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path
-      ];
+    final List<String> xcframeworkCommand = <String>[
+      ...globals.xcode.xcrunCommand(),
+      'xcodebuild',
+      '-create-xcframework',
+      for (Directory framework in frameworks) ...<String>[
+        '-framework',
+        framework.path
+      ],
+      '-output',
+      outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path
+    ];
 
-      final RunResult xcframeworkResult = await globals.processUtils.run(
-        xcframeworkCommand,
-        allowReentrantFlutter: false,
-      );
+    final RunResult xcframeworkResult = await globals.processUtils.run(
+      xcframeworkCommand,
+      allowReentrantFlutter: false,
+    );
 
-      if (xcframeworkResult.exitCode != 0) {
-        throwToolExit(
-            'Unable to create $frameworkBinaryName.xcframework: ${xcframeworkResult.stderr}');
-      }
+    if (xcframeworkResult.exitCode != 0) {
+      throwToolExit(
+          'Unable to create $frameworkBinaryName.xcframework: ${xcframeworkResult.stderr}');
+    }
   }
 
   Future<void> _produceUniversalFramework(Iterable<Directory> frameworks,
@@ -654,8 +654,8 @@ end
     if (!boolArg('universal')) {
       return;
     }
-    final Directory outputFrameworkDirectory = outputDirectory
-        .childDirectory('$frameworkBinaryName.framework');
+    final Directory outputFrameworkDirectory =
+        outputDirectory.childDirectory('$frameworkBinaryName.framework');
 
     // Copy the first framework over completely to get headers, resources, etc.
     globals.fsUtils.copyDirectorySync(
@@ -669,9 +669,7 @@ end
       'lipo',
       '-create',
       for (Directory framework in frameworks) ...<String>[
-        framework
-            .childFile(frameworkBinaryName)
-            .path
+        framework.childFile(frameworkBinaryName).path
       ],
       '-output',
       outputFrameworkDirectory.childFile(frameworkBinaryName).path
@@ -685,8 +683,7 @@ end
 
     if (lipoResult.exitCode != 0) {
       throwToolExit(
-          'Unable to create $frameworkBinaryName.framework: ${lipoResult
-              .stderr}');
+          'Unable to create $frameworkBinaryName.framework: ${lipoResult.stderr}');
     }
   }
 }


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/69731 and the next "Remove lipoing from debug stub framework step" PR were too big to review together.

Refactoring part of `build_ios_framework` to keep the reviews for https://github.com/flutter/flutter/issues/69334 small.

1. Rename `_produceXCFramework` to `_produceXCFrameworkFromUniversal`.  This existing method took a universal (fat) framework, split it into `iphoneos` and `iphonesimulator` frameworks, then turned them into an xcframework.
2. Pull logic to create an xcframework from non-fat frameworks out of  `_producePlugins`, combine with logic from `_produceNonDebugXCFramework`, and call the new method `_produceXCFramework`.  This method will be used in the next PR.
3. Pull logic to `lipo` together non-fat frameworks into a universal framework out of  `_producePlugins` and call it `_produceUniversalFramework `.  This method will also be used in the next PR.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/63508, will supersede https://github.com/flutter/flutter/pull/66541

## Tests

`build_ios_framework_module_test` thoroughly tests the output bundles.   My test suggestion in https://github.com/flutter/flutter/pull/66541#pullrequestreview-495991300 wasn't a great one and it didn't work.  `build_ios_framework_module_test` will confirm it doesn't regress the more normal case that the module and framework are named the same thing.