### PR TITLE
[flutter_tools] remove material design schema, use dart code

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -30,18 +30,16 @@ const String kFontManifestJson = 'FontManifest.json';
 ///   fonts:
 ///     - asset: fonts/MaterialIcons-Regular.otf
 ///```
-const Map<String, List<Map<String, Object>>> kMaterialFonts = <String, List<Map<String, Object>>>{
-  'material': <Map<String, Object>>[
-    <String, Object>{
-      'family': 'MaterialIcons',
-      'fonts': <Map<String, Object>>[
-        <String, Object>{
-          'asset': 'fonts/MaterialIcons-Regular.otf',
-        },
-      ],
-    },
-  ],
-};
+const List<Map<String, Object>> kMaterialFonts = <Map<String, Object>>[
+  <String, Object>{
+    'family': 'MaterialIcons',
+    'fonts': <Map<String, Object>>[
+      <String, Object>{
+        'asset': 'fonts/MaterialIcons-Regular.otf',
+      },
+    ],
+  },
+];
 
 /// Injected factory class for spawning [AssetBundle] instances.
 abstract class AssetBundleFactory {
@@ -116,7 +114,6 @@ class ManifestAssetBundle implements AssetBundle {
   DateTime _lastBuildTimestamp;
 
   static const String _kAssetManifestJson = 'AssetManifest.json';
-  static const String _kFontSetMaterial = 'material';
   static const String _kNoticeFile = 'NOTICES';
 
   @override
@@ -302,7 +299,7 @@ class ManifestAssetBundle implements AssetBundle {
     }
     final List<_Asset> materialAssets = <_Asset>[
       if (flutterManifest.usesMaterialDesign && includeDefaultFonts)
-        ..._getMaterialAssets(_kFontSetMaterial),
+        ..._getMaterialAssets(),
     ];
     for (final _Asset asset in materialAssets) {
       assert(asset.assetFileExists);
@@ -353,10 +350,9 @@ class ManifestAssetBundle implements AssetBundle {
     }
   }
 
-  List<_Asset> _getMaterialAssets(String fontSet) {
+  List<_Asset> _getMaterialAssets() {
     final List<_Asset> result = <_Asset>[];
-
-    for (final Map<String, Object> family in kMaterialFonts[fontSet]) {
+    for (final Map<String, Object> family in kMaterialFonts) {
       for (final Map<String, Object> font in family['fonts'] as List<Map<String, Object>>) {
         final Uri entryUri = _fileSystem.path.toUri(font['asset'] as String);
         result.add(_Asset(
@@ -380,7 +376,7 @@ class ManifestAssetBundle implements AssetBundle {
   }) {
     return <Map<String, dynamic>>[
       if (primary && manifest.usesMaterialDesign && includeDefaultFonts)
-        ...kMaterialFonts[ManifestAssetBundle._kFontSetMaterial],
+        ...kMaterialFonts,
       if (packageName == null)
         ...manifest.fontsDescriptor
       else

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -26,9 +26,9 @@ const String kFontManifestJson = 'FontManifest.json';
 ///
 ///```yaml
 /// material:
-/// - family: MaterialIcons
-///   fonts:
-///     - asset: fonts/MaterialIcons-Regular.otf
+///   - family: MaterialIcons
+///     fonts:
+///       - asset: fonts/MaterialIcons-Regular.otf
 ///```
 const List<Map<String, Object>> kMaterialFonts = <Map<String, Object>>[
   <String, Object>{

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -46,7 +46,10 @@ abstract class AssetBundleFactory {
   /// The singleton instance, pulled from the [AppContext].
   static AssetBundleFactory get instance => context.get<AssetBundleFactory>();
 
-  static AssetBundleFactory get defaultInstance => _ManifestAssetBundleFactory(logger: globals.logger, fileSystem: globals.fs);
+  static AssetBundleFactory defaultInstance({
+    @required Logger logger,
+    @required FileSystem fileSystem,
+  }) => _ManifestAssetBundleFactory(logger: logger, fileSystem: fileSystem);
 
   /// Creates a new [AssetBundle].
   AssetBundle createBundle();

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -46,8 +46,7 @@ abstract class AssetBundleFactory {
   /// The singleton instance, pulled from the [AppContext].
   static AssetBundleFactory get instance => context.get<AssetBundleFactory>();
 
-  static AssetBundleFactory get defaultInstance => _defaultInstance ??= _ManifestAssetBundleFactory(logger: globals.logger, fileSystem: globals.fs);
-  static AssetBundleFactory _defaultInstance;
+  static AssetBundleFactory get defaultInstance => _ManifestAssetBundleFactory(logger: globals.logger, fileSystem: globals.fs);
 
   /// Creates a new [AssetBundle].
   AssetBundle createBundle();
@@ -380,11 +379,11 @@ class ManifestAssetBundle implements AssetBundle {
       if (packageName == null)
         ...manifest.fontsDescriptor
       else
-        ..._createFontsDescriptor(_parsePackageFonts(
+        for (Font font in _parsePackageFonts(
           manifest,
           packageName,
           packageConfig,
-        )),
+        )) font.descriptor,
     ];
   }
 }
@@ -600,10 +599,6 @@ List<Font> _parsePackageFonts(
     packageFonts.add(Font('packages/$packageName/${font.familyName}', packageFontAssets));
   }
   return packageFonts;
-}
-
-List<Map<String, dynamic>> _createFontsDescriptor(List<Font> fonts) {
-  return fonts.map<Map<String, dynamic>>((Font font) => font.descriptor).toList();
 }
 
 // Given an assets directory like this:

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -44,7 +44,10 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
 
   final File pubspecFile =  environment.projectDir.childFile('pubspec.yaml');
   // Only the default asset bundle style is supported in assemble.
-  final AssetBundle assetBundle = AssetBundleFactory.defaultInstance.createBundle();
+  final AssetBundle assetBundle = AssetBundleFactory.defaultInstance(
+    logger: environment.logger,
+    fileSystem: environment.fileSystem,
+  ).createBundle();
   final int resultCode = await assetBundle.build(
     manifestPath: pubspecFile.path,
     packagesPath: environment.projectDir.childFile('.packages').path,

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -110,7 +110,12 @@ Future<T> runInContext<T>(
         cache: globals.cache,
         platform: globals.platform,
       ),
-      AssetBundleFactory: () => AssetBundleFactory.defaultInstance,
+      AssetBundleFactory: () {
+        return AssetBundleFactory.defaultInstance(
+          logger: globals.logger,
+          fileSystem: globals.fs,
+        );
+      },
       BuildSystem: () => FlutterBuildSystem(
         fileSystem: globals.fs,
         logger: globals.logger,

--- a/packages/flutter_tools/schema/material_fonts.yaml
+++ b/packages/flutter_tools/schema/material_fonts.yaml
@@ -1,4 +1,0 @@
-material:
-  - family: MaterialIcons
-    fonts:
-      - asset: fonts/MaterialIcons-Regular.otf


### PR DESCRIPTION
## Description

Instead of loading the use-material-design asset data from a yaml file, leave it in dart code and simplify. Remove some of the globals, but not enough to update to testWithoutContext
