### PR TITLE
Ignore several import_of_legacy_library_into_null_safe

### DIFF
--- a/dev/benchmarks/metrics_center/lib/src/common.dart
+++ b/dev/benchmarks/metrics_center/lib/src/common.dart
@@ -5,8 +5,8 @@
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
-import 'package:equatable/equatable.dart';
+import 'package:crypto/crypto.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:equatable/equatable.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 /// Common format of a metric data point.
 class MetricPoint extends Equatable {


### PR DESCRIPTION
We want to enforce the migration order, and show when a legacy library is imported into a Null Safe library.
See https://dart-review.googlesource.com/c/sdk/+/170441

There are several violations in Flutter.

Continuation of https://github.com/flutter/flutter/pull/69904