### PR TITLE
Mark flutter_gallery_ios32__start_up flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -503,6 +503,7 @@ tasks:
       Measures the startup time of the Flutter Gallery app on 32-bit iOS (iPhone 4S).
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
+      flaky: true # https://github.com/flutter/flutter/issues/71414
 
   flavors_test_ios:
     description: >


### PR DESCRIPTION
## Description

This marks `flutter_gallery_ios32__start_up` flaky, due to https://github.com/flutter/flutter/issues/71414
This will unblock the tree while the issue is resolved

## Related Issues

#71414
