### PR TITLE
Do not crash if RichText has recognizers without handlers

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -935,13 +935,19 @@ class RenderParagraph extends RenderBox
         final GestureRecognizer? recognizer = info.recognizer;
         if (recognizer != null) {
           if (recognizer is TapGestureRecognizer) {
-            configuration.onTap = recognizer.onTap;
-            configuration.isLink = true;
+            if (recognizer.onTap != null) {
+              configuration.onTap = recognizer.onTap;
+              configuration.isLink = true;
+            }
           } else if (recognizer is DoubleTapGestureRecognizer) {
-            configuration.onTap = recognizer.onDoubleTap;
-            configuration.isLink = true;
+            if (recognizer.onDoubleTap != null) {
+              configuration.onTap = recognizer.onDoubleTap;
+              configuration.isLink = true;
+            }
           } else if (recognizer is LongPressGestureRecognizer) {
-            configuration.onLongPress = recognizer.onLongPress;
+            if (recognizer.onLongPress != null) {
+              configuration.onLongPress = recognizer.onLongPress;
+            }
           } else {
             assert(false, '${recognizer.runtimeType} is not supported.');
           }

--- a/packages/flutter/test/widgets/rich_text_test.dart
+++ b/packages/flutter/test/widgets/rich_text_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('RichText with recognizers without handlers does not throw', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RichText(
+          text: TextSpan(text: 'root', children: <InlineSpan>[
+            TextSpan(text: 'one', recognizer: TapGestureRecognizer()),
+            TextSpan(text: 'two', recognizer: LongPressGestureRecognizer()),
+            TextSpan(text: 'three', recognizer: DoubleTapGestureRecognizer()),
+          ]),
+        ),
+      ),
+    );
+
+    expect(tester.getSemantics(find.byType(RichText)), matchesSemantics(
+      children: <Matcher>[
+        matchesSemantics(
+          label: 'root',
+          hasTapAction: false,
+          hasLongPressAction: false,
+        ),
+        matchesSemantics(
+          label: 'one',
+          hasTapAction: false,
+          hasLongPressAction: false,
+        ),
+        matchesSemantics(
+          label: 'two',
+          hasTapAction: false,
+          hasLongPressAction: false,
+        ),
+        matchesSemantics(
+          label: 'three',
+          hasTapAction: false,
+          hasLongPressAction: false,
+        ),
+      ],
+    ));
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/69788.