### PR TITLE
Revert "[flutter_tools] wire up alternative invalidation strategy to features"

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -49,9 +49,6 @@ abstract class FeatureFlags {
   /// Whether fast single widget reloads are enabled.
   bool get isSingleWidgetReloadEnabled => false;
 
-  /// Whether the CFE experimental invalidation strategy is enabled.
-  bool get isExperimentalInvalidationStrategyEnabled => false;
-
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -96,9 +93,6 @@ class FlutterFeatureFlags implements FeatureFlags {
   bool get isSingleWidgetReloadEnabled => isEnabled(singleWidgetReload);
 
   @override
-  bool get isExperimentalInvalidationStrategyEnabled => isEnabled(experimentalInvalidationStrategy);
-
-  @override
   bool isEnabled(Feature feature) {
     final String currentChannel = _flutterVersion.channel;
     final FeatureChannelSetting featureSetting = feature.getSettingForChannel(currentChannel);
@@ -131,7 +125,6 @@ const List<Feature> allFeatures = <Feature>[
   flutterAndroidFeature,
   flutterIOSFeature,
   flutterFuchsiaFeature,
-  experimentalInvalidationStrategy,
 ];
 
 /// The [Feature] for flutter web.
@@ -266,29 +259,6 @@ const Feature singleWidgetReload = Feature(
   dev: FeatureChannelSetting(
     available: true,
     enabledByDefault: true,
-  ),
-  beta: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: false,
-  ),
-  stable: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: false,
-  ),
-);
-
-/// The CFE experimental invalidation strategy.
-const Feature experimentalInvalidationStrategy = Feature(
-  name: 'Hot reload optimization that reduces incremental artifact size',
-  configSetting: 'experimental-invalidation-strategy',
-  environmentOverride: 'FLUTTER_CFE_EXPERIMENTAL_INVALIDATION',
-  master: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: true,
-  ),
-  dev: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: false,
   ),
   beta: FeatureChannelSetting(
     available: true,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -139,13 +139,12 @@ class FlutterDevice {
     } else {
       // The flutter-widget-cache feature only applies to run mode.
       List<String> extraFrontEndOptions = buildInfo.extraFrontEndOptions;
-      extraFrontEndOptions = <String>[
-        if (featureFlags.isSingleWidgetReloadEnabled)
-         '--flutter-widget-cache',
-        if (featureFlags.isExperimentalInvalidationStrategyEnabled)
-          '--enable-experiment=alternative-invalidation-strategy',
-        ...?extraFrontEndOptions,
-      ];
+      if (featureFlags.isSingleWidgetReloadEnabled) {
+        extraFrontEndOptions = <String>[
+          '--flutter-widget-cache',
+          ...?extraFrontEndOptions,
+        ];
+      }
       generator = ResidentCompiler(
         globals.artifacts.getArtifactPath(
           Artifact.flutterPatchedSdkPath,

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2578,33 +2578,6 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isSingleWidgetReloadEnabled: true)
   });
 
-   testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag when feature is enabled', () async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final MockDevice mockDevice = MockDevice();
-    when(mockDevice.targetPlatform).thenAnswer((Invocation invocation) async {
-      return TargetPlatform.android_arm;
-    });
-
-    final DefaultResidentCompiler residentCompiler = (await FlutterDevice.create(
-      mockDevice,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        extraFrontEndOptions: <String>[],
-      ),
-      target: null, platform: null,
-    )).generator as DefaultResidentCompiler;
-
-    expect(residentCompiler.extraFrontEndOptions,
-      contains('--enable-experiment=alternative-invalidation-strategy'));
-  }, overrides: <Type, Generator>{
-    Artifacts: () => Artifacts.test(),
-    FileSystem: () => MemoryFileSystem.test(),
-    ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: () => TestFeatureFlags(isExperimentalInvalidationStrategyEnabled: true)
-  });
-
   testUsingContext('connect sets up log reader', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final MockDevice mockDevice = MockDevice();

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -730,8 +730,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isAndroidEnabled = true,
     this.isIOSEnabled = true,
     this.isFuchsiaEnabled = false,
-    this.isExperimentalInvalidationStrategyEnabled = false,
-  });
+});
 
   @override
   final bool isLinuxEnabled;
@@ -758,9 +757,6 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isFuchsiaEnabled;
 
   @override
-  final bool isExperimentalInvalidationStrategyEnabled;
-
-  @override
   bool isEnabled(Feature feature) {
     switch (feature) {
       case flutterWebFeature:
@@ -779,8 +775,6 @@ class TestFeatureFlags implements FeatureFlags {
         return isIOSEnabled;
       case flutterFuchsiaFeature:
         return isFuchsiaEnabled;
-      case experimentalInvalidationStrategy:
-        return isExperimentalInvalidationStrategyEnabled;
     }
     return false;
   }


### PR DESCRIPTION
Reverts flutter/flutter#70865


```
2020-11-19T13:49:56.713482: stdout: 
2020-11-19T13:49:56.862618: stdout: Performing hot reload...                                        
2020-11-19T13:49:56.863954: stderr: Unhandled exception:
stdout: 
stderr: root::package:flutter/src/widgets/framework.dart::Widget::@=fields::package:flutter/src/widgets/widget_inspector.dart::_location is already bound
stdout: 
stderr: #0      CanonicalName.bindTo (package:kernel/canonical_name.dart:192:7)
stdout: 
2020-11-19T13:49:56.865330: stderr: #1      Class.computeCanonicalNames (package:kernel/ast.dart:1197:12)
stderr: #2      Library.computeCanonicalNames (package:kernel/ast.dart:559:14)
stdout: 
stdout: 
stderr: #3      Component.computeCanonicalNamesForLibrary (package:kernel/ast.dart:9674:13)
stdout: 
stderr: #4      Component.computeCanonicalNames (package:kernel/ast.dart:9636:7)
stdout: 
2020-11-19T13:49:56.865539: stderr: #5      sortComponent (package:vm/kernel_front_end.dart:679:13)
stderr: #6      FrontendCompiler.writeDillFile (package:frontend_server/frontend_server.dart:656:5)
stderr: #7      FrontendCompiler.recompileDelta (package:frontend_server/frontend_server.dart:766:13)
stderr: <asynchronous suspension>
stdout: 
stdout: 
stdout: 
2020-11-19T13:49:56.909058: stdout: 
2020-11-19T13:49:56.909124: stderr: the Dart compiler exited unexpectedly.
```