### PR TITLE
Run module tests on try builders when flutter_tools changes

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -11,7 +11,7 @@
          "repo":"flutter",
          "task_name":"linux_build_aar_module_test",
          "enabled":true,
-         "run_if": ["dev/**", "bin/**"]
+         "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Linux customer_testing",
@@ -102,21 +102,21 @@
          "repo":"flutter",
          "task_name":"linux_module_host_with_custom_build_test",
          "enabled":true,
-         "run_if": ["dev/**", "bin/**"]
+         "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Linux module_custom_host_app_name_test",
          "repo":"flutter",
          "task_name":"linux_module_custom_host_app_name_test",
          "enabled":true,
-         "run_if": ["dev/**", "bin/**"]
+         "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Linux module_test",
          "repo":"flutter",
          "task_name":"linux_module_test",
          "enabled":true,
-         "run_if": ["dev/**", "bin/**"]
+         "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Linux plugin_test",
@@ -186,14 +186,14 @@
          "repo":"flutter",
          "task_name":"mac_build_aar_module_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac build_ios_framework_module_test",
          "repo":"flutter",
          "task_name":"mac_build_ios_framework_module_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac build_tests",
@@ -253,28 +253,28 @@
          "repo":"flutter",
          "task_name":"mac_module_custom_host_app_name_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac module_host_with_custom_build_test",
          "repo":"flutter",
          "task_name":"mac_module_host_with_custom_build_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac module_test",
          "repo":"flutter",
          "task_name":"mac_module_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac module_test_ios",
          "repo":"flutter",
          "task_name":"mac_module_test_ios",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac plugin_lint_mac",
@@ -309,7 +309,7 @@
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows build_tests",
@@ -356,21 +356,21 @@
          "repo": "flutter",
          "task_name": "win_module_custom_host_app_name_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows module_test",
          "repo": "flutter",
          "task_name": "win_module_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows module_host_with_custom_build_test",
          "repo": "flutter",
          "task_name": "win_module_host_with_custom_build_test",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows plugin_test",


### PR DESCRIPTION
## Description

Module integration tests should be run in pre-submit when the Flutter tool code changes.

## Related Issues

https://github.com/flutter/flutter/pull/70790 failed `build_ios_framework_module_test` on post-submit.