### PR TITLE
Revert "[devicelab] LUCI builder flag"

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -30,12 +30,6 @@ String localEngine;
 /// The path to the engine "src/" directory.
 String localEngineSrcPath;
 
-/// Name of the LUCI builder this test is currently running on.
-///
-/// This is only passed on CI runs for Cocoon to be able to uniquely identify
-/// this test run.
-String luciBuilder;
-
 /// Whether to exit on first test failure.
 bool exitOnFirstTestFailure;
 
@@ -87,10 +81,9 @@ Future<void> main(List<String> rawArgs) async {
   }
 
   deviceId = args['device-id'] as String;
-  exitOnFirstTestFailure = args['exit'] as bool;
   localEngine = args['local-engine'] as String;
   localEngineSrcPath = args['local-engine-src-path'] as String;
-  luciBuilder = args['luci-builder'] as String;
+  exitOnFirstTestFailure = args['exit'] as bool;
   serviceAccountTokenFile = args['service-account-token-file'] as String;
   silent = args['silent'] as bool;
 
@@ -118,9 +111,7 @@ Future<void> _runTasks() async {
 
     if (serviceAccountTokenFile != null) {
       final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
-      /// Cocoon's definition of a task is more specific than [taskName], and to
-      /// upload we instead send the [luciBuilder] this is running on.
-      await cocoon.sendTaskResult(taskName: luciBuilder, result: result);
+      await cocoon.sendTaskResult(taskName: taskName, result: result);
     }
 
     if (!result.succeeded) {
@@ -346,10 +337,6 @@ final ArgParser _argParser = ArgParser()
     help: 'Path to your engine src directory, if you are building Flutter\n'
           'locally. Defaults to \$FLUTTER_ENGINE if set, or tries to guess at\n'
           'the location based on the value of the --flutter-root option.',
-  )
-  ..addOption(
-    'luci-builder',
-    help: '[Flutter infrastructure] Name of the LUCI builder being run on.'
   )
   ..addFlag(
     'match-host-platform',


### PR DESCRIPTION
Reverts flutter/flutter#70464

This isn't needed :-)

I confused how devicelab tasks worked. I was under the impression the tasks listed in devicelab/manifest.yaml were not unique, and Cocoon made them unique.

Instead, during migration there will be at most 2 possible entries for the given task. LUCI or Cocoon Agent. I'll update `/api/update-task-status` to pull the `chromebot` based task for updating when given the LUCI information.