### PR TITLE
AdoptAWidget: LongPressDraggable

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -358,6 +358,10 @@ class Draggable<T extends Object> extends StatefulWidget {
 }
 
 /// Makes its child draggable starting from long press.
+/// See also:
+///
+///  * [Draggable]
+///  * [DragTarget], a widget that receives data when the [LongPressDraggable] is dropped.
 class LongPressDraggable<T extends Object> extends Draggable<T> {
   /// Creates a widget that can be dragged starting from long press.
   ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -361,8 +361,8 @@ class Draggable<T extends Object> extends StatefulWidget {
 ///
 /// See also:
 ///
-///  * [Draggable]
-///  * [DragTarget], a widget that receives data when the [LongPressDraggable] is dragged.
+///  * [Draggable], similar to the [LongPressDraggable] widget but happens immediately.
+///  * [DragTarget], a widget that receives drags.
 class LongPressDraggable<T extends Object> extends Draggable<T> {
   /// Creates a widget that can be dragged starting from long press.
   ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -358,6 +358,7 @@ class Draggable<T extends Object> extends StatefulWidget {
 }
 
 /// Makes its child draggable starting from long press.
+///
 /// See also:
 ///
 ///  * [Draggable]

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -362,7 +362,7 @@ class Draggable<T extends Object> extends StatefulWidget {
 /// See also:
 ///
 ///  * [Draggable]
-///  * [DragTarget], a widget that receives data when the [LongPressDraggable] is dropped.
+///  * [DragTarget], a widget that receives data when the [LongPressDraggable] is dragged.
 class LongPressDraggable<T extends Object> extends Draggable<T> {
   /// Creates a widget that can be dragged starting from long press.
   ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -362,7 +362,7 @@ class Draggable<T extends Object> extends StatefulWidget {
 /// See also:
 ///
 ///  * [Draggable], similar to the [LongPressDraggable] widget but happens immediately.
-///  * [DragTarget], a widget that receives drags.
+///  * [DragTarget], a widget that receives data when Draggable widget is dropped.
 class LongPressDraggable<T extends Object> extends Draggable<T> {
   /// Creates a widget that can be dragged starting from long press.
   ///


### PR DESCRIPTION
AdoptAWidget: LongPressDraggable

<!-- Provide an explanation of the change -->
This change adds missing "See also" links to the LongPressDraggable widget.

<!-- Specify what this pull request does -->
This pull request is:

- [ ] A code sample
- [x] More references
- [ ] More explanation

<!-- Add the AdoptAWidget issue that is assigned to you: -->
closes #69473