### PR TITLE
Exclude ARM from macOS builds architectures

### DIFF
--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -96,6 +96,7 @@ Future<void> buildMacOS({
       else
         '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
+      'EXCLUDED_ARCHS=arm64', // TODO(jmagman): Allow ARM https://github.com/flutter/flutter/issues/69221
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ],
     trace: true,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -95,6 +95,7 @@ void main() {
         else
           '-quiet',
         'COMPILER_INDEX_STORE_ENABLE=NO',
+        'EXCLUDED_ARCHS=arm64',
       ],
       stdout: 'STDOUT STUFF',
       onRun: () {


### PR DESCRIPTION
## Description

Before this change `flutter build macos --release` failed even on an x86 mac because release builds include all "valid" architectures, which includes arm64 on Xcode 12.

Exclude arm64 from macOS builds until that architecture can be added to the FlutterMacOS.framework.

This "fixes" commands from `flutter` tooling, but not Xcode.  Archiving from Xcode would still fail.

## Related Issues

https://github.com/flutter/flutter/issues/70566

## Tests

build_macos_test
