### PR TITLE
[flutter_tools]fix typo in printHowToConsumeAar,which case sync fail

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,3 +71,4 @@ Nobuhiro Tabuki <japanese.around30@gmail.com>
 nt4f04uNd <nt4f04und@gmail.com>
 Anurag Roy <anuragr9847@gmail.com>
 Andrey Kabylin <andrey@kabylin.ru>
+vimerzhao <vimerzhao@gmail.com>

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -721,7 +721,7 @@ void printHowToConsumeAar({
             url '${repoDirectory.path}'
         }
         maven {
-            url '\$storageUrl/download.flutter.io'
+            url "\$storageUrl/download.flutter.io"
         }
       }
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -2588,7 +2588,7 @@ plugin1=${plugin1.path}
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url '\$storageUrl/download.flutter.io'\n"
+          '            url "\$storageUrl/download.flutter.io"\n'
           '        }\n'
           '      }\n'
           '\n'
@@ -2639,7 +2639,7 @@ plugin1=${plugin1.path}
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url '\$storageUrl/download.flutter.io'\n"
+          '            url "\$storageUrl/download.flutter.io"\n'
           '        }\n'
           '      }\n'
           '\n'
@@ -2677,7 +2677,7 @@ plugin1=${plugin1.path}
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url '\$storageUrl/download.flutter.io'\n"
+          '            url "\$storageUrl/download.flutter.io"\n'
           '        }\n'
           '      }\n'
           '\n'
@@ -2716,7 +2716,7 @@ plugin1=${plugin1.path}
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url '\$storageUrl/download.flutter.io'\n"
+          '            url "\$storageUrl/download.flutter.io"\n'
           '        }\n'
           '      }\n'
           '\n'


### PR DESCRIPTION
## Description
according to: [Groovy Language Documentation](http://docs.groovy-lang.org/latest/html/documentation/index.html#_string_interpolation):

>Any Groovy expression can be interpolated in all string literals, apart from single and triple-single-quoted strings.

I change typo `'` to `"`, and modify related tests.