### PR TITLE
[flutter_tools] remove global packages path

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -14,7 +14,6 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
-import 'package:flutter_tools/src/dart/package_map.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
@@ -108,13 +107,12 @@ Future<void> run(List<String> args) async {
     // TODO(tvolkert): Remove once flutter_tester no longer looks for this.
     globals.fs.link(sdkRootDest.childFile('platform.dill').path).createSync('platform_strong.dill');
 
-    globalPackagesPath =
-        globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String));
-
     Directory testDirectory;
     CoverageCollector collector;
     if (argResults['coverage'] as bool) {
       collector = CoverageCollector(
+        packagesFilePath: globals.fs.path.normalize(
+          globals.fs.path.absolute(argResults[_kOptionPackages] as String)),
         libraryPredicate: (String libraryName) {
           // If we have a specified coverage directory then accept all libraries.
           if (coverageDirectory != null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -171,6 +171,7 @@ class TestCommand extends FlutterCommand {
     final List<String> plainNames = stringsArg('plain-name');
     final String tags = stringArg('tags');
     final String excludeTags = stringArg('exclude-tags');
+    final BuildInfo buildInfo = getBuildInfo(forcedBuildMode: BuildMode.debug);
 
     if (buildTestAssets && flutterProject.manifest.assets.isNotEmpty) {
       await _buildTestAsset();
@@ -225,6 +226,7 @@ class TestCommand extends FlutterCommand {
       collector = CoverageCollector(
         verbose: !machine,
         libraryPredicate: (String libraryName) => libraryName.contains(projectName),
+        packagesFilePath: buildInfo.packagesPath,
       );
     }
 
@@ -236,7 +238,6 @@ class TestCommand extends FlutterCommand {
     }
 
     final bool disableServiceAuthCodes = boolArg('disable-service-auth-codes');
-    final BuildInfo buildInfo = getBuildInfo(forcedBuildMode: BuildMode.debug);
 
     final int result = await testRunner.runTests(
       testWrapper,

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -13,21 +13,10 @@ import '../base/logger.dart';
 
 const String kPackagesFileName = '.packages';
 
-// No touching!
-String get globalPackagesPath => _globalPackagesPath ?? kPackagesFileName;
-
-set globalPackagesPath(String value) {
-  _globalPackagesPath = value;
-}
-
-bool get isUsingCustomPackagesPath => _globalPackagesPath != null;
-
-String _globalPackagesPath;
-
 /// Load the package configuration from [file] or throws a [ToolExit]
 /// if the operation would fail.
 ///
-/// If [nonFatal] is true, in the event of an error an empty package
+/// If [throwOnError] is false, in the event of an error an empty package
 /// config is returned.
 Future<PackageConfig> loadPackageConfigWithLogging(File file, {
   @required Logger logger,

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -723,7 +723,6 @@ class WebDevFS implements DevFS {
   WebDevFS({
     @required this.hostname,
     @required int port,
-    @required this.packagesFilePath,
     @required this.urlTunneller,
     @required this.useSseForDebugProxy,
     @required this.useSseForDebugBackend,
@@ -738,7 +737,6 @@ class WebDevFS implements DevFS {
 
   final Uri entrypoint;
   final String hostname;
-  final String packagesFilePath;
   final UrlTunneller urlTunneller;
   final bool useSseForDebugProxy;
   final bool useSseForDebugBackend;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -498,7 +498,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
           port: debuggingOptions.port != null
             ? int.tryParse(debuggingOptions.port)
             : null,
-          packagesFilePath: packagesFilePath,
           urlTunneller: urlTunneller,
           useSseForDebugProxy: debuggingOptions.webUseSseForDebugProxy,
           useSseForDebugBackend: debuggingOptions.webUseSseForDebugBackend,
@@ -717,7 +716,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
     final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
       lastCompiled: device.devFS.lastCompiled,
       urisToMonitor: device.devFS.sources,
-      packagesPath: packagesFilePath,
+      packagesPath: debuggingOptions.buildInfo.packagesPath,
       packageConfig: device.devFS.lastPackageConfig,
     );
     final Status devFSStatus = globals.logger.startProgress(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -349,9 +349,8 @@ class FlutterDevice {
 
   Future<Uri> setupDevFS(
     String fsName,
-    Directory rootDirectory, {
-    String packagesFilePath,
-  }) {
+    Directory rootDirectory,
+  ) {
     // One devFS per device. Shared by all running instances.
     devFS = DevFS(
       vmService,
@@ -726,7 +725,6 @@ abstract class ResidentRunner {
     String dillOutputPath,
     this.machine = false,
   }) : mainPath = findMainDartFile(target),
-       packagesFilePath = debuggingOptions.buildInfo.packagesPath,
        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
        _dillOutputPath = dillOutputPath,
        artifactDirectory = dillOutputPath == null
@@ -755,7 +753,6 @@ abstract class ResidentRunner {
   final String _dillOutputPath;
   /// The parent location of the incremental artifacts.
   final Directory artifactDirectory;
-  final String packagesFilePath;
   final String projectRootPath;
   final String mainPath;
   final AssetBundle assetBundle;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -367,7 +367,6 @@ class HotRunner extends ResidentRunner {
         await device.setupDevFS(
           fsName,
           globals.fs.directory(projectRootPath),
-          packagesFilePath: packagesFilePath,
         ),
     ];
   }
@@ -386,7 +385,7 @@ class HotRunner extends ResidentRunner {
     final InvalidationResult invalidationResult = await projectFileInvalidator.findInvalidated(
       lastCompiled: flutterDevices[0].devFS.lastCompiled,
       urisToMonitor: flutterDevices[0].devFS.sources,
-      packagesPath: packagesFilePath,
+      packagesPath: debuggingOptions.buildInfo.packagesPath,
       asyncScanning: hotRunnerConfig.asyncScanning,
       packageConfig: flutterDevices[0].devFS.lastPackageConfig,
     );

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -21,7 +21,6 @@ import '../build_system/targets/icon_tree_shaker.dart' show kIconTreeShakerEnabl
 import '../bundle.dart' as bundle;
 import '../cache.dart';
 import '../dart/generate_synthetic_packages.dart';
-import '../dart/package_map.dart';
 import '../dart/pub.dart';
 import '../device.dart';
 import '../features.dart';
@@ -879,7 +878,7 @@ abstract class FlutterCommand extends Command<void> {
       bundleSkSLPath: bundleSkSLPath,
       dartExperiments: experiments,
       performanceMeasurementFile: performanceMeasurementFile,
-      packagesPath: globalResults['packages'] as String ?? '.packages',
+      packagesPath: globals.fs.path.absolute(globalResults['packages'] as String ?? '.packages'),
       nullSafetyMode: nullSafetyMode,
       codeSizeDirectory: codeSizeDirectory,
       androidGradleDaemon: androidGradleDaemon,
@@ -1175,7 +1174,7 @@ abstract class FlutterCommand extends Command<void> {
   @protected
   @mustCallSuper
   Future<void> validateCommand() async {
-    if (_requiresPubspecYaml && !isUsingCustomPackagesPath) {
+    if (_requiresPubspecYaml && !globalResults.wasParsed('packages')) {
       // Don't expect a pubspec.yaml file if the user passed in an explicit .packages file path.
 
       // If there is no pubspec in the current directory, look in the parent

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -219,7 +219,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
     // Set up the tooling configuration.
     final EngineBuildPaths engineBuildPaths = await globals.localEngineLocator.findEnginePath(
       topLevelResults['local-engine-src-path'] as String,
-      topLevelResults['local-engine'] as String
+      topLevelResults['local-engine'] as String,
+      topLevelResults['packages'] as String,
     );
     if (engineBuildPaths != null) {
       contextOverrides.addAll(<Type, dynamic>{
@@ -252,10 +253,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
         final bool machineFlag = topLevelResults['machine'] as bool;
         if (topLevelResults.command?.name != 'upgrade' && topLevelResults['version-check'] as bool && !machineFlag) {
           await globals.flutterVersion.checkFlutterVersionFreshness();
-        }
-
-        if (topLevelResults.wasParsed('packages')) {
-          globalPackagesPath = globals.fs.path.normalize(globals.fs.path.absolute(topLevelResults['packages'] as String));
         }
 
         // See if the user specified a specific device.

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -47,13 +47,13 @@ class LocalEngineLocator {
   final UserMessages _userMessages;
 
   /// Returns the engine build path of a local engine if one is located, otherwise `null`.
-  Future<EngineBuildPaths> findEnginePath(String engineSourcePath, String localEngine) async {
+  Future<EngineBuildPaths> findEnginePath(String engineSourcePath, String localEngine, String packagesPath) async {
     engineSourcePath ??= _platform.environment[kFlutterEngineEnvironmentVariableName];
 
     if (engineSourcePath == null && localEngine != null) {
       try {
         final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-          _fileSystem.file(globalPackagesPath),
+          _fileSystem.file(packagesPath ?? '.packages'),
           logger: _logger,
           throwOnError: false,
         );

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:coverage/coverage.dart' as coverage;
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
-import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../vmservice.dart';
 
@@ -17,9 +17,10 @@ import 'watcher.dart';
 
 /// A class that's used to collect coverage data during tests.
 class CoverageCollector extends TestWatcher {
-  CoverageCollector({this.libraryPredicate, this.verbose = true});
+  CoverageCollector({this.libraryPredicate, this.verbose = true, @required this.packagesFilePath});
 
   final bool verbose;
+  final String packagesFilePath;
   Map<String, Map<int, int>> _globalHitmap;
   bool Function(String) libraryPredicate;
 
@@ -66,7 +67,7 @@ class CoverageCollector extends TestWatcher {
     _logMessage('($observatoryUri): collected coverage data; merging...');
     _addHitmap(await coverage.createHitmap(
       data['coverage'] as List<Map<String, dynamic>>,
-      packagesPath: globalPackagesPath,
+      packagesPath: packagesFilePath,
       checkIgnoredLines: true,
     ));
     _logMessage('($observatoryUri): done merging coverage data into global coverage map.');
@@ -102,7 +103,7 @@ class CoverageCollector extends TestWatcher {
     _logMessage('pid $pid ($observatoryUri): collected coverage data; merging...');
     _addHitmap(await coverage.createHitmap(
       data['coverage'] as List<Map<String, dynamic>>,
-      packagesPath: globalPackagesPath,
+      packagesPath: packagesFilePath,
       checkIgnoredLines: true,
     ));
     _logMessage('pid $pid ($observatoryUri): done merging coverage data into global coverage map.');
@@ -121,7 +122,7 @@ class CoverageCollector extends TestWatcher {
       return null;
     }
     if (formatter == null) {
-      final coverage.Resolver resolver = coverage.Resolver(packagesPath: globalPackagesPath);
+      final coverage.Resolver resolver = coverage.Resolver(packagesPath: packagesFilePath);
       final String packagePath = globals.fs.currentDirectory.path;
       final List<String> reportOn = coverageDirectory == null
         ? <String>[globals.fs.path.join(packagePath, 'lib')]

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -377,7 +377,7 @@ class FlutterPlatform extends PlatformPlugin {
     int ourTestCount,
   ) async {
     _packageConfig ??= await loadPackageConfigWithLogging(
-      globals.fs.file(globalPackagesPath),
+      globals.fs.file(buildInfo.packagesPath),
       logger: globals.logger,
     );
     globals.printTrace('test $ourTestCount: starting test $testPath');
@@ -446,7 +446,7 @@ class FlutterPlatform extends PlatformPlugin {
       final Process process = await _startProcess(
         shellPath,
         mainDart,
-        packages: globalPackagesPath,
+        packages: buildInfo.packagesPath,
         enableObservatory: enableObservatory,
         startPaused: startPaused,
         disableServiceAuthCodes: disableServiceAuthCodes,

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -9,7 +9,6 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../build_info.dart';
-import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../web/compile.dart';
@@ -143,6 +142,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
             shellPath: shellPath,
             flutterProject: flutterProject,
             pauseAfterLoad: startPaused,
+            buildInfo: buildInfo,
           );
         },
       );
@@ -180,9 +180,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
 
     // Make the global packages path absolute.
     // (Makes sure it still works after we change the current directory.)
-    globalPackagesPath =
-        globals.fs.path.normalize(globals.fs.path.absolute(globalPackagesPath));
-
     // Call package:test's main method in the appropriate directory.
     final Directory saved = globals.fs.currentDirectory;
     try {

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -108,7 +108,7 @@ class TestCompiler {
       initializeFromDill: testFilePath,
       unsafePackageSerialization: false,
       dartDefines: buildInfo.dartDefines,
-      packagesPath: globalPackagesPath,
+      packagesPath: buildInfo.packagesPath,
       extraFrontEndOptions: buildInfo.extraFrontEndOptions,
       platform: globals.platform,
       testCompilation: true,
@@ -130,7 +130,7 @@ class TestCompiler {
     }
     if (_packageConfig == null) {
       _packageConfig ??= await loadPackageConfigWithLogging(
-        globals.fs.file(globalPackagesPath),
+        globals.fs.file(buildInfo.packagesPath),
         logger: globals.logger,
       );
       // Compilation will fail if there is no flutter_test dependency, since

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -194,7 +194,7 @@ void main() {
       compileExpression: anyNamed('compileExpression'),
       getSkSLMethod: anyNamed('getSkSLMethod'),
     )).thenAnswer((Invocation invocation) async { });
-    when(mockFlutterDevice.setupDevFS(any, any, packagesFilePath: anyNamed('packagesFilePath')))
+    when(mockFlutterDevice.setupDevFS(any, any))
       .thenAnswer((Invocation invocation) async {
         return testUri;
       });

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -43,7 +43,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(null, 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/ios_debug',
@@ -57,7 +57,7 @@ void main() {
       .writeAsStringSync('sky_engine:file:///symlink/src/out/ios_debug/gen/dart-pkg/sky_engine/lib/');
 
     expect(
-      await localEngineLocator.findEnginePath(null, 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/symlink/src/out/host_debug',
         targetEngine: '/symlink/src/out/ios_debug',
@@ -81,7 +81,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath('$kArbitraryEngineRoot/src', 'ios_debug'),
+      await localEngineLocator.findEnginePath('$kArbitraryEngineRoot/src', 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/ios_debug',
@@ -112,7 +112,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(null, 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: 'flutter/engine/src/out/host_debug',
         targetEngine: 'flutter/engine/src/out/ios_debug',

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -613,7 +613,6 @@ void main() {
     final WebDevFS webDevFS = WebDevFS(
       hostname: 'localhost',
       port: 0,
-      packagesFilePath: '.packages',
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
@@ -729,7 +728,6 @@ void main() {
     final WebDevFS webDevFS = WebDevFS(
       hostname: 'localhost',
       port: 0,
-      packagesFilePath: '.packages',
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
@@ -842,7 +840,6 @@ void main() {
     final WebDevFS webDevFS = WebDevFS(
       hostname: 'any',
       port: 0,
-      packagesFilePath: '.packages',
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
@@ -885,7 +882,6 @@ void main() {
     final WebDevFS webDevFS = WebDevFS(
       hostname: 'localhost',
       port: 0,
-      packagesFilePath: '.packages',
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,
@@ -936,7 +932,6 @@ void main() {
     final WebDevFS webDevFS = WebDevFS(
       hostname: 'localhost',
       port: 0,
-      packagesFilePath: '.packages',
       urlTunneller: null,
       useSseForDebugProxy: true,
       useSseForDebugBackend: true,

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
@@ -61,6 +61,7 @@ void main() {
       final TestGoldenComparator comparator = TestGoldenComparator(
         'shell',
         () => mockCompiler,
+        '.packages',
       );
 
       final String result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
@@ -84,6 +85,7 @@ void main() {
       final TestGoldenComparator comparator = TestGoldenComparator(
         'shell',
         () => mockCompiler,
+        '.packages',
       );
 
       final String result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
@@ -111,6 +113,7 @@ void main() {
       final TestGoldenComparator comparator = TestGoldenComparator(
         'shell',
         () => mockCompiler,
+        '.packages',
       );
 
       final String result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
@@ -141,6 +144,7 @@ void main() {
       final TestGoldenComparator comparator = TestGoldenComparator(
         'shell',
         () => mockCompiler,
+        '.packages'
       );
 
       final String result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
@@ -167,6 +171,7 @@ void main() {
       final TestGoldenComparator comparator = TestGoldenComparator(
         'shell',
         () => mockCompiler,
+        '.packages',
       );
 
       final String result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);


### PR DESCRIPTION
## Description

Split off from https://github.com/flutter/flutter/pull/69782

Only changes to using BuildInfo.packagePath instead of also switching to package_config.