### PR TITLE
70341 Correct dateHelpText for en_AU localization

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -4692,6 +4692,9 @@ class MaterialLocalizationEnAu extends MaterialLocalizationEn {
   String get unspecifiedDateRange => 'Date range';
 
   @override
+  String get dateHelpText => 'dd/mm/yyyy';
+
+  @override
   String get licensesPageTitle => 'Licences';
 
   @override

--- a/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en_AU.arb
@@ -23,7 +23,7 @@
   "unspecifiedDateRange": "Date range",
   "unspecifiedDate": "Date",
   "selectYearSemanticsLabel": "Select year",
-  "dateHelpText": "mm/dd/yyyy",
+  "dateHelpText": "dd/mm/yyyy",
   "moreButtonTooltip": "More",
   "tabLabel": "Tab $tabIndex of $tabCount",
   "showAccountsLabel": "Show accounts",


### PR DESCRIPTION
## Description

This PR closes #70341 by fixing the en_AU localisation for dateHelpText.

Previously, dateHelpText returned `mm/dd/yyyy` which is incorrect for Australian dates, and also did not reflect DateFormat's [compact date for en_AU](https://github.com/dart-lang/intl/blob/master/lib/date_symbol_data_local.dart#L3558).

## Related Issues

* #70341 

## Tests

There doesn't seem to be any tests for changing localizations. I have followed the instructions [here](https://github.com/flutter/flutter/tree/master/packages/flutter_localizations#updating-an-existing-string).

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
