### PR TITLE
[flutter_tools] Don't fail copying files if the destination is not writable

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -289,10 +289,7 @@ class ErrorHandlingFile
     // Next check if the destination file can be written. If not, bail through
     // error handling.
     _runSync<void>(
-      ()  {
-        resultFile.createSync(recursive: true);
-        resultFile.openSync(mode: FileMode.writeOnly).closeSync();
-      },
+      () => resultFile.createSync(recursive: true),
       platform: _platform,
       failureMessage: 'Flutter failed to copy $path to $newPath due to destination location error'
     );


### PR DESCRIPTION
## Description

When `dart:io` is used to copy files on macOS, it is able to clobber read-only files. This check for writable files is unnecessary.

https://github.com/flutter/flutter/blob/2ceb371d214cfe9122c2aeec7625863b21a1e41c/packages/flutter_tools/lib/src/base/error_handling_io.dart#L294

The check also breaks Google3 hot restart (on iOS) because the source files are Bazel runfiles which are readonly. 

1. When the application is first started (equivalent of `flutter run`), assets are copied to the simulator directory using `copySync` here. The file permissions remain the same after they are copied, and remain readonly.
2. During hot restart, the assets are copied over again to the simulator directory. However, in this case, the destination files already exist, and have readonly permissions. This check fails and causes the tool to exit, when the next operation to copy the files will work just fine.

I wasn't sure about `dart:io` being able to override readonly file, so I created a script and built it into a VM binary to be sure:

```dart
import 'dart:io';
void main(List<String> args) => File(args[0]).copySync(args[1]);
```

```sh
$ echo hello > hello
$ echo bye > bye

# Make the destination file readonly.
$ chmod -w hello
$ ls -lah
total 16
drwxr-xr-x    4 jiahaog  wheel   128B Nov 25 16:33 .
drwxrwxrwt  246 root     wheel   7.7K Nov 25 16:18 ..
-rw-r--r--    1 jiahaog  wheel     4B Nov 25 16:33 bye
-r--r--r--    1 jiahaog  wheel     6B Nov 25 16:33 hello

# `cp` doesn't work.
$ cp bye hello
cp: hello: Permission denied

# But `copySync` in Dart does.
$ /Users/jiahaog/dev/cp_dart/bin/cp_dart.exe bye hello

$ cat hello
bye
$ ls -lah
total 16
drwxr-xr-x    4 jiahaog  wheel   128B Nov 25 16:33 .
drwxrwxrwt  246 root     wheel   7.7K Nov 25 16:18 ..
-rw-r--r--    1 jiahaog  wheel     4B Nov 25 16:33 bye
-rw-r--r--    1 jiahaog  wheel     4B Nov 25 16:33 hello
```

This behavior above only happens on macOS, but not on Linux. On linux `dart:io`'s `copySync` still throws the permission error, but I didn't investigate further why. I think removing the check should still be fine though, because the subsequent fallback checks (below) will rethrow the same error when the permission check fails.

https://github.com/flutter/flutter/blob/2ceb371d214cfe9122c2aeec7625863b21a1e41c/packages/flutter_tools/lib/src/base/error_handling_io.dart#L313

## Related Issues

Issue was introduced in #69000

## Tests

I added the following tests:

- Added a new test that mocks a non-writable file, but I'm not sure if this is necessary

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
