### PR TITLE
Move Flutter.podspec to add-to-app project template

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -116,7 +116,6 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
   local flutter_engine_flag=""
   local local_engine_flag=""
   local flutter_framework="${framework_path}/Flutter.framework"
-  local flutter_podspec="${framework_path}/Flutter.podspec"
 
   if [[ -n "$FLUTTER_ENGINE" ]]; then
     flutter_engine_flag="--local-engine-src-path=${FLUTTER_ENGINE}"
@@ -137,7 +136,6 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     fi
     local_engine_flag="--local-engine=${LOCAL_ENGINE}"
     flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/Flutter.framework"
-    flutter_podspec="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/Flutter.podspec"
   fi
 
   local bitcode_flag=""
@@ -147,9 +145,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
 
   # TODO(jmagman): use assemble copied engine in add-to-app.
   if [[ -e "${project_path}/.ios" ]]; then
-    RunCommand rm -rf -- "${derived_dir}/engine"
-    mkdir "${derived_dir}/engine"
-    RunCommand cp -r -- "${flutter_podspec}" "${derived_dir}/engine"
+    RunCommand rm -rf -- "${derived_dir}/engine/Flutter.framework"
     RunCommand cp -r -- "${flutter_framework}" "${derived_dir}/engine"
   fi
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -653,7 +653,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   }
 
   void copyEngineArtifactToProject(BuildMode mode) {
-    // Copy podspec and framework from engine cache. The actual build mode
+    // Copy framework from engine cache. The actual build mode
     // doesn't actually matter as it will be overwritten by xcode_backend.sh.
     // However, cocoapods will run before that script and requires something
     // to be in this location.
@@ -665,12 +665,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       )
     );
     if (framework.existsSync()) {
-      final File podspec = framework.parent.childFile('Flutter.podspec');
       globals.fsUtils.copyDirectorySync(
         framework,
         engineCopyDirectory.childDirectory('Flutter.framework'),
       );
-      podspec.copySync(engineCopyDirectory.childFile('Flutter.podspec').path);
     }
   }
 

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Flutter/engine/Flutter.podspec.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Flutter/engine/Flutter.podspec.tmpl
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -30,12 +30,13 @@ end
 def install_flutter_engine_pod
   current_directory = File.expand_path('..', __FILE__)
   engine_dir = File.expand_path('engine', current_directory)
-  copied_engine = File.expand_path('Flutter.framework', engine_dir)
+  framework_name = 'Flutter.framework'
+  copied_engine = File.expand_path(framework_name, engine_dir)
   if !File.exist?(copied_engine)
     # Copy the debug engine to have something to link against if the xcode backend script has not run yet.
     # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
     debug_framework_dir = File.join(flutter_root, 'bin', 'cache', 'artifacts', 'engine', 'ios')
-    FileUtils.cp_r(File.join(debug_framework_dir, 'Flutter.framework'), engine_dir)
+    FileUtils.cp_r(File.join(debug_framework_dir, framework_name), engine_dir)
   end
 
   # Keep pod path relative so it can be checked into Podfile.lock.

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -30,11 +30,12 @@ end
 def install_flutter_engine_pod
   current_directory = File.expand_path('..', __FILE__)
   engine_dir = File.expand_path('engine', current_directory)
-  if !File.exist?(engine_dir)
+  copied_engine = File.expand_path('Flutter.framework', engine_dir)
+  if !File.exist?(copied_engine)
     # Copy the debug engine to have something to link against if the xcode backend script has not run yet.
     # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
     debug_framework_dir = File.join(flutter_root, 'bin', 'cache', 'artifacts', 'engine', 'ios')
-    FileUtils.cp_r(File.join(debug_framework_dir, 'Flutter.framework'), engine_dir)
+    FileUtils.cp_r(copied_engine, engine_dir)
   end
 
   # Keep pod path relative so it can be checked into Podfile.lock.

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -34,9 +34,7 @@ def install_flutter_engine_pod
     # Copy the debug engine to have something to link against if the xcode backend script has not run yet.
     # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
     debug_framework_dir = File.join(flutter_root, 'bin', 'cache', 'artifacts', 'engine', 'ios')
-    FileUtils.mkdir_p(engine_dir)
     FileUtils.cp_r(File.join(debug_framework_dir, 'Flutter.framework'), engine_dir)
-    FileUtils.cp(File.join(debug_framework_dir, 'Flutter.podspec'), engine_dir)
   end
 
   # Keep pod path relative so it can be checked into Podfile.lock.

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -35,7 +35,7 @@ def install_flutter_engine_pod
     # Copy the debug engine to have something to link against if the xcode backend script has not run yet.
     # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
     debug_framework_dir = File.join(flutter_root, 'bin', 'cache', 'artifacts', 'engine', 'ios')
-    FileUtils.cp_r(copied_engine, engine_dir)
+    FileUtils.cp_r(File.join(debug_framework_dir, 'Flutter.framework'), engine_dir)
   end
 
   # Keep pod path relative so it can be checked into Podfile.lock.

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -176,6 +176,7 @@
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Debug.xcconfig",
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Flutter.xcconfig",
         "templates/module/ios/host_app_ephemeral/Config.tmpl/Release.xcconfig",
+        "templates/module/ios/host_app_ephemeral/Flutter/engine/Flutter.podspec.tmpl",
         "templates/module/ios/host_app_ephemeral/Runner.tmpl/AppDelegate.h",
         "templates/module/ios/host_app_ephemeral/Runner.tmpl/AppDelegate.m",
         "templates/module/ios/host_app_ephemeral/Runner.tmpl/Assets.xcassets/AppIcon.appiconset/Contents.json",

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -134,6 +134,7 @@ void main() {
       '.gitignore',
       '.ios/Flutter',
       '.ios/Flutter/flutter_project.podspec',
+      '.ios/Flutter/engine/Flutter.podspec',
       '.metadata',
       'lib/main.dart',
       'pubspec.yaml',


### PR DESCRIPTION
## Description

`Flutter.podspec` is only used in add-to-app modules.  Stop using the one shipped in the engine artifacts and instead generate from the tool template.

This doesn't need a migration--previous versions of Flutter have already copied an identical `Flutter.podspec` to that spot, and `flutter clean` totally recreates `.ios` anyway.

## Related Issues

https://github.com/flutter/flutter/issues/60109 will require Flutter.podspec to change to `s.vendored_frameworks = 'Flutter.xcframework'`.  It will be easier to handle this migration in the tool instead of coordinating a framework repo change with the right engine roll.

## Tests

Added file to `create_test`.  This logic is also tested in `module_test_ios` and `build_ios_framework_module_test`.
