### PR TITLE
Revert "[null-safety] update Dart SDK constraints (#69831)"

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://flutter.dev
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.10.0-0.0.dev <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -5,7 +5,7 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.10.0-0.0.dev <3.0.0"
 
 dependencies:
   file: 6.0.0-nullsafety.4

--- a/packages/flutter_goldens/pubspec.yaml
+++ b/packages/flutter_goldens/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_goldens
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.10.0-4.0.dev <2.12.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_goldens_client/pubspec.yaml
+++ b/packages/flutter_goldens_client/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_goldens_client
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.10.0-4.0.dev <2.12.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.10.0-0.0.dev <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".


### PR DESCRIPTION
This reverts commit e375651cc542edeebbd74d7c12a120d958928111.

This was causing errors when running `flutter update-packages`
