### PR TITLE
[flutter_tools] remove unused/deprecated asset parameters

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -59,7 +59,6 @@ Future<void> run(List<String> args) async {
     manifestPath: argResults[_kOptionManifest] as String ?? defaultManifestPath,
     assetDirPath: assetDir,
     packagesPath: argResults[_kOptionPackages] as String,
-    includeDefaultFonts: false,
   );
 
   if (assets == null) {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -72,8 +72,6 @@ abstract class AssetBundle {
     String manifestPath = defaultManifestPath,
     String assetDirPath,
     @required String packagesPath,
-    bool includeDefaultFonts = true,
-    bool reportLicensedPackages = false,
   });
 }
 
@@ -162,8 +160,6 @@ class ManifestAssetBundle implements AssetBundle {
     String manifestPath = defaultManifestPath,
     String assetDirPath,
     @required String packagesPath,
-    bool includeDefaultFonts = true,
-    bool reportLicensedPackages = false,
   }) async {
     assetDirPath ??= getAssetBuildDirectory();
     FlutterProject flutterProject;
@@ -224,7 +220,6 @@ class ManifestAssetBundle implements AssetBundle {
     final bool includesMaterialFonts = flutterManifest.usesMaterialDesign;
     final List<Map<String, dynamic>> fonts = _parseFonts(
       flutterManifest,
-      includeDefaultFonts,
       packageConfig,
       primary: true,
     );
@@ -272,7 +267,6 @@ class ManifestAssetBundle implements AssetBundle {
         }
         fonts.addAll(_parseFonts(
           packageFlutterManifest,
-          includeDefaultFonts,
           packageConfig,
           packageName: package.name,
           primary: false,
@@ -309,7 +303,7 @@ class ManifestAssetBundle implements AssetBundle {
       }
     }
     final List<_Asset> materialAssets = <_Asset>[
-      if (flutterManifest.usesMaterialDesign && includeDefaultFonts)
+      if (flutterManifest.usesMaterialDesign)
         ..._getMaterialAssets(),
     ];
     for (final _Asset asset in materialAssets) {
@@ -381,13 +375,12 @@ class ManifestAssetBundle implements AssetBundle {
 
   List<Map<String, dynamic>> _parseFonts(
     FlutterManifest manifest,
-    bool includeDefaultFonts,
     PackageConfig packageConfig, {
     String packageName,
     @required bool primary,
   }) {
     return <Map<String, dynamic>>[
-      if (primary && manifest.usesMaterialDesign && includeDefaultFonts)
+      if (primary && manifest.usesMaterialDesign)
         ...kMaterialFonts,
       if (packageName == null)
         ...manifest.fontsDescriptor

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -191,8 +191,6 @@ Future<AssetBundle> buildAssets({
   String manifestPath,
   String assetDirPath,
   @required String packagesPath,
-  bool includeDefaultFonts = true,
-  bool reportLicensedPackages = false,
 }) async {
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= globals.fs.path.absolute(packagesPath);
@@ -203,8 +201,6 @@ Future<AssetBundle> buildAssets({
     manifestPath: manifestPath,
     assetDirPath: assetDirPath,
     packagesPath: packagesPath,
-    includeDefaultFonts: includeDefaultFonts,
-    reportLicensedPackages: reportLicensedPackages,
   );
   if (result != 0) {
     return null;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -123,7 +123,6 @@ Future<void> _buildAssets(
     manifestPath: fuchsiaProject.project.pubspecFile.path,
     packagesPath: fuchsiaProject.project.packagesFile.path,
     assetDirPath: assetDir,
-    includeDefaultFonts: false,
   );
 
   final Map<String, DevFSContent> assetEntries =

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -31,7 +31,6 @@ void main() {
       await asset.build(
         manifestPath : globals.fs.path.join(dataPath, 'main', 'pubspec.yaml'),
         packagesPath: globals.fs.path.join(dataPath, 'main', '.packages'),
-        includeDefaultFonts: false,
       );
 
       expect(asset.entries.containsKey('FontManifest.json'), isTrue);
@@ -55,7 +54,6 @@ void main() {
       await asset.build(
         manifestPath : globals.fs.path.join(dataPath, 'main', 'pubspec.yaml'), // file doesn't exist
         packagesPath: globals.fs.path.join(dataPath, 'main', '.packages'),
-        includeDefaultFonts: false,
       );
       expect(asset.wasBuiltOnce(), true);
     });


### PR DESCRIPTION
## Description

includeDefaultFonts is not necessary because applications can/should use `uses-material-design` to exclude the only default font.
reportLicensedPackages  was actually removed more than a year ago but the flag was not cleaned up due to g3 difficulties.