### PR TITLE
Wait for Android plugin to load before configuring plugin dependency

### DIFF
--- a/dev/devicelab/bin/tasks/android_plugin_example_app_build_test.dart
+++ b/dev/devicelab/bin/tasks/android_plugin_example_app_build_test.dart
@@ -1,0 +1,84 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
+final String gradlewExecutable = Platform.isWindows ? '.\\$gradlew' : './$gradlew';
+
+/// Tests that a plugin example app can be built using the current Flutter Gradle plugin.
+Future<void> main() async {
+  await task(() async {
+
+    section('Find Java');
+
+    final String javaHome = await findJavaHome();
+    if (javaHome == null) {
+      return TaskResult.failure('Could not find Java');
+    }
+
+    print('\nUsing JAVA_HOME=$javaHome');
+
+    section('Create Flutter plugin project');
+
+    await flutter(
+      'precache',
+      options: <String>['--android', '--no-ios'],
+    );
+
+    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_test.');
+    final Directory projectDir = Directory(path.join(tempDir.path, 'plugin_test'));
+    try {
+      await inDirectory(tempDir, () async {
+        await flutter(
+          'create',
+          options: <String>['--template=plugin', '--platforms=android', 'plugin_test'],
+        );
+      });
+
+      final Directory exampleAppDir = Directory(path.join(projectDir.path, 'example'));
+      if (!exists(exampleAppDir)) {
+        return TaskResult.failure('Example app directory doesn\'t exist');
+      }
+
+      section('Run flutter build apk');
+
+      await inDirectory(exampleAppDir, () async {
+        await flutter(
+          'build',
+          options: <String>[
+            'apk',
+            '--target-platform=android-arm',
+          ],
+        );
+      });
+
+      final String exampleApk = path.join(
+        exampleAppDir.path,
+        'build',
+        'app',
+        'outputs',
+        'flutter-apk',
+        'app-release.apk',
+      );
+
+      if (!exists(File(exampleApk))) {
+        return TaskResult.failure('Failed to build app-release.apk');
+      }
+
+      return TaskResult.success(null);
+    } on TaskResult catch (taskResult) {
+      return taskResult;
+    } catch (e) {
+      return TaskResult.failure(e.toString());
+    } finally {
+      rmTree(tempDir);
+    }
+  });
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -314,6 +314,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  android_plugin_example_app_build_test:
+    description: >
+      Tests that the plugin example app can be built using the Flutter Gradle plugin.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+
   run_release_test:
     description: >
       Checks that `flutter run --release` does not crash.

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -363,8 +363,11 @@ class FlutterPlugin implements Plugin<Project> {
                 !doesSupportAndroidPlatform(dependencyProject.projectDir.parentFile.path)) {
                 return
             }
-            pluginProject.dependencies {
-                implementation dependencyProject
+            // Wait for the Android plugin to load and add the dependency to the plugin project.
+            pluginProject.afterEvaluate {
+                pluginProject.dependencies {
+                    implementation dependencyProject
+                }
             }
         }
     }


### PR DESCRIPTION
`implementation` is provided by the Android Gradle plugin. It cannot be called before the Android plugin has loaded, and registered an `implementation` callback. 

`afterEvaluate` ensures that `implementation` is only called after this plugin loaded.
