### PR TITLE
Remove unused host_app_editable_cocoapods template files

### DIFF
--- a/packages/flutter_tools/templates/module/ios/host_app_editable_cocoapods/Config.tmpl/Flutter.xcconfig
+++ b/packages/flutter_tools/templates/module/ios/host_app_editable_cocoapods/Config.tmpl/Flutter.xcconfig
@@ -1,1 +1,0 @@
-#include "../../.ios/Flutter/Generated.xcconfig"

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -173,7 +173,6 @@
         "templates/module/common/pubspec.yaml.tmpl",
         "templates/module/common/README.md.tmpl",
         "templates/module/common/test/widget_test.dart.tmpl",
-        "templates/module/ios/host_app_editable_cocoapods/Config.tmpl/Flutter.xcconfig",
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Debug.xcconfig",
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Flutter.xcconfig",
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Release.xcconfig",


### PR DESCRIPTION
## Description

These template files are unused, `make-host-app-editable` is a deprecated no-op.

## Related Issues

Should have been removed with #61140.