### PR TITLE
[flutter_tools] improve hash performance

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -802,10 +802,12 @@ class _BuildInstance {
       // If we were missing the depfile, resolve input files after executing the
       // target so that all file hashes are up to date on the next run.
       if (node.missingDepfile) {
+        await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
         fileCache.diffFileList(node.inputs);
       }
 
       // Always update hashes for output files.
+      await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
       fileCache.diffFileList(node.outputs);
       node.target._writeStamp(node.inputs, node.outputs, environment);
       updateGraph();
@@ -1075,6 +1077,7 @@ class Node {
     // If we have files to diff, compute them asynchronously and then
     // update the result.
     if (sourcesToDiff.isNotEmpty) {
+      await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
       final List<File> dirty = fileStore.diffFileList(sourcesToDiff);
       if (dirty.isNotEmpty) {
         invalidatedReasons.add(InvalidatedReason.inputChanged);

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -802,11 +802,11 @@ class _BuildInstance {
       // If we were missing the depfile, resolve input files after executing the
       // target so that all file hashes are up to date on the next run.
       if (node.missingDepfile) {
-        await fileCache.diffFileList(node.inputs);
+        fileCache.diffFileList(node.inputs);
       }
 
       // Always update hashes for output files.
-      await fileCache.diffFileList(node.outputs);
+      fileCache.diffFileList(node.outputs);
       node.target._writeStamp(node.inputs, node.outputs, environment);
       updateGraph();
 
@@ -1075,7 +1075,7 @@ class Node {
     // If we have files to diff, compute them asynchronously and then
     // update the result.
     if (sourcesToDiff.isNotEmpty) {
-      final List<File> dirty = await fileStore.diffFileList(sourcesToDiff);
+      final List<File> dirty = fileStore.diffFileList(sourcesToDiff);
       if (dirty.isNotEmpty) {
         invalidatedReasons.add(InvalidatedReason.inputChanged);
         _dirty = true;

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -772,7 +772,7 @@ class _BuildInstance {
       // If we're missing a depfile, wait until after evaluating the target to
       // compute changes.
       final bool canSkip = !node.missingDepfile &&
-        await node.computeChanges(environment, fileCache, fileSystem, logger);
+        node.computeChanges(environment, fileCache, fileSystem, logger);
 
       if (canSkip) {
         skipped = true;
@@ -802,12 +802,10 @@ class _BuildInstance {
       // If we were missing the depfile, resolve input files after executing the
       // target so that all file hashes are up to date on the next run.
       if (node.missingDepfile) {
-        await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
         fileCache.diffFileList(node.inputs);
       }
 
       // Always update hashes for output files.
-      await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
       fileCache.diffFileList(node.outputs);
       node.target._writeStamp(node.inputs, node.outputs, environment);
       updateGraph();
@@ -1003,12 +1001,12 @@ class Node {
   /// Collect hashes for all inputs to determine if any have changed.
   ///
   /// Returns whether this target can be skipped.
-  Future<bool> computeChanges(
+  bool computeChanges(
     Environment environment,
     FileStore fileStore,
     FileSystem fileSystem,
     Logger logger,
-  ) async {
+  ) {
     final Set<String> currentOutputPaths = <String>{
       for (final File file in outputs) file.path,
     };
@@ -1077,7 +1075,6 @@ class Node {
     // If we have files to diff, compute them asynchronously and then
     // update the result.
     if (sourcesToDiff.isNotEmpty) {
-      await null; // TODO(jonahwilliams): update expectations in resident_runner_test.dart
       final List<File> dirty = fileStore.diffFileList(sourcesToDiff);
       if (dirty.isNotEmpty) {
         invalidatedReasons.add(InvalidatedReason.inputChanged);

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -229,14 +229,17 @@ class FileStore {
     }
     final int fileBytes = file.lengthSync();
     final Md5Hash hash = Md5Hash();
-    final RandomAccessFile openFile = file.openSync(mode: FileMode.read);
-    int bytes = 0;
-    while (bytes < fileBytes) {
-      final int bytesRead = openFile.readIntoSync(_readBuffer);
-      hash.addChunk(_readBuffer, bytesRead);
-      bytes += bytesRead;
+    try {
+      final RandomAccessFile openFile = file.openSync(mode: FileMode.read);
+      int bytes = 0;
+      while (bytes < fileBytes) {
+        final int bytesRead = openFile.readIntoSync(_readBuffer);
+        hash.addChunk(_readBuffer, bytesRead);
+        bytes += bytesRead;
+      }
+    } finally {
+      openFile.closeSync();
     }
-    openFile.closeSync();
     final Digest digest = Digest(hash.finalize().buffer.asUint8List());
     final String currentHash = digest.toString();
     if (currentHash != previousHash) {

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -2,22 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:collection';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
-import 'package:pool/pool.dart';
 
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/utils.dart';
 import '../convert.dart';
-import 'build_system.dart';
-
-/// The default threshold for file chunking is 250 KB, or about the size of `framework.dart`.
-const int kDefaultFileChunkThresholdBytes = 250000;
+import 'hash.dart';
 
 /// An encoded representation of all file hashes.
 class FileStorage {
@@ -94,16 +89,13 @@ class FileStore {
     @required File cacheFile,
     @required Logger logger,
     FileStoreStrategy strategy = FileStoreStrategy.hash,
-    int fileChunkThreshold = kDefaultFileChunkThresholdBytes,
   }) : _logger = logger,
        _strategy = strategy,
-       _cacheFile = cacheFile,
-       _fileChunkThreshold = fileChunkThreshold;
+       _cacheFile = cacheFile;
 
   final File _cacheFile;
   final Logger _logger;
   final FileStoreStrategy _strategy;
-  final int _fileChunkThreshold;
 
   final HashMap<String, String> previousAssetKeys = HashMap<String, String>();
   final HashMap<String, String> currentAssetKeys = HashMap<String, String>();
@@ -187,14 +179,13 @@ class FileStore {
 
   /// Computes a diff of the provided files and returns a list of files
   /// that were dirty.
-  Future<List<File>> diffFileList(List<File> files) async {
+  List<File> diffFileList(List<File> files) {
     final List<File> dirty = <File>[];
     switch (_strategy) {
       case FileStoreStrategy.hash:
-        final Pool openFiles = Pool(kMaxOpenFiles);
-        await Future.wait(<Future<void>>[
-          for (final File file in files) _hashFile(file, dirty, openFiles)
-        ]);
+        for (final File file in files) {
+          _hashFile(file, dirty);
+        }
         break;
       case FileStoreStrategy.timestamp:
         for (final File file in files) {
@@ -223,37 +214,34 @@ class FileStore {
     currentAssetKeys[absolutePath] = modifiedTime;
   }
 
-  Future<void> _hashFile(File file, List<File> dirty, Pool pool) async {
-    final PoolResource resource = await pool.request();
-    try {
-      final String absolutePath = file.path;
-      final String previousHash = previousAssetKeys[absolutePath];
-      // If the file is missing it is assumed to be dirty.
-      if (!file.existsSync()) {
-        currentAssetKeys.remove(absolutePath);
-        previousAssetKeys.remove(absolutePath);
-        dirty.add(file);
-        return;
-      }
-      Digest digest;
-      final int fileBytes = file.lengthSync();
-      // For files larger than a given threshold, chunk the conversion.
-      if (fileBytes > _fileChunkThreshold) {
-        final StreamController<Digest> digests = StreamController<Digest>();
-        final ByteConversionSink inputSink = md5.startChunkedConversion(digests);
-        await file.openRead().forEach(inputSink.add);
-        inputSink.close();
-        digest = await digests.stream.last;
-      } else {
-        digest = md5.convert(await file.readAsBytes());
-      }
-      final String currentHash = digest.toString();
-      if (currentHash != previousHash) {
-        dirty.add(file);
-      }
-      currentAssetKeys[absolutePath] = currentHash;
-    } finally {
-      resource.release();
+  // 64k is the same sized buffer used by dart:io for `File.openRead`.
+  static final Uint8List _readBuffer = Uint8List(64 * 1024);
+
+  void _hashFile(File file, List<File> dirty) {
+    final String absolutePath = file.path;
+    final String previousHash = previousAssetKeys[absolutePath];
+    // If the file is missing it is assumed to be dirty.
+    if (!file.existsSync()) {
+      currentAssetKeys.remove(absolutePath);
+      previousAssetKeys.remove(absolutePath);
+      dirty.add(file);
+      return;
     }
+    final int fileBytes = file.lengthSync();
+    final Md5Hash hash = Md5Hash();
+    final RandomAccessFile openFile = file.openSync(mode: FileMode.read);
+    int bytes = 0;
+    while (bytes < fileBytes) {
+      final int bytesRead = openFile.readIntoSync(_readBuffer);
+      hash.addChunk(_readBuffer, bytesRead);
+      bytes += bytesRead;
+    }
+    openFile.closeSync();
+    final Digest digest = Digest(hash.finalize().buffer.asUint8List());
+    final String currentHash = digest.toString();
+    if (currentHash != previousHash) {
+      dirty.add(file);
+    }
+    currentAssetKeys[absolutePath] = currentHash;
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -229,8 +229,9 @@ class FileStore {
     }
     final int fileBytes = file.lengthSync();
     final Md5Hash hash = Md5Hash();
+    RandomAccessFile openFile;
     try {
-      final RandomAccessFile openFile = file.openSync(mode: FileMode.read);
+      openFile = file.openSync(mode: FileMode.read);
       int bytes = 0;
       while (bytes < fileBytes) {
         final int bytesRead = openFile.readIntoSync(_readBuffer);
@@ -238,7 +239,7 @@ class FileStore {
         bytes += bytesRead;
       }
     } finally {
-      openFile.closeSync();
+      openFile?.closeSync();
     }
     final Digest digest = Digest(hash.finalize().buffer.asUint8List());
     final String currentHash = digest.toString();

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -49,30 +49,29 @@ class Md5Hash {
   int _remainingLength;
   int _contentLength = 0;
 
-  void addChunk(Uint8List data, [int stop]) {
+  void addChunk(Uint8List data, [int end]) {
     assert(_remainingLength == null);
-    stop ??= data.length;
+    end ??= data.length;
     int i = 0;
-    for (; i <= stop - _kChunkSize; i += _kChunkSize) {
-      final Uint32List view = Uint32List.view(data.buffer, i, 16);
-      _writeChunk(view);
+    for (; i <= end - _kChunkSize; i += _kChunkSize) {
+      _writeChunk(data, i);
     }
-    if (i != stop) {
+    if (i != end) {
       // The data must be copied so that the provided buffer can be reused.
       int j = 0;
-      for (; i < stop; i += 1) {
+      for (; i < end; i += 1) {
         _scratchSpace[j] = data[i];
         j += 1;
       }
       _remainingLength = j;
     }
-    _contentLength += stop;
+    _contentLength += end;
   }
 
-  void _writeChunk(Uint32List chunk) {
+  void _writeChunk(Uint8List chunk, int start) {
     // help dart remove bounds checks
     // ignore: unnecessary_statements
-    chunk[15];
+    chunk[63];
     // ignore: unnecessary_statements
     _shiftAmounts[63];
     // ignore: unnecessary_statements
@@ -87,49 +86,53 @@ class Md5Hash {
     int i = 0;
     for (; i < 16; i += 1) {
       e = (b & c) | ((~b & _mask32) & d);
-      f = i;
+      f = i * 4 + start;
       final int temp = d;
+      final int chunkValue = chunk[f+3] << 24 | chunk[f+2] << 16 | chunk[f+1] << 8 | chunk[f];
       d = c;
       c = b;
       b = _add32(
           b,
-          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunkValue)),
               _shiftAmounts[i]));
       a = temp;
     }
     for (; i < 32; i += 1) {
       e = (d & b) | ((~d & _mask32) & c);
-      f = ((5 * i) + 1) % 16;
+      f = ((((5 * i) + 1) % 16) * 4) + start;
       final int temp = d;
+      final int chunkValue = chunk[f+3] << 24 | chunk[f+2] << 16 | chunk[f+1] << 8 | chunk[f];
       d = c;
       c = b;
       b = _add32(
           b,
-          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunkValue)),
               _shiftAmounts[i]));
       a = temp;
     }
     for (; i < 48; i += 1) {
       e = b ^ c ^ d;
-      f = ((3 * i) + 5) % 16;
+      f = ((((3 * i) + 5) % 16) * 4) + start;
       final int temp = d;
+      final int chunkValue = chunk[f+3] << 24 | chunk[f+2] << 16 | chunk[f+1] << 8 | chunk[f];
       d = c;
       c = b;
       b = _add32(
           b,
-          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunkValue)),
               _shiftAmounts[i]));
       a = temp;
     }
     for (; i < 64; i+= 1) {
       e = c ^ (b | (~d & _mask32));
-      f = (7 * i) % 16;
+      f = (((7 * i) % 16) * 4) + start;
       final int temp = d;
+      final int chunkValue = chunk[f+3] << 24 | chunk[f+2] << 16 | chunk[f+1] << 8 | chunk[f];
       d = c;
       c = b;
       b = _add32(
           b,
-          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunkValue)),
               _shiftAmounts[i]));
       a = temp;
     }
@@ -154,7 +157,7 @@ class Md5Hash {
     }
     final int bitLength = _contentLength * 8;
     _scratchSpace.buffer.asByteData().setUint64(56, bitLength, Endian.little);
-    _writeChunk(Uint32List.view(_scratchSpace.buffer, 0, 16));
+    _writeChunk(_scratchSpace, 0);
     return _digest;
   }
 

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -1,0 +1,172 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+/// Data from a non-linear mathematical function that functions as
+/// reproducible noise.
+final Uint32List _noise = Uint32List.fromList(<int>[
+  0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a,
+  0xa8304613, 0xfd469501, 0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+  0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821, 0xf61e2562, 0xc040b340,
+  0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+  0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8,
+  0x676f02d9, 0x8d2a4c8a, 0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+  0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70, 0x289b7ec6, 0xeaa127fa,
+  0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+  0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92,
+  0xffeff47d, 0x85845dd1, 0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+  0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391
+]);
+
+/// Per-round shift amounts.
+const List<int> _shiftAmounts = <int>[
+  07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 07, 12, 17, 22, 05, 09, 14,
+  20, 05, 09, 14, 20, 05, 09, 14, 20, 05, 09, 14, 20, 04, 11, 16, 23, 04, 11,
+  16, 23, 04, 11, 16, 23, 04, 11, 16, 23, 06, 10, 15, 21, 06, 10, 15, 21, 06,
+  10, 15, 21, 06, 10, 15, 21
+];
+
+/// A bitmask that limits an integer to 32 bits.
+const int _mask32 = 0xFFFFFFFF;
+
+/// An incremental hash computation that approximates md5.
+///
+/// The byte finalization required for a true md5 is not implemented so the
+/// computations will not match up with other md5 packages.
+class Md5Hash {
+  Md5Hash() {
+    _digest[0] = 0x67452301;
+    _digest[1] = 0xefcdab89;
+    _digest[2] = 0x98badcfe;
+    _digest[3] = 0x10325476;
+  }
+
+  /// The current hash digest.
+  final Uint32List _digest = Uint32List(4);
+  static final Uint8List _scratchSpace = Uint8List(512);
+  static const int _signatureBytes = 8;
+  int _remainingLength;
+  int _contentLength = 0;
+
+  void addChunk(Uint8List data, [int stop]) {
+    assert(_remainingLength == null);
+    stop ??= data.length;
+    int i = 0;
+    for (; i < stop; i += 512) {
+      final Uint32List view = Uint32List.view(data.buffer, i, 16);
+      _writeChunk(view);
+    }
+    if (i != stop) {
+      i -= 512;
+      // The data must be copied so that the provided buffer can be reused.
+      int j = 0;
+      for (; i < stop; i += 1) {
+        _scratchSpace[j] = data[i];
+        j += 1;
+      }
+      _remainingLength = j;
+    }
+    _contentLength += stop;
+  }
+
+  void _writeChunk(Uint32List chunk) {
+    int a = _digest[0];
+    int b = _digest[1];
+    int c = _digest[2];
+    int d = _digest[3];
+    int e = 0;
+    int f = 0;
+    int i = 0;
+    for (; i < 16; i += 1) {
+      e = (b & c) | ((~b & _mask32) & d);
+      f = i;
+      final int temp = d;
+      d = c;
+      c = b;
+      b = _add32(
+          b,
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+              _shiftAmounts[i]));
+      a = temp;
+    }
+    for (; i < 32; i += 1) {
+      e = (d & b) | ((~d & _mask32) & c);
+      f = ((5 * i) + 1) % 16;
+      final int temp = d;
+      d = c;
+      c = b;
+      b = _add32(
+          b,
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+              _shiftAmounts[i]));
+      a = temp;
+    }
+    for (; i < 48; i += 1) {
+      e = b ^ c ^ d;
+      f = ((3 * i) + 5) % 16;
+      final int temp = d;
+      d = c;
+      c = b;
+      b = _add32(
+          b,
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+              _shiftAmounts[i]));
+      a = temp;
+    }
+    for (; i < 64; i+= 1) {
+      e = c ^ (b | (~d & _mask32));
+      f = (7 * i) % 16;
+      final int temp = d;
+      d = c;
+      c = b;
+      b = _add32(
+          b,
+          _rotl32(_add32(_add32(a, e), _add32(_noise[i], chunk[f])),
+              _shiftAmounts[i]));
+      a = temp;
+    }
+
+    _digest[0] += a;
+    _digest[1] += b;
+    _digest[2] += c;
+    _digest[3] += d;
+  }
+
+  Uint32List finalize() {
+    _remainingLength ??= 0;
+    // Pad out the data with 0x80, eight or sixteen 0s, and as many more 0s
+    // as we need to land cleanly on a chunk boundary. This zero should always
+    // be safe to write as _scratchSpace will only be written if there are 15
+    // elements remaining.
+    _scratchSpace[_remainingLength] = 0x80;
+    _remainingLength += 1;
+
+    final int contentsLength = _contentLength + 1 + _signatureBytes;
+    int zeroesRemaining = _roundUp(contentsLength, _remainingLength) - contentsLength;
+    while (zeroesRemaining > 0) {
+      for (int i = _remainingLength; i < 16; i += 1, zeroesRemaining -= 1) {
+        _scratchSpace[i] = 0;
+      }
+      final Uint32List view = Uint32List.view(_scratchSpace.buffer, 0, 16);
+      _writeChunk(view);
+      _remainingLength = 0;
+    }
+    return _digest;
+  }
+
+  /// Rounds [val] up to the next multiple of [n], as long as [n] is a power of
+  /// two.
+  int _roundUp(int val, int n) => (val + n - 1) & -n;
+
+  /// Adds [x] and [y] with 32-bit overflow semantics.
+  int _add32(int x, int y) => (x + y) & _mask32;
+
+  /// Bitwise rotates [val] to the left by [shift], obeying 32-bit overflow
+  /// semantics.
+  int _rotl32(int val, int shift) {
+    final int modShift = shift & 31;
+    return ((val << modShift) & _mask32) | ((val & _mask32) >> (32 - modShift));
+  }
+}

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -54,12 +54,11 @@ class Md5Hash {
     assert(_remainingLength == null);
     stop ??= data.length;
     int i = 0;
-    for (; i < stop; i += 512) {
+    for (; i <= stop - 512; i += 512) {
       final Uint32List view = Uint32List.view(data.buffer, i, 16);
       _writeChunk(view);
     }
     if (i != stop) {
-      i -= 512;
       // The data must be copied so that the provided buffer can be reused.
       int j = 0;
       for (; i < stop; i += 1) {

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -45,7 +45,7 @@ class Md5Hash {
 
   /// The current hash digest.
   final Uint32List _digest = Uint32List(4);
-  static final Uint8List _scratchSpace = Uint8List(512);
+  final Uint8List _scratchSpace = Uint8List(512);
   static const int _signatureBytes = 8;
   int _remainingLength;
   int _contentLength = 0;

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -71,8 +71,13 @@ class Md5Hash {
 
   void _writeChunk(Uint32List chunk) {
     // help dart remove bounds checks
-   // ignore: unnecessary_statements
+    // ignore: unnecessary_statements
     chunk[15];
+    // ignore: unnecessary_statements
+    _shiftAmounts[63];
+    // ignore: unnecessary_statements
+    _noise[63];
+
     int d = _digest[3];
     int c = _digest[2];
     int b = _digest[1];

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -4,8 +4,6 @@
 
 import 'dart:typed_data';
 
-import 'package:crypto/crypto.dart';
-
 /// Data from a non-linear mathematical function that functions as
 /// reproducible noise.
 final Uint32List _noise = Uint32List.fromList(<int>[
@@ -33,10 +31,7 @@ const List<int> _shiftAmounts = <int>[
 /// A bitmask that limits an integer to 32 bits.
 const int _mask32 = 0xFFFFFFFF;
 
-/// An incremental hash computation that approximates md5.
-///
-/// The byte finalization required for a true md5 is not implemented so the
-/// computations will not match up with other md5 packages.
+/// An incremental hash computation of md5.
 class Md5Hash {
   Md5Hash() {
     _digest[0] = 0x67452301;
@@ -141,6 +136,9 @@ class Md5Hash {
   }
 
   Uint32List finalize() {
+    // help dart remove bounds checks
+    // ignore: unnecessary_statements
+    _scratchSpace[63];
     _remainingLength ??= 0;
     _scratchSpace[_remainingLength] = 0x80;
     _remainingLength += 1;
@@ -150,8 +148,7 @@ class Md5Hash {
       _scratchSpace[i] = 0;
     }
     final int bitLength = _contentLength * 8;
-    _scratchSpace.buffer.asByteData().setUint64(56, bitLength);
-
+    _scratchSpace.buffer.asByteData().setUint64(56, bitLength, Endian.little);
     _writeChunk(Uint32List.view(_scratchSpace.buffer, 0, 16));
     return _digest;
   }

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -46,11 +46,11 @@ class Md5Hash {
   /// The current hash digest.
   final Uint32List _digest = Uint32List(4);
   final Uint8List _scratchSpace = Uint8List(_kChunkSize);
-  int _remainingLength;
+  int _remainingLength = 0;
   int _contentLength = 0;
 
   void addChunk(Uint8List data, [int stop]) {
-    assert(_remainingLength == null);
+    assert(_remainingLength == 0);
     stop ??= data.length;
     int i = 0;
     for (; i <= stop - _kChunkSize; i += _kChunkSize) {
@@ -144,7 +144,6 @@ class Md5Hash {
     // help dart remove bounds checks
     // ignore: unnecessary_statements
     _scratchSpace[63];
-    _remainingLength ??= 0;
     _scratchSpace[_remainingLength] = 0x80;
     _remainingLength += 1;
 

--- a/packages/flutter_tools/lib/src/build_system/hash.dart
+++ b/packages/flutter_tools/lib/src/build_system/hash.dart
@@ -71,10 +71,13 @@ class Md5Hash {
   }
 
   void _writeChunk(Uint32List chunk) {
-    int a = _digest[0];
-    int b = _digest[1];
-    int c = _digest[2];
+    // help dart remove bounds checks
+   // ignore: unnecessary_statements
+    chunk[15];
     int d = _digest[3];
+    int c = _digest[2];
+    int b = _digest[1];
+    int a = _digest[0];
     int e = 0;
     int f = 0;
     int i = 0;

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -45,13 +45,13 @@ void main() {
     final File file = fileSystem.file('test')..createSync();
 
     // Initial run does not contain any timestamps for file.
-    expect(await fileCache.diffFileList(<File>[file]), hasLength(1));
+    expect(fileCache.diffFileList(<File>[file]), hasLength(1));
 
     // Swap current timestamps to previous timestamps.
     fileCache.persistIncremental();
 
     // timestamp matches previous timestamp.
-    expect(await fileCache.diffFileList(<File>[file]), isEmpty);
+    expect(fileCache.diffFileList(<File>[file]), isEmpty);
 
     // clear current timestamp list.
     fileCache.persistIncremental();
@@ -60,7 +60,7 @@ void main() {
     file.writeAsStringSync('foo');
 
     // verify the file is marked as dirty again.
-    expect(await fileCache.diffFileList(<File>[file]), hasLength(1));
+    expect(fileCache.diffFileList(<File>[file]), hasLength(1));
   });
 
   testWithoutContext('FileStore saves and restores to file cache', () async {
@@ -75,7 +75,7 @@ void main() {
       ..writeAsStringSync('hello');
 
     fileCache.initialize();
-    await fileCache.diffFileList(<File>[file]);
+    fileCache.diffFileList(<File>[file]);
     fileCache.persist();
     final String currentHash =  fileCache.currentAssetKeys[file.path];
     final Uint8List buffer = cacheFile
@@ -119,7 +119,7 @@ void main() {
 
     cacheFile.parent.deleteSync(recursive: true);
 
-    await fileCache.diffFileList(<File>[file]);
+    fileCache.diffFileList(<File>[file]);
 
     expect(fileCache.persist, returnsNormally);
   });
@@ -133,7 +133,7 @@ void main() {
     );
     fileCache.initialize();
 
-    final List<File> results = await fileCache.diffFileList(<File>[fileSystem.file('hello.dart')]);
+    final List<File> results = fileCache.diffFileList(<File>[fileSystem.file('hello.dart')]);
 
     expect(results, hasLength(1));
     expect(results.single.path, 'hello.dart');
@@ -183,7 +183,6 @@ void main() {
     final FileStore fileCache = FileStore(
       cacheFile: cacheFile,
       logger: BufferLogger.test(),
-      fileChunkThreshold: 1, // Chunk files larger than 1 byte.
     );
     final File file = fileSystem.file('foo.dart')
       ..createSync()
@@ -192,7 +191,7 @@ void main() {
 
     cacheFile.parent.deleteSync(recursive: true);
 
-    await fileCache.diffFileList(<File>[file]);
+    fileCache.diffFileList(<File>[file]);
 
     // Validate that chunked hash is the same as non-chunked.
     expect(fileCache.currentAssetKeys['foo.dart'],

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -39,6 +39,7 @@ void main() {
     final FileStore fileCache = FileStore(
       cacheFile: cacheFile,
       logger: BufferLogger.test(),
+      strategy: FileStoreStrategy.timestamp,
     );
     fileCache.initialize();
     final File file = fileSystem.file('test')..createSync();
@@ -56,7 +57,7 @@ void main() {
     fileCache.persistIncremental();
 
     // modify the time stamp.
-    file.writeAsStringSync('foo');
+    file.setLastModifiedSync(DateTime(1991));
 
     // verify the file is marked as dirty again.
     expect(fileCache.diffFileList(<File>[file]), hasLength(1));
@@ -192,7 +193,7 @@ void main() {
 
     fileCache.diffFileList(<File>[file]);
 
-    expect(fileCache.currentAssetKeys['foo.dart'], '7236aff9140ef993d67d93b4b10171f2');
+    expect(fileCache.currentAssetKeys['foo.dart'], '48948bcc9a00807df35a9b341ca384c2');
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -193,7 +193,7 @@ void main() {
 
     fileCache.diffFileList(<File>[file]);
 
-    expect(fileCache.currentAssetKeys['foo.dart'], '48948bcc9a00807df35a9b341ca384c2');
+    expect(fileCache.currentAssetKeys['foo.dart'], '5d41402abc4b2a76b9719d911017c592');
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:typed_data';
 
-import 'package:crypto/crypto.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -193,9 +192,7 @@ void main() {
 
     fileCache.diffFileList(<File>[file]);
 
-    // Validate that chunked hash is the same as non-chunked.
-    expect(fileCache.currentAssetKeys['foo.dart'],
-      md5.convert(file.readAsBytesSync()).toString());
+    expect(fileCache.currentAssetKeys['foo.dart'], '7236aff9140ef993d67d93b4b10171f2');
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/hash_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/hash_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:flutter_tools/src/build_system/hash.dart';
+
+import '../../src/common.dart';
+
+// The exact hash values are not important. Md5Hash is currently only a
+// partial implementation of the hash algorithm.
+void main() {
+  testWithoutContext('Can hash bytes less than 512 length', () {
+    final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6]);
+    final Md5Hash hashA = Md5Hash();
+    hashA.addChunk(bytes);
+
+    expect(hashA.finalize(), <int>[1612744810, 621056961, 47724712, 3970165526]);
+
+    final Md5Hash hashB = Md5Hash();
+    hashB.addChunk(bytes);
+
+    expect(hashB.finalize(), <int>[1612744810, 621056961, 47724712, 3970165526]);
+  });
+
+  testWithoutContext('Can hash bytes exactly 512 length', () {
+    final Uint8List bytes = Uint8List.fromList(List<int>.filled(512, 2));
+    final Md5Hash hashA = Md5Hash();
+    hashA.addChunk(bytes);
+
+    expect(hashA.finalize(), <int>[2835007686, 3619227869, 2508241819, 593340697]);
+
+    final Md5Hash hashB = Md5Hash();
+    hashB.addChunk(bytes);
+
+    expect(hashB.finalize(), <int>[2835007686, 3619227869, 2508241819, 593340697]);
+  });
+
+  testWithoutContext('Can hash bytes more than 512 length', () {
+    final Uint8List bytes = Uint8List.fromList(List<int>.filled(514, 2));
+    final Md5Hash hashA = Md5Hash();
+    hashA.addChunk(bytes);
+
+    expect(hashA.finalize(), <int>[1611508367, 2487599003, 3736490415, 1528151435]);
+
+    final Md5Hash hashB = Md5Hash();
+    hashB.addChunk(bytes);
+
+    expect(hashB.finalize(), <int>[1611508367, 2487599003, 3736490415, 1528151435]);
+  });
+}

--- a/packages/flutter_tools/test/general.shard/build_system/hash_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/hash_test.dart
@@ -2,51 +2,73 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:convert/convert.dart';
 import 'package:flutter_tools/src/build_system/hash.dart';
 
 import '../../src/common.dart';
 
-// The exact hash values are not important. Md5Hash is currently only a
-// partial implementation of the hash algorithm.
 void main() {
-  testWithoutContext('Can hash bytes less than 512 length', () {
+
+  // Examples taken from https://en.wikipedia.org/wiki/MD5
+  testWithoutContext('md5 control test zero length string', () {
+    final Md5Hash hash = Md5Hash();
+
+    expect(hex.encode(hash.finalize().buffer.asUint8List()), 'd41d8cd98f00b204e9800998ecf8427e');
+  });
+
+  testWithoutContext('md5 control test fox test', () {
+    final Md5Hash hash = Md5Hash();
+    hash.addChunk(ascii.encode('The quick brown fox jumps over the lazy dog'));
+
+    expect(hex.encode(hash.finalize().buffer.asUint8List()), '9e107d9d372bb6826bd81d3542a419d6');
+  });
+
+  testWithoutContext('md5 control test fox test with period', () {
+    final Md5Hash hash = Md5Hash();
+    hash.addChunk(ascii.encode('The quick brown fox jumps over the lazy dog.'));
+
+    expect(hex.encode(hash.finalize().buffer.asUint8List()), 'e4d909c290d0fb1ca068ffaddf22cbd0');
+  });
+
+  testWithoutContext('Can hash bytes less than 64 length', () {
     final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6]);
     final Md5Hash hashA = Md5Hash();
     hashA.addChunk(bytes);
 
-    expect(hashA.finalize(), <int>[1612744810, 621056961, 47724712, 3970165526]);
+    expect(hashA.finalize(), <int>[1810219370, 268668871, 3900423769, 1277973076]);
 
     final Md5Hash hashB = Md5Hash();
     hashB.addChunk(bytes);
 
-    expect(hashB.finalize(), <int>[1612744810, 621056961, 47724712, 3970165526]);
+    expect(hashB.finalize(), <int>[1810219370, 268668871, 3900423769, 1277973076]);
   });
 
-  testWithoutContext('Can hash bytes exactly 512 length', () {
-    final Uint8List bytes = Uint8List.fromList(List<int>.filled(512, 2));
+  testWithoutContext('Can hash bytes exactly 64 length', () {
+    final Uint8List bytes = Uint8List.fromList(List<int>.filled(64, 2));
     final Md5Hash hashA = Md5Hash();
     hashA.addChunk(bytes);
 
-    expect(hashA.finalize(), <int>[2835007686, 3619227869, 2508241819, 593340697]);
+    expect(hashA.finalize(), <int>[260592333, 2557619848, 2729912077, 812879060]);
 
     final Md5Hash hashB = Md5Hash();
     hashB.addChunk(bytes);
 
-    expect(hashB.finalize(), <int>[2835007686, 3619227869, 2508241819, 593340697]);
+    expect(hashB.finalize(), <int>[260592333, 2557619848, 2729912077, 812879060]);
   });
 
-  testWithoutContext('Can hash bytes more than 512 length', () {
+  testWithoutContext('Can hash bytes more than 64 length', () {
     final Uint8List bytes = Uint8List.fromList(List<int>.filled(514, 2));
     final Md5Hash hashA = Md5Hash();
     hashA.addChunk(bytes);
 
-    expect(hashA.finalize(), <int>[1611508367, 2487599003, 3736490415, 1528151435]);
+    expect(hashA.finalize(), <int>[387658779, 2003142991, 243395797, 1487291259]);
 
     final Md5Hash hashB = Md5Hash();
     hashB.addChunk(bytes);
 
-    expect(hashB.finalize(), <int>[1611508367, 2487599003, 3736490415, 1528151435]);
+    expect(hashB.finalize(), <int>[387658779, 2003142991, 243395797, 1487291259]);
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -894,8 +894,8 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
       listViews,
-      listViews,
       setAssetBundlePath,
+      listViews,
       FakeVmServiceRequest(
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{
@@ -948,6 +948,7 @@ void main() {
       appStartedCompleter: onAppStart,
       connectionInfoCompleter: onConnectionInfo,
     ));
+    await onAppStart.future;
 
     final OperationResult result = await residentRunner.restart(fullRestart: false);
     expect(result.fatal, false);
@@ -969,12 +970,12 @@ void main() {
         jsonResponse: fakeVM.toJson(),
       ),
       listViews,
+      setAssetBundlePath,
       listViews,
       FakeVmServiceRequest(
         method: 'getVM',
         jsonResponse: fakeVM.toJson(),
       ),
-      setAssetBundlePath,
       const FakeVmServiceRequest(
         method: 'reloadSources',
         args: <String, Object>{
@@ -1057,6 +1058,7 @@ void main() {
       connectionInfoCompleter: onConnectionInfo,
     ));
 
+    await onAppStart.future;
     final OperationResult result = await residentRunner.restart(fullRestart: false);
 
     expect(result.fatal, false);


### PR DESCRIPTION
## Description

Improvements:

* Reuse buffers as much as possible, only copying bytes when the file content does not end on a chunk boundary (no copying to custom buffer types or List<int>).
* No streams
* Remove branches from loop in hash computation

Correctly implements md5 and is about 30% faster than package:crypto. This translates to about 500-600 ms improvement on a noop windows build. Still a lot of room for improvement.

Work towards https://github.com/flutter/flutter/issues/55157