### PR TITLE
Fix Editable(Text) shortcuts to respect read-only on desktop

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -777,7 +777,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
     if (key == LogicalKeyboardKey.keyX) {
-      if (!selection!.isCollapsed) {
+      if (!_readOnly && !selection!.isCollapsed) {
         Clipboard.setData(ClipboardData(text: selection!.textInside(_plainText)));
         textSelectionDelegate.textEditingValue = TextEditingValue(
           text: selection!.textBefore(_plainText)
@@ -788,19 +788,21 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
     if (key == LogicalKeyboardKey.keyV) {
-      // Snapshot the input before using `await`.
-      // See https://github.com/flutter/flutter/issues/11427
-      final TextEditingValue value = textSelectionDelegate.textEditingValue;
-      final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
-      if (data != null) {
-        textSelectionDelegate.textEditingValue = TextEditingValue(
-          text: value.selection.textBefore(value.text)
-              + data.text!
-              + value.selection.textAfter(value.text),
-          selection: TextSelection.collapsed(
-              offset: value.selection.start + data.text!.length
-          ),
-        );
+      if (!_readOnly) {
+        // Snapshot the input before using `await`.
+        // See https://github.com/flutter/flutter/issues/11427
+        final TextEditingValue value = textSelectionDelegate.textEditingValue;
+        final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
+        if (data != null) {
+          textSelectionDelegate.textEditingValue = TextEditingValue(
+            text: value.selection.textBefore(value.text)
+                + data.text!
+                + value.selection.textAfter(value.text),
+            selection: TextSelection.collapsed(
+                offset: value.selection.start + data.text!.length
+            ),
+          );
+        }
       }
       return;
     }
@@ -818,25 +820,27 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _handleDelete({ required bool forward }) {
     assert(_selection != null);
-    String textBefore = selection!.textBefore(_plainText);
-    String textAfter = selection!.textAfter(_plainText);
-    int cursorPosition = selection!.start;
-    // If not deleting a selection, delete the next/previous character.
-    if (selection!.isCollapsed) {
-      if (!forward && textBefore.isNotEmpty) {
-        final int characterBoundary = previousCharacter(textBefore.length, textBefore);
-        textBefore = textBefore.substring(0, characterBoundary);
-        cursorPosition = characterBoundary;
+    if (!_readOnly) {
+      String textBefore = selection!.textBefore(_plainText);
+      String textAfter = selection!.textAfter(_plainText);
+      int cursorPosition = selection!.start;
+      // If not deleting a selection, delete the next/previous character.
+      if (selection!.isCollapsed) {
+        if (!forward && textBefore.isNotEmpty) {
+          final int characterBoundary = previousCharacter(textBefore.length, textBefore);
+          textBefore = textBefore.substring(0, characterBoundary);
+          cursorPosition = characterBoundary;
+        }
+        if (forward && textAfter.isNotEmpty) {
+          final int deleteCount = nextCharacter(0, textAfter);
+          textAfter = textAfter.substring(deleteCount);
+        }
       }
-      if (forward && textAfter.isNotEmpty) {
-        final int deleteCount = nextCharacter(0, textAfter);
-        textAfter = textAfter.substring(deleteCount);
-      }
+      textSelectionDelegate.textEditingValue = TextEditingValue(
+        text: textBefore + textAfter,
+        selection: TextSelection.collapsed(offset: cursorPosition),
+      );
     }
-    textSelectionDelegate.textEditingValue = TextEditingValue(
-      text: textBefore + textAfter,
-      selection: TextSelection.collapsed(offset: cursorPosition),
-    );
   }
 
   /// Marks the render object as needing to be laid out again and have its text

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4364,6 +4364,203 @@ void main() {
     // On web, using keyboard for selection is handled by the browser.
   }, skip: kIsWeb);
 
+  Future<void> testReadOnlyShortcuts(WidgetTester tester, {required String platform}) async {
+    final TextEditingController controller = TextEditingController(text: testText);
+    controller.selection = const TextSelection(
+      baseOffset: 0,
+      extentOffset: testText.length ~/2,
+      affinity: TextAffinity.upstream,
+    );
+    TextSelection? selection;
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 400,
+          child: EditableText(
+            readOnly: true,
+            controller: controller,
+            autofocus: true,
+            focusNode: FocusNode(),
+            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!,
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+            textAlign: TextAlign.right,
+            onSelectionChanged: (TextSelection newSelection, SelectionChangedCause? newCause) {
+              selection = newSelection;
+            },
+          ),
+        ),
+      ),
+    ));
+
+    await tester.pump(); // Wait for autofocus to take effect.
+
+    const String clipboardContent = 'read-only';
+    await Clipboard.setData(const ClipboardData(text: clipboardContent));
+
+    // Paste
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.keyV,
+      ],
+      shortcutModifier: true,
+      platform: platform,
+    );
+
+    expect(selection, isNull, reason: 'on $platform');
+    expect(controller.text, equals(testText), reason: 'on $platform');
+
+    // Select All
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.keyA,
+      ],
+      shortcutModifier: true,
+      platform: platform,
+    );
+
+    expect(
+      selection!,
+      equals(
+        const TextSelection(
+          baseOffset: 0,
+          extentOffset: testText.length,
+          affinity: TextAffinity.upstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+    expect(controller.text, equals(testText), reason: 'on $platform');
+
+    // Cut
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.keyX,
+      ],
+      shortcutModifier: true,
+      platform: platform,
+    );
+
+    expect(
+      selection!,
+      equals(
+        const TextSelection(
+          baseOffset: 0,
+          extentOffset: testText.length,
+          affinity: TextAffinity.upstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+    expect(controller.text, equals(testText), reason: 'on $platform');
+    expect(
+      (await Clipboard.getData(Clipboard.kTextPlain))!.text,
+      equals(clipboardContent),
+      reason: 'on $platform',
+    );
+
+    // Copy
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.keyC,
+      ],
+      shortcutModifier: true,
+      platform: platform,
+    );
+
+    expect(
+      selection!,
+      equals(
+        const TextSelection(
+          baseOffset: 0,
+          extentOffset: testText.length,
+          affinity: TextAffinity.upstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+    expect(controller.text, equals(testText), reason: 'on $platform');
+    expect(
+      (await Clipboard.getData(Clipboard.kTextPlain))!.text,
+      equals(testText),
+      reason: 'on $platform',
+    );
+
+    // Delete
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.delete,
+      ],
+      platform: platform,
+    );
+    expect(
+      selection!,
+      equals(
+        const TextSelection(
+          baseOffset: 0,
+          extentOffset: testText.length,
+          affinity: TextAffinity.upstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+    expect(controller.text, equals(testText), reason: 'on $platform');
+
+    // Backspace
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.backspace,
+      ],
+      platform: platform,
+    );
+    expect(
+      selection!,
+      equals(
+        const TextSelection(
+          baseOffset: 0,
+          extentOffset: testText.length,
+          affinity: TextAffinity.upstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+    expect(controller.text, equals(testText), reason: 'on $platform');
+  }
+
+  testWidgets('keyboard shortcuts respect read-only on android', (WidgetTester tester) async {
+    await testReadOnlyShortcuts(tester, platform: 'android');
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb);
+
+  testWidgets('keyboard shortcuts respect read-only on fuchsia', (WidgetTester tester) async {
+    await testReadOnlyShortcuts(tester, platform: 'fuchsia');
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb);
+
+  testWidgets('keyboard shortcuts respect read-only on linux', (WidgetTester tester) async {
+    await testReadOnlyShortcuts(tester, platform: 'linux');
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb);
+
+  testWidgets('keyboard shortcuts respect read-only on macos', (WidgetTester tester) async {
+    await testReadOnlyShortcuts(tester, platform: 'macos');
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb);
+
+  testWidgets('keyboard shortcuts respect read-only on windows', (WidgetTester tester) async {
+    await testReadOnlyShortcuts(tester, platform: 'windows');
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb);
+
   // Regression test for https://github.com/flutter/flutter/issues/31287
   testWidgets('text selection handle visibility', (WidgetTester tester) async {
     // Text with two separate words to select.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4364,7 +4364,8 @@ void main() {
     // On web, using keyboard for selection is handled by the browser.
   }, skip: kIsWeb);
 
-  Future<void> testReadOnlyShortcuts(WidgetTester tester, {required String platform}) async {
+  testWidgets('keyboard shortcuts respect read-only', (WidgetTester tester) async {
+    final String platform = describeEnum(defaultTargetPlatform).toLowerCase();
     final TextEditingController controller = TextEditingController(text: testText);
     controller.selection = const TextSelection(
       baseOffset: 0,
@@ -4534,32 +4535,9 @@ void main() {
       reason: 'on $platform',
     );
     expect(controller.text, equals(testText), reason: 'on $platform');
-  }
-
-  testWidgets('keyboard shortcuts respect read-only on android', (WidgetTester tester) async {
-    await testReadOnlyShortcuts(tester, platform: 'android');
-    // On web, using keyboard for selection is handled by the browser.
-  }, skip: kIsWeb);
-
-  testWidgets('keyboard shortcuts respect read-only on fuchsia', (WidgetTester tester) async {
-    await testReadOnlyShortcuts(tester, platform: 'fuchsia');
-    // On web, using keyboard for selection is handled by the browser.
-  }, skip: kIsWeb);
-
-  testWidgets('keyboard shortcuts respect read-only on linux', (WidgetTester tester) async {
-    await testReadOnlyShortcuts(tester, platform: 'linux');
-    // On web, using keyboard for selection is handled by the browser.
-  }, skip: kIsWeb);
-
-  testWidgets('keyboard shortcuts respect read-only on macos', (WidgetTester tester) async {
-    await testReadOnlyShortcuts(tester, platform: 'macos');
-    // On web, using keyboard for selection is handled by the browser.
-  }, skip: kIsWeb);
-
-  testWidgets('keyboard shortcuts respect read-only on windows', (WidgetTester tester) async {
-    await testReadOnlyShortcuts(tester, platform: 'windows');
-    // On web, using keyboard for selection is handled by the browser.
-  }, skip: kIsWeb);
+  },
+  skip: kIsWeb,
+  variant: TargetPlatformVariant.all());
 
   // Regression test for https://github.com/flutter/flutter/issues/31287
   testWidgets('text selection handle visibility', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR fixes `EditableText` (or `RenderEditable` under the hood) to respect read-only mode when it comes to **cut/paste** shortcuts and **backspace/delete** keys on desktop.

## Related Issues

Pointed out by @rydmike in [#48099](https://github.com/flutter/flutter/issues/48099#issuecomment-721987875). This PR does not fix `enableInteractiveSelection` though, only `readOnly`.

## Tests

I added the following tests in `packages/flutter/test/widgets/editable_text_test.dart`:
- keyboard shortcuts respect read-only on android
- keyboard shortcuts respect read-only on fuchsia
- keyboard shortcuts respect read-only on linux
- keyboard shortcuts respect read-only on macos
- keyboard shortcuts respect read-only on windows

```
$ flutter test test/widgets/editable_text_test.dart 
Running "flutter pub get" in flutter...                            275ms
00:11 +151: All tests passed!

$ flutter analyze --flutter-repo
Building flutter tool...
Running "flutter pub get" in flutter...                            287ms
Analyzing 3 directories...                                              
No issues found! (ran in 46.9s)
````
## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
