### PR TITLE
Detect ARM ffi CocoaPods error, suggest gem install

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -135,6 +135,7 @@ Future<T> runInContext<T>(
         platform: globals.platform,
         xcodeProjectInterpreter: globals.xcodeProjectInterpreter,
         artifacts: globals.artifacts,
+        usage: globals.flutterUsage,
       ),
       CocoaPodsValidator: () => CocoaPodsValidator(
         globals.cocoaPods,

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -12,6 +12,7 @@ import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/version.dart';
@@ -19,6 +20,7 @@ import '../build_info.dart';
 import '../cache.dart';
 import '../ios/xcodeproj.dart';
 import '../project.dart';
+import '../reporting/reporting.dart';
 
 const String noCocoaPodsConsequence = '''
   CocoaPods is used to retrieve the iOS and macOS platform side's plugin code that responds to your plugin usage on the Dart side.
@@ -82,23 +84,33 @@ class CocoaPods {
     @required Logger logger,
     @required Platform platform,
     @required Artifacts artifacts,
+    @required Usage usage,
   }) : _fileSystem = fileSystem,
       _processManager = processManager,
       _xcodeProjectInterpreter = xcodeProjectInterpreter,
       _logger = logger,
       _platform = platform,
       _artifacts = artifacts,
+      _usage = usage,
       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
-      _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform);
+      _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
+      _operatingSystemUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
 
   final FileSystem _fileSystem;
   final ProcessManager _processManager;
   final FileSystemUtils _fileSystemUtils;
   final ProcessUtils _processUtils;
+  final OperatingSystemUtils _operatingSystemUtils;
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
   final Logger _logger;
   final Platform _platform;
   final Artifacts _artifacts;
+  final Usage _usage;
 
   Future<String> _versionText;
 
@@ -370,12 +382,29 @@ class CocoaPods {
   }
 
   void _diagnosePodInstallFailure(ProcessResult result) {
-    final dynamic stdout = result.stdout;
-    if (stdout is String && stdout.contains('out-of-date source repos')) {
+    if (result.stdout is! String) {
+      return;
+    }
+    final String stdout = result.stdout as String;
+    if (stdout.contains('out-of-date source repos')) {
       _logger.printError(
         "Error: CocoaPods's specs repository is too out-of-date to satisfy dependencies.\n"
         'To update the CocoaPods specs, run:\n'
         '  pod repo update\n',
+        emphasis: true,
+      );
+    } else if (stdout.contains('Init_ffi_c') &&
+        stdout.contains('symbol not found') &&
+        _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+      // https://github.com/flutter/flutter/issues/70796
+      UsageEvent(
+        'pod-install-failure',
+        'arm-ffi',
+        flutterUsage: _usage,
+      ).send();
+      _logger.printError(
+        'Error: To set up CocoaPods for ARM macOS, run:\n'
+        '  arch -x86_64 sudo gem install ffi\n',
         emphasis: true,
       );
     }


### PR DESCRIPTION
## Description

CocoaPods crashes on ARM Macs if the x86 version of the `ffi` gem isn't installed.

Detect this crash and tell users how to fix it. 

![Screen Shot 2020-11-19 at 12 41 11 PM](https://user-images.githubusercontent.com/682784/99721878-acda0e80-2a64-11eb-96bd-2bd2e1f390b0.png)


## Related Issues

https://github.com/flutter/flutter/issues/70796

## Tests

cocoapods_tests