### PR TITLE
Added enableFeedback property to DropdownButton

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -97,6 +97,7 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
     required this.buttonRect,
     required this.constraints,
     required this.itemIndex,
+    required this.enableFeedback,
   }) : super(key: key);
 
   final _DropdownRoute<T> route;
@@ -104,6 +105,7 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final Rect buttonRect;
   final BoxConstraints constraints;
   final int itemIndex;
+  final bool enableFeedback;
 
   @override
   _DropdownMenuItemButtonState<T> createState() => _DropdownMenuItemButtonState<T>();
@@ -173,6 +175,7 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     if (dropdownMenuItem.enabled) {
       child = InkWell(
         autofocus: widget.itemIndex == widget.route.selectedIndex,
+        enableFeedback: widget.enableFeedback,
         child: child,
         onTap: _handleOnTap,
         onFocusChange: _handleFocusChange,
@@ -197,6 +200,7 @@ class _DropdownMenu<T> extends StatefulWidget {
     required this.buttonRect,
     required this.constraints,
     this.dropdownColor,
+    required this.enableFeedback,
   }) : super(key: key);
 
   final _DropdownRoute<T> route;
@@ -204,6 +208,7 @@ class _DropdownMenu<T> extends StatefulWidget {
   final Rect buttonRect;
   final BoxConstraints constraints;
   final Color? dropdownColor;
+  final bool enableFeedback;
 
   @override
   _DropdownMenuState<T> createState() => _DropdownMenuState<T>();
@@ -253,6 +258,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           buttonRect: widget.buttonRect,
           constraints: widget.constraints,
           itemIndex: itemIndex,
+          enableFeedback: widget.enableFeedback,
         ),
       ];
 
@@ -411,6 +417,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     this.itemHeight,
     this.dropdownColor,
     this.menuMaxHeight,
+    required this.enableFeedback,
   }) : assert(style != null),
        itemHeights = List<double>.filled(items.length, itemHeight ?? kMinInteractiveDimension);
 
@@ -424,7 +431,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   final double? itemHeight;
   final Color? dropdownColor;
   final double? menuMaxHeight;
-
+  final bool enableFeedback;
 
   final List<double> itemHeights;
   ScrollController? scrollController;
@@ -456,6 +463,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
           capturedThemes: capturedThemes,
           style: style,
           dropdownColor: dropdownColor,
+          enableFeedback: enableFeedback,
         );
       },
     );
@@ -551,6 +559,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
     required this.capturedThemes,
     this.style,
     required this.dropdownColor,
+    required this.enableFeedback,
   }) : super(key: key);
 
   final _DropdownRoute<T> route;
@@ -563,6 +572,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
   final CapturedThemes capturedThemes;
   final TextStyle? style;
   final Color? dropdownColor;
+  final bool enableFeedback;
 
   @override
   Widget build(BuildContext context) {
@@ -586,6 +596,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
       buttonRect: buttonRect,
       constraints: constraints,
       dropdownColor: dropdownColor,
+      enableFeedback: enableFeedback,
     );
 
     return MediaQuery.removePadding(
@@ -854,6 +865,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.autofocus = false,
     this.dropdownColor,
     this.menuMaxHeight,
+    this.enableFeedback,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(items == null || items.isEmpty || value == null ||
@@ -1114,6 +1126,18 @@ class DropdownButton<T> extends StatefulWidget {
   /// and bottom of the menu by at one menu item's height.
   final double? menuMaxHeight;
 
+  /// Whether detected gestures should provide acoustic and/or haptic feedback.
+  ///
+  /// For example, on Android a tap will produce a clicking sound and a
+  /// long-press will produce a short vibration, when feedback is enabled.
+  ///
+  /// By default, platform-specific feedback is enabled.
+  ///
+  /// See also:
+  ///
+  ///  * [Feedback] for providing platform-specific feedback to certain actions.
+  final bool? enableFeedback;
+
   @override
   _DropdownButtonState<T> createState() => _DropdownButtonState<T>();
 }
@@ -1266,6 +1290,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       itemHeight: widget.itemHeight,
       dropdownColor: widget.dropdownColor,
       menuMaxHeight: widget.menuMaxHeight,
+      enableFeedback: widget.enableFeedback ?? true,
     );
 
     navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {


### PR DESCRIPTION
## Description

Added enableFeedback property to DropdownButton.

## Related Issues

#69397 

## Tests

I added the following tests:

- DropdownButton with enabled feedback.
- DropdownButton with disabled feedback.
- DropdownButton with enabled feedback by default.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
