### PR TITLE
[flutter_tools] always run pub with prebuilt applications on drive

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -131,6 +131,11 @@ class DriveCommand extends RunCommandBase {
           'Dart VM running The test script.');
   }
 
+  // `pub` must always be run due to the test script running from source,
+  // even if an application binary is used.
+  @override
+  bool get shouldRunPub => true;
+
   FlutterDriverFactory _flutterDriverFactory;
   final FileSystem _fileSystem;
   final Logger _logger;


### PR DESCRIPTION
## Description

The run logic dictates that pub get should never run if an application binary is used. For drive, this will not work since we still need to get the packages for the test script.