### PR TITLE
mark "smoke_catalina_hot_mode_dev_cycle_ios__benchmark" flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -657,6 +657,7 @@ tasks:
       A some test that runs on macOS Catalina, which is a clone of the Dart VM hot patching performance benchmarking.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
+    flaky: true # https://github.com/flutter/flutter/issues/71178
 
   smoke_catalina_start_up:
     description: >


### PR DESCRIPTION
This test is flaky due to https://github.com/flutter/flutter/issues/71178