### PR TITLE
[flutter_tools] restore pub caching functionality

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -94,6 +94,7 @@ abstract class Pub {
     bool offline = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
+    bool check = false,
   });
 
   /// Runs pub in 'batch' mode.
@@ -164,12 +165,32 @@ class _DefaultPub implements Pub {
     bool offline = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
+    bool check = false,
   }) async {
     directory ??= _fileSystem.currentDirectory.path;
     final File packageConfigFile = _fileSystem.file(
       _fileSystem.path.join(directory, '.dart_tool', 'package_config.json'));
     final Directory generatedDirectory = _fileSystem.directory(
       _fileSystem.path.join(directory, '.dart_tool', 'flutter_gen'));
+    final File lastVersion = _fileSystem.file(
+      _fileSystem.path.join(directory, '.dart_tool', 'version'));
+    final File currentVersion = _fileSystem.file(
+      _fileSystem.path.join(Cache.flutterRoot, 'version'));
+    final File pubspecYaml = _fileSystem.file(
+      _fileSystem.path.join(directory, 'pubspec.yaml'));
+
+    // If the pubspec.yaml is older than the package config file and the last
+    // flutter version used is the same as the current version. This will incorrectly
+    // skip pub on the master branch if dependencies are being added/removed from the
+    // flutter framework packages.
+    if (check &&
+        packageConfigFile.existsSync() &&
+        pubspecYaml.lastModifiedSync().isBefore(packageConfigFile.lastModifiedSync()) &&
+        lastVersion.existsSync() &&
+        lastVersion.readAsStringSync() == currentVersion.readAsStringSync()) {
+      _logger.printTrace('Skipping pub get: version match.');
+      return;
+    }
 
     final String command = upgrade ? 'upgrade' : 'get';
     final Status status = _logger.startProgress(
@@ -207,6 +228,7 @@ class _DefaultPub implements Pub {
     if (!packageConfigFile.existsSync()) {
       throwToolExit('$directory: pub did not create .dart_tools/package_config.json file.');
     }
+    lastVersion.writeAsStringSync(currentVersion.readAsStringSync());
     await _updatePackageConfig(
       packageConfigFile,
       generatedDirectory,

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -94,7 +94,7 @@ abstract class Pub {
     bool offline = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
-    bool check = false,
+    bool checkUpToDate = false,
   });
 
   /// Runs pub in 'batch' mode.
@@ -118,7 +118,6 @@ abstract class Pub {
     @required bool retry,
     bool showTraceForErrors,
   });
-
 
   /// Runs pub in 'interactive' mode.
   ///
@@ -165,7 +164,7 @@ class _DefaultPub implements Pub {
     bool offline = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
-    bool check = false,
+    bool checkUpToDate = false,
   }) async {
     directory ??= _fileSystem.currentDirectory.path;
     final File packageConfigFile = _fileSystem.file(
@@ -180,10 +179,11 @@ class _DefaultPub implements Pub {
       _fileSystem.path.join(directory, 'pubspec.yaml'));
 
     // If the pubspec.yaml is older than the package config file and the last
-    // flutter version used is the same as the current version. This will incorrectly
-    // skip pub on the master branch if dependencies are being added/removed from the
-    // flutter framework packages.
-    if (check &&
+    // flutter version used is the same as the current version skip pub get.
+    // This will incorrectly skip pub on the master branch if dependencies
+    // are being added/removed from the flutter framework packages, but this
+    // can be worked around by manually running pub.
+    if (checkUpToDate &&
         packageConfigFile.existsSync() &&
         pubspecYaml.lastModifiedSync().isBefore(packageConfigFile.lastModifiedSync()) &&
         lastVersion.existsSync() &&

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1061,7 +1061,7 @@ abstract class FlutterCommand extends Command<void> {
       await pub.get(
         context: PubContext.getVerifyContext(name),
         generateSyntheticPackage: project.manifest.generateSyntheticPackage,
-        check: true,
+        checkUpToDate: true,
       );
       await project.regeneratePlatformSpecificTooling();
     }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1061,6 +1061,7 @@ abstract class FlutterCommand extends Command<void> {
       await pub.get(
         context: PubContext.getVerifyContext(name),
         generateSyntheticPackage: project.manifest.generateSyntheticPackage,
+        check: true,
       );
       await project.regeneratePlatformSpecificTooling();
     }

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -30,7 +30,7 @@ void main() {
     MockDirectory.findCache = false;
   });
 
-  testWithoutContext('check skips pub get if the package config is newer than the pubspec '
+  testWithoutContext('checkUpToDate skips pub get if the package config is newer than the pubspec '
     'and the current framework version is the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
     final BufferLogger logger = BufferLogger.test();
@@ -60,7 +60,7 @@ void main() {
     expect(logger.traceText, contains('Skipping pub get: version match.'));
   });
 
-  testWithoutContext('check does not skip pub get if the package config is newer than the pubspec '
+  testWithoutContext('checkUpToDate does not skip pub get if the package config is newer than the pubspec '
     'but the current framework version is not the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
@@ -98,7 +98,7 @@ void main() {
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
-  testWithoutContext('check does not skip pub get if the package config is newer than the pubspec '
+  testWithoutContext('checkUpToDate does not skip pub get if the package config is newer than the pubspec '
     'but the current framework version does not exist yet', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
@@ -135,7 +135,7 @@ void main() {
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
-  testWithoutContext('check does not skip pub get if the package config does not exist', () async {
+  testWithoutContext('checkUpToDate does not skip pub get if the package config does not exist', () async {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
@@ -173,7 +173,7 @@ void main() {
   });
 
 
-  testWithoutContext('check does not skip pub get if the package config is older that the pubspec', () async {
+  testWithoutContext('checkUpToDate does not skip pub get if the package config is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/pub',

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -30,6 +30,187 @@ void main() {
     MockDirectory.findCache = false;
   });
 
+  testWithoutContext('check skips pub get if the package config is newer than the pubspec '
+    'and the current framework version is the same as the last version', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
+    final BufferLogger logger = BufferLogger.test();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+    fileSystem.file('.dart_tool/version').writeAsStringSync('a');
+    fileSystem.file('version').writeAsStringSync('a');
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: MockUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await pub.get(
+      context: PubContext.pubGet,
+      check: true,
+    );
+
+    expect(logger.traceText, contains('Skipping pub get: version match.'));
+  });
+
+  testWithoutContext('check does not skip pub get if the package config is newer than the pubspec '
+    'but the current framework version is not the same as the last version', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
+        'get',
+        '--no-precompile',
+      ])
+    ]);
+    final BufferLogger logger = BufferLogger.test();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+    fileSystem.file('.dart_tool/version').writeAsStringSync('a');
+    fileSystem.file('version').writeAsStringSync('b');
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: MockUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await pub.get(
+      context: PubContext.pubGet,
+      check: true,
+    );
+
+    expect(processManager.hasRemainingExpectations, false);
+    expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
+  });
+
+  testWithoutContext('check does not skip pub get if the package config is newer than the pubspec '
+    'but the current framework version does not exist yet', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
+        'get',
+        '--no-precompile',
+      ])
+    ]);
+    final BufferLogger logger = BufferLogger.test();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+    fileSystem.file('version').writeAsStringSync('b');
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: MockUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await pub.get(
+      context: PubContext.pubGet,
+      check: true,
+    );
+
+    expect(processManager.hasRemainingExpectations, false);
+    expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
+  });
+
+  testWithoutContext('check does not skip pub get if the package config does not exist', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(command: const <String>[
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
+        'get',
+        '--no-precompile',
+      ], onRun: () {
+        fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
+      })
+    ]);
+    final BufferLogger logger = BufferLogger.test();
+
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('version').writeAsStringSync('b');
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: MockUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await pub.get(
+      context: PubContext.pubGet,
+      check: true,
+    );
+
+    expect(processManager.hasRemainingExpectations, false);
+    expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
+  });
+
+
+  testWithoutContext('check does not skip pub get if the package config is older that the pubspec', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
+        'get',
+        '--no-precompile',
+      ])
+    ]);
+    final BufferLogger logger = BufferLogger.test();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..setLastModifiedSync(DateTime(1991));
+    fileSystem.file('version').writeAsStringSync('b');
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: MockUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await pub.get(
+      context: PubContext.pubGet,
+      check: true,
+    );
+
+    expect(processManager.hasRemainingExpectations, false);
+    expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
+  });
+
   testWithoutContext('pub get 69', () async {
     String error;
 
@@ -209,6 +390,7 @@ void main() {
         }
       ),
     );
+    fileSystem.file('version').createSync();
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('.dart_tool/package_config.json')
       ..createSync(recursive: true)
@@ -237,6 +419,7 @@ void main() {
         }
       ),
     );
+    fileSystem.file('version').createSync();
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('.dart_tool/package_config.json')
       ..createSync(recursive: true)
@@ -377,6 +560,7 @@ void main() {
       botDetector: const BotDetectorAlwaysNo()
     );
 
+    fileSystem.file('version').createSync();
     // the good scenario: .packages is old, pub updates the file.
     fileSystem.file('.dart_tool/package_config.json')
       ..createSync(recursive: true)

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -54,7 +54,7 @@ void main() {
 
     await pub.get(
       context: PubContext.pubGet,
-      check: true,
+      checkUpToDate: true,
     );
 
     expect(logger.traceText, contains('Skipping pub get: version match.'));
@@ -91,7 +91,7 @@ void main() {
 
     await pub.get(
       context: PubContext.pubGet,
-      check: true,
+      checkUpToDate: true,
     );
 
     expect(processManager.hasRemainingExpectations, false);
@@ -128,7 +128,7 @@ void main() {
 
     await pub.get(
       context: PubContext.pubGet,
-      check: true,
+      checkUpToDate: true,
     );
 
     expect(processManager.hasRemainingExpectations, false);
@@ -165,7 +165,7 @@ void main() {
 
     await pub.get(
       context: PubContext.pubGet,
-      check: true,
+      checkUpToDate: true,
     );
 
     expect(processManager.hasRemainingExpectations, false);
@@ -204,7 +204,7 @@ void main() {
 
     await pub.get(
       context: PubContext.pubGet,
-      check: true,
+      checkUpToDate: true,
     );
 
     expect(processManager.hasRemainingExpectations, false);

--- a/packages/flutter_tools/test/src/throwing_pub.dart
+++ b/packages/flutter_tools/test/src/throwing_pub.dart
@@ -30,6 +30,7 @@ class ThrowingPub implements Pub {
     bool skipPubspecYamlCheck = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
+    bool check = false,
   }) {
     throw UnsupportedError('Attempted to invoke pub during test.');
   }

--- a/packages/flutter_tools/test/src/throwing_pub.dart
+++ b/packages/flutter_tools/test/src/throwing_pub.dart
@@ -30,7 +30,7 @@ class ThrowingPub implements Pub {
     bool skipPubspecYamlCheck = false,
     bool generateSyntheticPackage = false,
     String flutterRootOverride,
-    bool check = false,
+    bool checkUpToDate = false,
   }) {
     throw UnsupportedError('Attempted to invoke pub during test.');
   }


### PR DESCRIPTION
## Description

Necessary to work around https://github.com/flutter/flutter/issues/70013 (this looks like it will be fixed, but should protect us in the future)

Restores some notion of skipping pub, with differences from the prior implementation:

1. Off by default, and only used by the flutter command automatic pub get
2. A single check parameter
3. Uses the framework version cached per-project instead of a timestamp of the tool, to avoid cases where downloading a prebuilt framework would cause this check to no longer work.
  * The caveat with master branch rebuilds is noted.