### PR TITLE
Fix crash when widgetspan does not produce a semantics node in render…

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -54,11 +54,11 @@ class TextParentData extends ContainerBoxParentData<RenderBox> {
   }
 }
 
-/// Used by the [RenderParagraph] to map its semantics children to its
-/// rendering children.
+/// Used by the [RenderParagraph] to map its rendering children to their
+/// corresponding semantics nodes.
 ///
-/// The [RichText] uses this tag the relation between its placeholder spans and
-/// their semantics nodes.
+/// The [RichText] uses this to tag the relation between its placeholder spans
+/// and their semantics nodes.
 @immutable
 class PlaceholderSpanIndexSemanticsTag extends SemanticsTag {
   /// Creates a semantics tag with the input `index`.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -942,9 +942,10 @@ class RenderParagraph extends RenderBox
       );
 
       if (info.isPlaceholder) {
-        // A placeholder span may not have a semantics node, we skip this
-        // placeholder semantics info if the tag does not match.
-        if (children.length > childIndex && children.elementAt(childIndex).isTagged(PlaceholderSpanIndexSemanticsTag(placeholderIndex))) {
+        // A placeholder span may have 0 to multple semantics nodes, we need
+        // to annotate all of the semantics nodes belong to this span.
+        while (children.length > childIndex &&
+               children.elementAt(childIndex).isTagged(PlaceholderSpanIndexSemanticsTag(placeholderIndex))) {
           final SemanticsNode childNode = children.elementAt(childIndex);
           final TextParentData parentData = child!.parentData! as TextParentData;
           childNode.rect = Rect.fromLTWH(
@@ -987,7 +988,7 @@ class RenderParagraph extends RenderBox
         newChildren.add(newChild);
       }
     }
-    // Makes sure we exhausted the list.
+    // Makes sure we annotated all of the semantics children.
     assert(childIndex == children.length);
     assert(child == null);
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3600,7 +3600,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     SemanticsHintOverrides? hintOverrides,
     TextDirection? textDirection,
     SemanticsSortKey? sortKey,
-    Set<SemanticsTag>? tagsForChildren,
+    SemanticsTag? tagForChildren,
     VoidCallback? onTap,
     VoidCallback? onDismiss,
     VoidCallback? onLongPress,
@@ -3656,7 +3656,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
        _hintOverrides = hintOverrides,
        _textDirection = textDirection,
        _sortKey = sortKey,
-       _tagsForChildren = tagsForChildren,
+       _tagForChildren = tagForChildren,
        _onTap = onTap,
        _onLongPress = onLongPress,
        _onScrollLeft = onScrollLeft,
@@ -4074,15 +4074,14 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  /// Adds Semenatics tags to the semantics subtree.
-  Set<SemanticsTag>? get tagsForChildren => _tagsForChildren;
-  Set<SemanticsTag>? _tagsForChildren;
-  set tagsForChildren(Set<SemanticsTag>? value) {
-    if (_tagsForChildren == value)
+  /// Adds a semenatics tag to the semantics subtree.
+  SemanticsTag? get tagForChildren => _tagForChildren;
+  SemanticsTag? _tagForChildren;
+  set tagForChildren(SemanticsTag? value) {
+    if (_tagForChildren == value)
       return;
-    if (!setEquals<SemanticsTag>(_tagsForChildren, value))
-      markNeedsSemanticsUpdate();
-    _tagsForChildren = value;
+    markNeedsSemanticsUpdate();
+    _tagForChildren = value;
   }
 
   /// The handler for [SemanticsAction.tap].
@@ -4562,8 +4561,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.textDirection = textDirection;
     if (sortKey != null)
       config.sortKey = sortKey;
-    if (tagsForChildren != null)
-      tagsForChildren!.forEach(config.addTagForChildren);
+    if (tagForChildren != null)
+      config.addTagForChildren(tagForChildren!);
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3600,6 +3600,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     SemanticsHintOverrides? hintOverrides,
     TextDirection? textDirection,
     SemanticsSortKey? sortKey,
+    Set<SemanticsTag>? tagsForChildren,
     VoidCallback? onTap,
     VoidCallback? onDismiss,
     VoidCallback? onLongPress,
@@ -3655,6 +3656,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
        _hintOverrides = hintOverrides,
        _textDirection = textDirection,
        _sortKey = sortKey,
+       _tagsForChildren = tagsForChildren,
        _onTap = onTap,
        _onLongPress = onLongPress,
        _onScrollLeft = onScrollLeft,
@@ -4070,6 +4072,17 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       return;
     _sortKey = value;
     markNeedsSemanticsUpdate();
+  }
+
+  /// Adds Semenatics tags to the semantics subtree.
+  Set<SemanticsTag>? get tagsForChildren => _tagsForChildren;
+  Set<SemanticsTag>? _tagsForChildren;
+  set tagsForChildren(Set<SemanticsTag>? value) {
+    if (_tagsForChildren == value)
+      return;
+    if (!setEquals<SemanticsTag>(_tagsForChildren, value))
+      markNeedsSemanticsUpdate();
+    _tagsForChildren = value;
   }
 
   /// The handler for [SemanticsAction.tap].
@@ -4549,6 +4562,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.textDirection = textDirection;
     if (sortKey != null)
       config.sortKey = sortKey;
+    if (tagsForChildren != null)
+      tagsForChildren!.forEach(config.addTagForChildren);
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -610,6 +610,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.hintOverrides,
     this.textDirection,
     this.sortKey,
+    this.tagsForChildren,
     this.onTap,
     this.onLongPress,
     this.onScrollLeft,
@@ -912,6 +913,12 @@ class SemanticsProperties extends DiagnosticableTree {
   /// traversed by the accessibility services on the platform (e.g. VoiceOver
   /// on iOS and TalkBack on Android).
   final SemanticsSortKey? sortKey;
+
+  /// Adds additional information onto the semantics subtree.
+  ///
+  /// This property provides a way for rendering objects to annotate their
+  /// semantics children without directly access them.
+  final Set<SemanticsTag>? tagsForChildren;
 
   /// The handler for [SemanticsAction.tap].
   ///

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -610,7 +610,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.hintOverrides,
     this.textDirection,
     this.sortKey,
-    this.tagsForChildren,
+    this.tagForChildren,
     this.onTap,
     this.onLongPress,
     this.onScrollLeft,
@@ -914,11 +914,21 @@ class SemanticsProperties extends DiagnosticableTree {
   /// on iOS and TalkBack on Android).
   final SemanticsSortKey? sortKey;
 
-  /// Adds additional information onto the semantics subtree.
+  /// A tag to be applied to the child [SemanticsNode]s of this widget.
   ///
-  /// This property provides a way for rendering objects to annotate their
-  /// semantics children without directly access them.
-  final Set<SemanticsTag>? tagsForChildren;
+  /// The tag is added to all child [SemanticsNode]s that pass through the
+  /// [RenderObject] corresponding to this widget while looking to be attached
+  /// to a parent SemanticsNode.
+  ///
+  /// Tags are used to communicate to a parent SemanticsNode that a child
+  /// SemanticsNode was passed through a particular RenderObject. The parent can
+  /// use this information to determine the shape of the semantics tree.
+  ///
+  /// See also:
+  ///
+  ///  * [SemanticsConfiguration.addTagForChildren], to which the tags provided
+  ///    here will be passed.
+  final SemanticsTag? tagForChildren;
 
   /// The handler for [SemanticsAction.tap].
   ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5369,6 +5369,48 @@ class Flow extends MultiChildRenderObjectWidget {
   }
 }
 
+class _SemanticsTagWidget extends SingleChildRenderObjectWidget {
+  const _SemanticsTagWidget({
+    Key? key,
+    required Widget child,
+    required this.index,
+  }) : super(key: key, child: child);
+
+  final int index;
+
+  @override
+  _SemanticsTagRenderObject createRenderObject(BuildContext context) {
+    return _SemanticsTagRenderObject(index);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _SemanticsTagRenderObject renderObject) {
+    super.updateRenderObject(context, renderObject);
+    renderObject.index = index;
+  }
+
+}
+
+class _SemanticsTagRenderObject extends RenderProxyBox {
+  _SemanticsTagRenderObject(int index) : _index = index,
+                                         super();
+
+  int get index => _index;
+  int _index;
+  set index(int value) {
+    if (_index != value) {
+      markNeedsSemanticsUpdate();
+      _index = value;
+    }
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.addTagForChildren(PlaceholderSpanIndexSemanticsTag(index));
+  }
+}
+
 /// A paragraph of rich text.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=rykDVh-QFfw}
@@ -5456,10 +5498,14 @@ class RichText extends MultiChildRenderObjectWidget {
   // Traverses the InlineSpan tree and depth-first collects the list of
   // child widgets that are created in WidgetSpans.
   static List<Widget> _extractChildren(InlineSpan span) {
+    int index = 0;
     final List<Widget> result = <Widget>[];
     span.visitChildren((InlineSpan span) {
       if (span is WidgetSpan) {
-        result.add(span.child);
+        result.add(_SemanticsTagWidget(
+          index: index++,
+          child: span.child,
+        ));
       }
       return true;
     });

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5461,7 +5461,7 @@ class RichText extends MultiChildRenderObjectWidget {
     span.visitChildren((InlineSpan span) {
       if (span is WidgetSpan) {
         result.add(Semantics(
-          tagsForChildren: <SemanticsTag>{PlaceholderSpanIndexSemanticsTag(index++)},
+          tagForChildren: PlaceholderSpanIndexSemanticsTag(index++),
           child: span.child,
         ));
       }
@@ -6894,7 +6894,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     String? onLongPressHint,
     TextDirection? textDirection,
     SemanticsSortKey? sortKey,
-    Set<SemanticsTag>? tagsForChildren,
+    SemanticsTag? tagForChildren,
     VoidCallback? onTap,
     VoidCallback? onLongPress,
     VoidCallback? onScrollLeft,
@@ -6949,7 +6949,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       hint: hint,
       textDirection: textDirection,
       sortKey: sortKey,
-      tagsForChildren: tagsForChildren,
+      tagForChildren: tagForChildren,
       onTap: onTap,
       onLongPress: onLongPress,
       onScrollLeft: onScrollLeft,
@@ -7066,7 +7066,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       hintOverrides: properties.hintOverrides,
       textDirection: _getTextDirection(context),
       sortKey: properties.sortKey,
-      tagsForChildren: properties.tagsForChildren,
+      tagForChildren: properties.tagForChildren,
       onTap: properties.onTap,
       onLongPress: properties.onLongPress,
       onScrollLeft: properties.onScrollLeft,
@@ -7138,7 +7138,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..namesRoute = properties.namesRoute
       ..textDirection = _getTextDirection(context)
       ..sortKey = properties.sortKey
-      ..tagsForChildren = properties.tagsForChildren
+      ..tagForChildren = properties.tagForChildren
       ..onTap = properties.onTap
       ..onLongPress = properties.onLongPress
       ..onScrollLeft = properties.onScrollLeft

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5369,48 +5369,6 @@ class Flow extends MultiChildRenderObjectWidget {
   }
 }
 
-class _SemanticsTagWidget extends SingleChildRenderObjectWidget {
-  const _SemanticsTagWidget({
-    Key? key,
-    required Widget child,
-    required this.index,
-  }) : super(key: key, child: child);
-
-  final int index;
-
-  @override
-  _SemanticsTagRenderObject createRenderObject(BuildContext context) {
-    return _SemanticsTagRenderObject(index);
-  }
-
-  @override
-  void updateRenderObject(BuildContext context, _SemanticsTagRenderObject renderObject) {
-    super.updateRenderObject(context, renderObject);
-    renderObject.index = index;
-  }
-
-}
-
-class _SemanticsTagRenderObject extends RenderProxyBox {
-  _SemanticsTagRenderObject(int index) : _index = index,
-                                         super();
-
-  int get index => _index;
-  int _index;
-  set index(int value) {
-    if (_index != value) {
-      markNeedsSemanticsUpdate();
-      _index = value;
-    }
-  }
-
-  @override
-  void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    super.describeSemanticsConfiguration(config);
-    config.addTagForChildren(PlaceholderSpanIndexSemanticsTag(index));
-  }
-}
-
 /// A paragraph of rich text.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=rykDVh-QFfw}
@@ -5502,8 +5460,8 @@ class RichText extends MultiChildRenderObjectWidget {
     final List<Widget> result = <Widget>[];
     span.visitChildren((InlineSpan span) {
       if (span is WidgetSpan) {
-        result.add(_SemanticsTagWidget(
-          index: index++,
+        result.add(Semantics(
+          tagsForChildren: <SemanticsTag>{PlaceholderSpanIndexSemanticsTag(index++)},
           child: span.child,
         ));
       }
@@ -6936,6 +6894,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     String? onLongPressHint,
     TextDirection? textDirection,
     SemanticsSortKey? sortKey,
+    Set<SemanticsTag>? tagsForChildren,
     VoidCallback? onTap,
     VoidCallback? onLongPress,
     VoidCallback? onScrollLeft,
@@ -6990,6 +6949,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       hint: hint,
       textDirection: textDirection,
       sortKey: sortKey,
+      tagsForChildren: tagsForChildren,
       onTap: onTap,
       onLongPress: onLongPress,
       onScrollLeft: onScrollLeft,
@@ -7106,6 +7066,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       hintOverrides: properties.hintOverrides,
       textDirection: _getTextDirection(context),
       sortKey: properties.sortKey,
+      tagsForChildren: properties.tagsForChildren,
       onTap: properties.onTap,
       onLongPress: properties.onLongPress,
       onScrollLeft: properties.onScrollLeft,
@@ -7177,6 +7138,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..namesRoute = properties.namesRoute
       ..textDirection = _getTextDirection(context)
       ..sortKey = properties.sortKey
+      ..tagsForChildren = properties.tagsForChildren
       ..onTap = properties.onTap
       ..onLongPress = properties.onLongPress
       ..onScrollLeft = properties.onScrollLeft

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -387,6 +387,54 @@ void main() {
     semantics.dispose();
   });
 
+    testWidgets('Semantics tagForChildren works', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          container: true,
+          tagForChildren: const SemanticsTag('custom tag'),
+          child: Column(
+            children: <Widget>[
+              Semantics(
+                container: true,
+                child: const Text('child 1'),
+              ),
+              Semantics(
+                container: true,
+                child: const Text('child 2'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final TestSemantics expectedSemantics = TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          children: <TestSemantics>[
+            TestSemantics(
+              label: 'child 1',
+              tags: <SemanticsTag>[const SemanticsTag('custom tag')],
+              textDirection: TextDirection.ltr,
+            ),
+            TestSemantics(
+              label: 'child 2',
+              tags: <SemanticsTag>[const SemanticsTag('custom tag')],
+              textDirection: TextDirection.ltr,
+            ),
+          ]
+        ),
+      ],
+    );
+
+    expect(semantics, hasSemantics(expectedSemantics, ignoreTransform: true, ignoreRect: true, ignoreId: true));
+    semantics.dispose();
+  });
+
   testWidgets('Semantics widget supports all actions', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1039,6 +1039,120 @@ void main() {
       ],
     )));
   }, semanticsEnabled: true, skip: isBrowser); // Browser semantics have different sizes.
+
+  // Regression test for https://github.com/flutter/flutter/issues/69787
+  testWidgets('WidgetSpans with no semantic information are elided from semantics - case 2', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    // Without the fix for this bug the pump widget will throw a RangeError.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RichText(
+          text: TextSpan(children: <InlineSpan>[
+            const WidgetSpan(child: SizedBox.shrink()),
+            const WidgetSpan(child: Text('included')),
+            TextSpan(
+              text: 'HELLO',
+              style: const TextStyle(color: Colors.black),
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+            const WidgetSpan(child: Text('included2')),
+          ]),
+        ),
+      )
+    );
+
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics(
+          children: <TestSemantics>[
+            TestSemantics(label: 'included'),
+            TestSemantics(
+              label: 'HELLO',
+              actions: <SemanticsAction>[
+                SemanticsAction.tap,
+              ],
+              flags: <SemanticsFlag>[
+                SemanticsFlag.isLink,
+              ],
+            ),
+            TestSemantics(label: 'included2'),
+          ],
+        ),
+      ],
+    ),
+    ignoreId: true,
+    ignoreRect: true,
+    ignoreTransform: true,
+    ));
+  }, semanticsEnabled: true, skip: isBrowser); // Browser does not support widget span.
+
+  // Regression test for https://github.com/flutter/flutter/issues/69787
+  testWidgets('WidgetSpans with no semantic information are elided from semantics - case 3', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    // Without the fix for this bug the pump widget will throw a RangeError.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: ClipRect(           // If you remove the clip, the crash goes away
+            child: Container(
+              color: Colors.green,
+              height: 100,
+              width: 100,
+              child: OverflowBox(
+                alignment: Alignment.topLeft,
+                maxWidth: double.infinity,
+                child: RichText(
+                  text: TextSpan(
+                    children: <InlineSpan>[
+                      const WidgetSpan(
+                        child: Icon(
+                          Icons.edit,
+                          size: 16,
+                          semanticLabel: 'not clipped',
+                        ),
+                      ),
+                      TextSpan(
+                        text: 'next WS is clipped',
+                        recognizer: TapGestureRecognizer()..onTap = () { },
+                      ),
+                      const WidgetSpan(
+                        child: Icon(
+                          Icons.edit,
+                          size: 16,
+                          semanticLabel: 'clipped',
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics(
+          children: <TestSemantics>[
+            TestSemantics(label: 'not clipped'),
+            TestSemantics(
+              label: 'next WS is clipped',
+              flags: <SemanticsFlag>[SemanticsFlag.isLink],
+              actions: <SemanticsAction>[SemanticsAction.tap],
+            ),
+          ],
+        ),
+      ],
+    ),
+    ignoreId: true,
+    ignoreRect: true,
+    ignoreTransform: true,
+    ));
+  }, semanticsEnabled: true, skip: isBrowser); // Browser does not support widget span
 }
 
 Future<void> _pumpTextWidget({


### PR DESCRIPTION
… paragraph

## Description
The change adds semantics tags to mark the relationship between semantics nodes and their corresponding render object.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69787

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
