### PR TITLE
Update CocoaPods minimum version to 1.9

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -160,12 +160,6 @@ class UserMessages {
 
   // Messages used in CocoaPodsValidator
   String cocoaPodsVersion(String version) => 'CocoaPods version $version';
-  String cocoaPodsUninitialized(String consequence) =>
-      'CocoaPods installed but not initialized.\n'
-      '$consequence\n'
-      'To initialize CocoaPods, run:\n'
-      '  pod setup\n'
-      "once to finalize CocoaPods' installation.";
   String cocoaPodsMissing(String consequence, String installInstructions) =>
       'CocoaPods not installed.\n'
       '$consequence\n'

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -89,11 +89,9 @@ class CocoaPods {
       _processManager = processManager,
       _xcodeProjectInterpreter = xcodeProjectInterpreter,
       _logger = logger,
-      _platform = platform,
       _artifacts = artifacts,
       _usage = usage,
       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
-      _fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform),
       _operatingSystemUtils = OperatingSystemUtils(
         fileSystem: fileSystem,
         logger: logger,
@@ -103,19 +101,17 @@ class CocoaPods {
 
   final FileSystem _fileSystem;
   final ProcessManager _processManager;
-  final FileSystemUtils _fileSystemUtils;
   final ProcessUtils _processUtils;
   final OperatingSystemUtils _operatingSystemUtils;
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
   final Logger _logger;
-  final Platform _platform;
   final Artifacts _artifacts;
   final Usage _usage;
 
   Future<String> _versionText;
 
-  String get cocoaPodsMinimumVersion => '1.6.0';
-  String get cocoaPodsRecommendedVersion => '1.9.0';
+  String get cocoaPodsMinimumVersion => '1.9.0';
+  String get cocoaPodsRecommendedVersion => '1.10.0';
 
   Future<bool> get isInstalled =>
     _processUtils.exitsHappy(<String>['which', 'pod']);
@@ -155,28 +151,6 @@ class CocoaPods {
     } on FormatException {
       return CocoaPodsStatus.notInstalled;
     }
-  }
-
-  /// Whether CocoaPods ran 'pod setup' once where the costly pods' specs are
-  /// cloned.
-  ///
-  /// Versions >= 1.8.0 do not require 'pod setup' and default to a CDN instead
-  /// of a locally cloned repository.
-  /// See http://blog.cocoapods.org/CocoaPods-1.8.0-beta/
-  ///
-  /// A user can override the default location via the CP_REPOS_DIR environment
-  /// variable.
-  ///
-  /// See https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/config.rb#L138
-  /// for details of this variable.
-  Future<bool> get isCocoaPodsInitialized async {
-    final Version installedVersion = Version.parse(await cocoaPodsVersionText);
-    if (installedVersion != null && installedVersion >= Version.parse('1.8.0')) {
-      return true;
-    }
-    final String cocoapodsReposDir = _platform.environment['CP_REPOS_DIR']
-      ?? _fileSystem.path.join(_fileSystemUtils.homeDirPath, '.cocoapods', 'repos');
-    return _fileSystem.isDirectory(_fileSystem.path.join(cocoapodsReposDir, 'master'));
   }
 
   Future<bool> processPods({
@@ -245,17 +219,6 @@ class CocoaPods {
         break;
       case CocoaPodsStatus.recommended:
         break;
-    }
-    if (!await isCocoaPodsInitialized) {
-      _logger.printError(
-        'Warning: CocoaPods installed but not initialized. Skipping pod install.\n'
-        '$noCocoaPodsConsequence\n'
-        'To initialize CocoaPods, run:\n'
-        '  pod setup\n'
-        "once to finalize CocoaPods' installation.",
-        emphasis: true,
-      );
-      return false;
     }
 
     return true;

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -30,12 +30,7 @@ class CocoaPodsValidator extends DoctorValidator {
 
     ValidationType status = ValidationType.installed;
     if (cocoaPodsStatus == CocoaPodsStatus.recommended) {
-      if (await _cocoaPods.isCocoaPodsInitialized) {
-        messages.add(ValidationMessage(_userMessages.cocoaPodsVersion(await _cocoaPods.cocoaPodsVersionText)));
-      } else {
-        status = ValidationType.partial;
-        messages.add(ValidationMessage.error(_userMessages.cocoaPodsUninitialized(noCocoaPodsConsequence)));
-      }
+      messages.add(ValidationMessage(_userMessages.cocoaPodsVersion(await _cocoaPods.cocoaPodsVersionText)));
     } else {
       if (cocoaPodsStatus == CocoaPodsStatus.notInstalled) {
         status = ValidationType.missing;

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -80,7 +80,7 @@ void main() {
       xcodeProjectInterpreter: mockXcodeProjectInterpreter,
       usage: usage,
     );
-    pretendPodVersionIs('1.9.0');
+    pretendPodVersionIs('1.10.0');
     fileSystem.file(fileSystem.path.join(
       Cache.flutterRoot, 'packages', 'flutter_tools', 'templates', 'cocoapods', 'Podfile-ios-objc',
     ))
@@ -177,32 +177,26 @@ void main() {
 
     testWithoutContext('detects below minimum version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.5.0');
+      pretendPodVersionIs('1.6.0');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowMinimumVersion);
     });
 
     testWithoutContext('detects below recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.6.0');
+      pretendPodVersionIs('1.9.0');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowRecommendedVersion);
     });
 
     testWithoutContext('detects at recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.9.0');
+      pretendPodVersionIs('1.10.0');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
     });
 
     testWithoutContext('detects above recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.9.1');
+      pretendPodVersionIs('1.10.1');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
-    });
-
-    testWithoutContext('detects initialized over 1.8.0', () async {
-      pretendPodIsInstalled();
-      pretendPodVersionIs('1.8.0');
-      expect(await cocoaPodsUnderTest.isCocoaPodsInitialized, isTrue);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
@@ -18,7 +18,6 @@ void main() {
       cocoaPods = MockCocoaPods();
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.recommended);
-      when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => true);
       when(cocoaPods.cocoaPodsVersionText).thenAnswer((_) async => '1.8.0');
     });
 
@@ -39,13 +38,6 @@ void main() {
     testWithoutContext('Emits partial status when CocoaPods is installed with unknown version', () async {
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.unknownVersion);
-      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
-      final ValidationResult result = await workflow.validate();
-      expect(result.type, ValidationType.partial);
-    });
-
-    testWithoutContext('Emits partial status when CocoaPods is not initialized', () async {
-      when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => false);
       final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);


### PR DESCRIPTION
## Description

[CocoaPods 1.9](https://blog.cocoapods.org/CocoaPods-1.9.0-beta/) introduced support for xcframeworks.  It was released in [February 2020](https://github.com/CocoaPods/CocoaPods/releases/tag/1.9.0).  

- Update minimum to support Flutter being [distributed as an xcframework](https://github.com/flutter/flutter/issues/60109) to support [Apple Silicon simulators](https://github.com/flutter/flutter/issues/64502).
- Update recommended version to [1.10](https://blog.cocoapods.org/CocoaPods-1.10.0-beta/), which fixed many xcframework bugs and added Xcode 12 support.
- Drop `isCocoaPodsInitialized` which only mattered for versions < 1.8.

## Related Issues

https://github.com/flutter/flutter/pull/69809 is in 1.24.0-10.1.pre (currently dev and beta).  This change will be in `flutter-1.25-candidate.*` so the recommended minimum nudge should make it to stable before this harsher minimum requirement.
