### PR TITLE
[flutter_tools] stop unit from writing real file

### DIFF
--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -57,7 +57,7 @@ void main() {
       Cache.flutterRoot = '../..';
       when(sdk.licensesAvailable).thenReturn(true);
       final FlutterProject project = FlutterProject.current();
-      globals.fs.file(project.android.hostAppGradleRoot.childFile(
+      fs.file(project.android.hostAppGradleRoot.childFile(
         globals.platform.isWindows ? 'gradlew.bat' : 'gradlew',
       ).path).createSync(recursive: true);
     });


### PR DESCRIPTION
## Description

This creates a real `android/gradle_wrapper.bat` file, which causes subsequent test runs to display a warning that the flutter tool is not on the current android embedding version.