### PR TITLE
Add casts to widgets_test.dart to fix the engine roll.

### DIFF
--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -689,8 +689,11 @@ void main() {
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale1 = ui.window.locales!.first;
-          final Locale locale2 = ui.window.locales![1];
+          // TODO(gspencergood): remove the casts once
+          // https://github.com/flutter/engine/pull/22473 rolls into the
+          // framework.
+          final Locale locale1 = ((ui.window.locales as dynamic) as List<Locale>).first;
+          final Locale locale2 = ((ui.window.locales as dynamic) as List<Locale>)[1];
           return Text('$locale1 $locale2');
         },
       )


### PR DESCRIPTION
## Description

Because of the timing of landing some changes, this fixes the engine roll so that some changes to the return value of `window.locales` and `window.locale` won't break the engine roll (as in [this failure](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8863790826614422880/+/steps/prepare_environment/0/steps/Analyze/0/steps/analyze/0/stdout))