### PR TITLE
ios_host_app Podfile search paths

### DIFF
--- a/dev/integration_tests/ios_host_app/Host.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_host_app/Host.xcodeproj/project.pbxproj
@@ -566,7 +566,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = FlutterUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -587,7 +586,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = FlutterUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/dev/integration_tests/ios_host_app/Podfile
+++ b/dev/integration_tests/ios_host_app/Podfile
@@ -5,9 +5,8 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Host' do
   install_all_flutter_pods flutter_application_path
+end
 
-  target 'FlutterUITests' do
-    inherit! :search_paths
-    install_all_flutter_pods flutter_application_path
-  end
+target 'FlutterUITests' do
+  inherit! :search_paths
 end


### PR DESCRIPTION
## Description

`FlutterUITests` should be not be enclosed in the app target.

On CocoaPods 1.9.3, module_test_ios failed in conjunction with [XCFramework adoption](https://github.com/flutter/flutter/pull/71495).

```
[module_test_ios] [STDOUT] stderr: Testing failed:
[module_test_ios] [STDOUT] stderr: 	Multiple commands produce '/Users/chrome-bot/Library/Developer/Xcode/DerivedData/Host-awwbtvmasrdobpfhghyvdjlbrers/Build/Products/Debug-iphonesimulator/cocoapods-artifacts-Debug.txt':
[module_test_ios] [STDOUT] stderr: 1) That command depends on command in Target 'FlutterUITests' (project 'Host'): script phase “[CP] Prepare Artifacts”
[module_test_ios] [STDOUT] stderr: 2) That command depends on command in Target 'Host' (project 'Host'): script phase “[CP] Prepare Artifacts”
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8862075951229786736/+/steps/run_module_test_ios/0/stdout

Move the test target out.

## Related Issues
https://github.com/flutter/flutter/pull/71495
https://github.com/CocoaPods/CocoaPods/issues/9670#issuecomment-706664684

## Tests
Tested by `module_test_ios`.
