### PR TITLE
[flutter_tools] post process the gradle log output

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -361,7 +361,7 @@ Future<void> buildGradleApp({
   }
   command.add(assembleTask);
 
-  final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(localGradleErrors);
+  final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(localGradleErrors, globals.logger.isVerbose);
   final Stopwatch sw = Stopwatch()..start();
   int exitCode = 1;
   try {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -23,6 +23,7 @@ import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import 'gradle_errors.dart';
+import 'gradle_log_processor.dart';
 import 'gradle_utils.dart';
 
 /// The directory where the APK artifact is generated.
@@ -360,31 +361,7 @@ Future<void> buildGradleApp({
   }
   command.add(assembleTask);
 
-  GradleHandledError detectedGradleError;
-  String detectedGradleErrorLine;
-  String consumeLog(String line) {
-    // This message was removed from first-party plugins,
-    // but older plugin versions still display this message.
-    if (androidXPluginWarningRegex.hasMatch(line)) {
-      // Don't pipe.
-      return null;
-    }
-    if (detectedGradleError != null) {
-      // Pipe stdout/stderr from Gradle.
-      return line;
-    }
-    for (final GradleHandledError gradleError in localGradleErrors) {
-      if (gradleError.test(line)) {
-        detectedGradleErrorLine = line;
-        detectedGradleError = gradleError;
-        // The first error match wins.
-        break;
-      }
-    }
-    // Pipe stdout/stderr from Gradle.
-    return line;
-  }
-
+  final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(localGradleErrors);
   final Stopwatch sw = Stopwatch()..start();
   int exitCode = 1;
   try {
@@ -393,13 +370,14 @@ Future<void> buildGradleApp({
       workingDirectory: project.android.hostAppGradleRoot.path,
       allowReentrantFlutter: true,
       environment: gradleEnvironment,
-      mapFunction: consumeLog,
+      mapFunction: gradleLogProcessor.consumeLog,
     );
   } on ProcessException catch (exception) {
-    consumeLog(exception.toString());
+    gradleLogProcessor.atFailureFooter = false;
+    gradleLogProcessor.consumeLog(exception.toString());
     // Rethrow the exception if the error isn't handled by any of the
     // `localGradleErrors`.
-    if (detectedGradleError == null) {
+    if (gradleLogProcessor.detectedGradleError == null) {
       rethrow;
     }
   } finally {
@@ -409,22 +387,22 @@ Future<void> buildGradleApp({
   globals.flutterUsage.sendTiming('build', 'gradle', sw.elapsed);
 
   if (exitCode != 0) {
-    if (detectedGradleError == null) {
+    if (gradleLogProcessor.detectedGradleError == null) {
       BuildEvent('gradle-unknown-failure', flutterUsage: globals.flutterUsage).send();
       throwToolExit(
         'Gradle task $assembleTask failed with exit code $exitCode',
         exitCode: exitCode,
       );
     } else {
-      final GradleBuildStatus status = await detectedGradleError.handler(
-        line: detectedGradleErrorLine,
+      final GradleBuildStatus status = await gradleLogProcessor.detectedGradleError.handler(
+        line: gradleLogProcessor.detectedGradleErrorLine,
         project: project,
         usesAndroidX: usesAndroidX,
         shouldBuildPluginAsAar: shouldBuildPluginAsAar,
       );
 
       if (retries >= 1) {
-        final String successEventLabel = 'gradle-${detectedGradleError.eventLabel}-success';
+        final String successEventLabel = 'gradle-${gradleLogProcessor.detectedGradleError.eventLabel}-success';
         switch (status) {
           case GradleBuildStatus.retry:
             await buildGradleApp(
@@ -454,7 +432,7 @@ Future<void> buildGradleApp({
             // noop.
         }
       }
-      BuildEvent('gradle-${detectedGradleError.eventLabel}-failure', flutterUsage: globals.flutterUsage).send();
+      BuildEvent('gradle-${gradleLogProcessor.detectedGradleError.eventLabel}-failure', flutterUsage: globals.flutterUsage).send();
       throwToolExit(
         'Gradle task $assembleTask failed with exit code $exitCode',
         exitCode: exitCode,

--- a/packages/flutter_tools/lib/src/android/gradle_log_processor.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_log_processor.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'gradle_errors.dart';
+
+/// Process log output from gradle, removing irrelevant output and capturing
+/// exception information.
+class GradleLogProcessor {
+  GradleLogProcessor(this.localGradleErrors);
+
+  final List<GradleHandledError> localGradleErrors;
+
+  GradleHandledError detectedGradleError;
+  String detectedGradleErrorLine;
+  bool atFailureFooter = false;
+
+  String consumeLog(String line) {
+    // All gradle failures lead to a fairly long footer which contains mostly
+    // irrelevant information for a flutter build, along with misleading advice to
+    // run with --stacktrace (which does not exist for the flutter CLI). remove this.
+    if (line.startsWith('FAILURE: Build failed with an exception.') || atFailureFooter) {
+      atFailureFooter = true;
+      return null;
+    }
+    // This message was removed from first-party plugins,
+    // but older plugin versions still display this message.
+    if (androidXPluginWarningRegex.hasMatch(line)) {
+      // Don't pipe.
+      return null;
+    }
+    if (detectedGradleError != null) {
+      // Pipe stdout/stderr from Gradle.
+      return line;
+    }
+    for (final GradleHandledError gradleError in localGradleErrors) {
+      if (gradleError.test(line)) {
+        detectedGradleErrorLine = line;
+        detectedGradleError = gradleError;
+        // The first error match wins.
+        break;
+      }
+    }
+    // Pipe stdout/stderr from Gradle.
+    return line;
+  }
+}

--- a/packages/flutter_tools/lib/src/android/gradle_log_processor.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_log_processor.dart
@@ -7,9 +7,10 @@ import 'gradle_errors.dart';
 /// Process log output from gradle, removing irrelevant output and capturing
 /// exception information.
 class GradleLogProcessor {
-  GradleLogProcessor(this.localGradleErrors);
+  GradleLogProcessor(this.localGradleErrors, this.verbose);
 
   final List<GradleHandledError> localGradleErrors;
+  final bool verbose;
 
   GradleHandledError detectedGradleError;
   String detectedGradleErrorLine;
@@ -19,7 +20,7 @@ class GradleLogProcessor {
     // All gradle failures lead to a fairly long footer which contains mostly
     // irrelevant information for a flutter build, along with misleading advice to
     // run with --stacktrace (which does not exist for the flutter CLI). remove this.
-    if (line.startsWith('FAILURE: Build failed with an exception.') || atFailureFooter) {
+    if (!verbose && (line.startsWith('FAILURE: Build failed with an exception.') || atFailureFooter)) {
       atFailureFooter = true;
       return null;
     }

--- a/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_tools/src/android/gradle_errors.dart';
 import 'package:flutter_tools/src/android/gradle_log_processor.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 
 final List<String> gradleErrorOutputLines = r'''
 Some other stuff.

--- a/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
@@ -28,14 +28,14 @@ BUILD FAILED in 24s
 '''.split('\n');
 
 void main() {
-  testUsingContext('Does not print failure footer in non-verbose mode', () async {
+  testWithoutContext('Does not print failure footer in non-verbose mode', () async {
     final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[], false);
 
     expect(gradleErrorOutputLines.map(gradleLogProcessor.consumeLog).where((String line) => line != null), <String>['Some other stuff.']);
     expect(gradleLogProcessor.atFailureFooter, true);
   });
 
-  testUsingContext('Does print failure footer in verbose mode', () async {
+  testWithoutContext('Does print failure footer in verbose mode', () async {
     final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[], true);
 
     expect(gradleErrorOutputLines.map(gradleLogProcessor.consumeLog).where((String line) => line != null), gradleErrorOutputLines);

--- a/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -9,9 +8,7 @@ import 'package:flutter_tools/src/android/gradle_log_processor.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 
-void main() {
-   testUsingContext('Does not print failure footer', () async {
-      final List<String> output = r'''
+final List<String> gradleErrorOutputLines = r'''
 Some other stuff.
 FAILURE: Build failed with an exception.
 
@@ -29,9 +26,19 @@ Run with --stacktrace option to get the stack trace. Run with --info or --debug 
 
 BUILD FAILED in 24s
 '''.split('\n');
-      final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[]);
 
-      expect(output.map(gradleLogProcessor.consumeLog).where((String line) => line != null), <String>['Some other stuff.']);
-      expect(gradleLogProcessor.atFailureFooter, true);
-    });
+void main() {
+  testUsingContext('Does not print failure footer in non-verbose mode', () async {
+    final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[], false);
+
+    expect(gradleErrorOutputLines.map(gradleLogProcessor.consumeLog).where((String line) => line != null), <String>['Some other stuff.']);
+    expect(gradleLogProcessor.atFailureFooter, true);
+  });
+
+  testUsingContext('Does print failure footer in verbose mode', () async {
+    final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[], true);
+
+    expect(gradleErrorOutputLines.map(gradleLogProcessor.consumeLog).where((String line) => line != null), gradleErrorOutputLines);
+    expect(gradleLogProcessor.atFailureFooter, false);
+  });
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_log_processor_test.dart
@@ -1,0 +1,37 @@
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/android/gradle_errors.dart';
+import 'package:flutter_tools/src/android/gradle_log_processor.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+   testUsingContext('Does not print failure footer', () async {
+      final List<String> output = r'''
+Some other stuff.
+FAILURE: Build failed with an exception.
+
+* Where:
+Script '/Users/mit/dev/flutter/packages/flutter_tools/gradle/flutter.gradle' line: 900
+
+* What went wrong:
+Execution failed for task ':app:compileFlutterBuildRelease'.
+> Process 'command '/Users/mit/dev/flutter/bin/flutter'' finished with non-zero exit value 1
+
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 24s
+'''.split('\n');
+      final GradleLogProcessor gradleLogProcessor = GradleLogProcessor(<GradleHandledError>[]);
+
+      expect(output.map(gradleLogProcessor.consumeLog).where((String line) => line != null), <String>['Some other stuff.']);
+      expect(gradleLogProcessor.atFailureFooter, true);
+    });
+}


### PR DESCRIPTION
## Description

The gradle error footer is super confusing, because it looks like a tool crash and refers to flags that do not exist on the flutter tool. Just remove it entirely on non-verbose builds.

Before:

```
jonahwilliams-macbookpro2% flutter build apk           
Building flutter tool...                                          
Running "flutter pub get" in hello_world...                        432ms
You are building a fat APK that includes binaries for android-arm, android-arm64, android-x64.
If you are deploying the app to the Play Store, it's recommended to use app bundles or split the APK to reduce the APK size.
    To generate an app bundle, run:
        flutter build appbundle --target-platform android-arm,android-arm64,android-x64
        Learn more: https://developer.android.com/guide/app-bundle
    To split the APKs per ABI, run:
        flutter build apk --target-platform android-arm,android-arm64,android-x64 --split-per-abi
        Learn more: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split
lib/main.dart:6:1: Error: Variables must be declared using the keywords 'const', 'final', 'var' or a type name.
Try adding the name of the type of the variable or the keyword 'var'.   
x;                                                                      
^                                                                       
                                                                        
                                                                        
FAILURE: Build failed with an exception.                                
                                                                        
* Where:                                                                
Script '/Users/jonahwilliams/Documents/flutter/packages/flutter_tools/gradle/flutter.gradle' line: 900
                                                                        
* What went wrong:                                                      
Execution failed for task ':app:compileFlutterBuildRelease'.            
> Process 'command '/Users/jonahwilliams/Documents/flutter/bin/flutter'' finished with non-zero exit value 1
                                                                        
* Try:                                                                  
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
                                                                        
* Get more help at https://help.gradle.org                              
                                                                        
BUILD FAILED in 5s                                                      
Running Gradle task 'assembleRelease'...                                
Running Gradle task 'assembleRelease'... Done                       5.9s
Gradle task assembleRelease failed with exit code 1
```

After:

```
jonahwilliams-macbookpro2% flutter build apk
Building flutter tool...                                          
Running "flutter pub get" in hello_world...                        437ms
You are building a fat APK that includes binaries for android-arm, android-arm64, android-x64.
If you are deploying the app to the Play Store, it's recommended to use app bundles or split the APK to reduce the APK size.
    To generate an app bundle, run:
        flutter build appbundle --target-platform android-arm,android-arm64,android-x64
        Learn more: https://developer.android.com/guide/app-bundle
    To split the APKs per ABI, run:
        flutter build apk --target-platform android-arm,android-arm64,android-x64 --split-per-abi
        Learn more: https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split
lib/main.dart:7:1: Error: Variables must be declared using the keywords 'const', 'final', 'var' or a type name.
Try adding the name of the type of the variable or the keyword 'var'.   
x;                                                                      
^                                                                       
                                                                        
                                                                        
Running Gradle task 'assembleRelease'...                                
Running Gradle task 'assembleRelease'... Done                       6.1s
Gradle task assembleRelease failed with exit code 1
```

Fixes https://github.com/flutter/flutter/issues/13466
Fixes https://github.com/flutter/flutter/issues/69022
Fixes https://github.com/flutter/flutter/issues/58337
Fixes https://github.com/flutter/flutter/issues/39201