### PR TITLE
[integration_test] Add a setter for defaultTestTimeout

### DIFF
--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -326,6 +326,6 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// Override the default timeout for [testWidgets].
   ///
   /// See [TestWidgetsFlutterBinding.defaultTestTimeout] for more details.
-  set defaultTestTimeout(timeout) => _defaultTestTimeout = timeout;
+  set defaultTestTimeout(Timeout timeout) => _defaultTestTimeout = timeout;
   Timeout _defaultTestTimeout;
 }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -323,7 +323,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   @override
   Timeout get defaultTestTimeout => _defaultTestTimeout ?? super.defaultTestTimeout;
 
-  /// Override the default timeout for [testWidgets].
+  /// Configures the default timeout for [testWidgets].
   ///
   /// See [TestWidgetsFlutterBinding.defaultTestTimeout] for more details.
   set defaultTestTimeout(Timeout timeout) => _defaultTestTimeout = timeout;

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -319,4 +319,13 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     reportData ??= <String, dynamic>{};
     reportData[reportKey] = frameTimes.summary;
   }
+
+  @override
+  Timeout get defaultTestTimeout => _defaultTestTimeout ?? super.defaultTestTimeout;
+
+  /// Override the default timeout for [testWidgets].
+  ///
+  /// See [TestWidgetsFlutterBinding.defaultTestTimeout] for more details.
+  set defaultTestTimeout(timeout) => _defaultTestTimeout = timeout;
+  Timeout _defaultTestTimeout;
 }

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -87,6 +87,19 @@ Future<void> main() async {
         json.encode(_kTimelines),
       );
     });
+
+    group('defaultTestTimeout', () {
+      final originalTimeout = integrationBinding.defaultTestTimeout;
+      tearDown(() {
+        integrationBinding.defaultTestTimeout = originalTimeout;
+      });
+
+      test('can be configured', () {
+        final newTimeout = Timeout(Duration(seconds: 17));
+        integrationBinding.defaultTestTimeout = newTimeout;
+        expect(integrationBinding.defaultTestTimeout, newTimeout);
+      });
+    });
   });
 
   tearDownAll(() async {

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -89,13 +89,13 @@ Future<void> main() async {
     });
 
     group('defaultTestTimeout', () {
-      final originalTimeout = integrationBinding.defaultTestTimeout;
+      final Timeout originalTimeout = integrationBinding.defaultTestTimeout;
       tearDown(() {
         integrationBinding.defaultTestTimeout = originalTimeout;
       });
 
       test('can be configured', () {
-        final newTimeout = Timeout(Duration(seconds: 17));
+        const Timeout newTimeout = Timeout(Duration(seconds: 17));
         integrationBinding.defaultTestTimeout = newTimeout;
         expect(integrationBinding.defaultTestTimeout, newTimeout);
       });


### PR DESCRIPTION
## Description

Default test timeout is the per-test timeout used for `testWidgets`.

Currently we inherit this value from `LiveTestWidgetsFlutterBinding`, which sets this value to unlimited. This is because `LiveTestWidgetsFlutterBinding` was designed for debugging flutter test on a real device, where timeouts while debugging breakpoints are undesired.

Internally, we want to configure this to 30 seconds to match the defaults of package:test.

The code is a bit ugly because we can't call super in a initializer like `Timeout defaultTestTimeout = super.defaultTestTimeout`.

Another option would be to explicitly set this to 10 minutes to match the default of `AutomatedTestWidgetsFlutter` binding (or some other value).

## Tests

I added the following tests:

Test for the setter

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
