### PR TITLE
Assert for RenderFlex intrinsics if using baseline alignment

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -512,6 +512,16 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     required double extent, // the extent in the direction that isn't the sizing direction
     required _ChildSizingFunction childSize, // a method to find the size in the sizing direction
   }) {
+    if (crossAxisAlignment == CrossAxisAlignment.baseline) {
+      // Intrinsics cannot be calculated without a full layout for
+      // baseline alignment. Throw an assertion and return 0.0 as documented
+      // on [RenderBox.computeMinIntrinsicWidth].
+      assert(
+        RenderObject.debugCheckingIntrinsics,
+        'Intrinsics are not available for CrossAxisAlignment.baseline.'
+      );
+      return 0.0;
+    }
     if (_direction == sizingDirection) {
       // INTRINSIC MAIN SIZE
       // Intrinsic main size is the smallest size the flex container can take

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -606,4 +606,30 @@ void main() {
     expect(box2.size, const Size(100.0, 100.0));
     expect(box3.size, const Size(100.0, 100.0));
   });
+
+  test('Intrinsics throw if alignment is baseline', () {
+    final RenderDecoratedBox box = RenderDecoratedBox(
+      decoration: const BoxDecoration(),
+    );
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      children: <RenderBox>[box],
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+    );
+    layout(flex, constraints: const BoxConstraints(
+      minWidth: 200.0, maxWidth: 200.0, minHeight: 200.0, maxHeight: 200.0,
+    ));
+
+    final Matcher cannotCalculateIntrinsics = throwsA(isAssertionError.having(
+      (AssertionError e) => e.message,
+      'message',
+      'Intrinsics are not available for CrossAxisAlignment.baseline.',
+    ));
+
+    expect(() => flex.getMaxIntrinsicHeight(100), cannotCalculateIntrinsics);
+    expect(() => flex.getMinIntrinsicHeight(100), cannotCalculateIntrinsics);
+    expect(() => flex.getMaxIntrinsicWidth(100), cannotCalculateIntrinsics);
+    expect(() => flex.getMinIntrinsicWidth(100), cannotCalculateIntrinsics);
+  });
 }


### PR DESCRIPTION
## Description

When `CrossAxisAlignment.baseline` is used in a `RenderFlex` we can't actually calculate any intrinsics sizes because baseline metrics are only available after layout (and the intrinsics are explicitly not doing a full layout). As documented for [computeMinIntrinsicWidth](https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html) under "When the intrinsic dimensions cannot be known", in these cases we should throw. Unfortunately, upto now that's not what we do. This PR implements the documented contract.

We do something similar for RenderParagraph in its [_canComputeIntrinsics](https://github.com/flutter/flutter/blob/e3bb51fa1f68cc4b88f02d0ce45bba6b166a4549/packages/flutter/lib/src/rendering/paragraph.dart#L370-L391) method.

## Related Issues

https://github.com/flutter/flutter/issues/65895

## Tests

I added the following tests:

* added a test for RenderFlex

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
