### PR TITLE
Revert "Actually consume top padding in bottomsheet if scrollcontrolled"

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -472,7 +472,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     // By definition, the bottom sheet is aligned to the bottom of the page
     // and isn't exposed to the top padding of the MediaQuery.
-    Widget bottomSheet = MediaQuery.removePadding(
+    final Widget bottomSheet = MediaQuery.removePadding(
       context: context,
       removeTop: true,
       child: Builder(
@@ -490,11 +490,6 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
         },
       ),
     );
-    if (isScrollControlled)
-      bottomSheet = Padding(
-        padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
-        child: bottomSheet
-      );
     return capturedThemes.wrap(bottomSheet);
   }
 }
@@ -577,8 +572,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// a bottom sheet that will utilize [DraggableScrollableSheet]. If you wish
 /// to have a bottom sheet that has a scrollable child such as a [ListView] or
 /// a [GridView] and have the bottom sheet be draggable, you should set this
-/// parameter to true. When this parameter is set to true the top of [BottomSheet] will be padded
-/// such that it avoids any system top padding given by the [MediaQuery]
+/// parameter to true.
 ///
 /// The `useRootNavigator` parameter ensures that the root navigator is used to
 /// display the [BottomSheet] when set to `true`. This is useful in the case

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -425,7 +425,7 @@ void main() {
     expect(find.text('BottomSheet'), findsNothing);
   });
 
-  testWidgets('modal BottomSheet has no top MediaQuery when not scroll controlled', (WidgetTester tester) async {
+  testWidgets('modal BottomSheet has no top MediaQuery', (WidgetTester tester) async {
     late BuildContext outerContext;
     late BuildContext innerContext;
 
@@ -474,60 +474,6 @@ void main() {
       MediaQuery.of(innerContext).padding,
       const EdgeInsets.only(left: 50.0, right: 50.0, bottom: 50.0),
     );
-  });
-
-  testWidgets('modal BottomSheet consumes top MediaQuery when scroll controlled', (WidgetTester tester) async {
-    late BuildContext outerContext;
-    late BuildContext innerContext;
-    final Key containerKey = UniqueKey();
-
-    await tester.pumpWidget(Localizations(
-      locale: const Locale('en', 'US'),
-      delegates: const <LocalizationsDelegate<dynamic>>[
-        DefaultWidgetsLocalizations.delegate,
-        DefaultMaterialLocalizations.delegate,
-      ],
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(
-            padding: EdgeInsets.all(50.0),
-            size: Size(400.0, 600.0),
-          ),
-          child: Navigator(
-            onGenerateRoute: (_) {
-              return PageRouteBuilder<void>(
-                pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-                  outerContext = context;
-                  return Container();
-                },
-              );
-            },
-          ),
-        ),
-      ),
-    ));
-
-    showModalBottomSheet<void>(
-      context: outerContext,
-      isScrollControlled: true,
-      builder: (BuildContext context) {
-        innerContext = context;
-        return Container(key: containerKey);
-      },
-    );
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
-
-    expect(
-      MediaQuery.of(outerContext).padding,
-      const EdgeInsets.all(50.0),
-    );
-    expect(
-      MediaQuery.of(innerContext).padding,
-      const EdgeInsets.only(left: 50.0, right: 50.0, bottom: 50.0),
-    );
-    expect(tester.getTopLeft(find.byKey(containerKey)), const Offset(0.0, 50.0));
   });
 
   testWidgets('modal BottomSheet has semantics', (WidgetTester tester) async {


### PR DESCRIPTION
Reverts flutter/flutter#66257

FYI @Kavantix 
This was found to break some valid use cases in further google testing. We may have to come up with a different approach.