### PR TITLE
[flutter_tools] remove experiment tracking analytics for null safety

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -632,7 +632,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
         fullRestart: true,
         reason: reason,
         overallTimeInMs: timer.elapsed.inMilliseconds,
-        nullSafety: usageNullSafety,
         fastReassemble: null,
       ).send();
     }

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -39,7 +39,6 @@ class HotEvent extends UsageEvent {
     @required this.sdkName,
     @required this.emulator,
     @required this.fullRestart,
-    @required this.nullSafety,
     @required this.fastReassemble,
     this.reason,
     this.finalLibraryCount,
@@ -57,7 +56,6 @@ class HotEvent extends UsageEvent {
   final String sdkName;
   final bool emulator;
   final bool fullRestart;
-  final bool nullSafety;
   final bool fastReassemble;
   final int finalLibraryCount;
   final int syncedLibraryCount;
@@ -93,8 +91,6 @@ class HotEvent extends UsageEvent {
         CustomDimensions.hotEventTransferTimeInMs: transferTimeInMs.toString(),
       if (overallTimeInMs != null)
         CustomDimensions.hotEventOverallTimeInMs: overallTimeInMs.toString(),
-      if (nullSafety != null)
-        CustomDimensions.nullSafety: nullSafety.toString(),
       if (fastReassemble != null)
         CustomDimensions.fastReassemble: fastReassemble.toString(),
     });

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -783,11 +783,6 @@ abstract class ResidentRunner {
   Completer<int> _finished = Completer<int>();
   bool hotMode;
 
-  /// Whether the compiler was instructed to run with null-safety enabled.
-  @protected
-  bool get usageNullSafety => debuggingOptions?.buildInfo
-    ?.extraFrontEndOptions?.any((String option) => option.contains('non-nullable')) ?? false;
-
   /// Returns true if every device is streaming observatory URIs.
   bool get isWaitingForObservatory {
     return flutterDevices.every((FlutterDevice device) {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -699,7 +699,6 @@ class HotRunner extends ResidentRunner {
         sdkName: sdkName,
         emulator: emulator,
         fullRestart: true,
-        nullSafety: usageNullSafety,
         reason: reason,
         fastReassemble: null,
       ).send();
@@ -750,7 +749,6 @@ class HotRunner extends ResidentRunner {
           emulator: emulator,
           fullRestart: false,
           reason: reason,
-          nullSafety: usageNullSafety,
           fastReassemble: null,
         ).send();
       } else {
@@ -759,7 +757,6 @@ class HotRunner extends ResidentRunner {
           sdkName: sdkName,
           emulator: emulator,
           fullRestart: false,
-          nullSafety: usageNullSafety,
           reason: reason,
           fastReassemble: null,
         ).send();
@@ -961,7 +958,6 @@ class HotRunner extends ResidentRunner {
       syncedBytes: updatedDevFS.syncedBytes,
       invalidatedSourcesCount: updatedDevFS.invalidatedSourcesCount,
       transferTimeInMs: devFSTimer.elapsed.inMilliseconds,
-      nullSafety: usageNullSafety,
       fastReassemble: featureFlags.isSingleWidgetReloadEnabled
         ? updatedDevFS.fastReassembleClassName != null
         : null,
@@ -1024,7 +1020,6 @@ class HotRunner extends ResidentRunner {
         emulator: emulator,
         fullRestart: false,
         reason: reason,
-        nullSafety: usageNullSafety,
         fastReassemble: null,
       ).send();
       // Reset devFS lastCompileTime to ensure the file will still be marked

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1014,10 +1014,6 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  List<String> get _enabledExperiments => argParser.options.containsKey(FlutterOptions.kEnableExperiment)
-    ? stringsArg(FlutterOptions.kEnableExperiment)
-    : <String>[];
-
   /// Perform validation then call [runCommand] to execute the command.
   /// Return a [Future] that completes with an exit code
   /// indicating whether execution was successful.
@@ -1072,7 +1068,6 @@ abstract class FlutterCommand extends Command<void> {
         <CustomDimensions, Object>{
           ...?await usageValues,
           CustomDimensions.commandHasTerminal: globals.stdio.hasTerminal,
-          CustomDimensions.nullSafety: _enabledExperiments.contains('non-nullable'),
         };
       Usage.command(commandPath, parameters: additionalUsageValues);
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -376,7 +376,7 @@ void main() {
         );
         // Allow any CustomDimensions.localTime (cd33) timestamp.
         final RegExp usageRegexp = RegExp(
-          'screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd47: false, cd33: .*, viewName: run'
+          'screenView {cd3: false, cd4: ios, cd22: iOS 13, cd23: debug, cd18: false, cd15: swift, cd31: false, cd33: .*, viewName: run'
         );
         expect(buffer.toString(), matches(usageRegexp));
       }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -525,7 +525,6 @@ void main() {
       cdKey(CustomDimensions.hotEventSdkName): 'Example',
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'false',
-      cdKey(CustomDimensions.nullSafety): 'false',
     })).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
@@ -580,7 +579,6 @@ void main() {
       cdKey(CustomDimensions.hotEventSdkName): 'Example',
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'false',
-      cdKey(CustomDimensions.nullSafety): 'false',
     })).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
@@ -645,7 +643,6 @@ void main() {
       cdKey(CustomDimensions.hotEventSdkName): 'Example',
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'false',
-      cdKey(CustomDimensions.nullSafety): 'true',
     })).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
@@ -1398,7 +1395,6 @@ void main() {
       cdKey(CustomDimensions.hotEventSdkName): 'Example',
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'true',
-      cdKey(CustomDimensions.nullSafety): 'false',
     })).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -96,30 +96,6 @@ void main() {
       expect(flutterCommand.hidden, isTrue);
     });
 
-    testUsingContext('null-safety is surfaced in command usage analytics', () async {
-      final FakeNullSafeCommand fake = FakeNullSafeCommand();
-      final CommandRunner<void> commandRunner = createTestCommandRunner(fake);
-
-      await commandRunner.run(<String>['safety', '--enable-experiment=non-nullable']);
-
-      final VerificationResult resultA = verify(usage.sendCommand(
-        'safety',
-        parameters: captureAnyNamed('parameters'),
-      ));
-      expect(resultA.captured.first, containsPair('cd47', 'true'));
-      reset(usage);
-
-      await commandRunner.run(<String>['safety', '--enable-experiment=foo']);
-
-      final VerificationResult resultB = verify(usage.sendCommand(
-        'safety',
-        parameters: captureAnyNamed('parameters'),
-      ));
-      expect(resultB.captured.first, containsPair('cd47', 'false'));
-    }, overrides: <Type, Generator>{
-      Usage: () => usage,
-    });
-
     testUsingContext('uses the error handling file system', () async {
       final DummyFlutterCommand flutterCommand = DummyFlutterCommand(
         commandFunction: () async {


### PR DESCRIPTION
## Description

The experiment no longer tracks whether null safety is enabled, so remove the experiment specific code.
