### PR TITLE
Fix android studio 4.1 plugin path for mac

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -69,23 +69,25 @@ class AndroidStudio implements Comparable<AndroidStudio> {
 
     final int major = version?.major;
     final int minor = version?.minor;
-    final String presetPluginsPath = pathsSelectorValue == null
-      ? null
-      : double.parse('$major.$minor') >= 4.1 
-        ? globals.fs.path.join(
+    String presetPluginsPath;
+    if (pathsSelectorValue != null) {
+      if (major >= 4 && minor >= 1) {
+        presetPluginsPath = globals.fs.path.join(
           globals.fsUtils.homeDirPath,
           'Library',
           'Application Support',
           'Google',
           pathsSelectorValue,
-          ) 
-        :
-        globals.fs.path.join(
+        );
+      } else {
+        presetPluginsPath = globals.fs.path.join(
           globals.fsUtils.homeDirPath,
           'Library',
           'Application Support',
           pathsSelectorValue,
-          );
+        );
+      }
+    }
     return AndroidStudio(studioPath, version: version, presetPluginsPath: presetPluginsPath);
   }
 
@@ -140,7 +142,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     final int minor = version?.minor;
     if (globals.platform.isMacOS) {
       /// plugin path of Android Studio has been changed after version 4.1.
-      if(double.parse('$major.$minor') >= 4.1) {
+      if (major >= 4 && minor >= 1) {
         return globals.fs.path.join(
           globals.fsUtils.homeDirPath,
           'Library',

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -127,7 +127,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     final int major = version?.major;
     final int minor = version?.minor;
     if (globals.platform.isMacOS) {
-      /// plugin path of Android Studio which version >= 4.1 has changed.
+      /// plugin path of Android Studio has been changed after version 4.1.
       if(double.parse('$major.$minor') >= 4.1) {
         return globals.fs.path.join(
           globals.fsUtils.homeDirPath,

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -127,12 +127,23 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     final int major = version?.major;
     final int minor = version?.minor;
     if (globals.platform.isMacOS) {
-      return globals.fs.path.join(
-        globals.fsUtils.homeDirPath,
-        'Library',
-        'Application Support',
-        'AndroidStudio$major.$minor',
-      );
+      /// plugin path of Android Studio which version >= 4.1 has changed.
+      if(double.parse('$major.$minor') >= 4.1) {
+        return globals.fs.path.join(
+          globals.fsUtils.homeDirPath,
+          'Library',
+          'Application Support',
+          'Google',
+          'AndroidStudio$major.$minor',
+        );
+      } else {
+        return globals.fs.path.join(
+          globals.fsUtils.homeDirPath,
+          'Library',
+          'Application Support',
+          'AndroidStudio$major.$minor',
+        );
+      }
     } else {
       return globals.fs.path.join(
         globals.fsUtils.homeDirPath,

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -71,7 +71,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     final int minor = version?.minor;
     String presetPluginsPath;
     if (pathsSelectorValue != null) {
-      if (major >= 4 && minor >= 1) {
+      if (major != null && major >= 4 && minor != null && minor >= 1) {
         presetPluginsPath = globals.fs.path.join(
           globals.fsUtils.homeDirPath,
           'Library',
@@ -142,7 +142,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     final int minor = version?.minor;
     if (globals.platform.isMacOS) {
       /// plugin path of Android Studio has been changed after version 4.1.
-      if (major >= 4 && minor >= 1) {
+      if (major != null && major >= 4 && minor != null && minor >= 1) {
         return globals.fs.path.join(
           globals.fsUtils.homeDirPath,
           'Library',

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -66,14 +66,26 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         pathsSelectorValue = jvmProperties['idea.paths.selector'] as String;
       }
     }
+
+    final int major = version?.major;
+    final int minor = version?.minor;
     final String presetPluginsPath = pathsSelectorValue == null
       ? null
-      : globals.fs.path.join(
-        globals.fsUtils.homeDirPath,
-        'Library',
-        'Application Support',
-        pathsSelectorValue,
-      );
+      : double.parse('$major.$minor') >= 4.1 
+        ? globals.fs.path.join(
+          globals.fsUtils.homeDirPath,
+          'Library',
+          'Application Support',
+          'Google',
+          pathsSelectorValue,
+          ) 
+        :
+        globals.fs.path.join(
+          globals.fsUtils.homeDirPath,
+          'Library',
+          'Application Support',
+          pathsSelectorValue,
+          );
     return AndroidStudio(studioPath, version: version, presetPluginsPath: presetPluginsPath);
   }
 

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -110,22 +110,22 @@ void main() {
     });
 
     testUsingContext('Can discover Android Studio >=4.1 location on Mac', () {
-    final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = globals.fs.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-    globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
-
-    final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
-    when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist4_1);
-
-    final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
+      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      
+      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist4_1);
+      final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
         globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
       );
-    expect(studio, isNotNull);
-    expect(studio.pluginsPath, equals(globals.fs.path.join(
+      
+      expect(studio, isNotNull);
+      expect(studio.pluginsPath, equals(globals.fs.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -140,25 +140,25 @@ void main() {
       // so we force the platform to fake Linux here.
       Platform: () => platform,
       PlistParser: () => plistUtils,
-  });
-
-  testUsingContext('Can discover Android Studio <4.1 location on Mac', () {
-    final String studioInApplicationPlistFolder = globals.fs.path.join(
+    });
+    
+    testUsingContext('Can discover Android Studio <4.1 location on Mac', () {
+      final String studioInApplicationPlistFolder = globals.fs.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-    globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-    final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
-    when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist);
-
-    final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
+      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist);
+      final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
         globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
       );
-    expect(studio, isNotNull);
-    expect(studio.pluginsPath, equals(globals.fs.path.join(
+      
+      expect(studio, isNotNull);
+      expect(studio.pluginsPath, equals(globals.fs.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -172,7 +172,7 @@ void main() {
       // so we force the platform to fake Linux here.
       Platform: () => platform,
       PlistParser: () => plistUtils,
-  });
+    });
 
     testUsingContext('extracts custom paths for directly downloaded Android Studio on Mac', () {
       final String studioInApplicationPlistFolder = globals.fs.path.join(

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -29,6 +29,19 @@ const Map<String, dynamic> macStudioInfoPlist = <String, dynamic>{
   },
 };
 
+const Map<String, dynamic> macStudioInfoPlist4_1 = <String, dynamic>{
+  'CFBundleGetInfoString': 'Android Studio 4.1, build AI-201.8743.12.41.6858069. Copyright JetBrains s.r.o., (c) 2000-2020',
+  'CFBundleShortVersionString': '4.1',
+  'CFBundleVersion': 'AI-201.8743.12.41.6858069',
+  'JVMOptions': <String, dynamic>{
+    'Properties': <String, dynamic>{
+      'idea.vendor.name' : 'Google',
+      'idea.paths.selector': 'AndroidStudio4.1',
+      'idea.platform.prefix': 'AndroidStudio',
+    },
+  },
+};
+
 final Platform linuxPlatform = FakePlatform(
   operatingSystem: 'linux',
   environment: <String, String>{'HOME': homeLinux},
@@ -95,6 +108,71 @@ void main() {
         platform: platform,
       );
     });
+
+    testUsingContext('Can discover Android Studio >=4.1 location on Mac', () {
+    final String studioInApplicationPlistFolder = globals.fs.path.join(
+        '/',
+        'Application',
+        'Android Studio.app',
+        'Contents',
+      );
+    globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+
+    final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+    when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist4_1);
+
+    final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
+        globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
+      );
+    expect(studio, isNotNull);
+    expect(studio.pluginsPath, equals(globals.fs.path.join(
+        homeMac,
+        'Library',
+        'Application Support',
+        'Google',
+        'AndroidStudio4.1',
+      )));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      FileSystemUtils: () => fsUtils,
+      ProcessManager: () => FakeProcessManager.any(),
+      // Custom home paths are not supported on macOS nor Windows yet,
+      // so we force the platform to fake Linux here.
+      Platform: () => platform,
+      PlistParser: () => plistUtils,
+  });
+
+  testUsingContext('Can discover Android Studio <4.1 location on Mac', () {
+    final String studioInApplicationPlistFolder = globals.fs.path.join(
+        '/',
+        'Application',
+        'Android Studio.app',
+        'Contents',
+      );
+    globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+
+    final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+    when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist);
+
+    final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
+        globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
+      );
+    expect(studio, isNotNull);
+    expect(studio.pluginsPath, equals(globals.fs.path.join(
+        homeMac,
+        'Library',
+        'Application Support',
+        'AndroidStudio3.3',
+      )));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      FileSystemUtils: () => fsUtils,
+      ProcessManager: () => FakeProcessManager.any(),
+      // Custom home paths are not supported on macOS nor Windows yet,
+      // so we force the platform to fake Linux here.
+      Platform: () => platform,
+      PlistParser: () => plistUtils,
+  });
 
     testUsingContext('extracts custom paths for directly downloaded Android Studio on Mac', () {
       final String studioInApplicationPlistFolder = globals.fs.path.join(

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -117,13 +117,13 @@ void main() {
         'Contents',
       );
       globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
-      
+
       final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
       when(plistUtils.parseFile(plistFilePath)).thenReturn(macStudioInfoPlist4_1);
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
         globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
       );
-      
+
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(globals.fs.path.join(
         homeMac,
@@ -141,7 +141,7 @@ void main() {
       Platform: () => platform,
       PlistParser: () => plistUtils,
     });
-    
+
     testUsingContext('Can discover Android Studio <4.1 location on Mac', () {
       final String studioInApplicationPlistFolder = globals.fs.path.join(
         '/',
@@ -156,7 +156,7 @@ void main() {
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
         globals.fs.directory(studioInApplicationPlistFolder)?.parent?.path,
       );
-      
+
       expect(studio, isNotNull);
       expect(studio.pluginsPath, equals(globals.fs.path.join(
         homeMac,


### PR DESCRIPTION
Resubmit #69364 with issues #69863 fixed.

I'm sorry for causing  the crash and  protect code for null point of 'major' and 'minor' has been added.
@mraleph @mit-mit @jonahwilliams

