### PR TITLE
[flutter_tools] report basic analytics for null-safety

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -49,4 +49,7 @@ abstract class BuildSubCommand extends FlutterCommand {
   BuildSubCommand() {
     requiresPubspecYaml();
   }
+
+  @override
+  bool get reportNullSafety => true;
 }

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -63,6 +63,9 @@ class BuildAarCommand extends BuildSubCommand {
   final String name = 'aar';
 
   @override
+  bool get reportNullSafety => false;
+
+  @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
     DevelopmentArtifact.androidGenSnapshot,
   };

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -109,6 +109,9 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   FlutterVersion _flutterVersion;
 
   @override
+  bool get reportNullSafety => false;
+
+  @override
   final String name = 'ios-framework';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -144,6 +144,9 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get runningWithPrebuiltApplication => argResults['use-application-binary'] != null;
   bool get trackWidgetCreation => boolArg('track-widget-creation');
 
+  @override
+  bool get reportNullSafety => true;
+
   /// Whether to start the application paused by default.
   bool get startPausedDefault;
 

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -249,3 +249,37 @@ class CodeSizeEvent extends UsageEvent {
 class ErrorHandlingEvent extends UsageEvent {
   ErrorHandlingEvent(String parameter) : super('error-handling', parameter, flutterUsage: globals.flutterUsage);
 }
+
+/// The category for analytics events related to null safety.
+const String kNullSafetyCategory = 'null-safety';
+
+/// Emit various null safety analytic events.
+///
+/// 1. The current null safety runtime mode.
+/// 2. The % of dependencies that are not migrated.
+/// 3. The main language version.
+void collectLanguageVersionEvents(
+  PackageConfig packageConfig,
+  NullSafetyMode nullSafetyMode,
+  String currentPackage,
+  Usage flutterUsage,
+) {
+  int migrated = 0;
+  LanguageVersion languageVersion;
+  for (final Package package in packageConfig.packages) {
+    if (package.name == currentPackage) {
+      languageVersion = package.languageVersion;
+    }
+    if (package.languageVersion.major >= nullSafeVersion.major &&
+        package.languageVersion.minor >= nullSafeVersion.minor) {
+      migrated += 1;
+    }
+  }
+  final int formattedPercentage = (migrated / packageConfig.packages.length * 100).round()
+  flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: nullSafetyMode.toString());
+  flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: formattedPercentage);
+  if (languageVersion != null) {
+    final String formattedVersion = '${languageVersion.major}.${languageVersion.minor}';
+    flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: formattedVersion);
+  }
+}

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -250,39 +250,64 @@ class ErrorHandlingEvent extends UsageEvent {
   ErrorHandlingEvent(String parameter) : super('error-handling', parameter, flutterUsage: globals.flutterUsage);
 }
 
-/// The category for analytics events related to null safety.
-const String kNullSafetyCategory = 'null-safety';
-
 /// Emit various null safety analytic events.
 ///
 /// 1. The current null safety runtime mode.
-/// 2. The % of dependencies that are not migrated.
-/// 3. The main language version.
-void collectLanguageVersionEvents(
-  PackageConfig packageConfig,
-  NullSafetyMode nullSafetyMode,
-  String currentPackage,
-  Usage flutterUsage,
-) {
-  if (packageConfig.packages.isEmpty) {
-    return;
-  }
-  int migrated = 0;
-  LanguageVersion languageVersion;
-  for (final Package package in packageConfig.packages) {
-    if (package.name == currentPackage) {
-      languageVersion = package.languageVersion;
+/// 2. The number of packages that are migrated, along with the total number of packages
+/// 3. The main packages language version.
+class NullSafetyAnalysisEvent implements UsageEvent {
+  NullSafetyAnalysisEvent(
+    this.packageConfig,
+    this.nullSafetyMode,
+    this.currentPackage,
+    this.flutterUsage,
+  );
+
+  /// The category for analytics events related to null safety.
+  static const String kNullSafetyCategory = 'null-safety';
+
+  final PackageConfig packageConfig;
+  final NullSafetyMode nullSafetyMode;
+  final String currentPackage;
+  @override
+  final Usage flutterUsage;
+
+  @override
+  void send() {
+    if (packageConfig.packages.isEmpty) {
+      return;
     }
-    if (package.languageVersion.major >= nullSafeVersion.major &&
-        package.languageVersion.minor >= nullSafeVersion.minor) {
-      migrated += 1;
+    int migrated = 0;
+    LanguageVersion languageVersion;
+    for (final Package package in packageConfig.packages) {
+      if (package.name == currentPackage) {
+        languageVersion = package.languageVersion;
+      }
+      if (package.languageVersion.major >= nullSafeVersion.major &&
+          package.languageVersion.minor >= nullSafeVersion.minor) {
+        migrated += 1;
+      }
+    }
+    flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: nullSafetyMode.toString());
+    flutterUsage.sendEvent(kNullSafetyCategory, 'stats', parameters: <String, String>{
+      cdKey(CustomDimensions.nullSafeMigratedLibraries): migrated.toString(),
+      cdKey(CustomDimensions.nullSafeTotalLibraries): packageConfig.packages.length.toString(),
+    });
+    if (languageVersion != null) {
+      final String formattedVersion = '${languageVersion.major}.${languageVersion.minor}';
+      flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: formattedVersion);
     }
   }
-  final int formattedPercentage = (migrated / packageConfig.packages.length * 100).round();
-  flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: nullSafetyMode.toString());
-  flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: formattedPercentage);
-  if (languageVersion != null) {
-    final String formattedVersion = '${languageVersion.major}.${languageVersion.minor}';
-    flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: formattedVersion);
-  }
+
+  @override
+  String get category => kNullSafetyCategory;
+
+  @override
+  String get label => throw UnsupportedError('');
+
+  @override
+  String get parameter => throw UnsupportedError('');
+
+  @override
+  int get value => throw UnsupportedError('');
 }

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -275,7 +275,7 @@ void collectLanguageVersionEvents(
       migrated += 1;
     }
   }
-  final int formattedPercentage = (migrated / packageConfig.packages.length * 100).round()
+  final int formattedPercentage = (migrated / packageConfig.packages.length * 100).round();
   flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: nullSafetyMode.toString());
   flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: formattedPercentage);
   if (languageVersion != null) {

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -264,6 +264,9 @@ void collectLanguageVersionEvents(
   String currentPackage,
   Usage flutterUsage,
 ) {
+  if (packageConfig.packages.isEmpty) {
+    return;
+  }
   int migrated = 0;
   LanguageVersion languageVersion;
   for (final Package package in packageConfig.packages) {

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
 import 'package:usage/usage_io.dart';
 
 import '../base/async_guard.dart';
@@ -21,8 +22,10 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/time.dart';
+import '../build_info.dart';
 import '../build_system/exceptions.dart';
 import '../convert.dart';
+import '../dart/language_version.dart';
 import '../devfs.dart';
 import '../doctor.dart';
 import '../features.dart';

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -59,6 +59,8 @@ enum CustomDimensions {
   commandPackagesAndroidEmbeddingVersion, // cd46
   nullSafety, // cd47
   fastReassemble, // cd48
+  nullSafeMigratedLibraries, // cd49
+  nullSafeTotalLibraries, // cd 50
 }
 
 String cdKey(CustomDimensions cd) => 'cd${cd.index + 1}';

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1103,6 +1103,7 @@ abstract class FlutterCommand extends Command<void> {
         checkUpToDate: cachePubGet,
       );
       await project.regeneratePlatformSpecificTooling();
+      await _sendNullSafetyAnalyticsEvents(project);
     }
 
     setupApplicationPackages();
@@ -1117,6 +1118,16 @@ abstract class FlutterCommand extends Command<void> {
     }
 
     return await runCommand();
+  }
+
+  Future<void> _sendNullSafetyAnalyticsEvents(FlutterProject project) async {
+    final BuildInfo buildInfo = await getBuildInfo();
+    collectLanguageVersionEvents(
+      buildInfo.packageConfig,
+      buildInfo.nullSafetyMode,
+      project.manifest.appName,
+      globals.flutterUsage,
+    );
   }
 
   /// The set of development artifacts required for this command.

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1121,7 +1121,7 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   Future<void> _sendNullSafetyAnalyticsEvents(FlutterProject project) async {
-    final BuildInfo buildInfo = await getBuildInfo();
+    final BuildInfo buildInfo = await getBuildInfo(forcedBuildMode: BuildMode.debug);
     collectLanguageVersionEvents(
       buildInfo.packageConfig,
       buildInfo.nullSafetyMode,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1126,7 +1126,7 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   Future<void> _sendNullSafetyAnalyticsEvents(FlutterProject project) async {
-    final BuildInfo buildInfo = await getBuildInfo(forcedBuildMode: BuildMode.debug);
+    final BuildInfo buildInfo = await getBuildInfo();
     NullSafetyAnalysisEvent(
       buildInfo.packageConfig,
       buildInfo.nullSafetyMode,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1127,12 +1127,12 @@ abstract class FlutterCommand extends Command<void> {
 
   Future<void> _sendNullSafetyAnalyticsEvents(FlutterProject project) async {
     final BuildInfo buildInfo = await getBuildInfo(forcedBuildMode: BuildMode.debug);
-    collectLanguageVersionEvents(
+    NullSafetyAnalysisEvent(
       buildInfo.packageConfig,
       buildInfo.nullSafetyMode,
       project.manifest.appName,
       globals.flutterUsage,
-    );
+    ).send();
   }
 
   /// The set of development artifacts required for this command.

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -487,6 +487,9 @@ abstract class FlutterCommand extends Command<void> {
   /// Whether it is safe for this command to use a cached pub invocation.
   bool get cachePubGet => true;
 
+  /// Whether this command should report null safety analytics.
+  bool get reportNullSafety => false;
+
   Duration get deviceDiscoveryTimeout {
     if (_deviceDiscoveryTimeout == null
         && argResults.options.contains(FlutterOptions.kDeviceTimeout)
@@ -1103,7 +1106,9 @@ abstract class FlutterCommand extends Command<void> {
         checkUpToDate: cachePubGet,
       );
       await project.regeneratePlatformSpecificTooling();
-      await _sendNullSafetyAnalyticsEvents(project);
+      if (reportNullSafety) {
+        await _sendNullSafetyAnalyticsEvents(project);
+      }
     }
 
     setupApplicationPackages();

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -61,16 +61,18 @@ void main() {
       Package('baz', Uri.parse('file:///bar/'), languageVersion: LanguageVersion(2, 2)),
     ]);
 
-    collectLanguageVersionEvents(
+    NullSafetyAnalysisEvent(
       packageConfig,
       NullSafetyMode.sound,
       'foo',
       usage,
-    );
+    ).send();
 
-    verify(usage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound'));
-    verify(usage.sendEvent(kNullSafetyCategory, 'migrated', value: 33));
-    verify(usage.sendEvent(kNullSafetyCategory, 'language-version', label: '2.12'));
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'stats', parameters: <String, String>{
+      'cd49': '1', 'cd50': '3',
+    })).called(1);
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'language-version', label: '2.12')).called(1);
   });
 
   testWithoutContext('Does not crash if main package is missing', () {
@@ -81,16 +83,18 @@ void main() {
       Package('baz', Uri.parse('file:///bar/lib/'), languageVersion: LanguageVersion(2, 2)),
     ]);
 
-    collectLanguageVersionEvents(
+    NullSafetyAnalysisEvent(
       packageConfig,
       NullSafetyMode.sound,
       'something-unrelated',
       usage,
-    );
+    ).send();
 
-    verify(usage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound'));
-    verify(usage.sendEvent(kNullSafetyCategory, 'migrated', value: 33));
-    verifyNever(usage.sendEvent(kNullSafetyCategory, 'language-version', label: anyNamed('label')));
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'stats', parameters: <String, String>{
+      'cd49': '1', 'cd50': '3',
+    })).called(1);
+    verifyNever(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'language-version', label: anyNamed('label')));
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/version.dart';
@@ -485,6 +486,45 @@ void main() {
         );
       }
     });
+
+    testUsingContext('reports null safety analytics when reportNullSafety is true', () async {
+      globals.fs.file('lib/main.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('// @dart=2.12');
+      globals.fs.file('pubspec.yaml')
+        .writeAsStringSync('name: example\n');
+      globals.fs.file('.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(r'''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "example",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ],
+  "generated": "2020-12-02T19:30:53.862346Z",
+  "generator": "pub",
+  "generatorVersion": "2.12.0-76.0.dev"
+} 
+ ''');
+      final FakeReportingNullSafetyCommand command = FakeReportingNullSafetyCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      await runner.run(<String>['test']);
+
+      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
+      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: 100)).called(1);
+      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: '2.7')).called(1);
+    }, overrides: <Type, Generator>{
+      Pub: () => FakePub(),
+      Usage: () => MockitoUsage(),
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
   });
 }
 
@@ -541,6 +581,25 @@ class FakeTargetCommand extends FlutterCommand {
   String get name => 'test';
 }
 
+class FakeReportingNullSafetyCommand extends FlutterCommand {
+  @override
+  String get description => 'test';
+
+  @override
+  String get name => 'test';
+
+  @override
+  bool get shouldRunPub => true;
+
+  @override
+  bool get reportNullSafety => true;
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    return FlutterCommandResult.success();
+  }
+}
+
 class MockVersion extends Mock implements FlutterVersion {}
 class MockProcessInfo extends Mock implements ProcessInfo {}
 class MockIoProcessSignal extends Mock implements io.ProcessSignal {}
@@ -568,4 +627,18 @@ class FakeSignals implements Signals {
 
   @override
   Stream<Object> get errors => delegate.errors;
+}
+
+class FakePub extends Fake implements Pub {
+  @override
+  Future<void> get({
+    PubContext context,
+    String directory,
+    bool skipIfAbsent = false,
+    bool upgrade = false,
+    bool offline = false,
+    bool generateSyntheticPackage = false,
+    String flutterRootOverride,
+    bool checkUpToDate = false,
+  }) async { }
 }

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -516,9 +516,11 @@ void main() {
 
       await runner.run(<String>['test']);
 
-      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
-      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: 100)).called(1);
-      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: '2.12')).called(1);
+      verify(globals.flutterUsage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
+      verify(globals.flutterUsage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'stats', parameters: <String, String>{
+        'cd49': '1', 'cd50': '1',
+      })).called(1);
+      verify(globals.flutterUsage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'language-version', label: '2.12')).called(1);
     }, overrides: <Type, Generator>{
       Pub: () => FakePub(),
       Usage: () => MockitoUsage(),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -584,6 +584,13 @@ class FakeTargetCommand extends FlutterCommand {
 }
 
 class FakeReportingNullSafetyCommand extends FlutterCommand {
+  FakeReportingNullSafetyCommand() {
+    argParser.addFlag('debug');
+    argParser.addFlag('release');
+    argParser.addFlag('jit-release');
+    argParser.addFlag('profile');
+  }
+
   @override
   String get description => 'test';
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -518,7 +518,7 @@ void main() {
 
       verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
       verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'migrated', value: 100)).called(1);
-      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: '2.7')).called(1);
+      verify(globals.flutterUsage.sendEvent(kNullSafetyCategory, 'language-version', label: '2.12')).called(1);
     }, overrides: <Type, Generator>{
       Pub: () => FakePub(),
       Usage: () => MockitoUsage(),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -509,7 +509,7 @@ void main() {
   "generated": "2020-12-02T19:30:53.862346Z",
   "generator": "pub",
   "generatorVersion": "2.12.0-76.0.dev"
-} 
+}
  ''');
       final FakeReportingNullSafetyCommand command = FakeReportingNullSafetyCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);


### PR DESCRIPTION
## Description

Start collecting some basic analytics for null safety usage, when either `flutter run` or `flutter build` is executed. This is intended to address some, but not all of the requests in https://github.com/flutter/flutter/issues/69601

To start with this will report:

* The null safety mode the app was built in, either sound or unsound
* The language version of the application library (2.7, 2.12)
* The percentage of dependencies that have a minimum language version at or above 2.12, (87, 33)