### PR TITLE
Run the flutter/plugins tests on presubmit, make it part of the tree status

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -163,6 +163,12 @@
         "flaky":false
       },
       {
+         "name":"Linux flutter_plugins",
+         "repo":"flutter",
+         "task_name":"flutter_plugins",
+         "flaky":false
+      },
+      {
          "name": "Mac build_aar_module_test",
          "repo": "flutter",
          "task_name": "mac_build_aar_module_test",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -396,6 +396,6 @@
          "repo":"flutter",
          "task_name":"flutter_plugins",
          "enabled":true
-      },
+      }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -390,6 +390,12 @@
          "repo": "flutter",
          "task_name": "win_web_tool_tests",
          "enabled":false
-      }
+      },
+      {
+         "name":"Linux flutter_plugins",
+         "repo":"flutter",
+         "task_name":"flutter_plugins",
+         "enabled":true
+      },
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -182,6 +182,12 @@
          "run_if":["examples/hello_world/**" ,"dev/**", "packages/flutter/**", "packages/flutter_driver/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "packages/flutter_web_plugins/**", "bin/**"]
       },
       {
+         "name":"Linux flutter_plugins",
+         "repo":"flutter",
+         "task_name":"flutter_plugins",
+         "enabled":true
+      },
+      {
          "name":"Mac build_aar_module_test",
          "repo":"flutter",
          "task_name":"mac_build_aar_module_test",
@@ -390,12 +396,6 @@
          "repo": "flutter",
          "task_name": "win_web_tool_tests",
          "enabled":false
-      },
-      {
-         "name":"Linux flutter_plugins",
-         "repo":"flutter",
-         "task_name":"flutter_plugins",
-         "enabled":true
       }
    ]
 }


### PR DESCRIPTION
The tests have been running for over a week now and did not flake (there was a legit failure detected).
At this point we should be good to allow it to block the tree.

https://github.com/flutter/flutter/issues/69309