### PR TITLE
[devicelab] LUCI builder flag

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -31,7 +31,7 @@ String localEngine;
 String localEngineSrcPath;
 
 /// Name of the LUCI builder this test is currently running on.
-/// 
+///
 /// This is only passed on CI runs for Cocoon to be able to uniquely identify
 /// this test run.
 String luciBuilder;


### PR DESCRIPTION
## Description

Cocoon LUCI tasks names are based on the builder name, and not the devicelab test name. Instead, we need to upload the builder name when sending metrics to Cocoon.

## Related Issues

https://github.com/flutter/flutter/issues/66191

## Tests

I ran a local run with the `--luci-builder` flag.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*