### PR TITLE
Fix cast in `message_codecs.dart`. The string can be `null`, so cast should be to `String?`

### DIFF
--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -579,7 +579,7 @@ class StandardMethodCodec implements MethodCodec {
     final dynamic errorDetails = messageCodec.readValue(buffer);
     final String? errorStacktrace = (buffer.hasRemaining) ? messageCodec.readValue(buffer) as String : null;
     if (errorCode is String && (errorMessage == null || errorMessage is String) && !buffer.hasRemaining)
-      throw PlatformException(code: errorCode, message: errorMessage as String, details: errorDetails, stacktrace: errorStacktrace);
+      throw PlatformException(code: errorCode, message: errorMessage as String?, details: errorDetails, stacktrace: errorStacktrace);
     else
       throw const FormatException('Invalid envelope');
   }


### PR DESCRIPTION
Fix an issue with null safety.

I caught the issue when running a google internal end to end test, not sure how to turn it into a unit test; we'd have to hit this line with null safety sound mode enabled and with `errorMessage` equal to `null`.