### PR TITLE
Allow Scaffold to decline SnackBars from ScaffoldMessenger

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1455,6 +1455,7 @@ class Scaffold extends StatefulWidget {
     this.drawerEdgeDragWidth,
     this.drawerEnableOpenDragGesture = true,
     this.endDrawerEnableOpenDragGesture = true,
+    this.registerWithMessenger =true,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(extendBodyBehindAppBar != null),
@@ -1772,6 +1773,12 @@ class Scaffold extends StatefulWidget {
   ///
   /// By default, the drag gesture is enabled.
   final bool endDrawerEnableOpenDragGesture;
+
+  /// Specifies if the Scaffold should register with the enclosing
+  /// [ScaffoldMessenger] to receive [SnackBar]s.
+  ///
+  /// Defaults to true.
+  final bool registerWithMessenger;
 
   /// Finds the [ScaffoldState] from the closest instance of this class that
   /// encloses the given context.
@@ -2749,7 +2756,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
   @override
   void didChangeDependencies() {
-    // nullOk is valid here since  both the Scaffold and ScaffoldMessenger are
+    // Null is valid here since  both the Scaffold and ScaffoldMessenger are
     // currently available for managing SnackBars.
     final ScaffoldMessengerState? _currentScaffoldMessenger = ScaffoldMessenger.maybeOf(context);
     // If our ScaffoldMessenger has changed, unregister with the old one first.
@@ -2757,9 +2764,12 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
       (_currentScaffoldMessenger == null || _scaffoldMessenger != _currentScaffoldMessenger)) {
       _scaffoldMessenger?._unregister(this);
     }
-    // Register with the current ScaffoldMessenger, if there is one.
-    _scaffoldMessenger = _currentScaffoldMessenger;
-    _scaffoldMessenger?._register(this);
+
+    if (widget.registerWithMessenger) {
+      // Register with the current ScaffoldMessenger, if there is one.
+      _scaffoldMessenger = _currentScaffoldMessenger;
+      _scaffoldMessenger?._register(this);
+    }
 
     // TODO(Piinks): Remove old SnackBar API after migrating ScaffoldMessenger
     final MediaQueryData mediaQuery = MediaQuery.of(context);

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2119,4 +2119,41 @@ void main() {
     final AssertionError error = exceptions.first as AssertionError;
     expect(error.message, contains('Only one API should be used to manage SnackBars.'));
   });
+
+  testWidgets('Scaffolds can decline SnackBars', (WidgetTester tester) async {
+    const String helloSnackBar = 'Hello SnackBar';
+    const Key tapTarget = Key('tap-target');
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        registerWithMessenger: false,
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onTap: () {
+                // The above Scaffold will not receive a SnackBar from the
+                // ScaffoldMessenger.
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                  content: Text(helloSnackBar),
+                  duration: Duration(seconds: 2),
+                ));
+              },
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+                key: tapTarget,
+              ),
+            );
+          }
+        ),
+      ),
+    ));
+    expect(find.text(helloSnackBar), findsNothing);
+    await tester.tap(find.byKey(tapTarget));
+    expect(find.text(helloSnackBar), findsNothing);
+    await tester.pump();
+    expect(find.text(helloSnackBar), findsNothing);
+    await tester.pump(const Duration(milliseconds: 750));
+    expect(find.text(helloSnackBar), findsNothing);
+  });
 }


### PR DESCRIPTION
## Description

This PR adds a flag to Scaffold that will allow users to not register that Scaffold with the ScaffoldMessenger. 

The ScaffoldMessenger is intended to be used to set a scope around the Scaffolds it manages SnackBars for.

When Scaffolds are nested inside one another, you can put a ScaffoldMessenger in between to control these SnackBar scopes, but recent customer feedback has shown this is might be improved by introducing a simple flag. I am not sure that this is the best approach though since adding a ScaffoldMessenger effectively closes the scope between Scaffolds.

TODO 
ScaffoldMessenger has not shipped to stable yet, so this is a good opportunity to improve the docs in anticipation of similar experiences.
- Update ScaffoldMessenger migration guide to speak more to nested Scaffolds
- Update Scaffold API docs to add to the Troubleshooting section on nested Scaffolds

## Related Issues

b/171649782

## Tests

Scaffolds can decline SnackBars

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
