### PR TITLE
[flutter_tools] allow hiding web server device, provide flags to re-enable

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -6,6 +6,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:completion/completion.dart';
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/web/web_device.dart';
 
 import '../artifacts.dart';
 import '../base/common.dart';
@@ -109,6 +110,11 @@ class FlutterCommandRunner extends CommandRunner<void> {
         hide: !verboseHelp,
         help: "List the special 'flutter-tester' device in device listings. "
               'This headless device is used to\ntest Flutter tooling.');
+    argParser.addFlag('show-web-server-device',
+        negatable: false,
+        hide: !verboseHelp,
+        help: "List the special 'web-server' device in device listings. "
+    );
   }
 
   @override
@@ -203,6 +209,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
     if (topLevelResults['show-test-device'] as bool ||
         topLevelResults['device-id'] == FlutterTesterDevices.kTesterDeviceId) {
       FlutterTesterDevices.showFlutterTesterDevice = true;
+    }
+    if (topLevelResults['show-web-server-device'] as bool ||
+        topLevelResults['device-id'] == WebServerDevice.kWebServerDeviceId) {
+      WebServerDevice.showWebServerDevice = true;
     }
 
     // Set up the tooling configuration.

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -6,7 +6,6 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:completion/completion.dart';
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/web/web_device.dart';
 
 import '../artifacts.dart';
 import '../base/common.dart';
@@ -19,6 +18,7 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../tester/flutter_tester.dart';
+import '../web/web_device.dart';
 
 const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
 const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -345,7 +345,8 @@ class WebDevices extends PollingDeviceDiscovery {
       return <Device>[];
     }
     return <Device>[
-      _webServerDevice,
+      if (WebServerDevice.showWebServerDevice)
+        _webServerDevice,
       if (_chromeDevice.isSupported())
         _chromeDevice,
       if (await _edgeDevice?._meetsVersionConstraint() ?? false)
@@ -374,6 +375,9 @@ class WebServerDevice extends Device {
           category: Category.web,
           ephemeral: false,
        );
+
+  static const String kWebServerDeviceId = 'web-server';
+  static bool showWebServerDevice = true;
 
   final Logger _logger;
 

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -159,7 +159,8 @@ void main() {
       isNot(contains(isA<MicrosoftEdgeDevice>())));
   });
 
-  testWithoutContext('Web Server device is listed by default', () async {
+  testWithoutContext('Web Server device is listed if enabled via showWebServerDevice', () async {
+    WebServerDevice.showWebServerDevice = true;
     final WebDevices webDevices = WebDevices(
       featureFlags: TestFeatureFlags(isWebEnabled: true),
       fileSystem: MemoryFileSystem.test(),
@@ -173,6 +174,23 @@ void main() {
 
     expect(await webDevices.pollingGetDevices(),
       contains(isA<WebServerDevice>()));
+  });
+
+  testWithoutContext('Web Server device is not listed if disabled via showWebServerDevice', () async {
+    WebServerDevice.showWebServerDevice = false;
+    final WebDevices webDevices = WebDevices(
+      featureFlags: TestFeatureFlags(isWebEnabled: true),
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{}
+      ),
+      processManager: FakeProcessManager.any(),
+    );
+
+    expect(await webDevices.pollingGetDevices(),
+      isNot(contains(isA<WebServerDevice>())));
   });
 
   testWithoutContext('Chrome invokes version command on non-Windows platforms', () async {


### PR DESCRIPTION
## Description

Sets up the flags that are need to enable the web-server device, either by passing --show-web-server-device or specifying a device ID of exactly "web-server".

A future PR could swap the default after CI has been updated.