### PR TITLE
add fillColor for unselected toggle button

### DIFF
--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -175,6 +175,7 @@ class ToggleButtons extends StatelessWidget {
     this.selectedColor,
     this.disabledColor,
     this.fillColor,
+    this.unselectedFillColor,
     this.focusColor,
     this.highlightColor,
     this.hoverColor,
@@ -280,6 +281,14 @@ class ToggleButtons extends StatelessWidget {
   /// [ToggleButtonsThemeData.fillColor] is also null, then
   /// the fill color is null.
   final Color? fillColor;
+
+  /// The fill color for unselected toggle buttons.
+  ///
+  /// If this property is null, then
+  /// ToggleButtonTheme.of(context).unselectedFillColor is used. If
+  /// [ToggleButtonsThemeData.unselectedFillColor] is also null, then
+  /// the fill color is null.
+  final Color? unselectedFillColor;
 
   /// The color to use for filling the button when the button has input focus.
   ///
@@ -599,6 +608,7 @@ class ToggleButtons extends StatelessWidget {
             selectedColor: selectedColor,
             disabledColor: disabledColor,
             fillColor: fillColor ?? toggleButtonsTheme.fillColor,
+            unselectedFillColor: unselectedFillColor ?? toggleButtonsTheme.unselectedFillColor,
             focusColor: focusColor ?? toggleButtonsTheme.focusColor,
             highlightColor: highlightColor ?? toggleButtonsTheme.highlightColor,
             hoverColor: hoverColor ?? toggleButtonsTheme.hoverColor,
@@ -635,6 +645,7 @@ class ToggleButtons extends StatelessWidget {
     properties.add(ColorProperty('selectedColor', selectedColor, defaultValue: null));
     properties.add(ColorProperty('disabledColor', disabledColor, defaultValue: null));
     properties.add(ColorProperty('fillColor', fillColor, defaultValue: null));
+    properties.add(ColorProperty('unselectedFillColor', unselectedFillColor, defaultValue: null));
     properties.add(ColorProperty('focusColor', focusColor, defaultValue: null));
     properties.add(ColorProperty('highlightColor', highlightColor, defaultValue: null));
     properties.add(ColorProperty('hoverColor', hoverColor, defaultValue: null));
@@ -668,6 +679,7 @@ class _ToggleButton extends StatelessWidget {
     this.selectedColor,
     this.disabledColor,
     required this.fillColor,
+    required this.unselectedFillColor,
     required this.focusColor,
     required this.highlightColor,
     required this.hoverColor,
@@ -711,8 +723,11 @@ class _ToggleButton extends StatelessWidget {
   /// If [onPressed] is null, this color will be used.
   final Color? disabledColor;
 
-  /// The color of the button's [Material].
+  /// The color of the button's [Material] if the button is selected.
   final Color? fillColor;
+
+  /// The color of the button's [Material] if the button is unselected.
+  final Color? unselectedFillColor;
 
   /// The color for the button's [Material] when it has the input focus.
   final Color? focusColor;
@@ -794,7 +809,8 @@ class _ToggleButton extends StatelessWidget {
       currentColor = color
         ?? toggleButtonsTheme.color
         ?? theme.colorScheme.onSurface.withOpacity(0.87);
-      currentFillColor = theme.colorScheme.surface.withOpacity(0.0);
+      currentFillColor = unselectedFillColor
+        ?? theme.colorScheme.surface.withOpacity(0.0);
       currentFocusColor = focusColor
         ?? toggleButtonsTheme.focusColor
         ?? theme.colorScheme.onSurface.withOpacity(0.12);

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -35,6 +35,7 @@ class ToggleButtonsThemeData with Diagnosticable {
     this.selectedColor,
     this.disabledColor,
     this.fillColor,
+    this.unselectedFillColor,
     this.focusColor,
     this.highlightColor,
     this.hoverColor,
@@ -72,6 +73,9 @@ class ToggleButtonsThemeData with Diagnosticable {
 
   /// The fill color for selected toggle buttons.
   final Color? fillColor;
+
+  /// The fill color for unselected toggle buttons.
+  final Color? unselectedFillColor;
 
   /// The color to use for filling the button when the button has input focus.
   final Color? focusColor;
@@ -116,6 +120,7 @@ class ToggleButtonsThemeData with Diagnosticable {
     Color? selectedColor,
     Color? disabledColor,
     Color? fillColor,
+    Color? unselectedFillColor,
     Color? focusColor,
     Color? highlightColor,
     Color? hoverColor,
@@ -133,6 +138,7 @@ class ToggleButtonsThemeData with Diagnosticable {
       selectedColor: selectedColor ?? this.selectedColor,
       disabledColor: disabledColor ?? this.disabledColor,
       fillColor: fillColor ?? this.fillColor,
+      unselectedFillColor: unselectedFillColor ?? this.unselectedFillColor,
       focusColor: focusColor ?? this.focusColor,
       highlightColor: highlightColor ?? this.highlightColor,
       hoverColor: hoverColor ?? this.hoverColor,
@@ -157,6 +163,7 @@ class ToggleButtonsThemeData with Diagnosticable {
       selectedColor: Color.lerp(a?.selectedColor, b?.selectedColor, t),
       disabledColor: Color.lerp(a?.disabledColor, b?.disabledColor, t),
       fillColor: Color.lerp(a?.fillColor, b?.fillColor, t),
+      unselectedFillColor: Color.lerp(a?.unselectedFillColor, b?.unselectedFillColor, t),
       focusColor: Color.lerp(a?.focusColor, b?.focusColor, t),
       highlightColor: Color.lerp(a?.highlightColor, b?.highlightColor, t),
       hoverColor: Color.lerp(a?.hoverColor, b?.hoverColor, t),
@@ -178,6 +185,7 @@ class ToggleButtonsThemeData with Diagnosticable {
       selectedColor,
       disabledColor,
       fillColor,
+      unselectedFillColor,
       focusColor,
       highlightColor,
       hoverColor,
@@ -203,6 +211,7 @@ class ToggleButtonsThemeData with Diagnosticable {
         && other.selectedColor == selectedColor
         && other.disabledColor == disabledColor
         && other.fillColor == fillColor
+        && other.unselectedFillColor == unselectedFillColor
         && other.focusColor == focusColor
         && other.highlightColor == highlightColor
         && other.hoverColor == hoverColor
@@ -223,6 +232,7 @@ class ToggleButtonsThemeData with Diagnosticable {
     properties.add(ColorProperty('selectedColor', selectedColor, defaultValue: null));
     properties.add(ColorProperty('disabledColor', disabledColor, defaultValue: null));
     properties.add(ColorProperty('fillColor', fillColor, defaultValue: null));
+    properties.add(ColorProperty('unselectedFillColor', unselectedFillColor, defaultValue: null));
     properties.add(ColorProperty('focusColor', focusColor, defaultValue: null));
     properties.add(ColorProperty('highlightColor', highlightColor, defaultValue: null));
     properties.add(ColorProperty('hoverColor', hoverColor, defaultValue: null));

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -662,6 +662,33 @@ void main() {
     expect(material.type, MaterialType.button);
   });
 
+  testWidgets('Custom button unselectedFillColor', (WidgetTester tester) async {
+    const Color customFillColor = Colors.green;
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            unselectedFillColor: customFillColor,
+            isSelected: const <bool>[false],
+            onPressed: (int index) {},
+            children: <Widget>[
+              Row(children: const <Widget>[
+                Text('First child'),
+              ]),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(find.descendant(
+      of: find.byType(RawMaterialButton),
+      matching: find.byType(Material),
+    ));
+    expect(material.color, customFillColor);
+    expect(material.type, MaterialType.button);
+  });
+
   testWidgets('Default InkWell colors - unselected', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -30,6 +30,7 @@ void main() {
     expect(themeData.selectedColor, null);
     expect(themeData.disabledColor, null);
     expect(themeData.fillColor, null);
+    expect(themeData.unselectedFillColor, null);
     expect(themeData.focusColor, null);
     expect(themeData.highlightColor, null);
     expect(themeData.hoverColor, null);
@@ -47,6 +48,7 @@ void main() {
     expect(theme.data.selectedColor, null);
     expect(theme.data.disabledColor, null);
     expect(theme.data.fillColor, null);
+    expect(theme.data.unselectedFillColor, null);
     expect(theme.data.focusColor, null);
     expect(theme.data.highlightColor, null);
     expect(theme.data.hoverColor, null);
@@ -79,6 +81,7 @@ void main() {
       selectedColor: Color(0xfffffff1),
       disabledColor: Color(0xfffffff2),
       fillColor: Color(0xfffffff3),
+      unselectedFillColor: Color(0xfffffffb),
       focusColor: Color(0xfffffff4),
       highlightColor: Color(0xfffffff5),
       hoverColor: Color(0xfffffff6),
@@ -103,6 +106,7 @@ void main() {
       'selectedColor: Color(0xfffffff1)',
       'disabledColor: Color(0xfffffff2)',
       'fillColor: Color(0xfffffff3)',
+      'unselectedFillColor: Color(0xfffffffb)',
       'focusColor: Color(0xfffffff4)',
       'highlightColor: Color(0xfffffff5)',
       'hoverColor: Color(0xfffffff6)',
@@ -343,6 +347,35 @@ void main() {
             data: const ToggleButtonsThemeData(fillColor: customFillColor),
             child: ToggleButtons(
               isSelected: const <bool>[true],
+              onPressed: (int index) {},
+              children: <Widget>[
+                Row(children: const <Widget>[
+                  Text('First child'),
+                ]),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(find.descendant(
+      of: find.byType(RawMaterialButton),
+      matching: find.byType(Material),
+    ));
+    expect(material.color, customFillColor);
+    expect(material.type, MaterialType.button);
+  });
+
+  testWidgets('Theme button unselectedFillColor', (WidgetTester tester) async {
+    const Color customFillColor = Colors.green;
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: ToggleButtonsTheme(
+            data: const ToggleButtonsThemeData(unselectedFillColor: customFillColor),
+            child: ToggleButtons(
+              isSelected: const <bool>[false],
               onPressed: (int index) {},
               children: <Widget>[
                 Row(children: const <Widget>[


### PR DESCRIPTION
## Description

Added fillColor for unselected Toggle button

## Related Issues

fixes: #66049 

## Tests

I edited a tests in toggle_buttons_theme_test.dart

I added the following tests in:

toggle_buttons_theme_test.dart
toggle_buttons_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
