### PR TITLE
Remove add-to-app Xcode build phase input files

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -118,12 +118,6 @@ def install_flutter_application_pod(flutter_application_path)
   flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
   script_phase :name => 'Run Flutter Build {{projectName}} Script',
     :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
-    :input_files => [
-      File.join('${SRCROOT}', flutter_application_path, '.metadata'),
-      File.join('${SRCROOT}', relative, 'App.framework', 'App'),
-      File.join('${SRCROOT}', relative, 'engine', 'Flutter.framework', 'Flutter'),
-      flutter_export_environment_path
-    ],
     :execution_position => :before_compile
 end
 


### PR DESCRIPTION
## Description

Remove the input files in the add-to-app CocoaPods build script to always run the Flutter script.
![Screen Shot 2020-11-04 at 5 53 32 PM](https://user-images.githubusercontent.com/682784/98187829-a9705000-1ec6-11eb-9dc6-09b90ea0ca82.png)

1. As of https://github.com/flutter/flutter/pull/69699 App.framework isn't written to `.ios/Flutter`
2. App.framework should have been listed as an output, not an input.
3. This probably doesn't run the script when it should, like when you switch from a real device to a simulator.
4. There's already logic in the flutter tool to not recompile the dart app when nothing changes.

## Related Issues

Follow up to https://github.com/flutter/flutter/pull/69699