### PR TITLE
Fixes TabController Listener call twice. (#69763)

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -218,7 +218,6 @@ class TabController extends ChangeNotifier {
     _index = value;
     if (duration != null) {
       _indexIsChangingCount += 1;
-      notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
         .animateTo(_index.toDouble(), duration: duration, curve: curve!)
         .whenCompleteOrCancel(() {


### PR DESCRIPTION
## Description

TabController addListener calls once then call twice when switching tab index, 

notifyListeners only when animate complete
[#69763](https://github.com/flutter/flutter/issues/69763) 