### PR TITLE
[flutter_tools] Treat public_member_api_docs similar to others linter output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -81,8 +81,11 @@ abstract class AnalyzeBase {
   }
 
   bool get isFlutterRepo => argResults['flutter-repo'] as bool;
+
   String get sdkPath => argResults['dart-sdk'] as String ?? artifacts.getArtifactPath(Artifact.engineDartSdkPath);
+
   bool get isBenchmarking => argResults['benchmark'] as bool;
+
   bool get isDartDocs => argResults['dartdocs'] as bool;
 
   static int countMissingDartDocs(List<AnalysisError> errors) {
@@ -91,32 +94,12 @@ abstract class AnalyzeBase {
     }).length;
   }
 
-  static String generateDartDocMessage(int undocumentedMembers) {
-    String dartDocMessage;
-
-    assert(undocumentedMembers >= 0);
-    switch (undocumentedMembers) {
-      case 0:
-        dartDocMessage = 'all public member have documentation';
-        break;
-      case 1:
-        dartDocMessage = 'one public member lacks documentation';
-        break;
-      default:
-        dartDocMessage = '$undocumentedMembers public members lack documentation';
-    }
-
-    return dartDocMessage;
-  }
-
   /// Generate an analysis summary for both [AnalyzeOnce], [AnalyzeContinuously].
   static String generateErrorsMessage({
     @required int issueCount,
     int issueDiff,
     int files,
     @required String seconds,
-    int undocumentedMembers = 0,
-    String dartDocMessage = '',
   }) {
     final StringBuffer errorsMessage = StringBuffer(issueCount > 0
       ? '$issueCount ${pluralize('issue', issueCount)} found.'
@@ -136,11 +119,8 @@ abstract class AnalyzeBase {
       errorsMessage.write(' • analyzed $files ${pluralize('file', files)}');
     }
 
-    if (undocumentedMembers > 0) {
-      errorsMessage.write(' (ran in ${seconds}s; $dartDocMessage)');
-    } else {
-      errorsMessage.write(' (ran in ${seconds}s)');
-    }
+    errorsMessage.write(' (ran in ${seconds}s)');
+
     return errorsMessage.toString();
   }
 }
@@ -150,15 +130,19 @@ class PackageDependency {
   // of places that ask for that target (.packages or pubspec.yaml files)
   Map<String, List<String>> values = <String, List<String>>{};
   String canonicalSource;
+
   void addCanonicalCase(String packagePath, String pubSpecYamlPath) {
     assert(canonicalSource == null);
     add(packagePath, pubSpecYamlPath);
     canonicalSource = pubSpecYamlPath;
   }
+
   void add(String packagePath, String sourcePath) {
     values.putIfAbsent(packagePath, () => <String>[]).add(sourcePath);
   }
+
   bool get hasConflict => values.length > 1;
+
   bool get hasConflictAffectingFlutterRepo {
     assert(globals.fs.path.isAbsolute(Cache.flutterRoot));
     for (final List<String> targetSources in values.values) {
@@ -171,6 +155,7 @@ class PackageDependency {
     }
     return false;
   }
+
   void describeConflict(StringBuffer result) {
     assert(hasConflict);
     final List<String> targets = values.keys.toList();
@@ -190,6 +175,7 @@ class PackageDependency {
       }
     }
   }
+
   String get target => values.keys.single;
 }
 

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -142,14 +142,11 @@ class AnalyzeContinuously extends AnalyzeBase {
       final int issueDiff = issueCount - lastErrorCount;
       lastErrorCount = issueCount;
       final String seconds = (analysisTimer.elapsedMilliseconds / 1000.0).toStringAsFixed(2);
-      final String dartDocMessage = AnalyzeBase.generateDartDocMessage(undocumentedMembers);
       final String errorsMessage = AnalyzeBase.generateErrorsMessage(
         issueCount: issueCount,
         issueDiff: issueDiff,
         files: analyzedPaths.length,
         seconds: seconds,
-        undocumentedMembers: undocumentedMembers,
-        dartDocMessage: dartDocMessage,
       );
 
       logger.printStatus(errorsMessage);

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -168,12 +168,9 @@ class AnalyzeOnce extends AnalyzeBase {
 
     final int errorCount = errors.length;
     final String seconds = (timer.elapsedMilliseconds / 1000.0).toStringAsFixed(1);
-    final String dartDocMessage = AnalyzeBase.generateDartDocMessage(undocumentedMembers);
     final String errorsMessage = AnalyzeBase.generateErrorsMessage(
       issueCount: errorCount,
       seconds: seconds,
-      undocumentedMembers: undocumentedMembers,
-      dartDocMessage: dartDocMessage,
     );
 
     if (errorCount > 0) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -13,21 +13,13 @@ import '../../src/common.dart';
 const String _kFlutterRoot = '/data/flutter';
 
 void main() {
-  testWithoutContext('analyze generate correct DartDoc message', () async {
-    expect(AnalyzeBase.generateDartDocMessage(0), 'all public member have documentation');
-    expect(AnalyzeBase.generateDartDocMessage(1), 'one public member lacks documentation');
-    expect(AnalyzeBase.generateDartDocMessage(2), '2 public members lack documentation');
-  });
-
   testWithoutContext('analyze generate correct errors message', () async {
     expect(
       AnalyzeBase.generateErrorsMessage(
         issueCount: 0,
         seconds: '0.1',
-        undocumentedMembers: 1,
-        dartDocMessage: 'one public member lacks documentation',
       ),
-      'No issues found! (ran in 0.1s; one public member lacks documentation)',
+      'No issues found! (ran in 0.1s)',
     );
 
     expect(
@@ -36,10 +28,8 @@ void main() {
         issueDiff: 2,
         files: 1,
         seconds: '0.1',
-        undocumentedMembers: 1,
-        dartDocMessage: 'one public member lacks documentation',
       ),
-      '3 issues found. (2 new) • analyzed 1 file (ran in 0.1s; one public member lacks documentation)',
+      '3 issues found. (2 new) • analyzed 1 file (ran in 0.1s)',
     );
   });
 

--- a/packages/flutter_tools/test/general.shard/commands/analyze_base_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/analyze_base_test.dart
@@ -11,7 +11,6 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 0,
       seconds: '10',
-      undocumentedMembers: 0,
     );
 
     expect(message, 'No issues found! (ran in 10s)');
@@ -21,18 +20,15 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 0,
       seconds: '10',
-      undocumentedMembers: 1,
-      dartDocMessage: 'test'
     );
 
-    expect(message, 'No issues found! (ran in 10s; test)');
+    expect(message, 'No issues found! (ran in 10s)');
   });
 
   testWithoutContext('AnalyzeBase message formatting with one issue', () async {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 1,
       seconds: '10',
-      undocumentedMembers: 0,
     );
 
     expect(message, '1 issue found. (ran in 10s)');
@@ -42,7 +38,6 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 10,
       seconds: '10',
-      undocumentedMembers: 0,
     );
 
     expect(message, '10 issues found. (ran in 10s)');
@@ -52,7 +47,6 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 0,
       seconds: '10',
-      undocumentedMembers: 0,
       files: 10,
     );
 
@@ -63,7 +57,6 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 1,
       seconds: '10',
-      undocumentedMembers: 0,
       issueDiff: 1,
     );
 
@@ -74,7 +67,6 @@ void main() {
     final String message = AnalyzeBase.generateErrorsMessage(
       issueCount: 0,
       seconds: '10',
-      undocumentedMembers: 0,
       issueDiff: -1,
     );
 


### PR DESCRIPTION
## Description

Current status is error.code == `public_member_api_docs` will be counted and summarized in one sentence(dartDocMessage).  
e.g. * public member lacks documentation

Now we treat public_member_api_docs similar to others linter output.

## Related Issues

https://github.com/flutter/flutter/issues/62483

## Tests

I added the following tests:

packages/flutter_tools/test/general.shard/commands/analyze_base_test.dart
packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
