### PR TITLE
Increase timeouts on XCUITest existence checks

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -19,13 +19,13 @@
 
     [app.buttons[@"Full Screen (Cold)"] tap];
 
-    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
-    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
 }
 
 - (void)testFullScreenWarm {
@@ -34,13 +34,13 @@
 
     [app.buttons[@"Full Screen (Warm)"] tap];
 
-    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
-    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
 }
 
 - (void)testFlutterViewWarm {
@@ -49,13 +49,13 @@
 
     [app.buttons[@"Flutter View (Warm)"] tap];
 
-    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
-    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
 }
 
 - (void)testHybridViewWarm {
@@ -64,20 +64,20 @@
 
     [app.buttons[@"Hybrid View (Warm)"] tap];
 
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.otherElements[@"Platform button tapped 0 times."].exists);
 
     [app.otherElements[@"Increment via Flutter"] tap];
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.otherElements[@"Platform button tapped 0 times."].exists);
 
     [app.buttons[@"Increment via iOS"] tap];
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.otherElements[@"Platform button tapped 1 time."].exists);
 
     // Back navigation.
     [app.navigationBars[@"Hybrid Flutter/Native"].buttons[@"Flutter iOS Demos Home"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
 }
 
 - (void)testDualCold {
@@ -87,12 +87,12 @@
     [app.buttons[@"Dual Flutter View (Cold)"] tap];
 
     // There are two marquees.
-    XCTAssertTrue([app.otherElements[@"This is Marquee"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.otherElements[@"This is Marquee"] waitForExistenceWithTimeout:60.0]);
     XCTAssertEqual([app.otherElements matchingType:XCUIElementTypeOther identifier:@"This is Marquee"].count, 2);
 
     // Back navigation.
     [app.navigationBars[@"Dual Flutter Views"].buttons[@"Flutter iOS Demos Home"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:1.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
 }
 
 @end


### PR DESCRIPTION
We're currently waiting 1s, which may not be enough time on slower CI machines. Increases timeouts to 60s. Ideally we'd just have no timeout at all here, but if it takes more than a minute for these conditions something else must be wrong.

@jmagman 

This will be landed on red to help make the tree green - current redness is due to https://github.com/flutter/flutter/issues/70630

Fixes https://github.com/flutter/flutter/issues/70630