### PR TITLE
Validate empty observatory URI for screenshot

### DIFF
--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -77,6 +77,9 @@ class ScreenshotCommand extends FlutterCommand {
         if (observatoryUri == null) {
           throwToolExit('Observatory URI must be specified for screenshot type $screenshotType');
         }
+        if (observatoryUri.isEmpty || Uri.tryParse(observatoryUri) == null) {
+          throwToolExit('Observatory URI "$observatoryUri" is invalid');
+        }
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
@@ -15,8 +15,18 @@ void main() {
     });
 
     testUsingContext('rasterizer and skia screenshots require observatory uri', () async {
-      expect(() => ScreenshotCommand.validateOptions('rasterizer', null, null), throwsToolExit());
-      expect(() => ScreenshotCommand.validateOptions('skia', null, null), throwsToolExit());
+      expect(
+          () => ScreenshotCommand.validateOptions('rasterizer', null, null),
+          throwsToolExit(
+              message:
+                  'Observatory URI must be specified for screenshot type rasterizer'));
+      expect(
+          () => ScreenshotCommand.validateOptions('skia', null, null),
+          throwsToolExit(
+              message:
+                  'Observatory URI must be specified for screenshot type skia'));
+      expect(() => ScreenshotCommand.validateOptions('skia', null, ''),
+          throwsToolExit(message: 'Observatory URI "" is invalid'));
     });
 
     testUsingContext('device screenshots require device', () async {


### PR DESCRIPTION
## Description

Throw tool exception if URI is not valid.

Seen in the wild with an errant space `--observatory-uri= http://127.0.0.1:49257/phC5T1gWW5E=/`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71398