### PR TITLE
Add extra Flutter settings to ios_app_with_extensions Podfile

### DIFF
--- a/dev/integration_tests/ios_app_with_extensions/ios/Podfile
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Podfile
@@ -41,3 +41,9 @@ target 'watch Extension' do
 
   pod 'EFQRCode/watchOS', '5.1.6'
 end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end


### PR DESCRIPTION
## Description

#70224 requires the Flutter targets to call `flutter_additional_ios_build_settings` in their Podfile, which is the default in the template.  I had removed it from `ios_app_with_extensions` test one because it didn't used to be necessary.  This caused a ios_app_with_extensions failure.

[ios_app_with_extensions_test_26ba184_2.log](https://github.com/flutter/flutter/files/5556360/ios_app_with_extensions_test_26ba184_2.log)

```
2020-11-17T13:16:21.915252: stdout:     ** BUILD FAILED **
stdout: 
stdout: 
stdout: Xcode's output:
stdout: ↳
stdout:     Command CompileSwift failed with a nonzero exit code
stdout:     Command CompileSwift failed with a nonzero exit code
stdout:     In file included from /Users/flutter/.pub-cache/hosted/pub.dartlang.org/device_info-2.0.0-nullsafety.1/ios/Classes/FLTDeviceInfoPlugin.m:5:
stdout:     /Users/flutter/.pub-cache/hosted/pub.dartlang.org/device_info-2.0.0-nullsafety.1/ios/Classes/FLTDeviceInfoPlugin.h:5:9: fatal error: 'Flutter/Flutter.h' file not found
stdout:     #import <Flutter/Flutter.h>
2020-11-17T13:16:21.915312: stdout:             ^~~~~~~~~~~~~~~~~~~
stdout:     1 error generated.
stdout:     note: Using new build system
stdout:     note: Planning build
stdout:     note: Constructing build description
```
