### PR TITLE
[flutter_tools] Set basic error matcher for Linux builds

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -16,6 +16,12 @@ import '../globals.dart' as globals;
 import '../plugins.dart';
 import '../project.dart';
 
+// Matches the following error and warning patterns:
+// - <file path>:<line>:<column>: error: <error...>
+// - <file path>:<line>:<column>: warning: <warning...>
+// - clang: error: <link error...>
+final RegExp errorMatcher = RegExp(r'(?:.*:\d+:\d+|clang):\s?(?:error|warning):\s.*', caseSensitive: false);
+
 /// Builds the Linux project through the Makefile.
 Future<void> buildLinux(
   LinuxProject linuxProject,
@@ -130,6 +136,7 @@ Future<void> _runBuild(Directory buildDir) async {
           'VERBOSE_SCRIPT_LOGGING': 'true'
       },
       trace: true,
+      stdoutErrorMatcher: errorMatcher,
     );
   } on ArgumentError {
     throwToolExit("ninja not found. Run 'flutter doctor' for more information.");


### PR DESCRIPTION
## Description

This improves the situation a lot because, in contrast to not showing any error, this patch makes at least the most important part of the error visible. Notice that Clang includes [expressive diagnostics](https://clang.llvm.org/diagnostics.html) on consequent lines, but they are not caught by this regexp.

### Before

Any build error:
```
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
Exception: Build process failed
```

### After

Dart error:
``` 
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
lib/main.dart:10:3: Error: Type 'UnknownWidget' not found.
Exception: Build process failed
```

C++ error:
``` 
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
/path/to/linux/main.cc:4:3: error: unknown type name 'UnknownType'
Exception: Build process failed
```

## Related Issues

#33584

## Tests

I added the following tests:

- `test/commands.shard/hermetic/build_linux_test.dart`: 'Linux build extracts errors from stdout'

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
