### PR TITLE
only use code single path for verification of target file existence

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -211,6 +211,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
 
   Future<void> _attachToDevice(Device device) async {
     final FlutterProject flutterProject = FlutterProject.current();
+
     Future<int> getDevicePort() async {
       if (debugPort != null) {
         return debugPort;
@@ -388,7 +389,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
       device,
       fileSystemRoots: stringsArg('filesystem-root'),
       fileSystemScheme: stringArg('filesystem-scheme'),
-      target: stringArg('target'),
+      target: targetFile,
       targetModel: TargetModel(stringArg('target-model')),
       buildInfo: buildInfo,
       userIdentifier: userIdentifier,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -447,6 +447,7 @@ class RunCommand extends RunCommandBase {
     // debug mode.
     final BuildInfo buildInfo = await getBuildInfo();
     final bool hotMode = shouldUseHotMode(buildInfo);
+    final String applicationBinaryPath = stringArg('use-application-binary');
 
     writePidFile(stringArg('pid-file'));
 
@@ -464,7 +465,6 @@ class RunCommand extends RunCommandBase {
       );
       AppInstance app;
       try {
-        final String applicationBinaryPath = stringArg('use-application-binary');
         app = await daemon.appDomain.startApp(
           devices.first, globals.fs.currentDirectory.path, targetFile, route,
           await createDebuggingOptions(), hotMode,
@@ -535,7 +535,7 @@ class RunCommand extends RunCommandBase {
           fileSystemRoots: stringsArg('filesystem-root'),
           fileSystemScheme: stringArg('filesystem-scheme'),
           experimentalFlags: expFlags,
-          target: stringArg('target'),
+          target: targetFile,
           buildInfo: buildInfo,
           userIdentifier: userIdentifier,
           platform: globals.platform,
@@ -548,7 +548,6 @@ class RunCommand extends RunCommandBase {
                          await devices.single.targetPlatform == TargetPlatform.web_javascript;
 
     ResidentRunner runner;
-    final String applicationBinaryPath = stringArg('use-application-binary');
     if (hotMode && !webMode) {
       runner = HotRunner(
         flutterDevices,

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -468,16 +468,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
       globals.printStatus('This application is not configured to build on the web.');
       globals.printStatus('To add web support to a project, run `flutter create .`.');
     }
-    if (!globals.fs.isFileSync(mainPath)) {
-      String message = 'Tried to run $mainPath, but that file does not exist.';
-      if (target == null) {
-        message +=
-            '\nConsider using the -t option to specify the Dart file to start.';
-      }
-      globals.printError(message);
-      appFailedToStart();
-      return 1;
-    }
     final String modeName = debuggingOptions.buildInfo.friendlyModeName;
     globals.printStatus(
       'Launching ${globals.fsUtils.getDisplayPath(target)} '

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -712,7 +712,7 @@ class FlutterDevice {
 abstract class ResidentRunner {
   ResidentRunner(
     this.flutterDevices, {
-    this.target,
+    @required this.target,
     @required this.debuggingOptions,
     String projectRootPath,
     this.ipv6,
@@ -720,7 +720,7 @@ abstract class ResidentRunner {
     this.hotMode = true,
     String dillOutputPath,
     this.machine = false,
-  }) : mainPath = findMainDartFile(target),
+  }) : mainPath = target,
        packagesFilePath = debuggingOptions.buildInfo.packagesPath,
        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
        _dillOutputPath = dillOutputPath,
@@ -1372,17 +1372,6 @@ class OperationResult {
   bool get isOk => code == 0;
 
   static final OperationResult ok = OperationResult(0, '');
-}
-
-/// Given the value of the --target option, return the path of the Dart file
-/// where the app's main function should be.
-String findMainDartFile([ String target ]) {
-  target ??= '';
-  final String targetPath = globals.fs.path.absolute(target);
-  if (globals.fs.isDirectorySync(targetPath)) {
-    return globals.fs.path.join(targetPath, 'lib', 'main.dart');
-  }
-  return targetPath;
 }
 
 Future<String> getMissingPackageHintForPlatform(TargetPlatform platform) async {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -720,7 +720,7 @@ abstract class ResidentRunner {
     this.hotMode = true,
     String dillOutputPath,
     this.machine = false,
-  }) : mainPath = target,
+  }) : mainPath = globals.fs.path.absolute(target),
        packagesFilePath = debuggingOptions.buildInfo.packagesPath,
        projectRootPath = projectRootPath ?? globals.fs.currentDirectory.path,
        _dillOutputPath = dillOutputPath,

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -17,7 +17,7 @@ import 'vmservice.dart';
 class ColdRunner extends ResidentRunner {
   ColdRunner(
     List<FlutterDevice> devices, {
-    String target,
+    @required String target,
     @required DebuggingOptions debuggingOptions,
     this.traceStartup = false,
     this.awaitFirstFrameWhenTracing = true,
@@ -52,18 +52,6 @@ class ColdRunner extends ResidentRunner {
     Completer<void> appStartedCompleter,
     String route,
   }) async {
-    final bool prebuiltMode = applicationBinary != null;
-    if (!prebuiltMode) {
-      if (!globals.fs.isFileSync(mainPath)) {
-        String message = 'Tried to run $mainPath, but that file does not exist.';
-        if (target == null) {
-          message += '\nConsider using the -t option to specify the Dart file to start.';
-        }
-        globals.printError(message);
-        return 1;
-      }
-    }
-
     try {
       for (final FlutterDevice device in flutterDevices) {
         final int result = await device.runCold(

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -66,7 +66,7 @@ class DeviceReloadReport {
 class HotRunner extends ResidentRunner {
   HotRunner(
     List<FlutterDevice> devices, {
-    String target,
+    @required String target,
     @required DebuggingOptions debuggingOptions,
     this.benchmarkMode = false,
     this.applicationBinary,
@@ -295,15 +295,6 @@ class HotRunner extends ResidentRunner {
     Completer<void> appStartedCompleter,
     String route,
   }) async {
-    if (!globals.fs.isFileSync(mainPath)) {
-      String message = 'Tried to run $mainPath, but that file does not exist.';
-      if (target == null) {
-        message += '\nConsider using the -t option to specify the Dart file to start.';
-      }
-      globals.printError(message);
-      return 1;
-    }
-
     firstBuildTime = DateTime.now();
 
     final List<Future<bool>> startupTasks = <Future<bool>>[];

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -259,12 +259,12 @@ abstract class FlutterCommand extends Command<void> {
 
   String get targetFile {
     if (argResults.wasParsed('target')) {
-      return stringArg('target');
+      return globals.fs.path.absolute(stringArg('target'));
     }
     if (argResults.rest.isNotEmpty) {
-      return argResults.rest.first;
+      return globals.fs.path.absolute(argResults.rest.first);
     }
-    return bundle.defaultMainPath;
+    return globals.fs.path.absolute(bundle.defaultMainPath);
   }
 
   void usesPubOption({bool hide = false}) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -259,12 +259,12 @@ abstract class FlutterCommand extends Command<void> {
 
   String get targetFile {
     if (argResults.wasParsed('target')) {
-      return globals.fs.path.absolute(stringArg('target'));
+      return stringArg('target');
     }
     if (argResults.rest.isNotEmpty) {
-      return globals.fs.path.absolute(argResults.rest.first);
+      return argResults.rest.first;
     }
-    return globals.fs.path.absolute(bundle.defaultMainPath);
+    return bundle.defaultMainPath;
   }
 
   void usesPubOption({bool hide = false}) {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -39,6 +39,7 @@ void main() {
 
     final int exitCode = await ColdRunner(devices,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     ).attach();
     expect(exitCode, 2);
   });
@@ -61,6 +62,7 @@ void main() {
 
       await ColdRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
       ).cleanupAtFinish();
 
       verify(mockDevice1.dispose());
@@ -71,21 +73,6 @@ void main() {
   });
 
   group('cold run', () {
-    testUsingContext('returns 1 if not prebuilt mode & mainPath does not exist', () async {
-      final MockDevice mockDevice = MockDevice();
-      final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
-      when(mockFlutterDevice.device).thenReturn(mockDevice);
-      final List<FlutterDevice> devices = <FlutterDevice>[mockFlutterDevice];
-      final int result = await ColdRunner(
-        devices,
-        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
-      ).run();
-
-      expect(result, 1);
-      expect(testLogger.errorText, matches(r'Tried to run .*, but that file does not exist\.'));
-      expect(testLogger.errorText, matches(r'Consider using the -t option to specify the Dart file to start\.'));
-    });
-
     testUsingContext('calls runCold on attached device', () async {
       final MockDevice mockDevice = MockDevice();
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
@@ -100,6 +87,7 @@ void main() {
         devices,
         applicationBinary: applicationBinary,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
       ).run();
 
       expect(result, 1);

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -184,6 +184,7 @@ void main() {
       final OperationResult result = await HotRunner(
         devices,
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
       ).restart(fullRestart: true);
       // Expect hot restart failed.
       expect(result.isOk, false);
@@ -214,7 +215,8 @@ void main() {
       ];
       final OperationResult result = await HotRunner(
         devices,
-        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug)
+        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
       ).restart(fullRestart: true);
       // Expect hot restart failed.
       expect(result.isOk, false);
@@ -317,6 +319,7 @@ void main() {
       final HotRunner hotRunner = HotRunner(
         devices,
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
       );
       final OperationResult result = await hotRunner.restart(fullRestart: true);
       // Expect hot restart was successful.
@@ -345,6 +348,7 @@ void main() {
       final OperationResult result = await HotRunner(
         devices,
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
       ).restart(fullRestart: true);
       expect(result.isOk, false);
       expect(result.message, 'setupHotRestart failed');
@@ -410,6 +414,7 @@ void main() {
       final HotRunner hotRunner = HotRunner(
         devices,
         debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
       );
       final OperationResult result = await hotRunner.restart(fullRestart: true);
       // Expect hot restart successful.
@@ -446,7 +451,8 @@ void main() {
         ];
         await HotRunner(
           devices,
-          debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug)
+          debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+          target: 'main.dart',
         ).cleanupAfterSignal();
         expect(shutdownTestingConfig.shutdownHookCalled, true);
       }, overrides: <Type, Generator>{
@@ -470,7 +476,8 @@ void main() {
         ];
         await HotRunner(
           devices,
-          debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug)
+          debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+          target: 'main.dart',
         ).preExit();
         expect(shutdownTestingConfig.shutdownHookCalled, true);
       }, overrides: <Type, Generator>{
@@ -514,6 +521,7 @@ void main() {
 
       final int exitCode = await HotRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
       ).attach();
       expect(exitCode, 2);
     }, overrides: <Type, Generator>{
@@ -546,6 +554,7 @@ void main() {
 
       await HotRunner(devices,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
       ).cleanupAtFinish();
 
       verify(mockDevice1.dispose());

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -151,6 +151,7 @@ void main() {
         ],
         stayResident: false,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+        target: 'main.dart',
       );
     });
     mockFlutterDevice = MockFlutterDevice();
@@ -244,6 +245,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.generator).thenReturn(residentCompiler);
     when(residentCompiler.recompile(
@@ -285,6 +287,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.generator).thenReturn(residentCompiler);
     when(residentCompiler.recompile(
@@ -319,6 +322,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runCold(
       coldRunner: anyNamed('coldRunner'),
@@ -343,6 +347,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.release),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runCold(
       coldRunner: anyNamed('coldRunner'),
@@ -372,6 +377,7 @@ void main() {
       applicationBinary: globals.fs.file('app.apk'),
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.generator).thenReturn(residentCompiler);
     when(residentCompiler.recompile(
@@ -461,6 +467,7 @@ void main() {
         fastStart: true,
         startPaused: true,
       ),
+      target: 'main.dart',
     );
     final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
     final Completer<void> onAppStart = Completer<void>.sync();
@@ -599,6 +606,7 @@ void main() {
         mockFlutterDevice,
       ],
       stayResident: false,
+      target: 'main.dart',
       debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
         BuildMode.debug, '', treeShakeIcons: false, extraFrontEndOptions: <String>[
         '--enable-experiment=non-nullable',
@@ -677,6 +685,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
@@ -1017,6 +1026,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
@@ -1416,6 +1426,7 @@ void main() {
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       dillOutputPath: globals.fs.path.join('foobar', 'app.dill'),
+      target: 'main.dart',
     );
     expect(otherRunner.artifactDirectory.path, contains('foobar'));
   }));
@@ -1525,6 +1536,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
     residentRunner.printHelp(details: true);
 
@@ -1662,6 +1674,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
     await residentRunner.screenshot(mockFlutterDevice);
 
@@ -1768,6 +1781,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
     when(mockDevice.supportsScreenshot).thenReturn(true);
     when(mockDevice.takeScreenshot(any))
@@ -1916,6 +1930,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugDumpApp(), false);
@@ -1937,6 +1952,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugDumpRenderTree(), false);
@@ -1958,6 +1974,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugDumpLayerTree(), false);
@@ -1979,6 +1996,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugDumpSemanticsTreeInTraversalOrder(), false);
@@ -2000,6 +2018,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder(), false);
@@ -2021,6 +2040,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleDebugPaintSizeEnabled(), false);
@@ -2042,6 +2062,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleBrightness(), false);
@@ -2086,6 +2107,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleInvertOversizedImages(), false);
@@ -2100,6 +2122,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleInvertOversizedImages(), false);
@@ -2144,6 +2167,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleDebugCheckElevationsEnabled(), false);
@@ -2165,6 +2189,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugTogglePerformanceOverlayOverride(), false);
@@ -2187,6 +2212,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleWidgetInspector(), false);
@@ -2208,6 +2234,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+      target: 'main.dart',
     );
 
     expect(await residentRunner.debugToggleProfileWidgetBuilds(), false);
@@ -2228,6 +2255,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runHot(
       hotRunner: anyNamed('hotRunner'),
@@ -2254,6 +2282,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
     when(mockFlutterDevice.runHot(
@@ -2288,6 +2317,7 @@ void main() {
           dartDefines: <String>['a', 'b'],
         )
       ),
+      target: 'main.dart',
     );
     residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
     when(mockFlutterDevice.runHot(
@@ -2323,6 +2353,7 @@ void main() {
           extraFrontEndOptions: <String>['--enable-experiment=non-nullable>']
         )
       ),
+      target: 'main.dart',
     );
     residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
     when(mockFlutterDevice.runHot(
@@ -2352,6 +2383,7 @@ void main() {
       stayResident: false,
       dillOutputPath: 'test',
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
     when(mockFlutterDevice.runHot(
@@ -2384,6 +2416,7 @@ void main() {
         treeShakeIcons: false,
         trackWidgetCreation: true,
       )),
+      target: 'main.dart',
     );
     residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
     when(mockFlutterDevice.runHot(
@@ -2412,6 +2445,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runHot(
       hotRunner: anyNamed('hotRunner'),
@@ -2442,6 +2476,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runHot(
       hotRunner: anyNamed('hotRunner'),
@@ -2470,6 +2505,7 @@ void main() {
       ],
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
     );
     when(mockFlutterDevice.runCold(
       coldRunner: anyNamed('coldRunner'),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -248,33 +248,6 @@ void main() {
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
-  testUsingContext('Exits on run if target file does not exist', () async {
-    fileSystem.file('.packages')
-      ..createSync(recursive: true)
-      ..writeAsStringSync('\n');
-    final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
-      mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
-      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ipv6: true,
-      stayResident: true,
-      urlTunneller: null,
-    ) as ResidentWebRunner;
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    fileSystem.file('pubspec.yaml').createSync();
-    fileSystem.file(fileSystem.path.join('web', 'index.html'))
-      .createSync(recursive: true);
-
-    expect(await residentWebRunner.run(), 1);
-    final String absoluteMain = fileSystem.path.absolute(fileSystem.path.join('lib', 'main.dart'));
-    expect(testLogger.errorText, contains('Tried to run $absoluteMain, but that file does not exist.'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => processManager,
-    Pub: () => MockPub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
-  });
-
   testUsingContext('Can successfully run and connect to vmservice', () async {
     fileSystem.file('.packages')
       ..createSync(recursive: true)

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -114,7 +114,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
       await runner.run(<String>['test']);
 
-      expect(fakeTargetCommand.cachedTargetFile, 'lib/main.dart');
+      expect(fakeTargetCommand.cachedTargetFile, '/lib/main.dart');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
@@ -126,19 +126,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
       await runner.run(<String>['test', '-t', 'lib/foo.dart']);
 
-      expect(fakeTargetCommand.cachedTargetFile, 'lib/foo.dart');
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem.test(),
-      ProcessManager: () => FakeProcessManager.any(),
-    });
-
-        testUsingContext('finds the target file with specified value', () async {
-      globals.fs.file('lib/foo.dart').createSync(recursive: true);
-      final FakeTargetCommand fakeTargetCommand = FakeTargetCommand();
-      final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
-      await runner.run(<String>['test', '-t', 'lib/foo.dart']);
-
-      expect(fakeTargetCommand.cachedTargetFile, 'lib/foo.dart');
+      expect(fakeTargetCommand.cachedTargetFile, '/lib/foo.dart');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -6,8 +6,10 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/time.dart';
@@ -104,6 +106,52 @@ void main() {
         }
       );
       await flutterCommand.run();
+    });
+
+    testUsingContext('finds the target file with default values', () async {
+      globals.fs.file('lib/main.dart').createSync(recursive: true);
+      final FakeTargetCommand fakeTargetCommand = FakeTargetCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
+      await runner.run(<String>['test']);
+
+      expect(fakeTargetCommand.cachedTargetFile, 'lib/main.dart');
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('finds the target file with specified value', () async {
+      globals.fs.file('lib/foo.dart').createSync(recursive: true);
+      final FakeTargetCommand fakeTargetCommand = FakeTargetCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
+      await runner.run(<String>['test', '-t', 'lib/foo.dart']);
+
+      expect(fakeTargetCommand.cachedTargetFile, 'lib/foo.dart');
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+        testUsingContext('finds the target file with specified value', () async {
+      globals.fs.file('lib/foo.dart').createSync(recursive: true);
+      final FakeTargetCommand fakeTargetCommand = FakeTargetCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
+      await runner.run(<String>['test', '-t', 'lib/foo.dart']);
+
+      expect(fakeTargetCommand.cachedTargetFile, 'lib/foo.dart');
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('throws tool exit if specified file does not exist', () async {
+      final FakeTargetCommand fakeTargetCommand = FakeTargetCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
+
+      expect(() async => await runner.run(<String>['test', '-t', 'lib/foo.dart']), throwsToolExit());
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     void testUsingCommandContext(String testName, dynamic Function() testBody) {
@@ -483,6 +531,26 @@ class FakeNullSafeCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     return FlutterCommandResult.success();
   }
+}
+
+class FakeTargetCommand extends FlutterCommand {
+  FakeTargetCommand() {
+    usesTargetOption();
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    cachedTargetFile = targetFile;
+    return FlutterCommandResult.success();
+  }
+
+  String cachedTargetFile;
+
+  @override
+  String get description => '';
+
+  @override
+  String get name => 'test';
 }
 
 class MockVersion extends Mock implements FlutterVersion {}

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -114,7 +114,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
       await runner.run(<String>['test']);
 
-      expect(fakeTargetCommand.cachedTargetFile, '/lib/main.dart');
+      expect(fakeTargetCommand.cachedTargetFile, 'lib/main.dart');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
@@ -126,7 +126,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(fakeTargetCommand);
       await runner.run(<String>['test', '-t', 'lib/foo.dart']);
 
-      expect(fakeTargetCommand.cachedTargetFile, '/lib/foo.dart');
+      expect(fakeTargetCommand.cachedTargetFile, 'lib/foo.dart');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

Currently the flutter tool has two different ways of finding the target file and a few existence checks in each resident runner. Move to a single code path that uses the existing validation.

This causes a crash in beta, because the tool need to know the correct target file earlier so that it can determine the language version.

Fixes crash:

```
Thread 0 main threadFileSystemException: FileSystemException: Cannot open file, path = 'lib/main.dart' (OS Error: No such file or directory, errno = 2)

  | at _File.throwIfError | (file_impl.dart:635)
-- | -- | --
  | at _File.openSync | (file_impl.dart:479)
  | at _File.readAsBytesSync | (file_impl.dart:539)
  | at _File.readAsStringSync | (file_impl.dart:584)
  | at _File.readAsLinesSync | (file_impl.dart:590)
  | at ForwardingFile.readAsLinesSync | (forwarding_file.dart:104)
  | at ForwardingFile.readAsLinesSync | (forwarding_file.dart:104)
  | at determineLanguageVersion | (language_version.dart:27)
  | at FlutterDevice.create | (resident_runner.dart:113)
  | at <asynchronous gap> | (async)
  | at RunCommand.runCommand | (run.dart:531)
  | at <asynchronous gap> | (async)
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:1080)
  | at <asynchronous gap> | (async)
  | at FlutterCommand.run.<anonymous closure> | (flutter_command.dart:931)
  | at <asynchronous gap> | (async)
  | at AppContext.run.<anonymous closure> | (context.dart:150)
  | at <asynchronous gap> | (async)
  | at AppContext.run | (context.dart:149)
  | at <asynchronous gap> | (async)
  | at CommandRunner.runCommand | (command_runner.dart:197)
  | at <asynchronous gap> | (async)
  | at FlutterCommandRunner.runCommand.<anonymous closure> | (flutter_command_runner.dart:284)
  | at <asynchronous gap> | (async)
  | at AppContext.run.<anonymous closure> | (context.dart:150)
  | at <asynchronous gap> | (async)
  | at AppContext.run | (context.dart:149)
  | at <asynchronous gap> | (async)
  | at FlutterCommandRunner.runCommand | (flutter_command_runner.dart:230)
  | at <asynchronous gap> | (async)
  | at run.<anonymous closure>.<anonymous closure> | (runner.dart:63)
  | at <asynchronous gap> | (async)
  | at run.<anonymous closure> | (runner.dart:61)
  | at <asynchronous gap> | (async)
  | at AppContext.run.<anonymous closure> | (context.dart:150)
  | at <asynchronous gap> | (async)
  | at AppContext.run | (context.dart:149)
  | at <asynchronous gap> | (async)
  | at runInContext | (context_runner.dart:70)
  | at <asynchronous gap> | (async)
  | at main | (executable.dart:90)
  | at <asynchronous gap> | (async)
```
