### PR TITLE
Card respects surface color 

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -121,7 +121,8 @@ class Card extends StatelessWidget {
   /// Defines the card's [Material.color].
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
-  /// is used. If that's null then [ThemeData.cardColor] is used.
+  /// is used. If that's null then [ThemeData.cardColor] is used. If that's
+  /// null too, then [ColorScheme.surface] of [ThemeData.colorScheme] is used.
   final Color? color;
 
   /// The color to paint the shadow below the card.

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -326,7 +326,7 @@ class ThemeData with Diagnosticable {
     shadowColor ??= Colors.black;
     scaffoldBackgroundColor ??= canvasColor;
     bottomAppBarColor ??= isDark ? Colors.grey[800]! : Colors.white;
-    cardColor ??= isDark ? Colors.grey[800]! : Colors.white;
+    cardColor ??= isDark ? colorScheme?.surface ?? Colors.grey[800]! : colorScheme?.surface ?? Colors.white;
     dividerColor ??= isDark ? const Color(0x1FFFFFFF) : const Color(0x1F000000);
 
     // Create a ColorScheme that is backwards compatible as possible

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -221,4 +221,28 @@ void main() {
     expect(_getCardMaterial(tester).shadowColor, _getCard(tester).shadowColor);
     expect(_getCardMaterial(tester).shadowColor, Colors.red);
   });
+
+  testWidgets('Card uses colorScheme surface color as default', (WidgetTester tester) async {
+    final ColorScheme colorScheme = const ColorScheme.light().copyWith(surface: Colors.purple);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(cardColor: colorScheme.surface),
+        home: const Scaffold(
+          body: Card(
+            child: Text('card'),
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(
+      find.descendant(
+        of: find.byType(Card),
+        matching: find.byType(Material),
+      ),
+    );
+
+    expect(material.type, MaterialType.card);
+    expect(material.color, colorScheme.surface);
+  });
 }


### PR DESCRIPTION
## Description

**Existing Behaviour**
Card takes default white color even if surface color is not-null.

**Modified Behaviour**
If surface color is given then card respects the surface color else it takes default white color.

<details>
<summary>Runnable Code Snippets</summary>

MyApp.dart

```Dart
class MyApp extends StatelessWidget {
  static ColorScheme colorScheme = ColorScheme.light().copyWith(
    surface: Colors.purple,
  );
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        colorScheme: colorScheme,
      ),
      home: Scaffold(
        body: Center(
          child: Card(
            child: Text(
              "Card",
              style: TextStyle(fontSize: 20),
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

## Related Issues

fixes #28783

## Tests

I added the following tests:

- Test written for verifying card applies surface color if Color property in Card, [CardTheme.color] and [ThemeData.cardColor] not given respectively.
- This test written for```ColorScheme.light().copyWith() ``` , but this implementation remains true for ```ColorScheme.dark() ``` , ```ColorScheme() ```. Should I write test for all of them?

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
