### PR TITLE
properly pass on gradle exit code (#71484)

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -645,8 +645,8 @@ Future<void> buildGradleAar({
     globals.printStatus(result.stdout, wrap: false);
     globals.printError(result.stderr, wrap: false);
     throwToolExit(
-      'Gradle task $aarTask failed with exit code $exitCode.',
-      exitCode: exitCode,
+      'Gradle task $aarTask failed with exit code ${result.exitCode}.',
+      exitCode: result.exitCode,
     );
   }
   final Directory repoDirectory = getRepoDirectory(outputDirectory);

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1741,10 +1741,6 @@ plugin1=${plugin1.path}
         )
       , throwsToolExit(exitCode: 108, message: 'Gradle task assembleAarRelease failed with exit code 108.'));
 
-      expect(
-        testLogger.statusText.contains('Consuming the Module'),
-        isFalse,
-      );
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1704,6 +1704,56 @@ plugin1=${plugin1.path}
       ProcessManager: () => mockProcessManager,
     });
 
+    testUsingContext("gradle exit code is properly passed on", () async {
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        '''
+      );
+
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+
+      fileSystem.file('.android/gradle.properties')
+          .writeAsStringSync('irrelevant');
+
+      fileSystem.file('.android/build.gradle')
+          .createSync(recursive: true);
+
+      // Let any process start. Assert after.
+      when(mockProcessManager.run(
+        any,
+        environment: anyNamed('environment'),
+        workingDirectory: anyNamed('workingDirectory'),
+      )).thenAnswer((_) async => ProcessResult(1, 108, '', ''));
+
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      await expectLater(() async =>
+        await buildGradleAar(
+          androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
+          project: FlutterProject.current(),
+          outputDirectory: fileSystem.directory('build/'),
+          target: '',
+          buildNumber: '1.0',
+        )
+      , throwsToolExit(exitCode: 108, message: 'Gradle task assembleAarRelease failed with exit code 108.'));
+
+      expect(
+        testLogger.statusText.contains('Consuming the Module'),
+        isFalse,
+      );
+    }, overrides: <Type, Generator>{
+      AndroidSdk: () => mockAndroidSdk,
+      AndroidStudio: () => mockAndroidStudio,
+      Cache: () => cache,
+      Platform: () => android,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('build apk uses selected local engine,the engine abi is arm', () async {
       when(mockArtifacts.getArtifactPath(
         Artifact.flutterFramework,

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1704,7 +1704,7 @@ plugin1=${plugin1.path}
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext("gradle exit code is properly passed on", () async {
+    testUsingContext('gradle exit code is properly passed on', () async {
       final File manifestFile = fileSystem.file('pubspec.yaml');
       manifestFile.createSync(recursive: true);
       manifestFile.writeAsStringSync('''


### PR DESCRIPTION
## Description

the gradle process's exit code variable was not properly referenced. That way, when the flutter build failed, it did not fail the gradle task. see #71484 for more info

## Related Issues

fix #71484
fix #74479

## Tests

I added the following tests:

I have not written any test yet as I don't have any clue where to start. Please provide some pointer/example?

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

**I ran all tests using dev channel and master channel flutter, but a lot of tests failed. The errors don't seem related to my change though. How to properly run the tests?**

flutter analyze --flutter-repo also reports lots of errors like this:
```
  error - The function 'Offset' isn't defined - ..\..\..\..\programs\flutter\packages\flutter\lib\src\material\animated_icons\data\event_add.g.dart:95:13 - undefined_function
  error - The values in a const list literal must be constants - ..\..\..\..\programs\flutter\packages\flutter\lib\src\material\animated_icons\data\event_add.g.dart:95:13 - non_constant_list_element
  error - Const variables must be initialized with a constant value - ..\..\..\..\programs\flutter\packages\flutter\lib\src\material\animated_icons\data\event_add.g.dart:96:13 - const_initialized_with_non_constant_value
  error - Invalid constant value - ..\..\..\..\programs\flutter\packages\flutter\lib\src\material\animated_icons\data\event_add.g.dart:96:13 - invalid_constant
```

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
