### PR TITLE
Make AboutDialog customizable. 

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -16,6 +16,7 @@ import 'card.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'dialog.dart';
+import 'dialog_theme.dart';
 import 'divider.dart';
 import 'floating_action_button.dart';
 import 'floating_action_button_location.dart';
@@ -242,6 +243,7 @@ void showAboutDialog({
   Widget? applicationIcon,
   String? applicationLegalese,
   List<Widget>? children,
+  DialogTheme? dialogTheme,
   bool useRootNavigator = true,
   RouteSettings? routeSettings,
 }) {
@@ -257,6 +259,7 @@ void showAboutDialog({
         applicationIcon: applicationIcon,
         applicationLegalese: applicationLegalese,
         children: children,
+        dialogTheme: dialogTheme,
       );
     },
     routeSettings: routeSettings,
@@ -334,6 +337,7 @@ class AboutDialog extends StatelessWidget {
     this.applicationIcon,
     this.applicationLegalese,
     this.children,
+    this.dialogTheme,
   }) : super(key: key);
 
   /// The name of the application.
@@ -372,6 +376,9 @@ class AboutDialog extends StatelessWidget {
   /// Defaults to nothing.
   final List<Widget>? children;
 
+  /// A theme for customizing the backgroundColor, elevation, shape of a dialog.
+  final DialogTheme? dialogTheme;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -379,6 +386,9 @@ class AboutDialog extends StatelessWidget {
     final String version = applicationVersion ?? _defaultApplicationVersion(context);
     final Widget? icon = applicationIcon ?? _defaultApplicationIcon(context);
     return AlertDialog(
+      backgroundColor: dialogTheme?.backgroundColor,
+      elevation: dialogTheme?.elevation,
+      shape: dialogTheme?.shape,
       content: ListBody(
         children: <Widget>[
           Row(
@@ -390,10 +400,10 @@ class AboutDialog extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 24.0),
                   child: ListBody(
                     children: <Widget>[
-                      Text(name, style: Theme.of(context).textTheme.headline5),
-                      Text(version, style: Theme.of(context).textTheme.bodyText2),
+                      Text(name, style: dialogTheme?.titleTextStyle ?? Theme.of(context).textTheme.headline5),
+                      Text(version, style: dialogTheme?.contentTextStyle ?? Theme.of(context).textTheme.bodyText2),
                       const SizedBox(height: _textVerticalSeparation),
-                      Text(applicationLegalese ?? '', style: Theme.of(context).textTheme.caption),
+                      Text(applicationLegalese ?? '', style: dialogTheme?.contentTextStyle ?? Theme.of(context).textTheme.caption),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Description

- Added ```dialogTheme``` as a property to the ```AboutDialog``` and ```showAboutDialog```. 
- Previously properties like ```elevation```, ```shape```, ```backgroundColor``` are by default to ```AlertDialog```. (Example https://github.com/flutter/flutter/issues/17509#issuecomment-735743918)


<details>
<summary>Example</summary>

Customize About dialog using ```dialogTheme```

```dart
showAboutDialog(
     context: context,
     applicationName: "Flutter App",
     applicationVersion: "2.1.0",
	 applicationLegalese: "",
     dialogTheme: DialogTheme(
     titleTextStyle:customTitleTextStyle,
     contentTextStyle:customContentTextStyle,
     backgroundColor: customBackgroundColor,
     elevation: customElevation,
     shape: customShape,
      ),
   );
```

</details>

### Few points should be considered

1. Difficulty in co-relating ```applicationName```, ```applicationVersion```  ```Textstyle``` with ```titleTextStyle``` and ```contentTextStyle``` properties of ```dialogTheme```  respectively.

2. What should be the ```textStyle``` for applicationLegalese (In this PR ```applicationLegalese``` & ```applicationVersion``` having same ```contentTextStyle``` ).	


## Related Issues

fixes #17509

## Tests

I added the following tests:

Test which verifies working of ```dialogTheme``` for custom theming of the ```AboutDialog``` .

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
