### PR TITLE
[devicelab] Upload metrics on linux_web_benchmarks_html

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -119,7 +119,7 @@
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_html",
          "flaky": false,
-	 "upload_metrics": true
+         "upload_metrics": true
       },
       {
          "name": "Linux web_tests",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -118,7 +118,8 @@
          "name": "Linux web_benchmarks_html",
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_html",
-         "flaky": false
+         "flaky": false,
+	 "upload_metrics": true
       },
       {
          "name": "Linux web_tests",


### PR DESCRIPTION
## Description

Pass "upload_metrics" for this builder to start uploading metrics to Cocoon.

If this builder shows no issues, we can update all existing devicelab builders and look into migrating the tests running on Cocoon Agent.

## Related Issues

https://github.com/flutter/flutter/issues/66191 - Upload metrics on LUCI devicelab tests

https://github.com/flutter/flutter/issues/66225 - Migrate DeviceLab tests running on Linux VM

## Tests

No tests added since I am modifying a LUCI builder property. This will require manual validation on rollout.