### PR TITLE
Rename SdkType -> EnvironmentType

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -12,7 +12,6 @@ import 'base/logger.dart';
 import 'base/utils.dart';
 import 'build_system/targets/icon_tree_shaker.dart';
 import 'globals.dart' as globals;
-import 'macos/xcode.dart';
 
 /// Information about a build to be performed or used.
 class BuildInfo {
@@ -316,6 +315,12 @@ BuildMode getBuildModeForName(String name) {
   return BuildMode.fromName(name);
 }
 
+/// Environment type of the target device.
+enum EnvironmentType {
+  physical,
+  simulator,
+}
+
 String validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String buildNumber, Logger logger) {
   if (buildNumber == null) {
     return null;
@@ -477,22 +482,18 @@ enum AndroidArch {
 }
 
 /// The default set of iOS device architectures to build for.
-List<DarwinArch> defaultIOSArchsForSdk(SdkType sdkType) {
-  switch (sdkType) {
-    case SdkType.iPhone:
-      return <DarwinArch>[
-        DarwinArch.armv7,
-        DarwinArch.arm64,
-      ];
-    case SdkType.iPhoneSimulator:
-      return <DarwinArch>[
-        // Apple Silicon ARM simulators not yet supported.
-        DarwinArch.x86_64,
-      ];
-    default:
-      assert(false, 'Unknown SDK type $sdkType');
-      return null;
+List<DarwinArch> defaultIOSArchsForEnvironment(
+    EnvironmentType environmentType) {
+  if (environmentType == EnvironmentType.simulator) {
+    return <DarwinArch>[
+      // Apple Silicon ARM simulators not yet supported.
+      DarwinArch.x86_64,
+    ];
   }
+  return <DarwinArch>[
+    DarwinArch.armv7,
+    DarwinArch.arm64,
+  ];
 }
 
 String getNameForDarwinArch(DarwinArch arch) {

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -21,7 +21,6 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
-import '../macos/xcode.dart';
 import '../plugins.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
@@ -375,11 +374,13 @@ end
     final Status status = globals.logger.startProgress(
       ' ├─Building App.framework...',
     );
-    final List<SdkType> sdkTypes = <SdkType>[SdkType.iPhone];
+    final List<EnvironmentType> environmentTypes = <EnvironmentType>[
+      EnvironmentType.physical,
+    ];
     final List<Directory> frameworks = <Directory>[];
     Target target;
     if (buildInfo.isDebug) {
-      sdkTypes.add(SdkType.iPhoneSimulator);
+      environmentTypes.add(EnvironmentType.simulator);
       target = const DebugIosApplicationBundle();
     } else if (buildInfo.isProfile) {
       target = const ProfileIosApplicationBundle();
@@ -388,10 +389,11 @@ end
     }
 
     try {
-      for (final SdkType sdkType in sdkTypes) {
-        final Directory outputBuildDirectory = sdkType == SdkType.iPhone
-            ? iPhoneBuildOutput
-            : simulatorBuildOutput;
+      for (final EnvironmentType sdkType in environmentTypes) {
+        final Directory outputBuildDirectory =
+            sdkType == EnvironmentType.physical
+                ? iPhoneBuildOutput
+                : simulatorBuildOutput;
         frameworks.add(outputBuildDirectory.childDirectory(appFrameworkName));
         final Environment environment = Environment(
           projectDir: globals.fs.currentDirectory,
@@ -411,7 +413,7 @@ end
                   buildInfo.extraGenSnapshotOptions.join(','),
             if (buildInfo?.extraFrontEndOptions?.isNotEmpty ?? false)
               kExtraFrontEndOptions: buildInfo.extraFrontEndOptions.join(','),
-            kIosArchs: defaultIOSArchsForSdk(sdkType)
+            kIosArchs: defaultIOSArchsForEnvironment(sdkType)
                 .map(getNameForDarwinArch)
                 .join(' '),
             kSdkRoot: await globals.xcode.sdkLocation(sdkType),

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -300,9 +300,8 @@ void main() {
         });
 
         testWithoutContext('SDK name', () {
-          expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
-          expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
-          expect(getNameForSdk(SdkType.macOS), 'macosx');
+          expect(getSDKNameForIOSEnvironmentType(EnvironmentType.physical), 'iphoneos');
+          expect(getSDKNameForIOSEnvironmentType(EnvironmentType.simulator), 'iphonesimulator');
         });
 
         group('SDK location', () {
@@ -314,17 +313,7 @@ void main() {
               stdout: sdkroot,
             ));
 
-            expect(await xcode.sdkLocation(SdkType.iPhone), sdkroot);
-            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-          });
-
-          testWithoutContext('--show-sdk-path macosx', () async {
-            fakeProcessManager.addCommand(const FakeCommand(
-              command: <String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
-              stdout: sdkroot,
-            ));
-
-            expect(await xcode.sdkLocation(SdkType.macOS), sdkroot);
+            expect(await xcode.sdkLocation(EnvironmentType.physical), sdkroot);
             expect(fakeProcessManager.hasRemainingExpectations, isFalse);
           });
 
@@ -335,7 +324,7 @@ void main() {
               stderr: 'xcrun: error:',
             ));
 
-            expect(() async => await xcode.sdkLocation(SdkType.iPhone),
+            expect(() async => await xcode.sdkLocation(EnvironmentType.physical),
               throwsToolExit(message: 'Could not find SDK location'));
             expect(fakeProcessManager.hasRemainingExpectations, isFalse);
           });


### PR DESCRIPTION
## Description

Rename SdkType to EnvironmentType to make it more generic than just the SDK used to build.  

The macOS code path was unused.

## Related Issues

Will be used as part of https://github.com/flutter/flutter/issues/60109 to specify simulator and non-simulator engine framework paths.