### PR TITLE
[integration_test] Wrap pumped widgets with a RepaintBoundary

### DIFF
--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -328,4 +328,12 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// See [TestWidgetsFlutterBinding.defaultTestTimeout] for more details.
   set defaultTestTimeout(Timeout timeout) => _defaultTestTimeout = timeout;
   Timeout _defaultTestTimeout;
+
+  @override
+  void attachRootWidget(Widget rootWidget) {
+    // This is a workaround where screenshots of root widgets have incorrect
+    // bounds.
+    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
+    super.attachRootWidget(RepaintBoundary(child: rootWidget));
+  }
 }

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -100,6 +100,13 @@ Future<void> main() async {
         expect(integrationBinding.defaultTestTimeout, newTimeout);
       });
     });
+
+    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
+    testWidgets('root widgets are wrapped with a RepaintBoundary', (WidgetTester tester) async {
+      await tester.pumpWidget(const Placeholder());
+
+      expect(find.byType(RepaintBoundary), findsOneWidget);
+    });
   });
 
   tearDownAll(() async {


### PR DESCRIPTION

## Description

Workaround for https://github.com/flutter/flutter/issues/66006, where screenshots have incorrect bounds. Let me know if otherwise, but adding it here instead of `LiveTestWidgetsFlutterBinding` since taking screenshots doesn't seem like a common use case for that.

## Tests

I added the following tests:

Test that widgets are wrapped by the `RepaintBoundary`


## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
