### PR TITLE
mark catalina ios tasks as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -645,12 +645,14 @@ tasks:
       A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
+    flaky: true
 
   smoke_catalina_hot_mode_dev_cycle_ios__benchmark:
     description: >
       A some test that runs on macOS Catalina, which is a clone of the Dart VM hot patching performance benchmarking.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
+    flaky: true
 
   smoke_catalina_start_up:
     description: >


### PR DESCRIPTION
This is to open the tree, due to issue https://github.com/flutter/flutter/issues/70244