### PR TITLE
Restart EditableText cursor timer when it moves

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2089,6 +2089,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         ));
       }
     }
+
+    // To keep the cursor from blinking while it moves, restart the timer here.
+    if (_cursorTimer != null) {
+      _stopCursorTimer(resetCharTicks: false);
+      _startCursorTimer();
+    }
   }
 
   bool _textChangedSinceLastCaretUpdate = false;


### PR DESCRIPTION
## Description

Reset the cursor timer in _handleSelectionChanged() so as to keep it from blinking when it's moved using keyboard.

## Related Issues

#69321

## Tests

I added the following tests:

```
packages/flutter/test/widgets/editable_text_cursor_test.dart:
testWidgets('Cursor animation restarts when it is moved using keys on desktop', (WidgetTester tester) async {
```
Relevant tests passing:
```
% flutter test test/widgets/editable_text_cursor_test.dart
00:15 +24: All tests passed!
% flutter test test/widgets/editable_text_show_on_screen_test.dart
00:05 +9: All tests passed!
% flutter test test/widgets/editable_text_test.dart
00:12 +152: All tests passed!
```

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

