### PR TITLE
e2e perf tests don't have CPU/GPU/memory metrics

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -548,8 +548,8 @@ class PerfTest {
   const PerfTest.e2e(
     this.testDirectory,
     this.testTarget, {
-    this.measureCpuGpu = true,
-    this.measureMemory = true,
+    this.measureCpuGpu = false,
+    this.measureMemory = false,
     this.testDriver =  'test_driver/e2e_test.dart',
     this.needsFullTimeline = false,
     this.benchmarkScoreKeys = _kCommonScoreKeys,


### PR DESCRIPTION
Address comment in https://github.com/flutter/flutter/pull/66386/files#r522671103
