### PR TITLE
[flutter_tools] disable SWR optimization on dev

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -258,7 +258,7 @@ const Feature singleWidgetReload = Feature(
   ),
   dev: FeatureChannelSetting(
     available: true,
-    enabledByDefault: true,
+    enabledByDefault: false,
   ),
   beta: FeatureChannelSetting(
     available: true,


### PR DESCRIPTION
## Description

The oct-nov period where this feature was enabled show a large variance in hot reload times compared to prior months, and not an average improvement. its possible this is related to null safety work, but to be sure - disable this feature so that we can gather stats for december/jan