### PR TITLE
Add XCFramework artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -12,6 +12,7 @@ import '../../base/io.dart';
 import '../../base/process.dart';
 import '../../build_info.dart';
 import '../../globals.dart' as globals hide fs, logger, processManager, artifacts;
+import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';
@@ -267,10 +268,16 @@ abstract class UnpackIOS extends Target {
 
   @override
   Future<void> build(Environment environment) async {
+    if (environment.defines[kSdkRoot] == null) {
+      throw MissingDefineException(kSdkRoot, name);
+    }
+    final Directory sdkRoot = environment.fileSystem.directory(environment.defines[kSdkRoot]);
+    final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot);
     final String basePath = environment.artifacts.getArtifactPath(
       Artifact.flutterFramework,
       platform: TargetPlatform.ios,
       mode: buildMode,
+      environmentType: environmentType,
     );
 
     final ProcessResult result = environment.processManager.runSync(<String>[

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -459,7 +459,7 @@ end
       // copy the corresponding engine.
       // A plugin framework built with bitcode must link against the bitcode version
       // of Flutter.framework (Release).
-      _project.ios.copyEngineArtifactToProject(mode);
+      _project.ios.copyEngineArtifactToProject(mode, EnvironmentType.physical);
 
       final String bitcodeGenerationMode = mode == BuildMode.release ?
           'bitcode' : 'marker'; // In release, force bitcode embedding without archiving.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -648,11 +648,11 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
           ephemeralDirectory,
         );
       }
-      copyEngineArtifactToProject(BuildMode.debug);
+      copyEngineArtifactToProject(BuildMode.debug, EnvironmentType.physical);
     }
   }
 
-  void copyEngineArtifactToProject(BuildMode mode) {
+  void copyEngineArtifactToProject(BuildMode mode, EnvironmentType environmentType) {
     // Copy framework from engine cache. The actual build mode
     // doesn't actually matter as it will be overwritten by xcode_backend.sh.
     // However, cocoapods will run before that script and requires something
@@ -662,6 +662,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
         Artifact.flutterFramework,
         platform: TargetPlatform.ios,
         mode: mode,
+        environmentType: environmentType,
       )
     );
     if (framework.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -544,8 +544,12 @@ include ':app'
       String expectedBuildName,
       String expectedBuildNumber,
     }) async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.android_arm, mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: TargetPlatform.android_arm,
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(globals.fs.path.join('out', 'android_arm'));
 
       final File manifestFile = globals.fs.file('path/to/project/pubspec.yaml');
@@ -1686,8 +1690,12 @@ plugin1=${plugin1.path}
     });
 
     testUsingContext('build apk uses selected local engine,the engine abi is arm', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.android_arm, mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: TargetPlatform.android_arm,
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm'));
 
       fileSystem.file('out/android_arm/flutter_embedding_release.pom')
@@ -1779,8 +1787,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build apk uses selected local engine,the engine abi is arm64', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm64'));
 
       fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
@@ -1872,8 +1884,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build apk uses selected local engine,the engine abi is x86', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x86'));
 
       fileSystem.file('out/android_x86/flutter_embedding_release.pom')
@@ -1965,8 +1981,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build apk uses selected local engine,the engine abi is x64', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x64'));
 
       fileSystem.file('out/android_x64/flutter_embedding_release.pom')
@@ -2110,8 +2130,12 @@ plugin1=${plugin1.path}
     });
 
     testUsingContext('build aar uses selected local engine，the engine abi is arm', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.android_arm, mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: TargetPlatform.android_arm,
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm'));
 
       fileSystem.file('out/android_arm/flutter_embedding_release.pom')
@@ -2207,8 +2231,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build aar uses selected local engine，the engine abi is arm64', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm64'));
 
       fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
@@ -2305,8 +2333,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build aar uses selected local engine，the engine abi is x86', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x86'));
 
       fileSystem.file('out/android_x86/flutter_embedding_release.pom')
@@ -2403,8 +2435,12 @@ plugin1=${plugin1.path}
 
     testUsingContext(
         'build aar uses selected local engine，the engine abi is x64', () async {
-      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: anyNamed('platform'), mode: anyNamed('mode'))).thenReturn('engine');
+      when(mockArtifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+        environmentType: anyNamed('environmentType'),
+      )).thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x64'));
 
       fileSystem.file('out/android_x64/flutter_embedding_release.pom')

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -47,6 +47,10 @@ void main() {
         fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'ios-release', 'Flutter.framework'),
       );
       expect(
+        artifacts.getArtifactPath(Artifact.flutterXcframework, platform: TargetPlatform.ios, mode: BuildMode.release),
+        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'ios-release', 'Flutter.xcframework'),
+      );
+      expect(
         artifacts.getArtifactPath(Artifact.flutterTester),
         fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester'),
       );
@@ -135,6 +139,10 @@ void main() {
       expect(
         artifacts.getArtifactPath(Artifact.flutterFramework, platform: TargetPlatform.ios, mode: BuildMode.release),
         fileSystem.path.join('/out', 'android_debug_unopt', 'Flutter.framework'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterXcframework, platform: TargetPlatform.ios, mode: BuildMode.release),
+        fileSystem.path.join('/out', 'android_debug_unopt', 'Flutter.xcframework'),
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -238,30 +238,65 @@ void main() {
     Platform: () => macPlatform,
   });
 
-  testWithoutContext('Unpack copies Flutter.framework', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    final Directory outputDir = fileSystem.directory('output');
-    final Environment environment = Environment.test(
-      fileSystem.currentDirectory,
-      processManager: processManager,
-      artifacts: artifacts,
-      logger: logger,
-      fileSystem: fileSystem,
-      outputDir: outputDir,
-    );
+  group('copy engine Flutter.framework', () {
+    testWithoutContext('iphonesimulator', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('output');
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kSdkRoot: 'path/to/iPhoneSimulator.sdk',
+        },
+      );
 
-    processManager.addCommand(
-      FakeCommand(command: <String>[
-        'rsync',
-        '-av',
-        '--delete',
-        '--filter',
-        '- .DS_Store/',
-        'Artifact.flutterFramework.TargetPlatform.ios.debug',
-        outputDir.path,
-      ]),
-    );
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'rsync',
+          '-av',
+          '--delete',
+          '--filter',
+          '- .DS_Store/',
+          'Artifact.flutterFramework.TargetPlatform.ios.debug.EnvironmentType.simulator',
+          outputDir.path,
+        ]),
+      );
 
-    await const DebugUnpackIOS().build(environment);
+      await const DebugUnpackIOS().build(environment);
+    });
+
+    testWithoutContext('iphoneos', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('output');
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kSdkRoot: 'path/to/iPhoneOS.sdk',
+        },
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'rsync',
+          '-av',
+          '--delete',
+          '--filter',
+          '- .DS_Store/',
+          'Artifact.flutterFramework.TargetPlatform.ios.debug.EnvironmentType.physical',
+          outputDir.path,
+        ]),
+      );
+
+      await const DebugUnpackIOS().build(environment);
+    });
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -638,7 +638,10 @@ Information about project "Runner":
 
     testUsingOsxContext('sets OTHER_LDFLAGS for iOS', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn(fs.path.join('engine', 'Flutter.framework'));
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn(fs.path.join('engine', 'Flutter.framework'));
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
@@ -663,7 +666,10 @@ Information about project "Runner":
 
     testUsingOsxContext('do not set OTHER_LDFLAGS for macOS', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterMacOSFramework,
-          platform: TargetPlatform.darwin_x64, mode: anyNamed('mode'))).thenReturn(fs.path.join('engine', 'FlutterMacOS.framework'));
+              platform: TargetPlatform.darwin_x64,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn(fs.path.join('engine', 'FlutterMacOS.framework'));
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
@@ -689,7 +695,10 @@ Information about project "Runner":
 
     testUsingOsxContext('sets ARCHS=armv7 when armv7 local engine is set', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
@@ -714,7 +723,10 @@ Information about project "Runner":
 
     testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
@@ -738,7 +750,10 @@ Information about project "Runner":
 
     testUsingOsxContext('does not set TRACK_WIDGET_CREATION when trackWidgetCreation is false', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
@@ -762,7 +777,10 @@ Information about project "Runner":
 
     testUsingOsxContext('sets ARCHS=armv7 when armv7 local engine is set', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
 
@@ -795,7 +813,10 @@ Information about project "Runner":
       String expectedBuildNumber,
     }) async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
+              platform: TargetPlatform.ios,
+              mode: anyNamed('mode'),
+              environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios'));
 
       final File manifestFile = fs.file('path/to/project/pubspec.yaml');


### PR DESCRIPTION
## Description

Add unused `Artifact.flutterXcframework` to get ready for the XCFramework being added to the uploaded engine artifacts.

Pass `EnvironmentType` into the artifacts logic.  This will be used to differentiate `Flutter.xcframework/ios-x86_64-simulator/Flutter.framework` from `Flutter.xcframework/ios-arm64_armv7/Flutter.framework`.  Parse the environment (iOS vs iOS simulator) in the ios build system target.

## Related Issues

Will be used as part of #60109 when the xcframework is added to artifacts.

## Tests

artifacts test, ios build system target test
