### PR TITLE
fixing platform channel errors

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -155,7 +155,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
 
   @override
   // ignore: unnecessary_non_null_assertion
-  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale!;
+  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale;
   ui.Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
   set localeTestValue(ui.Locale localeTestValue) {
@@ -170,7 +170,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
 
   @override
   // ignore: unnecessary_non_null_assertion
-  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales!;
+  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales;
   List<ui.Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.
   set localesTestValue(List<ui.Locale> localesTestValue) {

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -154,12 +154,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  ui.Locale? get locale {
-    if (_localeTestValue !=null) {
-      return _localeTestValue!;
-    }
-    return platformDispatcher.locale;
-  }
+  ui.Locale? get locale => _localeTestValue ?? platformDispatcher.locale;
 
   ui.Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
@@ -174,13 +169,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  List<ui.Locale>? get locales {
-    if (_localesTestValue !=null) {
-      return _localesTestValue!;
-    } else {
-      return platformDispatcher.locales;
-    }
-  }
+  List<ui.Locale>? get locales => _localesTestValue ?? platformDispatcher.locales;
 
   List<ui.Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -154,8 +154,13 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // ignore: unnecessary_non_null_assertion
-  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale;
+  ui.Locale? get locale {
+    if (_localeTestValue !=null) {
+      return _localeTestValue!;
+    }
+    return platformDispatcher.locale;
+  }
+
   ui.Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
   set localeTestValue(ui.Locale localeTestValue) {
@@ -169,8 +174,14 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // ignore: unnecessary_non_null_assertion
-  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales;
+  List<ui.Locale>? get locales {
+    if (_localesTestValue !=null) {
+      return _localesTestValue!;
+    } else {
+      return platformDispatcher.locales;
+    }
+  }
+
   List<ui.Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.
   set localesTestValue(List<ui.Locale> localesTestValue) {


### PR DESCRIPTION
## Description

The [PR](https://github.com/flutter/flutter/pull/69617) created an error for platform channels

```
../../../.dart_tool/flutter/packages/flutter_test/lib/src/window.dart:158:66: Warning: Operand of null-aware operation '!' has type 'Locale' which excludes null.
 - 'Locale' is from 'dart:ui'.                                          
  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale!;
                                                                 ^      
../../../.dart_tool/flutter/packages/flutter_test/lib/src/window.dart:173:74: Warning: Operand of null-aware operation '!' has type 'List<Locale>' which excludes null.
 - 'List' is from 'dart:core'.                                          
 - 'Locale' is from 'dart:ui'.                                          
  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales!;
```

Even though the tests were failing it wasn't recognized due to another issue on `flutter drive`:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8864078515260893920/+/steps/prepare_environment/0/steps/Web_e2e_tests/0/steps/web_e2e_test/0/stdout

## Tests

I added the following tests: test are there but not failing (https://ci.chromium.org/p/flutter/builders/try/Linux%20web_e2e_test/1646?), investigating...

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
