### PR TITLE
Ignore import_of_legacy_library_into_null_safe

### DIFF
--- a/dev/benchmarks/metrics_center/lib/google_benchmark.dart
+++ b/dev/benchmarks/metrics_center/lib/google_benchmark.dart
@@ -9,7 +9,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:metrics_center/src/common.dart';
+import 'package:metrics_center/src/common.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 const String _kTimeUnitKey = 'time_unit';
 


### PR DESCRIPTION
We want to enforce the migration order, and show when a legacy library is imported into a Null Safe library.
See https://dart-review.googlesource.com/c/sdk/+/170441

There are several violations in Flutter.

Continuation of #69904 and https://github.com/flutter/flutter/pull/70107.