### PR TITLE
[flutter] Update package README

### DIFF
--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -1,9 +1,9 @@
-Flutter
-=======
+# Flutter
 
-Flutter is a new way to build high-performance, cross-platform mobile apps.
-Flutter is optimized for today's — and tomorrow's — mobile devices. We are
-focused on low-latency input and high frame rates on Android and iOS.
+Flutter is a new way to build high-performance, cross-platform mobile, web,
+and desktop apps. Flutter is optimized for today's — and tomorrow's — mobile
+and desktop devices. We are focused on low-latency input and high frame rates
+on all platforms.
 
 See the [getting started guide](https://flutter.dev/getting-started/) for
 information about using Flutter.


### PR DESCRIPTION
## Description

It bugs me that I see this outdated README every time I open the `flutter` framework package for reading or contributing.

I adjusted the header syntax to match [the main README](https://github.com/flutter/flutter/blob/master/README.md) and other READMEs of packages in the framework (e.g. `flutter_localizations` or `flutter_tools`).  
Additionally, I made sure that the information in the short description now also matches the inclusion of web and desktop efforts.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
