### PR TITLE
Set the mixWithOthers option in the Gallery video demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
@@ -360,11 +360,15 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
   final VideoPlayerController butterflyController = VideoPlayerController.asset(
     'videos/butterfly.mp4',
     package: 'flutter_gallery_assets',
+    videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
   );
 
   // TODO(sigurdm): This should not be stored here.
   static const String beeUri = 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
-  final VideoPlayerController beeController = VideoPlayerController.network(beeUri);
+  final VideoPlayerController beeController = VideoPlayerController.network(
+    beeUri,
+    videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
+  );
 
   final Completer<void> connectedCompleter = Completer<void>();
   bool isSupported = true;


### PR DESCRIPTION
This allows the two videos in the demo to play simultaneously
(matching the behavior from before the recent upgrade to the
video player plugin)
