### PR TITLE
[flutter_tools] skip ck restart on all platforms

### DIFF
--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -68,5 +68,5 @@ void main() {
     } finally {
       await subscription.cancel();
     }
-  }, skip: platform.isWindows); // https://github.com/flutter/flutter/issues/70486
+  }, skip: true); // https://github.com/flutter/flutter/issues/70486
 }


### PR DESCRIPTION
## Description

This is broken because there is an invalid require define in the ck codebase