### PR TITLE
Force regeneration of old Podfile

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -134,6 +134,7 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         platform: globals.platform,
         xcodeProjectInterpreter: globals.xcodeProjectInterpreter,
+        artifacts: globals.artifacts,
       ),
       CocoaPodsValidator: () => CocoaPodsValidator(
         globals.cocoaPods,

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -5,7 +5,6 @@
 import '../base/fingerprint.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
-import '../ios/xcodeproj.dart';
 import '../plugins.dart';
 import '../project.dart';
 
@@ -14,8 +13,7 @@ import '../project.dart';
 Future<void> processPodsIfNeeded(
   XcodeBasedProject xcodeProject,
   String buildDirectory,
-  BuildMode buildMode,
-) async {
+  BuildMode buildMode) async {
   final FlutterProject project = xcodeProject.parent;
   // Ensure that the plugin list is up to date, since hasPlugins relies on it.
   await refreshPluginsList(project, macOSPlatform: project.macos.existsSync());
@@ -37,7 +35,7 @@ Future<void> processPodsIfNeeded(
 
   final bool didPodInstall = await globals.cocoaPods.processPods(
     xcodeProject: xcodeProject,
-    engineDir: flutterFrameworkDir(buildMode),
+    buildMode: buildMode,
     dependenciesChanged: !fingerprinter.doesFingerprintMatch(),
   );
   if (didPodInstall) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -258,6 +259,7 @@ void main() {
       'DART_OBFUSCATION=true',
       'EXTRA_FRONT_END_OPTIONS=--enable-experiment%3Dnon-nullable',
       'EXTRA_GEN_SNAPSHOT_OPTIONS=--enable-experiment%3Dnon-nullable',
+      'FLUTTER_FRAMEWORK_DIR=.',
       'SPLIT_DEBUG_INFO=foo/',
       'TRACK_WIDGET_CREATION=true',
       'TREE_SHAKE_ICONS=true',
@@ -271,6 +273,7 @@ void main() {
     ]),
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    Artifacts: () => Artifacts.test(),
   });
 
   testUsingContext('macOS build supports build-name and build-number', () async {

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(generatedConfig, exists);
     expect(generatedConfig.readAsStringSync(), allOf(
       contains('DART_OBFUSCATION=true'),
-      contains('FLUTTER_FRAMEWORK_DIR=${fileSystem.path.absolute(getFlutterRoot(), 'bin', 'cache', 'artifacts', 'engine')}'),
+      isNot(contains('FLUTTER_FRAMEWORK_DIR')),
     ));
 
     // file that only exists if app was fully built.


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/59044 migrated the Podfile logic into the tool, and #59201 introduced a soft warning encouraging users to regenerate their Podfile (available in 1.20.0-1.0.pre, 2 stables ago).  As of #70224 the Flutter framework search paths are hooked up in the tool-side code, so apps with the old Podfile won't compile anymore (Flutter.framework won't be found).

1. Switch the warning message to a tool exit.
2. Remove the now-dead `FLUTTER_FRAMEWORK_DIR` build setting logic for iOS.  It's still needed for macOS.
https://github.com/flutter/flutter/blob/dda74a1993986b2bedfe35efed85f56332032559/packages/flutter_tools/templates/cocoapods/Podfile-macos#L63

## Tests

- Updated call sites
- Added `runs macOS pod install, if Manifest.lock is missing`
- Added `FLUTTER_FRAMEWORK_DIR` check to `macOS build supports standard desktop build options`