### PR TITLE
Ignore DismissIntent when barrier is not dismissible

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -651,8 +651,12 @@ mixin LocalHistoryRoute<T> on Route<T> {
 
 class _DismissModalAction extends DismissAction {
   @override
-  Object invoke(DismissIntent intent) {
-    return Navigator.of(primaryFocus!.context!)!.maybePop();
+  Object? invoke(DismissIntent intent) {
+    final BuildContext context = primaryFocus!.context!;
+    final ModalRoute<dynamic> route = ModalRoute.of<dynamic>(context)!;
+    if (route.barrierDismissible) {
+      return Navigator.of(context)!.maybePop();
+    }
   }
 }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -650,13 +650,19 @@ mixin LocalHistoryRoute<T> on Route<T> {
 }
 
 class _DismissModalAction extends DismissAction {
+  _DismissModalAction(this.context);
+
+  final BuildContext context;
+
   @override
-  Object? invoke(DismissIntent intent) {
-    final BuildContext context = primaryFocus!.context!;
+  bool isEnabled(DismissIntent intent) {
     final ModalRoute<dynamic> route = ModalRoute.of<dynamic>(context)!;
-    if (route.barrierDismissible) {
-      return Navigator.of(context)!.maybePop();
-    }
+    return route.barrierDismissible;
+  }
+
+  @override
+  Object invoke(DismissIntent intent) {
+    return Navigator.of(context)!.maybePop();
   }
 }
 
@@ -771,10 +777,6 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
     setState(fn);
   }
 
-  static final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
-    DismissIntent: _DismissModalAction(),
-  };
-
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
@@ -794,33 +796,51 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
           offstage: widget.route.offstage, // _routeSetState is called if this updates
           child: PageStorage(
             bucket: widget.route._storageBucket, // immutable
-            child: Actions(
-              actions: _actionMap,
-              child: FocusScope(
-                node: focusScopeNode, // immutable
-                child: RepaintBoundary(
-                  child: AnimatedBuilder(
-                    animation: _listenable, // immutable
-                    builder: (BuildContext context, Widget? child) {
-                      return widget.route.buildTransitions(
-                        context,
-                        widget.route.animation!,
-                        widget.route.secondaryAnimation!,
-                        // This additional AnimatedBuilder is include because if the
-                        // value of the userGestureInProgressNotifier changes, it's
-                        // only necessary to rebuild the IgnorePointer widget and set
-                        // the focus node's ability to focus.
-                        AnimatedBuilder(
-                          animation: widget.route.navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
-                          builder: (BuildContext context, Widget? child) {
-                            final bool ignoreEvents = _shouldIgnoreFocusRequest;
-                            focusScopeNode.canRequestFocus = !ignoreEvents;
-                            return IgnorePointer(
-                              ignoring: ignoreEvents,
+            child: Builder(
+              builder: (BuildContext context) {
+                return Actions(
+                  actions: <Type, Action<Intent>>{
+                    DismissIntent: _DismissModalAction(context),
+                  },
+                  child: FocusScope(
+                    node: focusScopeNode, // immutable
+                    child: RepaintBoundary(
+                      child: AnimatedBuilder(
+                        animation: _listenable, // immutable
+                        builder: (BuildContext context, Widget? child) {
+                          return widget.route.buildTransitions(
+                            context,
+                            widget.route.animation!,
+                            widget.route.secondaryAnimation!,
+                            // This additional AnimatedBuilder is include because if the
+                            // value of the userGestureInProgressNotifier changes, it's
+                            // only necessary to rebuild the IgnorePointer widget and set
+                            // the focus node's ability to focus.
+                            AnimatedBuilder(
+                              animation: widget.route.navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
+                              builder: (BuildContext context, Widget? child) {
+                                final bool ignoreEvents = _shouldIgnoreFocusRequest;
+                                focusScopeNode.canRequestFocus = !ignoreEvents;
+                                return IgnorePointer(
+                                  ignoring: ignoreEvents,
+                                  child: child,
+                                );
+                              },
                               child: child,
-                            );
-                          },
-                          child: child,
+                            ),
+                          );
+                        },
+                        child: _page ??= RepaintBoundary(
+                          key: widget.route._subtreeKey, // immutable
+                          child: Builder(
+                            builder: (BuildContext context) {
+                              return widget.route.buildPage(
+                                context,
+                                widget.route.animation!,
+                                widget.route.secondaryAnimation!,
+                              );
+                            },
+                          ),
                         ),
                       );
                     },
@@ -837,8 +857,8 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                       ),
                     ),
                   ),
-                ),
-              ),
+                );
+              }
             ),
           ),
         ),

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -842,23 +842,11 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                             },
                           ),
                         ),
-                      );
-                    },
-                    child: _page ??= RepaintBoundary(
-                      key: widget.route._subtreeKey, // immutable
-                      child: Builder(
-                        builder: (BuildContext context) {
-                          return widget.route.buildPage(
-                            context,
-                            widget.route.animation!,
-                            widget.route.secondaryAnimation!,
-                          );
-                        },
                       ),
                     ),
                   ),
                 );
-              }
+              },
             ),
           ),
         ),

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -137,6 +137,7 @@ void main() {
       '     FocusScope\n'
       '     _ActionsMarker\n'
       '     Actions\n'
+      '     Builder\n'
       '     PageStorage\n'
       '     Offstage\n'
       '     _ModalScopeStatus\n'

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1641,6 +1641,29 @@ void main() {
     expect(find.text('dialog1'), findsNothing);
   });
 
+  testWidgets('can not be dismissed with escape keyboard shortcut if barrier not dismissible', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navigatorKey,
+      home: const Text('dummy1'),
+    ));
+    final Element textOnPageOne = tester.element(find.text('dummy1'));
+
+    // Show a simple dialog
+    showDialog<void>(
+      context: textOnPageOne,
+      barrierDismissible: false,
+      builder: (BuildContext context) => const Text('dialog1'),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('dialog1'), findsOneWidget);
+
+    // Try to dismiss the dialog with the shortcut key
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('dialog1'), findsOneWidget);
+  });
+
   testWidgets('ModalRoute.of works for void routes', (WidgetTester tester) async {
     final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
     await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Description

Currently, if a caller opens a modal dialog and sets `barrierDismissible` to false, the user can still dismiss the modal dialog by pressing the escape key on the keyboard, thus triggering a `DismissIntent`.

This change updates the action that handles the dismiss intent when a modal dialog is open such that it consults the `barrierDismissible` flag of the route and respects it.

## Tests

I added the following tests:

* A test that the esc key doesn't close a modal dialog when its `barrierDismissible` flag is set to false.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
