### PR TITLE
[devicelab] make hot reload benchmark more verbose

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -33,7 +33,7 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
     rm(benchmarkFile);
     final List<String> options = <String>[
-      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon',
+      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--dart-flags=--trace-reload'
     ];
     int hotReloadCount = 0;
     Map<String, dynamic> smallReloadData;

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -33,7 +33,7 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
     rm(benchmarkFile);
     final List<String> options = <String>[
-      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--dart-flags=--trace-reload'
+      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--dart-flags=--trace-reload,--trace-kernel', '--verbose',
     ];
     int hotReloadCount = 0;
     Map<String, dynamic> smallReloadData;


### PR DESCRIPTION
## Description

Waiting on engine roll containing https://github.com/flutter/engine/pull/22812 that will allow using --trace-kernel flag to try and track down https://github.com/flutter/flutter/issues/71178
