### PR TITLE
Add -miphoneos-version-min=8.0 to App framework stub

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -406,6 +406,8 @@ Future<RunResult> createStubAppFramework(File outputFile, String sdkRoot,
       stubSource.path,
       '-dynamiclib',
       '-fembed-bitcode-marker',
+      // Keep version in sync with AOTSnapshotter flag
+      '-miphoneos-version-min=8.0',
       '-Xlinker', '-rpath', '-Xlinker', '@executable_path/Frameworks',
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -24,6 +24,7 @@ final Platform macPlatform = FakePlatform(operatingSystem: 'macos', environment:
 const List<String> _kSharedConfig = <String>[
   '-dynamiclib',
   '-fembed-bitcode-marker',
+  '-miphoneos-version-min=8.0',
   '-Xlinker',
   '-rpath',
   '-Xlinker',


### PR DESCRIPTION
## Description

Add `-miphoneos-version-min=8.0` when building the stub framework.

Before this change:
```
Load command 8
       cmd LC_BUILD_VERSION
   cmdsize 32
  platform 7
       sdk 14.2
     minos 14.2
    ntools 1
      tool 3
   version 609.7
```
After this change:
```
Load command 8
      cmd LC_VERSION_MIN_IPHONEOS
  cmdsize 16
  version 8.0
      sdk 14.2
```
## Related Issues

Fixes https://github.com/flutter/flutter/issues/52817
