### PR TITLE
[flutter_conductor] fix and re-enable roll_dev_integration test

### DIFF
--- a/dev/tools/test/roll_dev_integration_test.dart
+++ b/dev/tools/test/roll_dev_integration_test.dart
@@ -58,6 +58,8 @@ void main() {
       final FakeArgResults fakeArgResults = FakeArgResults(
         level: 'm',
         commit: latestCommit,
+        // Ensure this test passes after a dev release with hotfixes
+        force: true,
         remote: 'origin',
       );
 
@@ -95,6 +97,8 @@ void main() {
       final FakeArgResults fakeArgResults = FakeArgResults(
         level: 'y',
         commit: latestCommit,
+        // Ensure this test passes after a dev release with hotfixes
+        force: true,
         remote: 'origin',
       );
 
@@ -128,7 +132,5 @@ void main() {
     });
   }, onPlatform: <String, dynamic>{
     'windows': const Skip('Flutter Conductor only supported on macos/linux'),
-  // TODO(fujino): re-enable once
-  // https://github.com/flutter/flutter/issues/70652 is resolved
-  }, skip: true);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/70652. Re-enables test skipped in https://github.com/flutter/flutter/issues/70652 to unblock the tree.

This change has the integration test always pass the "force" flag to the roll-dev command, to ensure that this test will pass even if the latest dev release has cherrypicks.