### PR TITLE
Run more xcodebuild commands in native arm on Apple Silicon

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -12,7 +12,6 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
-import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../build_info.dart';
@@ -66,18 +65,11 @@ class Xcode {
   })  : _platform = platform,
         _fileSystem = fileSystem,
         _xcodeProjectInterpreter = xcodeProjectInterpreter,
-        _operatingSystemUtils = OperatingSystemUtils(
-          fileSystem: fileSystem,
-          logger: logger,
-          platform: platform,
-          processManager: processManager,
-        ),
         _processUtils =
             ProcessUtils(logger: logger, processManager: processManager);
 
   final Platform _platform;
   final ProcessUtils _processUtils;
-  final OperatingSystemUtils _operatingSystemUtils;
   final FileSystem _fileSystem;
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
 
@@ -169,24 +161,8 @@ class Xcode {
     return false;
   }
 
-  /// The `xcrun` Xcode command to run or locate development
-  /// tools and properties.
-  ///
-  /// Returns `xcrun` on x86 macOS.
-  /// Returns `/usr/bin/arch -arm64e xcrun` on ARM macOS to force Xcode commands
-  /// to run outside the x86 Rosetta translation, which may cause crashes.
-  List<String> xcrunCommand() {
-    final List<String> xcrunCommand = <String>[];
-    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
-      // Force Xcode commands to run outside Rosetta.
-      xcrunCommand.addAll(<String>[
-        '/usr/bin/arch',
-        '-arm64e',
-      ]);
-    }
-    xcrunCommand.add('xcrun');
-    return xcrunCommand;
-  }
+  /// See [XcodeProjectInterpreter.xcrunCommand].
+  List<String> xcrunCommand() => _xcodeProjectInterpreter.xcrunCommand();
 
   Future<RunResult> cc(List<String> args) {
     return _processUtils.run(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -77,14 +77,6 @@ void main() {
     'xattr', '-r', '-d', 'com.apple.FinderInfo', '/ios'
   ]);
 
-  const FakeCommand armCheckCommand = FakeCommand(
-    command: <String>[
-      'sysctl',
-      'hw.optional.arm64',
-    ],
-    exitCode: 1,
-  );
-
   // Creates a FakeCommand for the xcodebuild call to build the app
   // in the given configuration.
   FakeCommand setUpMockXcodeBuildHandler({ bool verbose = false, bool showBuildSettings = false, void Function() onRun }) {
@@ -215,7 +207,6 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
-      armCheckCommand,
       setUpMockXcodeBuildHandler(),
       setUpMockXcodeBuildHandler(showBuildSettings: true),
     ]),
@@ -234,7 +225,6 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
-      armCheckCommand,
       setUpMockXcodeBuildHandler(verbose: true),
       setUpMockXcodeBuildHandler(verbose: true, showBuildSettings: true),
     ]),
@@ -263,7 +253,6 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
-      armCheckCommand,
       setUpMockXcodeBuildHandler(onRun: () {
         fileSystem.file('build/flutter_size_01/snapshot.arm64.json')
           ..createSync(recursive: true)
@@ -311,7 +300,6 @@ void main() {
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
           xattrCommand,
-          armCheckCommand,
           setUpMockXcodeBuildHandler(),
           setUpMockXcodeBuildHandler(showBuildSettings: true),
           exportArchiveCommand,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -478,13 +478,6 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
-      const FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        exitCode: 1,
-      ),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',
@@ -593,13 +586,6 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
-      const FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        exitCode: 1,
-      ),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',
@@ -677,13 +663,6 @@ void main() {
         '--lazy-async-stacks',
         '$build/app.dill',
       ]),
-      const FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        exitCode: 1,
-      ),
       FakeCommand(command: <String>[
         'xcrun',
         'cc',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -71,14 +71,6 @@ void main() {
   testUsingContext('DebugUniveralFramework creates expected binary with arm64 only arch', () async {
     environment.defines[kIosArchs] = 'arm64';
     processManager.addCommands(<FakeCommand>[
-      // Create iphone stub.
-      const FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        exitCode: 1,
-      ),
       const FakeCommand(command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path']),
       FakeCommand(command: <String>[
         'xcrun',

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -414,6 +414,9 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
       BufferLogger.test(),
     );
   }
+
+  @override
+  List<String> xcrunCommand() => <String>['xcrun'];
 }
 
 class MockFlutterVersion extends Mock implements FlutterVersion {


### PR DESCRIPTION
## Description

Missed the `XcodeProjectInterpreter` `xcodebuild` commands while working on #68050.
Push the `arch` check to that layer and make the `Xcode.xcrunCommand()` delegate to it.

## Related Issues

#68050.