### PR TITLE
Make RenderFlex flex to fill min extent and remove intrinsics from SliverFillRemaining

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -678,7 +678,9 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     int totalChildren = 0;
     assert(constraints != null);
     final double maxMainSize = _direction == Axis.horizontal ? constraints.maxWidth : constraints.maxHeight;
-    final bool canFlex = maxMainSize < double.infinity;
+    final double minMainSize = _direction == Axis.horizontal ? constraints.minWidth : constraints.minHeight;
+    final bool canFlex = maxMainSize < double.infinity || minMainSize > 0.0;
+    final double spaceToFill = canFlex ? (maxMainSize == double.infinity ? minMainSize : maxMainSize) : 0.0;
 
     double crossSize = 0.0;
     double allocatedSize = 0.0; // Sum of the sizes of the non-flexible children.
@@ -785,7 +787,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }
 
     // Distribute free space to flexible children, and determine baseline.
-    final double freeSpace = math.max(0.0, (canFlex ? maxMainSize : 0.0) - allocatedSize);
+    final double freeSpace = math.max(0.0, spaceToFill - allocatedSize);
     double allocatedFlexSpace = 0.0;
     double maxBaselineDistance = 0.0;
     if (totalFlex > 0 || crossAxisAlignment == CrossAxisAlignment.baseline) {
@@ -871,7 +873,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }
 
     // Align items along the main axis.
-    final double idealSize = canFlex && mainAxisSize == MainAxisSize.max ? maxMainSize : allocatedSize;
+    final double idealSize = canFlex && mainAxisSize == MainAxisSize.max && maxMainSize < double.infinity ? maxMainSize : allocatedSize;
     final double actualSize;
     switch (_direction) {
       case Axis.horizontal:

--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -213,6 +213,9 @@ class RenderSliverFillRemainingAndOverscroll extends RenderSliverSingleBoxAdapte
 
     if (child != null) {
       final double childExtent;
+      // Using intrinsics to figure out the natural extent of the child if we
+      // wouldn't force it to occupy the overscroll area. This is going to be
+      // the scroll extent of the child.
       switch (constraints.axis) {
         case Axis.horizontal:
           childExtent = child!.getMaxIntrinsicWidth(constraints.crossAxisExtent);

--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -141,24 +141,19 @@ class RenderSliverFillRemaining extends RenderSliverSingleBoxAdapter {
     double extent = constraints.viewportMainAxisExtent - constraints.precedingScrollExtent;
 
     if (child != null) {
-      final double childExtent;
+      child!.layout(constraints.asBoxConstraints(
+        minExtent: math.max(0.0, extent),
+        maxExtent: double.infinity,
+      ), parentUsesSize: true);
+
       switch (constraints.axis) {
         case Axis.horizontal:
-          childExtent = child!.getMaxIntrinsicWidth(constraints.crossAxisExtent);
+          extent = child!.size.width;
           break;
         case Axis.vertical:
-          childExtent = child!.getMaxIntrinsicHeight(constraints.crossAxisExtent);
+          extent = child!.size.height;
           break;
       }
-
-      // If the childExtent is greater than the computed extent, we want to use
-      // that instead of potentially cutting off the child. This allows us to
-      // safely specify a maxExtent.
-      extent = math.max(extent, childExtent);
-      child!.layout(constraints.asBoxConstraints(
-        minExtent: extent,
-        maxExtent: extent,
-      ));
     }
 
     assert(extent.isFinite,

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -137,4 +137,54 @@ void main() {
     await tester.pumpWidget(Flex(direction: Axis.vertical, clipBehavior: Clip.antiAlias));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
+
+  testWidgets('Flex to fill min extent - horizontal', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          minWidth: 200,
+          maxWidth: double.infinity,
+          child: Flex(
+            direction: Axis.horizontal,
+            textDirection: TextDirection.ltr,
+            children: const <Widget>[
+              Flexible(child: SizedBox.expand()),
+              SizedBox(width: 50.0, height: 200.0)
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox flexible = tester.renderObject(find.byType(Flexible));
+    expect(flexible.size.width, 200.0 - 50.0);
+
+    final RenderBox flex = tester.renderObject(find.byType(Flex));
+    expect(flex.size.width, 200.0);
+  });
+
+  testWidgets('Flex to fill min extent - vertically', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          minHeight: 200,
+          maxHeight: double.infinity,
+          child: Flex(
+            direction: Axis.vertical,
+            textDirection: TextDirection.ltr,
+            children: const <Widget>[
+              Flexible(child: SizedBox.expand()),
+              SizedBox(width: 50.0, height: 50.0)
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox flexible = tester.renderObject(find.byType(Flexible));
+    expect(flexible.size.height, 200.0 - 50.0);
+
+    final RenderBox flex = tester.renderObject(find.byType(Flex));
+    expect(flex.size.height, 200.0);
+  });
 }


### PR DESCRIPTION
## Description

With a fix to RenderFlex we can remove intrinsics from one of the `SliverFillRemaining`s.

Fix to RenderFlex: If a min extent is given, it should flex its children to at least fill the min extent even when the max extent is unbound. After all, it was asked to provide content for at least the min extent.

The `RenderSliverFillRemainingAndOverscroll` is still using intrinsics because it needs to know how much space the child would occupy if it doesn't reach into the overscroll. For that, we need to know the intrinsics of the child.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
