### PR TITLE
preserve detailFiles entry in TaskResult JSON

### DIFF
--- a/dev/devicelab/lib/framework/task_result.dart
+++ b/dev/devicelab/lib/framework/task_result.dart
@@ -42,8 +42,11 @@ class TaskResult {
     final bool success = json['success'] as bool;
     if (success) {
       final List<String> benchmarkScoreKeys = (json['benchmarkScoreKeys'] as List<dynamic> ?? <String>[]).cast<String>();
+      final List<String> detailFiles = (json['detailFiles'] as List<dynamic> ?? <String>[]).cast<String>();
       return TaskResult.success(json['data'] as Map<String, dynamic>,
-          benchmarkScoreKeys: benchmarkScoreKeys);
+        benchmarkScoreKeys: benchmarkScoreKeys,
+        detailFiles: detailFiles,
+      );
     }
 
     return TaskResult.failure(json['reason'] as String);

--- a/dev/devicelab/lib/framework/task_result.dart
+++ b/dev/devicelab/lib/framework/task_result.dart
@@ -10,7 +10,7 @@ class TaskResult {
   /// Constructs a successful result.
   TaskResult.success(this.data, {
     this.benchmarkScoreKeys = const <String>[],
-    this.detailFiles,
+    this.detailFiles = const <String>[],
   })
       : succeeded = true,
         message = 'success' {
@@ -29,11 +29,14 @@ class TaskResult {
   }
 
   /// Constructs a successful result using JSON data stored in a file.
-  factory TaskResult.successFromFile(File file,
-      {List<String> benchmarkScoreKeys}) {
+  factory TaskResult.successFromFile(File file, {
+    List<String> benchmarkScoreKeys = const <String>[],
+    List<String> detailFiles = const <String>[],
+  }) {
     return TaskResult.success(
       json.decode(file.readAsStringSync()) as Map<String, dynamic>,
       benchmarkScoreKeys: benchmarkScoreKeys,
+      detailFiles: detailFiles,
     );
   }
 
@@ -57,7 +60,7 @@ class TaskResult {
       : succeeded = false,
         data = null,
         detailFiles = null,
-        benchmarkScoreKeys = const <String>[];
+        benchmarkScoreKeys = null;
 
   /// Whether the task succeeded.
   final bool succeeded;
@@ -101,8 +104,7 @@ class TaskResult {
 
     if (succeeded) {
       json['data'] = data;
-      if (detailFiles != null)
-        json['detailFiles'] = detailFiles;
+      json['detailFiles'] = detailFiles;
       json['benchmarkScoreKeys'] = benchmarkScoreKeys;
     } else {
       json['reason'] = message;

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -119,15 +119,14 @@ class GalleryTransitionTest {
       summary['transitions'] = transitions;
       summary['missed_transition_count'] = _countMissedTransitions(transitions);
     }
-    final List<String> detailFiles = <String>[
-      if (transitionDurationFile != null)
-        '${galleryDirectory.path}/build/$transitionDurationFile.json',
-      if (timelineTraceFile != null)
-        '${galleryDirectory.path}/build/$timelineTraceFile.json'
-    ];
 
     return TaskResult.success(summary,
-      detailFiles: detailFiles.isNotEmpty ? detailFiles : null,
+      detailFiles: <String>[
+        if (transitionDurationFile != null)
+          '${galleryDirectory.path}/build/$transitionDurationFile.json',
+        if (timelineTraceFile != null)
+          '${galleryDirectory.path}/build/$timelineTraceFile.json'
+      ],
       benchmarkScoreKeys: <String>[
         if (transitionDurationFile != null)
           'missed_transition_count',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -640,10 +640,6 @@ class PerfTest {
       final Map<String, dynamic> data = json.decode(
         file('$testDirectory/build/$resultFilename.json').readAsStringSync(),
       ) as Map<String, dynamic>;
-      final List<String> detailFiles = <String>[
-        if (saveTraceFile)
-          '$testDirectory/build/$traceFilename.json',
-      ];
 
       if (data['frame_count'] as int < 5) {
         return TaskResult.failure(
@@ -657,7 +653,10 @@ class PerfTest {
       final bool isAndroid = deviceOperatingSystem == DeviceOperatingSystem.android;
       return TaskResult.success(
         data,
-        detailFiles: detailFiles.isNotEmpty ? detailFiles : null,
+        detailFiles: <String>[
+          if (saveTraceFile)
+            '$testDirectory/build/$traceFilename.json',
+        ],
         benchmarkScoreKeys: benchmarkScoreKeys ?? <String>[
           ..._kCommonScoreKeys,
           'average_vsync_transitions_missed',

--- a/dev/devicelab/test/task_result_test.dart
+++ b/dev/devicelab/test/task_result_test.dart
@@ -17,6 +17,7 @@ void main() {
           'not_a_metric': 'something',
         },
         'benchmarkScoreKeys': <String>['i', 'j'],
+        'detailFiles': <String>[],
       };
       final TaskResult result = TaskResult.fromJson(expectedJson);
       expect(result.toJson(), expectedJson);
@@ -30,6 +31,7 @@ void main() {
         'success': true,
         'data': null,
         'benchmarkScoreKeys': <String>[],
+        'detailFiles': <String>[],
       };
       expect(result.toJson(), expectedJson);
     });


### PR DESCRIPTION
We used to have the detailFiles available at the point where we printed out the log and/or tried to upload them to the GCS buckets, but recently the necessary information has been missing from the results. It looks like we now translate the original TaskResult produced by the benchmarks into JSON and back to a TaskResult and the detailFiles got lost in the transition.

Adding the missing code in fromJson to restore the data...