### PR TITLE
Remove private OutlinedButton default outline geometry class

### DIFF
--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -242,7 +242,7 @@ class OutlinedButton extends ButtonStyleButton {
         color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
         width: 1,
       ),
-      shape: const _Outline(borderRadius: BorderRadius.all(Radius.circular(4))),
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
       enabledMouseCursor: SystemMouseCursors.click,
       disabledMouseCursor: SystemMouseCursors.forbidden,
       visualDensity: theme.visualDensity,
@@ -347,71 +347,5 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[icon, SizedBox(width: gap), label],
     );
-  }
-}
-
-
-// This subclass only exists for the sake of backwards compatibility with the
-// outline drawn by the original OutlineButton widget. The paint override
-// draws a Path that's stroked with BorderSide, rather than filling a rounded
-// rect whose inner path is the outer path inset by the BorderSide's width.
-class _Outline extends RoundedRectangleBorder {
-  const _Outline({
-    BorderSide side = BorderSide.none,
-    required BorderRadiusGeometry borderRadius,
-  }) : super(side: side, borderRadius: borderRadius);
-
-  @override
-  ShapeBorder scale(double t) {
-    return _Outline(
-      side: side.scale(t),
-      borderRadius: borderRadius * t,
-    );
-  }
-
-  @override
-  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
-    assert(t != null);
-    if (a is _Outline) {
-      return _Outline(
-        side: BorderSide.lerp(a.side, side, t),
-        borderRadius: BorderRadiusGeometry.lerp(a.borderRadius, borderRadius, t)!,
-      );
-    }
-    return super.lerpFrom(a, t);
-  }
-
-  @override
-  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
-    assert(t != null);
-    if (b is _Outline) {
-      return _Outline(
-        side: BorderSide.lerp(side, b.side, t),
-        borderRadius: BorderRadiusGeometry.lerp(borderRadius, b.borderRadius, t)!,
-      );
-    }
-    return super.lerpTo(b, t);
-  }
-
-  @override
-  _Outline copyWith({ BorderSide? side, BorderRadius? borderRadius }) {
-    return _Outline(
-      side: side ?? this.side,
-      borderRadius: borderRadius ?? this.borderRadius,
-    );
-  }
-
-  @override
-  void paint(Canvas canvas, Rect rect, { TextDirection? textDirection }) {
-    switch (side.style) {
-      case BorderStyle.none:
-        break;
-      case BorderStyle.solid:
-        if (side.width == 0.0) {
-          super.paint(canvas, rect, textDirection: textDirection);
-        } else {
-          canvas.drawPath(getOuterPath(rect, textDirection: textDirection), side.toPaint());
-        }
-    }
   }
 }

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -542,12 +542,12 @@ void main() {
     final Finder outlinedButton = find.byType(OutlinedButton);
 
     // Default, not disabled.
-    expect(outlinedButton, paints..path(color: defaultColor));
+    expect(outlinedButton, paints..drrect(color: defaultColor));
 
     // Focused.
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(outlinedButton, paints..path(color: focusedColor));
+    expect(outlinedButton, paints..drrect(color: focusedColor));
 
     // Hovered.
     final Offset center = tester.getCenter(find.byType(OutlinedButton));
@@ -558,12 +558,12 @@ void main() {
     addTearDown(gesture.removePointer);
     await gesture.moveTo(center);
     await tester.pumpAndSettle();
-    expect(outlinedButton, paints..path(color: hoverColor));
+    expect(outlinedButton, paints..drrect(color: hoverColor));
 
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pumpAndSettle();
-    expect(outlinedButton, paints..path(color: pressedColor));
+    expect(outlinedButton, paints..drrect(color: pressedColor));
   });
 
   testWidgets('OutlinedButton onPressed and onLongPress callbacks are correctly called when non-null', (WidgetTester tester) async {


### PR DESCRIPTION
Remove OutlinedButton's private `_Outline`  RoundedRectangleBorder subclass. 

It was added in https://github.com/flutter/flutter/pull/70393 to satisfy a backwards incompatibility (a one pixel difference) in the way the default outline was rendered. This is no longer necessary as of (internal Google change) cl/339303032.