### PR TITLE
Fix for the ListTile horizontalTitleGap calculation introduced with PR #64222.

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1404,7 +1404,7 @@ class _RenderListTile extends RenderBox {
        _textDirection = textDirection,
        _titleBaselineType = titleBaselineType,
        _subtitleBaselineType = subtitleBaselineType,
-       _horizontalTitleGap = horizontalTitleGap + visualDensity.horizontal * 2.0,
+       _horizontalTitleGap = horizontalTitleGap,
        _minVerticalPadding = minVerticalPadding,
        _minLeadingWidth = minLeadingWidth;
 
@@ -1519,6 +1519,7 @@ class _RenderListTile extends RenderBox {
 
   double get horizontalTitleGap => _horizontalTitleGap;
   double _horizontalTitleGap;
+  double get _effectiveHorizontalTitleGap => _horizontalTitleGap + visualDensity.horizontal * 2.0;
 
   set horizontalTitleGap(double value) {
     assert(value != null);
@@ -1602,7 +1603,7 @@ class _RenderListTile extends RenderBox {
   @override
   double computeMinIntrinsicWidth(double height) {
     final double leadingWidth = leading != null
-      ? math.max(leading!.getMinIntrinsicWidth(height), _minLeadingWidth) + _horizontalTitleGap
+      ? math.max(leading!.getMinIntrinsicWidth(height), _minLeadingWidth) + _effectiveHorizontalTitleGap
       : 0.0;
     return leadingWidth
       + math.max(_minWidth(title, height), _minWidth(subtitle, height))
@@ -1612,7 +1613,7 @@ class _RenderListTile extends RenderBox {
   @override
   double computeMaxIntrinsicWidth(double height) {
     final double leadingWidth = leading != null
-      ? math.max(leading!.getMaxIntrinsicWidth(height), _minLeadingWidth) + _horizontalTitleGap
+      ? math.max(leading!.getMaxIntrinsicWidth(height), _minLeadingWidth) + _effectiveHorizontalTitleGap
       : 0.0;
     return leadingWidth
       + math.max(_maxWidth(title, height), _maxWidth(subtitle, height))
@@ -1708,10 +1709,10 @@ class _RenderListTile extends RenderBox {
     );
 
     final double titleStart = hasLeading
-      ? math.max(_minLeadingWidth, leadingSize.width) + _horizontalTitleGap
+      ? math.max(_minLeadingWidth, leadingSize.width) + _effectiveHorizontalTitleGap
       : 0.0;
     final double adjustedTrailingWidth = hasTrailing
-        ? math.max(trailingSize.width + _horizontalTitleGap, 32.0)
+        ? math.max(trailingSize.width + _effectiveHorizontalTitleGap, 32.0)
         : 0.0;
     final BoxConstraints textConstraints = looseConstraints.tighten(
       width: tileWidth - titleStart - adjustedTrailingWidth,

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1929,6 +1929,54 @@ void main() {
     expect(right('title'), 728.0);
   });
 
+  testWidgets('ListTile horizontalTitleGap with visualDensity', (WidgetTester tester) async {
+    Widget buildFrame({
+      double? horizontalTitleGap,
+      VisualDensity? visualDensity
+    }) {
+      return MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.zero,
+          textScaleFactor: 1.0,
+        ),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Container(
+              alignment: Alignment.topLeft,
+              child: ListTile(
+                visualDensity: visualDensity,
+                horizontalTitleGap: horizontalTitleGap,
+                leading: const Text('L'),
+                title: const Text('title'),
+                trailing: const Text('T'),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    double left(String text) => tester.getTopLeft(find.text(text)).dx;
+
+    await tester.pumpWidget(buildFrame(
+      horizontalTitleGap: 10.0,
+      visualDensity: const VisualDensity(horizontal: VisualDensity.minimumDensity),
+    ));
+    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 56.0));
+    expect(left('title'), 58.0);
+
+    // Pump another frame of the same widget to ensure the underlying render
+    // object did not cache the original horizontalTitleGap calculation based on the
+    // visualDensity
+    await tester.pumpWidget(buildFrame(
+      horizontalTitleGap: 10.0,
+      visualDensity: const VisualDensity(horizontal: VisualDensity.minimumDensity),
+    ));
+    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 56.0));
+    expect(left('title'), 58.0);
+  });
+
   testWidgets('ListTile minVerticalPadding = 80.0', (WidgetTester tester) async {
     Widget buildFrame(TextDirection textDirection, { double? themeMinVerticalPadding, double? widgetMinVerticalPadding }) {
       return MediaQuery(


### PR DESCRIPTION
## Description

There was a subtle bug introduced with #64222 that is addressed by the PR. The original `_horizontalTitleGap` getter on the `_RenderListTile` recalculated the gap based on the visual density every time it was accessed. With the changes in #64222, this is now a property and the calculation only took place on construction. On an update the value was not recalculated but used as is. This caused some internal layout tests to fail. Apologies for not catching this in the review.

## Tests

I added a new test that exercises the gap with visual density calculations across multiple frames so that the update mechanism is triggered.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
