### PR TITLE
Persist Chrome Default Directory

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -296,12 +296,9 @@ class ChromiumLauncher {
     }
   }
 
-  // This is a JSON file which contains configuration from the browser session,
-  // such as window position. It is located under the Chrome data-dir folder.
-  String get _preferencesPath => _fileSystem.path.join('Default', 'preferences');
-
-  // The directory that Chrome uses to store local storage information for web apps.
-  String get _localStoragePath => _fileSystem.path.join('Default', 'Local Storage');
+  // This is a directory which Chrome uses to store cookies, preferences and
+  // other session data.
+  String get _chromeDefaultPath => _fileSystem.path.join('Default');
 
   /// Copy Chrome user information from a Chrome session into a per-project
   /// cache.
@@ -309,23 +306,13 @@ class ChromiumLauncher {
   /// Note: more detailed docs of the Chrome user preferences store exists here:
   /// https://www.chromium.org/developers/design-documents/preferences.
   void _cacheUserSessionInformation(Directory userDataDir, Directory cacheDir) {
-    final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir?.path ?? '', _preferencesPath));
-    final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
-    final Directory targetLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(cacheDir?.path ?? '', _localStoragePath));
-    final Directory sourceLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _localStoragePath));
+    final Directory targetChromeDefault = _fileSystem.directory(_fileSystem.path.join(cacheDir?.path ?? '', _chromeDefaultPath));
+    final Directory sourceChromeDefault = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _chromeDefaultPath));
 
-    if (sourcePreferencesFile.existsSync()) {
-      targetPreferencesFile.parent.createSync(recursive: true);
-      // If the file contains a crash string, remove it to hide the popup on next run.
-      final String contents = sourcePreferencesFile.readAsStringSync();
-      targetPreferencesFile.writeAsStringSync(contents
-          .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));
-    }
-
-    if (sourceLocalStorageDir.existsSync()) {
-      targetLocalStorageDir.createSync(recursive: true);
+    if (sourceChromeDefault.existsSync()) {
+      targetChromeDefault.createSync(recursive: true);
       try {
-        _fileSystemUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+        _fileSystemUtils.copyDirectorySync(sourceChromeDefault, targetChromeDefault);
       } on FileSystemException catch (err) {
         // This is a best-effort update. Display the message in case the failure is relevant.
         // one possible example is a file lock due to multiple running chrome instances.
@@ -337,19 +324,12 @@ class ChromiumLauncher {
   /// Restore Chrome user information from a per-project cache into Chrome's
   /// user data directory.
   void _restoreUserSessionInformation(Directory cacheDir, Directory userDataDir) {
-    final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir.path ?? '', _preferencesPath));
-    final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
-    final Directory sourceLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(cacheDir.path ?? '', _localStoragePath));
-    final Directory targetLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _localStoragePath));
+    final Directory sourceChromeDefault = _fileSystem.directory(_fileSystem.path.join(cacheDir.path ?? '', _chromeDefaultPath));
+    final Directory targetChromeDefault = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _chromeDefaultPath));
 
-    if (sourcePreferencesFile.existsSync()) {
-      targetPreferencesFile.parent.createSync(recursive: true);
-      sourcePreferencesFile.copySync(targetPreferencesFile.path);
-    }
-
-    if (sourceLocalStorageDir.existsSync()) {
-      targetLocalStorageDir.createSync(recursive: true);
-      _fileSystemUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+    if (sourceChromeDefault.existsSync()) {
+      targetChromeDefault.createSync(recursive: true);
+      _fileSystemUtils.copyDirectorySync(sourceChromeDefault, targetChromeDefault);
     }
   }
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -327,12 +327,12 @@ class ChromiumLauncher {
     final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir?.path ?? '', _preferencesPath));
     final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
 
-    if (sourcePreferencesFile.existsSync()) {	
-       targetPreferencesFile.parent.createSync(recursive: true);	
-       // If the file contains a crash string, remove it to hide the popup on next run.	
-       final String contents = sourcePreferencesFile.readAsStringSync();	
-       targetPreferencesFile.writeAsStringSync(contents	
-           .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));	
+    if (sourcePreferencesFile.existsSync()) {
+       targetPreferencesFile.parent.createSync(recursive: true);
+       // If the file contains a crash string, remove it to hide the popup on next run.
+       final String contents = sourcePreferencesFile.readAsStringSync();
+       targetPreferencesFile.writeAsStringSync(contents
+           .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));
     }
   }
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -300,6 +300,10 @@ class ChromiumLauncher {
   // other session data.
   String get _chromeDefaultPath => _fileSystem.path.join('Default');
 
+  // This is a JSON file which contains configuration from the browser session,
+  // such as window position. It is located under the Chrome data-dir folder.
+  String get _preferencesPath => _fileSystem.path.join('Default', 'preferences');
+
   /// Copy Chrome user information from a Chrome session into a per-project
   /// cache.
   ///
@@ -318,6 +322,17 @@ class ChromiumLauncher {
         // one possible example is a file lock due to multiple running chrome instances.
         _logger.printError('Failed to save Chrome preferences: $err');
       }
+    }
+
+    final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir?.path ?? '', _preferencesPath));
+    final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
+
+    if (sourcePreferencesFile.existsSync()) {	
+       targetPreferencesFile.parent.createSync(recursive: true);	
+       // If the file contains a crash string, remove it to hide the popup on next run.	
+       final String contents = sourcePreferencesFile.readAsStringSync();	
+       targetPreferencesFile.writeAsStringSync(contents	
+           .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));	
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:file/memory.dart';
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
@@ -201,13 +200,10 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync('"exit_type":"Crashed"');
 
-    final Directory localStorageContentsDirectory = dataDir
+    final Directory defaultContentDirectory = dataDir
         .childDirectory('Default')
-        .childDirectory('Local Storage')
-        .childDirectory('leveldb');
-    localStorageContentsDirectory.createSync(recursive: true);
-    localStorageContentsDirectory.childFile('LOCK').writeAsBytesSync(<int>[]);
-    localStorageContentsDirectory.childFile('LOG').writeAsStringSync('contents');
+        .childDirectory('Foo');
+        defaultContentDirectory.createSync(recursive: true);
 
     processManager.addCommand(FakeCommand(
       command: const <String>[
@@ -233,20 +229,14 @@ void main() {
     // writes non-crash back to dart_tool
     expect(preferencesFile.readAsStringSync(), '"exit_type":"Normal"');
 
-    // validate local storage
-    final Directory storageDir = fileSystem
+
+    // validate any Default content is copied 
+    final Directory defaultContentDir = fileSystem
         .directory('.tmp_rand0/flutter_tools_chrome_device.rand0')
         .childDirectory('Default')
-        .childDirectory('Local Storage')
-        .childDirectory('leveldb');
+        .childDirectory('Foo');
 
-    expect(storageDir.existsSync(), true);
-
-    expect(storageDir.childFile('LOCK'), exists);
-    expect(storageDir.childFile('LOCK').readAsBytesSync(), hasLength(0));
-
-    expect(storageDir.childFile('LOG'), exists);
-    expect(storageDir.childFile('LOG').readAsStringSync(), 'contents');
+    expect(defaultContentDir.existsSync(), true);
   });
 
   testWithoutContext('can retry launch when glibc bug happens', () async {

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -230,7 +230,7 @@ void main() {
     expect(preferencesFile.readAsStringSync(), '"exit_type":"Normal"');
 
 
-    // validate any Default content is copied 
+    // validate any Default content is copied
     final Directory defaultContentDir = fileSystem
         .directory('.tmp_rand0/flutter_tools_chrome_device.rand0')
         .childDirectory('Default')


### PR DESCRIPTION
Cache and restore the entire Chrome `Default` directory across Flutter Tool runs. This ensures that cookies, history and logged in sites are maintained. Related to https://github.com/flutter/flutter/pull/53030.