### PR TITLE
RefreshIndicator can be shown when dragging from non-zero scroll position

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -27,8 +27,10 @@ class OverscrollDemoState extends State<OverscrollDemo> {
 
   Future<void> _handleRefresh() {
     final Completer<void> completer = Completer<void>();
-    Timer(const Duration(seconds: 3), () { completer.complete(); });
+    Timer(const Duration(seconds: 3), () => completer.complete());
     return completer.future.then((_) {
+      if (!mounted)
+        return;
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         content: const Text('Refresh complete'),
         action: SnackBarAction(

--- a/dev/integration_tests/flutter_gallery/test/smoke_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/smoke_test.dart
@@ -84,7 +84,12 @@ Future<void> smokeDemo(WidgetTester tester, GalleryDemo demo) async {
   // Scroll the demo around a bit more.
   await tester.flingFrom(const Offset(400.0, 300.0), const Offset(0.0, 400.0), 1000.0);
   await tester.pump();
-  await tester.pump(const Duration(milliseconds: 400));
+  if (demo.title == 'Pull to refresh') {
+    // This fling gesture will trigger 'OverscrollDemo' [RefreshIndicator.onRefresh].
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump(const Duration(milliseconds: 400));
+  }
   await tester.flingFrom(const Offset(400.0, 300.0), const Offset(-200.0, 0.0), 500.0);
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 50));

--- a/dev/integration_tests/flutter_gallery/test/smoke_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/smoke_test.dart
@@ -84,12 +84,7 @@ Future<void> smokeDemo(WidgetTester tester, GalleryDemo demo) async {
   // Scroll the demo around a bit more.
   await tester.flingFrom(const Offset(400.0, 300.0), const Offset(0.0, 400.0), 1000.0);
   await tester.pump();
-  if (demo.title == 'Pull to refresh') {
-    // This fling gesture will trigger 'OverscrollDemo' [RefreshIndicator.onRefresh].
-    await tester.pumpAndSettle();
-  } else {
-    await tester.pump(const Duration(milliseconds: 400));
-  }
+  await tester.pump(const Duration(milliseconds: 400));
   await tester.flingFrom(const Offset(400.0, 300.0), const Offset(-200.0, 0.0), 500.0);
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 50));

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -218,7 +218,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   bool _handleScrollNotification(ScrollNotification notification) {
     if (!widget.notificationPredicate(notification))
       return false;
-    if (notification is ScrollStartNotification && notification.metrics.extentBefore == 0.0 &&
+    if ((notification is ScrollStartNotification || notification is ScrollUpdateNotification) &&
+        notification.metrics.extentBefore == 0.0 &&
         _mode == null && _start(notification.metrics.axisDirection)) {
       setState(() {
         _mode = _RefreshIndicatorMode.drag;

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -88,7 +88,6 @@ void main() {
     await tester.pump(const Duration(seconds: 1)); // finish the indicator hide animation
     expect(refreshCalled, false);
 
-
     await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0); // vertical fling
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
@@ -500,5 +499,74 @@ void main() {
         tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,
         4.0,
     );
+  });
+
+  testWidgets('Top RefreshIndicator showed when dragging from non-zero scroll position', (WidgetTester tester) async {
+    refreshCalled = false;
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          child: ListView(
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('X'),
+              ),
+              SizedBox(
+                height: 800.0,
+                child: Text('Y'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(50.0);
+
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
+  });
+
+  testWidgets('Bottom RefreshIndicator showed when dragging from non-zero scroll position', (WidgetTester tester) async {
+    refreshCalled = false;
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          child: ListView(
+            reverse: true,
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('X'),
+              ),
+              SizedBox(
+                height: 800.0,
+                child: Text('Y'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(50.0);
+
+    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, greaterThan(300.0));
   });
 }


### PR DESCRIPTION
## Description

This change fixes that `RefreshIndicator ` can not pull out when the scrollable widget has a non-zero scroll position.

I have tested the Android native behavior, it can be pulled out from the non-zero scroll position.

This change also triggers a `flutter_gallery` APP bug, see changed files for more information.

### Bug Reproduce Screenshot
![20201127_150049](https://user-images.githubusercontent.com/61075224/100420429-69fde380-30c1-11eb-82d8-71fb8e45e746.gif)



## Related Issues

Fixes #71304

## Tests

I added the following tests:

See files.
