### PR TITLE
iOS aot assembly requires SDK root

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -47,6 +47,10 @@ abstract class AotAssemblyBase extends Target {
     if (environment.defines[kTargetPlatform] == null) {
       throw MissingDefineException(kTargetPlatform, 'aot_assembly');
     }
+    if (environment.defines[kSdkRoot] == null) {
+      throw MissingDefineException(kSdkRoot, 'aot_assembly');
+    }
+
     final List<String> extraGenSnapshotOptions = decodeDartDefines(environment.defines, kExtraGenSnapshotOptions);
     final bool bitcode = environment.defines[kBitcodeFlag] == 'true';
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -187,6 +187,7 @@ void main() {
       fileSystem.currentDirectory,
       defines: <String, String>{
         kTargetPlatform: 'ios',
+        kSdkRoot: 'path/to/sdk',
       },
       processManager: processManager,
       artifacts: artifacts,
@@ -202,6 +203,34 @@ void main() {
         'description',
         contains('release/profile builds are only supported for physical devices.'),
       )
+    ));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => macPlatform,
+  });
+
+  testUsingContext('AotAssemblyRelease throws exception if sdk root is missing', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Environment environment = Environment.test(
+      fileSystem.currentDirectory,
+      defines: <String, String>{
+        kTargetPlatform: 'ios',
+      },
+      processManager: processManager,
+      artifacts: artifacts,
+      logger: logger,
+      fileSystem: fileSystem,
+    );
+    environment.defines[kBuildMode] = 'release';
+    environment.defines[kIosArchs] = 'x86_64';
+
+    expect(const AotAssemblyRelease().build(environment), throwsA(isA<Exception>()
+        .having(
+          (Exception exception) => exception.toString(),
+      'description',
+      contains('required define SdkRoot but it was not provided'),
+    )
     ));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,


### PR DESCRIPTION
## Description

#69840 added a requirement that `kSdkRoot` [be passed into the aot build system target](https://github.com/flutter/flutter/blob/2529e358b6b12920d642db2c9e349d652cabd7f6/packages/flutter_tools/lib/src/build_system/targets/ios.dart#L93) (from [xcodebuild.sh](https://github.com/flutter/flutter/blob/2529e358b6b12920d642db2c9e349d652cabd7f6/packages/flutter_tools/bin/xcode_backend.sh#L184)).  Enforce this with a `MissingDefineException` to match the other expected passed in variables.

## Related Issues

#69840

## Tests

`AotAssemblyRelease throws exception if sdk root is missing`