### PR TITLE
[flutter_tools] fix port leak in flutter_driver

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -235,16 +235,9 @@ class FlutterDriverService extends DriverService {
     int driverPort,
     List<String> browserDimension,
   }) async {
-    // Check if package:test is available. If not, fall back to invoking
-    // the test script directly. `pub run test` is strictly better because
-    // in the even that a socket or something similar is left open, the
-    // test runner will correctly shutdown the VM instead of hanging forever.
     return _processUtils.stream(<String>[
       _dartSdkPath,
-      if (packageConfig['test'] != null)
-        ...<String>['pub', 'run', 'test', ...arguments, testFile, '-rexpanded']
-      else
-        ...<String>[...arguments, testFile, '-rexpanded'],
+      ...<String>[...arguments, testFile, '-rexpanded'],
     ], environment: <String, String>{
       'VM_SERVICE_URL': _vmServiceUri,
       ...environment,

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -153,7 +153,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', 'pub', 'run', 'test', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
+        command: <String>['dart', '--enable-experiment=non-nullable', 'foo.test', '-rexpanded'],
         exitCode: 23,
         environment: <String, String>{
           'FOO': 'BAR',
@@ -214,7 +214,7 @@ void main() {
     ]);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['dart', 'pub', 'run', 'test', 'foo.test', '-rexpanded'],
+        command: <String>['dart', 'foo.test', '-rexpanded'],
         exitCode: 11,
         environment: <String, String>{
           'VM_SERVICE_URL': 'http://127.0.0.1:1234/'


### PR DESCRIPTION
## Description

The connect URI method in flutter driver was leaking a port. Fix this so that the tool does not need to run through pub.

Fixes https://github.com/flutter/flutter/issues/70983