### PR TITLE
Update dartdoc to 0.37.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.36.2
+    "$PUB" global activate dartdoc 0.37.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -188,6 +188,7 @@ Future<void> main(List<String> arguments) async {
     ].join(','),
     '--exclude',
     <String>[
+      'dart:io/network_policy.dart', // dart-lang/dartdoc#2437
       'package:Flutter/temp_doc.dart',
       'package:http/browser_client.dart',
       'package:intl/intl_browser.dart',


### PR DESCRIPTION
## Description

Updates dartdoc to 0.37.0.  See the release notes at:  https://github.com/dart-lang/dartdoc/releases/tag/v0.37.0.

## Related Issues

Works around dart-lang/dartdoc#2437 with an `--exclude`.

## Tests

Tested by hand and clicked around.
