### PR TITLE
[flutter_tools] Display "no platforms" message based on results when creating plugins project

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -482,6 +482,7 @@ You example app code is in $relativeExampleMain.
     globals.printStatus('''
 Host platform code is in the $platformsString directories under $pluginPath.
 To edit platform code in an IDE see https://flutter.dev/developing-packages/#edit-plugin-package.
+
     ''');
   }
 }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -477,9 +477,13 @@ Your plugin code is in $relativePluginMain.
 
 You example app code is in $relativeExampleMain.
 
-Host platform code is in the $platformsString directories under $relativePluginMain.
-To edit platform code in an IDE see https://flutter.dev/developing-packages/#edit-plugin-package.
 ''');
+  if (platformsString != null && platformsString.isNotEmpty) {
+    globals.printStatus('''
+Host platform code is in the $platformsString directories under $pluginPath.
+To edit platform code in an IDE see https://flutter.dev/developing-packages/#edit-plugin-package.
+    ''');
+  }
 }
 
 void _printPluginUpdatePubspecMessage(String pluginPath, String platformsString) {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:yaml/yaml.dart';
-
 import '../android/gradle_utils.dart' as gradle;
 import '../base/common.dart';
 import '../base/context.dart';
@@ -17,7 +15,6 @@ import '../features.dart';
 import '../flutter_manifest.dart';
 import '../flutter_project_metadata.dart';
 import '../globals.dart' as globals;
-import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -489,8 +489,7 @@ void _printPluginUpdatePubspecMessage(String pluginPath, String platformsString)
   globals.printStatus('''
 
 You need to update $pluginPath/pubspec.yaml to support $platformsString.
-See the following for details:
-https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
+For more information, see https://flutter.dev/go/developing-plugins.
 
 ''', emphasis: true, color: TerminalColor.red);
 }
@@ -498,7 +497,5 @@ https://flutter.dev/docs/development/packages-and-plugins/developing-packages#pl
 const String _kNoPlatformsArgMessage = '''
 
 Must specify at least one platform using --platforms.
-See the following for details:
-https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
-
+For more information, see https://flutter.dev/go/developing-plugins.
 ''';

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -290,13 +290,13 @@ class CreateCommand extends CreateBase {
       ));
       globals.printStatus('Your module code is in $relativeMainPath.');
     } else if (generatePlugin) {
-      final List<String> platforms = _getSupportedPlatformsFromTemplateContext(templateContext);
-      final String platformsString = platforms.join(', ');
       final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
+      final List<String> platforms = _getUserRequestedPlatforms();
+      final String platformsString = platforms.join(', ');
       _printPluginDirectoryLocationMessage(relativePluginPath, projectName, platformsString);
       if (!creatingNewProject && argResults.wasParsed('platforms')) {
         _printPluginUpdatePubspecMessage(relativePluginPath, platformsString);
-      } else {
+      } else if (_getSupportedPlatformsInPlugin(projectDir).isEmpty){
         globals.printError(_kNoPlatformsArgMessage);
       }
     } else  {
@@ -449,6 +449,14 @@ Your $application code is in $relativeAppMain.
       if (templateContext['macos'] == true)
         'macos',
     ];
+  }
+
+  // Returns a list of platforms that are explicitly requested by user via `--platforms`.
+  List<String> _getUserRequestedPlatforms() {
+    if (!argResults.wasParsed('platforms')) {
+      return <String>[];
+    }
+    return stringsArg('platforms');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -291,10 +291,10 @@ class CreateCommand extends CreateBase {
       globals.printStatus('Your module code is in $relativeMainPath.');
     } else if (generatePlugin) {
       final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
-      final List<String> platforms = _getUserRequestedPlatforms();
-      final String platformsString = platforms.join(', ');
+      final List<String> requestedPlatforms = _getUserRequestedPlatforms();
+      final String platformsString = requestedPlatforms.join(', ');
       _printPluginDirectoryLocationMessage(relativePluginPath, projectName, platformsString);
-      if (!creatingNewProject && argResults.wasParsed('platforms')) {
+      if (!creatingNewProject && requestedPlatforms.isNotEmpty) {
         _printPluginUpdatePubspecMessage(relativePluginPath, platformsString);
       } else if (_getSupportedPlatformsInPlugin(projectDir).isEmpty){
         globals.printError(_kNoPlatformsArgMessage);

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -458,8 +458,8 @@ List<String> _getSupportedPlatformsInPlugin(Directory projectDir) {
   final String pubspecPath = globals.fs.path.join(projectDir.absolute.path, 'pubspec.yaml');
   final FlutterManifest manifest = FlutterManifest.createFromPath(pubspecPath, fileSystem: globals.fs, logger: globals.logger);
   final List<String> platforms = manifest.validSupportedPlatforms == null
-                                ? <String>[]
-                                : manifest.validSupportedPlatforms.keys.toList();
+    ? <String>[]
+    : manifest.validSupportedPlatforms.keys.toList();
   return platforms;
 }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -23,13 +23,6 @@ import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
 import 'create_base.dart';
 
-const String _kNoPlatformsErrorMessage = '''
-The plugin project was generated without specifying the `--platforms` flag, no new platforms are added.
-To add platforms, run `flutter create -t plugin --platforms <platforms> .` under the same
-directory. You can also find detailed instructions on how to add platforms in the `pubspec.yaml`
-at https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms.
-''';
-
 class CreateCommand extends CreateBase {
   CreateCommand() {
     addPlatformsOptions(customHelp: 'The platforms supported by this project. '

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -465,7 +465,7 @@ List<String> _getSupportedPlatformsInPlugin(Directory projectDir) {
 
 void _printPluginDirectoryLocationMessage(String pluginPath, String projectName, String platformsString) {
   final String relativePluginMain = globals.fs.path.join(pluginPath, 'lib', '$projectName.dart');
-final String relativeExampleMain = globals.fs.path.join(pluginPath, 'example', 'lib', 'main.dart');
+  final String relativeExampleMain = globals.fs.path.join(pluginPath, 'example', 'lib', 'main.dart');
   globals.printStatus('''
 
 Your plugin code is in $relativePluginMain.

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -275,7 +275,6 @@ class CreateCommand extends CreateBase {
     globals.printStatus('Wrote $generatedFileCount files.');
     globals.printStatus('\nAll done!');
     final String application = sampleCode != null ? 'sample application' : 'application';
-    final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
     if (generatePackage) {
       final String relativeMainPath = globals.fs.path.normalize(globals.fs.path.join(
         relativeDirPath,
@@ -293,6 +292,7 @@ class CreateCommand extends CreateBase {
     } else if (generatePlugin) {
       final List<String> platforms = _getSupportedPlatformsFromTemplateContext(templateContext);
       final String platformsString = platforms.join(', ');
+      final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
       _printPluginDirectoryLocationMessage(relativePluginPath, projectName, platformsString);
       if (!creatingNewProject && argResults.wasParsed('platforms')) {
         _printPluginUpdatePubspecMessage(relativePluginPath, platformsString);
@@ -489,7 +489,8 @@ https://flutter.dev/docs/development/packages-and-plugins/developing-packages#pl
 
 const String _kNoPlatformsArgMessage = '''
 
-Must specify at least one platform using --platforms. See the following for details:
+Must specify at least one platform using --platforms.
+See the following for details:
 https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
 
 ''';

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -12,6 +12,10 @@ import 'base/user_messages.dart';
 import 'base/utils.dart';
 import 'plugins.dart';
 
+const Set<String> _kValidPluginPlatforms = <String>{
+  'android', 'ios', 'web', 'windows', 'linux', 'macos'
+};
+
 /// A wrapper around the `flutter` section in the `pubspec.yaml` file.
 class FlutterManifest {
   FlutterManifest._(this._logger);
@@ -197,6 +201,20 @@ class FlutterManifest {
       }
     }
     return null;
+  }
+
+  /// Like [supportedPlatforms], but only returns the valid platforms that are supported in flutter plugins.
+  Map<String, dynamic> get validSupportedPlatforms {
+    final Map<String, dynamic> allPlatforms = supportedPlatforms;
+    if (allPlatforms == null) {
+      return null;
+    }
+    final Map<String, dynamic> platforms = <String, dynamic>{}..addAll(supportedPlatforms);
+    platforms.removeWhere((String key, dynamic _) => !_kValidPluginPlatforms.contains(key));
+    if (platforms.isEmpty) {
+      return null;
+    }
+    return platforms;
   }
 
   List<Map<String, dynamic>> get fontsDescriptor {

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -33,7 +33,7 @@ flutter:
     platforms:
 {{#no_platforms}}
     # This plugin project was generated without specifying any
-    # platforms with the `--platform` argument. If you see the `fake_platform` map below, remove it and
+    # platforms with the `--platform` argument. If you see the `some_platform` map below, remove it and
     # then add platforms following the instruction here:
     # https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms
     # -------------------

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -32,6 +32,7 @@ import '../../src/context.dart';
 import '../../src/pubspec_schema.dart';
 import '../../src/testbed.dart';
 
+const String _kNoPlatformsMessage = 'Must specify at least one platform using --platforms.';
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 // TODO(fujino): replace FakePlatform.fromPlatform() with FakePlatform()
@@ -389,8 +390,6 @@ void main() {
         'android/src/main/java/com/example/flutter_project/FlutterProjectPlugin.java',
         'example/android/app/src/main/java/com/example/flutter_project_example/MainActivity.java',
         'lib/flutter_project_web.dart',
-        // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
-        // https://github.com/flutter/flutter/issues/59787
       ],
     );
     return _runFlutterTest(projectDir.childDirectory('example'));
@@ -421,6 +420,7 @@ void main() {
     // The platform is correctly registered
     expect(pubspec.flutter['plugin']['platforms']['web']['pluginClass'], 'FlutterProjectWeb');
     expect(pubspec.flutter['plugin']['platforms']['web']['fileName'], 'flutter_project_web.dart');
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
     Pub: () => Pub(
@@ -731,6 +731,7 @@ void main() {
     expect(projectDir.childDirectory('windows'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -766,6 +767,7 @@ void main() {
         ],
         pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -793,6 +795,7 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('windows'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -825,6 +828,7 @@ void main() {
       'macos',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -851,6 +855,7 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -913,6 +918,7 @@ void main() {
       'windows'
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -940,6 +946,7 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('windows'), isNot(exists));
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
@@ -1651,8 +1658,6 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
 
-    // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
-    // https://github.com/flutter/flutter/issues/59787
     expect(projectDir.childDirectory('ios'), isNot(exists));
     expect(projectDir.childDirectory('android'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
@@ -1660,8 +1665,6 @@ void main() {
     expect(projectDir.childDirectory('windows'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
 
-    // TODO(cyanglaz): no-op iOS folder should be removed after 1.20.0 release
-    // https://github.com/flutter/flutter/issues/59787
     expect(projectDir.childDirectory('example').childDirectory('ios'),
         isNot(exists));
     expect(projectDir.childDirectory('example').childDirectory('android'),
@@ -1682,7 +1685,6 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
-
   testUsingContext('plugin supports ios if requested', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
@@ -1699,6 +1701,7 @@ void main() {
       'ios',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
@@ -1721,6 +1724,7 @@ void main() {
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform'],
     androidIdentifier: 'com.example.flutter_project');
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
@@ -1743,6 +1747,7 @@ void main() {
     unexpectedPlatforms: <String>['some_platform'],
     androidIdentifier: 'com.example.flutter_project',
     webFileName: 'flutter_project_web.dart');
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
   });
@@ -1763,6 +1768,7 @@ void main() {
       'some_platform'
     ], pluginClass: 'somePluginClass',
     unexpectedPlatforms: <String>['web']);
+    expect(testLogger.errorText, contains(_kNoPlatformsMessage));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
   });
@@ -2274,6 +2280,37 @@ void main() {
     expect(cmakeContents, contains('set(PLUGIN_NAME "foo_bar_plugin_plugin")'));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+  });
+
+  testUsingContext('created plugin supports no platforms should print `no platforms` message', () async {
+    Cache.flutterRoot = '../..';
+    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
+    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+    expect(testLogger.errorText, contains(_kNoPlatformsMessage));
+
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+  });
+
+  testUsingContext('created plugin with no --platforms flag should not print `no platforms` message if the existing plugin supports a platform.', () async {
+    Cache.flutterRoot = '../..';
+    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
+    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
+
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
+    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2102,7 +2102,7 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
     final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
-    expect(logger.statusText, isNot(contains('You need to update ${relativePluginPath}/pubspec.yaml to support android.\n')));
+    expect(logger.statusText, isNot(contains('You need to update $relativePluginPath/pubspec.yaml to support android.\n')));
   }, overrides: <Type, Generator> {
     Logger: () => logger,
   });
@@ -2117,9 +2117,9 @@ void main() {
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
     final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
-    expect(logger.statusText, isNot(contains('You need to update ${relativePluginPath}/pubspec.yaml to support ios.\n')));
+    expect(logger.statusText, isNot(contains('You need to update $relativePluginPath/pubspec.yaml to support ios.\n')));
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
-    expect(logger.statusText, contains('You need to update ${relativePluginPath}/pubspec.yaml to support android.\n'));
+    expect(logger.statusText, contains('You need to update $relativePluginPath/pubspec.yaml to support android.\n'));
   }, overrides: <Type, Generator> {
     Logger: () => logger,
   });

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -32,7 +32,7 @@ import '../../src/context.dart';
 import '../../src/pubspec_schema.dart';
 import '../../src/testbed.dart';
 
-const String _kNoPlatformsMessage = 'Must specify at least one platform using --platforms.';
+const String _kNoPlatformsMessage = 'Must specify at least one platform using --platforms.\n';
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 // TODO(fujino): replace FakePlatform.fromPlatform() with FakePlatform()
@@ -420,7 +420,7 @@ void main() {
     // The platform is correctly registered
     expect(pubspec.flutter['plugin']['platforms']['web']['pluginClass'], 'FlutterProjectWeb');
     expect(pubspec.flutter['plugin']['platforms']['web']['fileName'], 'flutter_project_web.dart');
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
     Pub: () => Pub(
@@ -431,6 +431,7 @@ void main() {
       botDetector: globals.botDetector,
       platform: globals.platform,
     ),
+    Logger: ()=>logger,
   });
 
   testUsingContext('plugin example app depends on plugin', () async {
@@ -660,7 +661,9 @@ void main() {
     // Import for the new embedding class.
     expect(mainActivity.contains('import io.flutter.embedding.android.FlutterActivity'), true);
 
-    expect(testLogger.statusText, isNot(contains('https://flutter.dev/go/android-project-migration')));
+    expect(logger.statusText, isNot(contains('https://flutter.dev/go/android-project-migration')));
+  }, overrides: <Type, Generator>{
+    Logger: () => logger,
   });
 
   testUsingContext('app does not include desktop or web by default', () async {
@@ -731,9 +734,10 @@ void main() {
     expect(projectDir.childDirectory('windows'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin supports Linux if requested', () async {
@@ -767,9 +771,10 @@ void main() {
         ],
         pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('app supports macOS if requested', () async {
@@ -795,9 +800,10 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('windows'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin supports macOS if requested', () async {
@@ -828,9 +834,10 @@ void main() {
       'macos',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('app supports Windows if requested', () async {
@@ -855,9 +862,10 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('web'), isNot(exists));
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('Windows has correct VERSIONINFO', () async {
@@ -918,9 +926,10 @@ void main() {
       'windows'
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('app supports web if requested', () async {
@@ -946,9 +955,10 @@ void main() {
     expect(projectDir.childDirectory('linux'), isNot(exists));
     expect(projectDir.childDirectory('macos'), isNot(exists));
     expect(projectDir.childDirectory('windows'), isNot(exists));
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin uses new platform schema', () async {
@@ -1701,9 +1711,10 @@ void main() {
       'ios',
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin supports android if requested', () async {
@@ -1724,9 +1735,10 @@ void main() {
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform'],
     androidIdentifier: 'com.example.flutter_project');
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin supports web if requested', () async {
@@ -1747,9 +1759,10 @@ void main() {
     unexpectedPlatforms: <String>['some_platform'],
     androidIdentifier: 'com.example.flutter_project',
     webFileName: 'flutter_project_web.dart');
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    Logger: () => logger,
   });
 
   testUsingContext('plugin doe not support web if feature is not enabled', () async {
@@ -1768,9 +1781,10 @@ void main() {
       'some_platform'
     ], pluginClass: 'somePluginClass',
     unexpectedPlatforms: <String>['web']);
-    expect(testLogger.errorText, contains(_kNoPlatformsMessage));
+    expect(logger.errorText, contains(_kNoPlatformsMessage));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
+    Logger: () => logger,
   });
 
   testUsingContext('create an empty plugin, then add ios', () async {
@@ -2086,7 +2100,9 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
-    expect(logger.statusText, isNot(contains('The `pubspec.yaml` under the project directory must be updated to support')));
+    final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
+    final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
+    expect(logger.statusText, isNot(contains('You need to update ${relativePluginPath}/pubspec.yaml to support android.\n')));
   }, overrides: <Type, Generator> {
     Logger: () => logger,
   });
@@ -2098,10 +2114,12 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
+    final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
+    final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
-    expect(logger.statusText, isNot(contains('The `pubspec.yaml` under the project directory must be updated to support')));
+    expect(logger.statusText, isNot(contains('You need to update ${relativePluginPath}/pubspec.yaml to support ios.\n')));
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
-    expect(logger.statusText, contains('The `pubspec.yaml` under the project directory must be updated to support'));
+    expect(logger.statusText, contains('You need to update ${relativePluginPath}/pubspec.yaml to support android.\n'));
   }, overrides: <Type, Generator> {
     Logger: () => logger,
   });
@@ -2291,10 +2309,11 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    expect(testLogger.errorText, contains(_kNoPlatformsMessage));
+    expect(logger.errorText, contains(_kNoPlatformsMessage));
 
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+    Logger: ()=> logger,
   });
 
   testUsingContext('created plugin with no --platforms flag should not print `no platforms` message if the existing plugin supports a platform.', () async {
@@ -2307,10 +2326,11 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    expect(testLogger.errorText, isNot(contains(_kNoPlatformsMessage)));
+    expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
 
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+    Logger: () => logger,
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -972,6 +972,49 @@ flutter:
     expect(flutterManifest.supportedPlatforms, null);
   });
 
+  testWithoutContext('FlutterManifest validSupportedPlatforms return null if the platform keys are not valid', () {
+    const String manifest = '''
+name: test
+flutter:
+  plugin:
+    platforms:
+      some_platform:
+        pluginClass: SomeClass
+''';
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest.isPlugin, true);
+    expect(flutterManifest.validSupportedPlatforms, null);
+  });
+
+  testWithoutContext('FlutterManifest validSupportedPlatforms only returns valid platforms', () {
+    const String manifest = '''
+name: test
+flutter:
+  plugin:
+    platforms:
+      some_platform:
+        pluginClass: SomeClass
+      ios:
+        pluginClass: SomeClass
+''';
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest.isPlugin, true);
+    expect(flutterManifest.validSupportedPlatforms['ios'],
+                              <String, dynamic>{'pluginClass': 'SomeClass'});
+    expect(flutterManifest.validSupportedPlatforms['some_platform'],
+                              isNull);
+  });
+
   testWithoutContext('FlutterManifest getSupportedPlatforms returns valid platforms.', () {
     const String manifest = '''
 name: test


### PR DESCRIPTION
## Description

1. This PR mainly focused displaying the "no platforms" message based on the plugin project's file structure.
It also moved the "no platforms" message to the very end of the log to make it more visible when executing `flutter create -t plugin .` The "no platforms" message was also edited to reflect the change.

2. While I'm here, I also moved the "update pubspec" message towards the end a bit, also edited the final message of creating plugins to encourage users to find the "update pubspec" message. (Although this could be improved to be more smart, but it requires more refactoring of the code so I left it there for now)

3. Cleaned up some stale TODO comments

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66058
Fixes https://github.com/flutter/flutter/issues/70492

## Tests

I added the following tests:

created plugin with no --platforms flag should not print `no platforms` message if the existing plugin supports a platform.
created plugin supports no platforms should print `no platforms` message

Also edited some existing test to also check for this message.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
