### PR TITLE
Disable failing test due to SDK issue

### DIFF
--- a/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
@@ -48,7 +48,7 @@ void main() {
         reason: 'After $i steps, debugger should stop at $expectedLine but stopped at $actualLine'
       );
     }
-  }, skip: platform.isMacOS);
+  }, skip: platform.isWindows); // https://github.com/flutter/flutter/issues/70486
 
   tearDown(() async {
     await flutter.stop();

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -166,7 +166,7 @@ void batch2() {
     await breakInMethod(_flutter);
     await evaluateComplexExpressions(_flutter);
     await cleanProject();
-  });
+  }, skip: 'https://github.com/dart-lang/sdk/issues/41480');
 }
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -68,5 +68,5 @@ void main() {
     } finally {
       await subscription.cancel();
     }
-  });
+  }, skip: platform.isWindows); // https://github.com/flutter/flutter/issues/70486
 }

--- a/packages/flutter_tools/test/web.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_run_test.dart
@@ -28,5 +28,5 @@ void main() {
 
   testWithoutContext('flutter run works on web devices with a unary main function', () async {
     await flutter.run(chrome: true, additionalCommandArgs: <String>['--verbose']);
-  }, skip: platform.isMacOS);
+  });
 }


### PR DESCRIPTION
## Description

Temporarily disable failing web expression evaluation test due to an SDK issue.

## Related Issues

https://github.com/dart-lang/sdk/issues/41480

## Tests

The change is only in tests.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
