### PR TITLE
Remove some unnecessary casts, now that changes have rolled from the engine

### DIFF
--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -689,11 +689,8 @@ void main() {
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          // TODO(gspencergood): remove the casts once
-          // https://github.com/flutter/engine/pull/22473 rolls into the
-          // framework.
-          final Locale locale1 = ((ui.window.locales as dynamic) as List<Locale>).first;
-          final Locale locale2 = ((ui.window.locales as dynamic) as List<Locale>)[1];
+          final Locale locale1 = ui.window.locales.first;
+          final Locale locale2 = ui.window.locales[1];
           return Text('$locale1 $locale2');
         },
       )

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -154,8 +154,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // TODO(gspencergoog): remove the casts once https://github.com/flutter/engine/pull/22267 lands
-  ui.Locale get locale => _localeTestValue ?? ((platformDispatcher.locale as dynamic) as ui.Locale);
+  ui.Locale get locale => _localeTestValue ?? platformDispatcher.locale;
   ui.Locale? _localeTestValue;
   /// Hides the real locale and reports the given [localeTestValue] instead.
   set localeTestValue(ui.Locale localeTestValue) {
@@ -169,8 +168,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  // TODO(gspencergoog): remove the casts once https://github.com/flutter/engine/pull/22267 lands
-  List<ui.Locale> get locales => _localesTestValue ?? ((platformDispatcher.locales as dynamic) as List<ui.Locale>);
+  List<ui.Locale> get locales => _localesTestValue ?? platformDispatcher.locales;
   List<ui.Locale>? _localesTestValue;
   /// Hides the real locales and reports the given [localesTestValue] instead.
   set localesTestValue(List<ui.Locale> localesTestValue) {


### PR DESCRIPTION
## Description

Removes some temporary casts needed to migrate an API in the engine (Window.locales and Window.locale).

Now that https://github.com/flutter/engine/pull/22267 has rolled into the framework, they are no longer needed.
