### PR TITLE
Append comma to iOS simulator launch args list

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -424,7 +424,7 @@ class IOSSimulator extends Device {
         if (debuggingOptions.skiaDeterministicRendering) '--skia-deterministic-rendering',
         if (debuggingOptions.useTestFonts) '--use-test-fonts',
         if (debuggingOptions.traceAllowlist != null) '--trace-allowlist="${debuggingOptions.traceAllowlist}"',
-        if (dartVmFlags.isNotEmpty) '--dart-flags=$dartVmFlags'
+        if (dartVmFlags.isNotEmpty) '--dart-flags=$dartVmFlags',
         '--observatory-port=${debuggingOptions.hostVmServicePort ?? 0}',
       ],
     ];

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/protocol_discovery.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -886,10 +887,12 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
   group('startApp', () {
     SimControl simControl;
     MockXcode mockXcode;
+    MockPrototcolDiscovery mockPrototcolDiscovery;
 
     setUp(() {
       simControl = MockSimControl();
       mockXcode = MockXcode();
+      mockPrototcolDiscovery = MockPrototcolDiscovery();
     });
 
     testUsingContext("startApp uses compiled app's Info.plist to find CFBundleIdentifier", () async {
@@ -901,15 +904,23 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         xcode: mockXcode,
       );
       when(globals.plistParser.getValueFromFile(any, any)).thenReturn('correct');
+      when(mockPrototcolDiscovery.uri)
+          .thenAnswer((_) async => Uri.parse('http://localhost:5678'));
 
       final Directory mockDir = globals.fs.currentDirectory;
       final IOSApp package = PrebuiltIOSApp(projectBundleId: 'incorrect', bundleName: 'name', bundleDir: mockDir);
 
       const BuildInfo mockInfo = BuildInfo(BuildMode.debug, 'flavor', treeShakeIcons: false);
-      final DebuggingOptions mockOptions = DebuggingOptions.disabled(mockInfo);
+      final DebuggingOptions mockOptions =
+          DebuggingOptions.enabled(mockInfo, hostVmServicePort: 8888);
       await device.startApp(package, prebuiltApplication: true, debuggingOptions: mockOptions);
 
-      verify(simControl.launch(any, 'correct', any));
+      verify(simControl.launch(any, 'correct', <String>[
+        '--enable-dart-profiling',
+        '--enable-checked-mode',
+        '--verify-entry-points',
+        '--observatory-port=8888',
+      ]));
     }, overrides: <Type, Generator>{
       PlistParser: () => MockPlistUtils(),
       FileSystem: () => fileSystem,
@@ -985,4 +996,5 @@ flutter:
   });
 }
 
+class MockPrototcolDiscovery extends Mock implements ProtocolDiscovery {}
 class MockBuildSystem extends Mock implements BuildSystem {}


### PR DESCRIPTION
## Description

Trailing comma is missing from #63416, which is in the 1.22 stable.  It was fixed in #65873 (1.23.0-3.0.pre), so no longer reproduces on beta.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69722

## Tests

simulators_test