### PR TITLE
Add Dart SDK constraint to a pubspec

### DIFF
--- a/packages/flutter_test/test/test_config/project_root/pubspec.yaml
+++ b/packages/flutter_test/test/test_config/project_root/pubspec.yaml
@@ -3,4 +3,7 @@
 
 name: dummy
 
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
 # PUBSPEC CHECKSUM: 0000


### PR DESCRIPTION
This will unblock the roll of the next Dart SDK
