### PR TITLE
[flutter_tools] hide web server by default

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -377,7 +377,7 @@ class WebServerDevice extends Device {
        );
 
   static const String kWebServerDeviceId = 'web-server';
-  static bool showWebServerDevice = true;
+  static bool showWebServerDevice = false;
 
   final Logger _logger;
 


### PR DESCRIPTION
## Description

The web-server device will only appear if run with -d web-server or with --show-web-server-device
