### PR TITLE
[devicelab] LUCI builder flag

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -30,6 +30,12 @@ String localEngine;
 /// The path to the engine "src/" directory.
 String localEngineSrcPath;
 
+/// Name of the LUCI builder this test is currently running on.
+///
+/// This is only passed on CI runs for Cocoon to be able to uniquely identify
+/// this test run.
+String luciBuilder;
+
 /// Whether to exit on first test failure.
 bool exitOnFirstTestFailure;
 
@@ -81,9 +87,10 @@ Future<void> main(List<String> rawArgs) async {
   }
 
   deviceId = args['device-id'] as String;
+  exitOnFirstTestFailure = args['exit'] as bool;
   localEngine = args['local-engine'] as String;
   localEngineSrcPath = args['local-engine-src-path'] as String;
-  exitOnFirstTestFailure = args['exit'] as bool;
+  luciBuilder = args['luci-builder'] as String;
   serviceAccountTokenFile = args['service-account-token-file'] as String;
   silent = args['silent'] as bool;
 
@@ -111,7 +118,9 @@ Future<void> _runTasks() async {
 
     if (serviceAccountTokenFile != null) {
       final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
-      await cocoon.sendTaskResult(taskName: taskName, result: result);
+      /// Cocoon's definition of a task is more specific than [taskName], and to
+      /// upload we instead send the [luciBuilder] this is running on.
+      await cocoon.sendTaskResult(taskName: luciBuilder, result: result);
     }
 
     if (!result.succeeded) {
@@ -337,6 +346,10 @@ final ArgParser _argParser = ArgParser()
     help: 'Path to your engine src directory, if you are building Flutter\n'
           'locally. Defaults to \$FLUTTER_ENGINE if set, or tries to guess at\n'
           'the location based on the value of the --flutter-root option.',
+  )
+  ..addOption(
+    'luci-builder',
+    help: '[Flutter infrastructure] Name of the LUCI builder being run on.'
   )
   ..addFlag(
     'match-host-platform',

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -118,9 +118,8 @@ Future<void> _runTasks() async {
 
     if (serviceAccountTokenFile != null) {
       final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
-      /// Cocoon's definition of a task is more specific than [taskName], and to
-      /// upload we instead send the [luciBuilder] this is running on.
-      await cocoon.sendTaskResult(taskName: luciBuilder, result: result);
+      /// Cocoon references LUCI tasks by the [luciBuilder] instead of [taskName].
+      await cocoon.sendTaskResult(builderName: luciBuilder, result: result);
     }
 
     if (!result.succeeded) {

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -75,7 +75,7 @@ class Cocoon {
   }
 
   /// Send [TaskResult] to Cocoon.
-  Future<void> sendTaskResult({String taskName, TaskResult result}) async {
+  Future<void> sendTaskResult({String builderName, TaskResult result}) async {
     // Skip logging on test runs
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((LogRecord rec) {
@@ -85,7 +85,7 @@ class Cocoon {
     final Map<String, dynamic> status = <String, dynamic>{
       'CommitBranch': commitBranch,
       'CommitSha': commitSha,
-      'TaskName': taskName,
+      'BuilderName': builderName,
       'NewStatus': result.succeeded ? 'Succeeded' : 'Failed',
     };
 

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -93,7 +93,7 @@ void main() {
 
       final TaskResult result = TaskResult.success(<String, dynamic>{});
       // This should not throw an error.
-      await cocoon.sendTaskResult(taskName: 'taskAbc', result: result);
+      await cocoon.sendTaskResult(builderName: 'builderAbc', result: result);
     });
 
     test('throws client exception on non-200 responses', () async {
@@ -106,7 +106,7 @@ void main() {
       );
 
       final TaskResult result = TaskResult.success(<String, dynamic>{});
-      expect(() => cocoon.sendTaskResult(taskName: 'taskAbc', result: result), throwsA(isA<ClientException>()));
+      expect(() => cocoon.sendTaskResult(builderName: 'builderAbc', result: result), throwsA(isA<ClientException>()));
     });
   });
 


### PR DESCRIPTION
## Description

Reland of https://github.com/flutter/flutter/pull/70464 with some cleanup by renaming `taskName` to `builderName`.

## Related Issues

https://github.com/flutter/flutter/issues/66191

## Tests

Updated `cocoon` tests to use builder name instead of task name.