### PR TITLE
[flutter_tools] dont use autodetect enum for web

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -124,7 +124,7 @@ class WebAssetServer implements AssetReader {
     this.internetAddress,
     this._modules,
     this._digests,
-    this._buildInfo,
+    this._nullSafetyMode,
   ) : basePath = _parseBasePathFromIndexHtml(globals.fs.currentDirectory
             .childDirectory('web')
             .childFile('index.html'));
@@ -169,7 +169,8 @@ class WebAssetServer implements AssetReader {
     BuildInfo buildInfo,
     bool enableDwds,
     Uri entrypoint,
-    ExpressionCompiler expressionCompiler, {
+    ExpressionCompiler expressionCompiler,
+    NullSafetyMode nullSafetyMode, {
     bool testMode = false,
     DwdsLauncher dwdsLauncher = Dwds.start,
   }) async {
@@ -209,7 +210,7 @@ class WebAssetServer implements AssetReader {
       address,
       modules,
       digests,
-      buildInfo,
+      nullSafetyMode,
     );
     if (testMode) {
       return server;
@@ -293,7 +294,7 @@ class WebAssetServer implements AssetReader {
     return server;
   }
 
-  final BuildInfo _buildInfo;
+  final NullSafetyMode _nullSafetyMode;
   final HttpServer _httpServer;
   // If holding these in memory is too much overhead, this can be switched to a
   // RandomAccessFile and read on demand.
@@ -672,12 +673,12 @@ class WebAssetServer implements AssetReader {
 
   File get _resolveDartSdkJsFile =>
       globals.fs.file(globals.artifacts.getArtifactPath(
-          _dartSdkJsArtifactMap[webRenderer][_buildInfo.nullSafetyMode]
+          _dartSdkJsArtifactMap[webRenderer][_nullSafetyMode]
       ));
 
   File get _resolveDartSdkJsMapFile =>
     globals.fs.file(globals.artifacts.getArtifactPath(
-        _dartSdkJsMapArtifactMap[webRenderer][_buildInfo.nullSafetyMode]
+        _dartSdkJsMapArtifactMap[webRenderer][_nullSafetyMode]
     ));
 
   @override
@@ -735,6 +736,7 @@ class WebDevFS implements DevFS {
     @required this.expressionCompiler,
     @required this.chromiumLauncher,
     @required this.nullAssertions,
+    @required this.nullSafetyMode,
     this.testMode = false,
   }) : _port = port;
 
@@ -751,6 +753,7 @@ class WebDevFS implements DevFS {
   final ChromiumLauncher chromiumLauncher;
   final bool nullAssertions;
   final int _port;
+  final NullSafetyMode nullSafetyMode;
 
   WebAssetServer webAssetServer;
 
@@ -823,6 +826,7 @@ class WebDevFS implements DevFS {
       enableDwds,
       entrypoint,
       expressionCompiler,
+      nullSafetyMode,
       testMode: testMode,
     );
     final int selectedPort = webAssetServer.selectedPort;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -508,6 +508,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           expressionCompiler: expressionCompiler,
           chromiumLauncher: _chromiumLauncher,
           nullAssertions: debuggingOptions.nullAssertions,
+          nullSafetyMode: device.nullSafetyMode,
         );
         final Uri url = await device.devFS.create();
         if (debuggingOptions.buildInfo.isDebug) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -48,6 +48,7 @@ class FlutterDevice {
     TargetPlatform targetPlatform,
     ResidentCompiler generator,
     this.userIdentifier,
+    this.nullSafetyMode = NullSafetyMode.autodetect,
   }) : assert(buildInfo.trackWidgetCreation != null),
        generator = generator ?? ResidentCompiler(
          globals.artifacts.getArtifactPath(
@@ -83,6 +84,7 @@ class FlutterDevice {
     String userIdentifier,
   }) async {
     ResidentCompiler generator;
+    NullSafetyMode nullSafetyMode = buildInfo.nullSafetyMode;
     final TargetPlatform targetPlatform = await device.targetPlatform;
     if (device.platformType == PlatformType.fuchsia) {
       targetModel = TargetModel.flutterRunner;
@@ -118,12 +120,14 @@ class FlutterDevice {
             ...?buildInfo.extraFrontEndOptions,
             '--sound-null-safety',
           ];
+          nullSafetyMode = NullSafetyMode.sound;
         } else {
           platformDillArtifact = Artifact.webPlatformKernelDill;
           extraFrontEndOptions =  <String>[
             ...?buildInfo.extraFrontEndOptions,
             '--no-sound-null-safety',
           ];
+          nullSafetyMode = NullSafetyMode.unsound;
         }
       }
 
@@ -198,6 +202,7 @@ class FlutterDevice {
       generator: generator,
       buildInfo: buildInfo,
       userIdentifier: userIdentifier,
+      nullSafetyMode: nullSafetyMode,
     );
   }
 
@@ -205,6 +210,7 @@ class FlutterDevice {
   final ResidentCompiler generator;
   final BuildInfo buildInfo;
   final String userIdentifier;
+  final NullSafetyMode nullSafetyMode;
 
   DevFSWriter devFSWriter;
   Stream<Uri> observatoryUris;

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -629,6 +629,7 @@ void main() {
       testMode: true,
       expressionCompiler: null,
       chromiumLauncher: null,
+      nullSafetyMode: NullSafetyMode.unsound,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -745,6 +746,7 @@ void main() {
       testMode: true,
       expressionCompiler: null,
       chromiumLauncher: null,
+      nullSafetyMode: NullSafetyMode.autodetect,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -853,6 +855,7 @@ void main() {
       expressionCompiler: null,
       chromiumLauncher: null,
       nullAssertions: true,
+      nullSafetyMode: NullSafetyMode.sound,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -903,6 +906,7 @@ void main() {
       testMode: true,
       expressionCompiler: null,
       chromiumLauncher: null,
+      nullSafetyMode: NullSafetyMode.sound,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -954,6 +958,7 @@ void main() {
       testMode: true,
       expressionCompiler: null,
       chromiumLauncher: null,
+      nullSafetyMode: NullSafetyMode.sound,
     );
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
@@ -980,6 +985,7 @@ void main() {
       ),
       false,
       Uri.base,
+      null,
       null,
       testMode: true);
 


### PR DESCRIPTION
## Description

Continuation of https://github.com/flutter/flutter/issues/70121

For web builds, the tool needs to determine whether sound null safety is enabled if autodetect is used. This update changes the determination to switch the autodetect mode on the device to the resolved version (sound/unsound) so the correct arguments are used.

The correct long term fix is to determine the null safety mode when computing the build info, but that involves a little more refactoring than I have time for now.