### PR TITLE
[flutter_tools] do not validate unused services key

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -405,7 +405,6 @@ void _validateFlutter(YamlMap yaml, List<String> errors) {
         }
         break;
       case 'assets':
-      case 'services':
         if (kvp.value is! YamlList || kvp.value[0] is! String) {
           errors.add('Expected "${kvp.key}" to be a list, but got ${kvp.value} (${kvp.value.runtimeType}).');
         }


### PR DESCRIPTION
## Description

The services key is not used, so don't do any validation on it. No tests removed because it wasn't tested anymore