### PR TITLE
Fix Platform channel errors in web tests

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -154,8 +154,8 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // ignore: unnecessary_non_null_assertion
-  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale!;
+  // TODO(gspencergoog): remove the casts once https://github.com/flutter/engine/pull/22267 lands
+  ui.Locale get locale => _localeTestValue ?? ((platformDispatcher.locale as dynamic) as ui.Locale);
   ui.Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
   set localeTestValue(ui.Locale localeTestValue) {
@@ -169,8 +169,8 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // ignore: unnecessary_non_null_assertion
-  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales!;
+  // TODO(gspencergoog): remove the casts once https://github.com/flutter/engine/pull/22267 lands
+  List<ui.Locale> get locales => _localesTestValue ?? ((platformDispatcher.locales as dynamic) as List<ui.Locale>);
   List<ui.Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.
   set localesTestValue(List<ui.Locale> localesTestValue) {


### PR DESCRIPTION
## Description

This fixes problems in the web smoke tests because the warnings produced aren't from the analyzer, and so aren't ignored as I expected them to be.

This is a temporary fix until https://github.com/flutter/engine/pull/22267 lands to make the platform dispatcher and SingletonFlutterWindow (and Window) return non-nullable values for `locale` and `locales` in the same way that the web interface does.