### PR TITLE
[flutter_tools] Add bot configuration to run web_tool_tests for linux, mac, and windows

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -259,12 +259,6 @@
          "flaky": false
       },
       {
-         "name": "Mac web_tool_tests",
-         "repo": "flutter",
-         "task_name": "mac_web_tool_tests",
-         "flaky": true
-      },
-      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -115,6 +115,12 @@
          "flaky": false
       },
       {
+         "name": "Linux web_tool_tests",
+         "repo": "flutter",
+         "task_name": "linux_web_tool_tests",
+         "flaky": true
+      },
+      {
          "name": "Linux web_benchmarks_html",
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_html",
@@ -253,6 +259,12 @@
          "flaky": false
       },
       {
+         "name": "Mac web_tool_tests",
+         "repo": "flutter",
+         "task_name": "mac_web_tool_tests",
+         "flaky": true
+      },
+      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
@@ -329,6 +341,12 @@
          "repo": "flutter",
          "task_name": "win_tool_tests",
          "flaky": false
+      },
+      {
+         "name": "Windows web_tool_tests",
+         "repo": "flutter",
+         "task_name": "win_web_tool_tests",
+         "flaky": true
       }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -298,6 +298,13 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
+         "name":"Mac web_tool_tests",
+         "repo":"flutter",
+         "task_name":"mac_web_tool_tests",
+         "enabled":false,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
+      },
+      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
@@ -382,7 +389,7 @@
          "name": "Windows web_tool_tests",
          "repo": "flutter",
          "task_name": "win_web_tool_tests",
-         "enabled":true
+         "enabled":false
       }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -133,6 +133,13 @@
          "run_if":["dev/", "packages/flutter_tools/", "bin/"]
       },
       {
+         "name":"Linux web_tool_tests",
+         "repo":"flutter",
+         "task_name":"linux_web_tool_tests",
+         "enabled":true,
+         "run_if":["dev/", "packages/flutter_tools/", "bin/"]
+      },
+      {
          "name":"Linux web_benchmarks_html",
          "repo":"flutter",
          "task_name":"linux_web_benchmarks_html",
@@ -291,6 +298,13 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
+         "name":"Mac web_tool_tests",
+         "repo":"flutter",
+         "task_name":"mac_web_tool_tests",
+         "enabled":true,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
+      },
+      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
@@ -370,6 +384,12 @@
         "repo": "flutter",
         "task_name": "win_tool_tests",
         "enabled":true
-      }
+      },
+      {
+         "name": "Windows web_tool_tests",
+         "repo": "flutter",
+         "task_name": "win_web_tool_tests",
+         "enabled":true
+       }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -298,13 +298,6 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name":"Mac web_tool_tests",
-         "repo":"flutter",
-         "task_name":"mac_web_tool_tests",
-         "enabled":true,
-         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
-      },
-      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -383,6 +383,6 @@
          "repo": "flutter",
          "task_name": "win_web_tool_tests",
          "enabled":true
-       }
+      }
    ]
 }

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -536,10 +536,8 @@ class LocalEngineArtifacts implements Artifacts {
   @override
   String getArtifactPath(Artifact artifact, { TargetPlatform platform, BuildMode mode }) {
     platform ??= _currentHostPlatform(_platform);
-    final String artifactFileName =
-      (artifact == Artifact.flutterWebSdk || artifact == Artifact.flutterPatchedSdkPath)
-        ? null
-        : _artifactToFileName(artifact, platform, mode);
+    final bool isDirectoryArtifact = artifact == Artifact.flutterWebSdk || artifact == Artifact.flutterPatchedSdkPath;
+    final String artifactFileName = isDirectoryArtifact ? null : _artifactToFileName(artifact, platform, mode);
     switch (artifact) {
       case Artifact.genSnapshot:
         return _genSnapshotPath();

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -536,10 +536,10 @@ class LocalEngineArtifacts implements Artifacts {
   @override
   String getArtifactPath(Artifact artifact, { TargetPlatform platform, BuildMode mode }) {
     platform ??= _currentHostPlatform(_platform);
-    final String artifactFileName = 
-    (artifact == Artifact.flutterWebSdk || artifact == Artifact.flutterPatchedSdkPath)
-      ? null 
-      : _artifactToFileName(artifact, platform, mode);
+    final String artifactFileName =
+      (artifact == Artifact.flutterWebSdk || artifact == Artifact.flutterPatchedSdkPath)
+        ? null
+        : _artifactToFileName(artifact, platform, mode);
     switch (artifact) {
       case Artifact.genSnapshot:
         return _genSnapshotPath();

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -536,7 +536,10 @@ class LocalEngineArtifacts implements Artifacts {
   @override
   String getArtifactPath(Artifact artifact, { TargetPlatform platform, BuildMode mode }) {
     platform ??= _currentHostPlatform(_platform);
-    final String artifactFileName = _artifactToFileName(artifact, platform, mode);
+    final String artifactFileName = 
+    (artifact == Artifact.flutterWebSdk || artifact == Artifact.flutterPatchedSdkPath)
+      ? null 
+      : _artifactToFileName(artifact, platform, mode);
     switch (artifact) {
       case Artifact.genSnapshot:
         return _genSnapshotPath();

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -334,7 +334,7 @@ class StdoutLogger extends Logger {
   void writeToStdErr(String message) => _stdio.stderrWrite(message);
 
   @override
-  void printTrace(String message) { }// => _stdio.stdoutWrite('TRACE: $message');
+  void printTrace(String message) { }
 
   @override
   Status startProgress(

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -334,7 +334,7 @@ class StdoutLogger extends Logger {
   void writeToStdErr(String message) => _stdio.stderrWrite(message);
 
   @override
-  void printTrace(String message) { }
+  void printTrace(String message) { }// => _stdio.stdoutWrite('TRACE: $message');
 
   @override
   Status startProgress(


### PR DESCRIPTION
## Description

Add bot configuration to run web_tool_tests for linux and windows. 

## Related Issues

#69711
#69914

## Tests

The change is only in test and test configuration.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
