### PR TITLE
Add a test for intrinsic size checks

### DIFF
--- a/packages/flutter/test/rendering/dynamic_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/dynamic_intrinsics_test.dart
@@ -83,4 +83,42 @@ void main() {
     pumpFrame();
     expect(root.size, equals(inner.size));
   });
+
+  group('When RenderObject.debugCheckingIntrinsics is true', () {
+    setUp(() => RenderObject.debugCheckingIntrinsics = true);
+    tearDown(() => RenderObject.debugCheckingIntrinsics = false);
+    test('parent returns correct intrinsics', () {
+      RenderParentSize parent;
+      RenderFixedSize inner;
+      layout(
+        RenderIntrinsicSize(
+          child: parent = RenderParentSize(
+            child: inner = RenderFixedSize()
+          )
+        ),
+        constraints: const BoxConstraints(
+          minWidth: 0.0,
+          minHeight: 0.0,
+          maxWidth: 1000.0,
+          maxHeight: 1000.0,
+        ),
+      );
+
+      _expectIntrinsicDimensions(parent, 100);
+
+      inner.grow();
+      pumpFrame();
+
+      _expectIntrinsicDimensions(parent, 200);
+    });
+  });
+}
+
+/// Asserts that all unbounded intrinsic dimensions for [object] match
+/// [dimension].
+void _expectIntrinsicDimensions(RenderBox object, double dimension) {
+  expect(object.getMinIntrinsicWidth(double.infinity), equals(dimension));
+  expect(object.getMaxIntrinsicWidth(double.infinity), equals(dimension));
+  expect(object.getMinIntrinsicHeight(double.infinity), equals(dimension));
+  expect(object.getMaxIntrinsicHeight(double.infinity), equals(dimension));
 }

--- a/packages/flutter/test/rendering/dynamic_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/dynamic_intrinsics_test.dart
@@ -84,12 +84,13 @@ void main() {
     expect(root.size, equals(inner.size));
   });
 
-  group('When RenderObject.debugCheckingIntrinsics is true', () {
-    setUp(() => RenderObject.debugCheckingIntrinsics = true);
-    tearDown(() => RenderObject.debugCheckingIntrinsics = false);
-    test('parent returns correct intrinsics', () {
+  test('When RenderObject.debugCheckingIntrinsics is true, parent returns correct intrinsics', () {
+    RenderObject.debugCheckingIntrinsics = true;
+
+    try {
       RenderParentSize parent;
       RenderFixedSize inner;
+
       layout(
         RenderIntrinsicSize(
           child: parent = RenderParentSize(
@@ -110,7 +111,9 @@ void main() {
       pumpFrame();
 
       _expectIntrinsicDimensions(parent, 200);
-    });
+    } finally {
+      RenderObject.debugCheckingIntrinsics = false;
+    }
   });
 }
 


### PR DESCRIPTION
## Description

Add a test to assert that when doing intrinsic size checks, the parent `RenderBox` returns the correct intrinsics.

## Related Issues

#70730

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
