### PR TITLE
[gen-l10n] Fix forwarding of output-dir in l10n.yaml file

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/localizations.dart
@@ -43,7 +43,7 @@ void generateLocalizations({
 
   precacheLanguageAndRegionTags();
 
-  final String inputPathString = options?.arbDirectory?.toFilePath() ?? globals.fs.path.join('lib', 'l10n');
+  final String inputPathString = options?.arbDirectory?.path ?? globals.fs.path.join('lib', 'l10n');
   final String templateArbFileName = options?.templateArbFile?.toFilePath() ?? 'app_en.arb';
   final String outputFileString = options?.outputLocalizationsFile?.toFilePath() ?? 'app_localizations.dart';
 
@@ -55,6 +55,7 @@ void generateLocalizations({
         inputPathString: inputPathString,
         templateArbFileName: templateArbFileName,
         outputFileString: outputFileString,
+        outputPathString: options?.outputDirectory?.path,
         classNameString: options.outputClass ?? 'AppLocalizations',
         preferredSupportedLocale: options.preferredSupportedLocales,
         headerString: options.header,
@@ -155,6 +156,7 @@ class LocalizationOptions {
     this.untranslatedMessagesFile,
     this.header,
     this.outputClass,
+    this.outputDirectory,
     this.preferredSupportedLocales,
     this.headerFile,
     this.deferredLoading,
@@ -164,7 +166,7 @@ class LocalizationOptions {
 
   /// The `--arb-dir` argument.
   ///
-  /// The directory where all localization files should reside.
+  /// The directory where all input localization files should reside.
   final Uri arbDirectory;
 
   /// The `--template-arb-file` argument.
@@ -189,6 +191,11 @@ class LocalizationOptions {
 
   /// The `--output-class` argument.
   final String outputClass;
+
+  /// The `--output-dir` argument.
+  ///
+  /// The directory where all output localization files should be generated.
+  final Uri outputDirectory;
 
   /// The `--preferred-supported-locales` argument.
   final List<String> preferredSupportedLocales;
@@ -244,6 +251,7 @@ LocalizationOptions parseLocalizationsOptions({
     untranslatedMessagesFile: _tryReadUri(yamlMap, 'untranslated-messages-file', logger),
     header: _tryReadString(yamlMap, 'header', logger),
     outputClass: _tryReadString(yamlMap, 'output-class', logger),
+    outputDirectory: _tryReadUri(yamlMap, 'output-dir', logger),
     preferredSupportedLocales: _tryReadStringList(yamlMap, 'preferred-supported-locales', logger),
     headerFile: _tryReadUri(yamlMap, 'header-file', logger),
     deferredLoading: _tryReadBool(yamlMap, 'use-deferred-loading', logger),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -54,7 +54,7 @@ void main() {
     verify(
       mockLocalizationsGenerator.initialize(
         inputPathString: 'arb',
-        outputPathString: 'lib/l10n/',
+        outputPathString: fileSystem.path.join('lib', 'l10n/'),
         templateArbFileName: 'example.arb',
         outputFileString: 'bar',
         classNameString: 'Foo',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -35,6 +35,7 @@ void main() {
       deferredLoading: true,
       outputClass: 'Foo',
       outputLocalizationsFile: Uri.file('bar'),
+      outputDirectory: Uri.directory(fileSystem.path.join('lib', 'l10n')),
       preferredSupportedLocales: <String>['en_US'],
       templateArbFile: Uri.file('example.arb'),
       untranslatedMessagesFile: Uri.file('untranslated'),
@@ -50,11 +51,10 @@ void main() {
       projectDir: fileSystem.currentDirectory,
       dependenciesDir: fileSystem.currentDirectory,
     );
-
     verify(
       mockLocalizationsGenerator.initialize(
         inputPathString: 'arb',
-        outputPathString: null,
+        outputPathString: 'lib/l10n/',
         templateArbFileName: 'example.arb',
         outputFileString: 'bar',
         classNameString: 'Foo',


### PR DESCRIPTION
## Description

Forwards `--output-dir` to the l10n.yaml way of setting up `gen-l10n`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71127.

## Tests

I added the following tests:

- Modify existing test to take extra option into account.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
