### PR TITLE
Build either iphoneos or iphonesimulator App.framework, not both

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -244,7 +244,7 @@ LipoExecutable() {
         all_executables+=("${output}")
       else
         echo "Failed to extract ${arch} for ${executable}. Running lipo -info:"
-        lipo -info "${executable}"
+        RunCommand lipo -info "${executable}"
         exit 1
       fi
     fi
@@ -254,10 +254,10 @@ LipoExecutable() {
   # Skip this step for non-fat executables.
   if [[ ${#all_executables[@]} > 0 ]]; then
     local merged="${executable}_merged"
-    lipo -output "${merged}" -create "${all_executables[@]}"
+    RunCommand lipo -output "${merged}" -create "${all_executables[@]}"
 
-    cp -f -- "${merged}" "${executable}" > /dev/null
-    rm -f -- "${merged}" "${all_executables[@]}"
+    RunCommand cp -f -- "${merged}" "${executable}" > /dev/null
+    RunCommand rm -f -- "${merged}" "${all_executables[@]}"
   fi
 }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -10,7 +10,6 @@ import '../../base/io.dart';
 import '../../base/process.dart';
 import '../../build_info.dart';
 import '../../globals.dart' as globals hide fs, logger, processManager, artifacts;
-import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';
@@ -209,45 +208,19 @@ class DebugUniversalFramework extends Target {
   @override
   Future<void> build(Environment environment) async {
     // Generate a trivial App.framework.
-    final Set<DarwinArch> iosArchs = environment.defines[kIosArchs]
+    final Set<String> iosArchNames = environment.defines[kIosArchs]
       ?.split(' ')
-      ?.map(getIOSArchForName)
-      ?.toSet()
-      ?? <DarwinArch>{DarwinArch.arm64};
-    final File iphoneFile = environment.buildDir.childFile('iphone_framework');
-    final File simulatorFile = environment.buildDir.childFile('simulator_framework');
-    final File lipoOutputFile = environment.buildDir
+      ?.toSet();
+    final File output = environment.buildDir
       .childDirectory('App.framework')
       .childFile('App');
-    lipoOutputFile.parent.createSync(recursive: true);
-    final RunResult iphoneResult = await createStubAppFramework(
-      iphoneFile,
-      SdkType.iPhone,
-      // Only include 32bit if it is contained in the active architectures.
-      include32Bit: iosArchs.contains(DarwinArch.armv7)
+    environment.buildDir.createSync(recursive: true);
+    final RunResult createFrameworkResult = await createStubAppFramework(
+      output,
+      environment.defines[kSdkRoot],
+      iosArchNames,
     );
-    final RunResult simulatorResult = await createStubAppFramework(
-      simulatorFile,
-      SdkType.iPhoneSimulator,
-    );
-    if (iphoneResult.exitCode != 0 || simulatorResult.exitCode != 0) {
-      throw Exception('Failed to create App.framework.');
-    }
-    final List<String> lipoCommand = <String>[
-      ...globals.xcode.xcrunCommand(),
-      'lipo',
-      '-create',
-      iphoneFile.path,
-      simulatorFile.path,
-      '-output',
-      lipoOutputFile.path,
-    ];
-
-    final RunResult lipoResult = await globals.processUtils.run(
-      lipoCommand,
-    );
-
-    if (lipoResult.exitCode != 0) {
+    if (createFrameworkResult.exitCode != 0) {
       throw Exception('Failed to create App.framework.');
     }
   }
@@ -410,7 +383,8 @@ class ReleaseIosApplicationBundle extends IosAssetBundle {
 /// This framework needs to exist for the Xcode project to link/bundle,
 /// but it isn't actually executed. To generate something valid, we compile a trivial
 /// constant.
-Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk, { bool include32Bit = true }) async {
+Future<RunResult> createStubAppFramework(File outputFile, String sdkRoot,
+    Set<String> iosArchNames) async {
   try {
     outputFile.createSync(recursive: true);
   } on Exception catch (e) {
@@ -425,32 +399,17 @@ Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk, { bool in
   static const int Moo = 88;
   ''');
 
-    List<String> archFlags;
-    if (sdk == SdkType.iPhone) {
-      archFlags = <String>[
-        if (include32Bit)
-          ...<String>['-arch', getNameForDarwinArch(DarwinArch.armv7)],
-        '-arch',
-        getNameForDarwinArch(DarwinArch.arm64),
-      ];
-    } else {
-      archFlags = <String>[
-        '-arch',
-        getNameForDarwinArch(DarwinArch.x86_64),
-      ];
-    }
-
     return await globals.xcode.clang(<String>[
       '-x',
       'c',
-      ...archFlags,
+      for (String arch in iosArchNames) ...<String>['-arch', arch],
       stubSource.path,
       '-dynamiclib',
       '-fembed-bitcode-marker',
       '-Xlinker', '-rpath', '-Xlinker', '@executable_path/Frameworks',
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',
-      '-isysroot', await globals.xcode.sdkLocation(sdk),
+      '-isysroot', sdkRoot,
       '-o', outputFile.path,
     ]);
   } finally {


### PR DESCRIPTION
## Description

Next piece of #69334.

With the upcoming support for [Apple Silicon ARM simulators](https://github.com/flutter/flutter/issues/69334), App.framework can no longer contain architectures for both `iphoneos` and `iphonesimulator` since they need to be build against different SDKs, but they can no longer be `lipo`d together (`lipo` complains both binaries contain arm64 and fails).

1. Output App.framework to different `iphoneos` and `iphonesimulator` directories (https://github.com/flutter/flutter/pull/69699)
2. Refactor the build system to take either the `iphoneos` and `iphonesimulator` SDK from Xcode instead of trying to guess from the architectures (to stop assuming x86 == simulator).  Use it for `aot` (https://github.com/flutter/flutter/pull/69731).
3. Refactor `flutter build ios-framework` to pull out the universal and xcframework methods to be reused in this PR (https://github.com/flutter/flutter/pull/69736)
4. Remove `lipo`ing from debug stub framework step and only use the requested `iphoneos` or `iphonesimulator` SDK, not for both.  Refactor `flutter build ios-framework` as needed (this PR). 

## Related Issues

Support https://github.com/flutter/flutter/issues/69334