### PR TITLE
Stop extra framework copy during build ios-framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -453,12 +453,6 @@ end
       ' ├─Building plugins...'
     );
     try {
-      // Regardless of the last "flutter build" build mode,
-      // copy the corresponding engine.
-      // A plugin framework built with bitcode must link against the bitcode version
-      // of Flutter.framework (Release).
-      _project.ios.copyEngineArtifactToProject(mode);
-
       final String bitcodeGenerationMode = mode == BuildMode.release ?
           'bitcode' : 'marker'; // In release, force bitcode embedding without archiving.
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -648,11 +648,11 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
           ephemeralDirectory,
         );
       }
-      copyEngineArtifactToProject(BuildMode.debug);
+      _copyEngineArtifactToModule(BuildMode.debug);
     }
   }
 
-  void copyEngineArtifactToProject(BuildMode mode) {
+  void _copyEngineArtifactToModule(BuildMode mode) {
     // Copy podspec and framework from engine cache. The actual build mode
     // doesn't actually matter as it will be overwritten by xcode_backend.sh.
     // However, cocoapods will run before that script and requires something
@@ -662,8 +662,9 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
         Artifact.flutterFramework,
         platform: TargetPlatform.ios,
         mode: mode,
-      )
-    );
+      ));
+    final Directory engineCopyDirectory =
+        ephemeralDirectory.childDirectory('Flutter').childDirectory('engine');
     if (framework.existsSync()) {
       final File podspec = framework.parent.childFile('Flutter.podspec');
       globals.fsUtils.copyDirectorySync(
@@ -709,12 +710,6 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   File get pluginRegistrantImplementation {
     final Directory registryDirectory = isModule ? pluginRegistrantHost.childDirectory('Classes') : pluginRegistrantHost;
     return registryDirectory.childFile('GeneratedPluginRegistrant.m');
-  }
-
-  Directory get engineCopyDirectory {
-    return isModule
-        ? ephemeralDirectory.childDirectory('Flutter').childDirectory('engine')
-        : hostAppRoot.childDirectory('Flutter');
   }
 
   Future<void> _overwriteFromTemplate(String path, Directory target) async {


### PR DESCRIPTION
## Description

`flutter build ios-framework` no longer needs `Flutter.framework` to be copied around to build plugins.  #70224 handled this by adding the artifacts directory to plugin search paths.

## Tests

`build_ios_framework_module_test` is already testing this flow.