### PR TITLE
Ensure the packaging script does not overwrite a previous upload

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -715,14 +715,14 @@ Future<void> main(List<String> rawArguments) async {
   }
 
   final String revision = parsedArguments['revision'] as String;
-  if (revision == null) {
+  if (!parsedArguments.wasParsed('revision')) {
     errorExit('Invalid argument: --revision must be specified.');
   }
   if (revision.length != 40) {
     errorExit('Invalid argument: --revision must be the entire hash, not just a prefix.');
   }
 
-  if (parsedArguments['branch'] == null) {
+  if (!parsedArguments.wasParsed('branch')) {
     errorExit('Invalid argument: --branch must be specified.');
   }
 

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -689,6 +689,12 @@ Future<void> main(List<String> rawArguments) async {
         'directory: $baseUrl$releaseFolder',
   );
   argParser.addFlag(
+    'force',
+    abbr: 'f',
+    defaultsTo: false,
+    help: 'Overwrite a previously uploaded package.',
+  );
+  argParser.addFlag(
     'help',
     defaultsTo: false,
     negatable: false,
@@ -709,14 +715,14 @@ Future<void> main(List<String> rawArguments) async {
   }
 
   final String revision = parsedArguments['revision'] as String;
-  if (revision.isEmpty) {
+  if (revision == null) {
     errorExit('Invalid argument: --revision must be specified.');
   }
   if (revision.length != 40) {
     errorExit('Invalid argument: --revision must be the entire hash, not just a prefix.');
   }
 
-  if ((parsedArguments['branch'] as String).isEmpty) {
+  if (parsedArguments['branch'] == null) {
     errorExit('Invalid argument: --branch must be specified.');
   }
 
@@ -758,7 +764,7 @@ Future<void> main(List<String> rawArguments) async {
         version,
         outputFile,
       );
-      await publisher.publishArchive();
+      await publisher.publishArchive(parsedArguments['force'] as bool);
     }
   } on PreparePackageException catch (e) {
     exitCode = e.exitCode;

--- a/dev/bots/test/fake_process_manager.dart
+++ b/dev/bots/test/fake_process_manager.dart
@@ -55,8 +55,6 @@ class FakeProcessManager extends Mock implements ProcessManager {
 
   ProcessResult _popResult(List<String> command) {
     final String key = command.join(' ');
-    expect(key, 'blah');
-    expect(fakeResults, isNotEmpty);
     expect(fakeResults, contains(key));
     expect(fakeResults[key], isNotEmpty);
     return fakeResults[key].removeAt(0);

--- a/dev/bots/test/fake_process_manager.dart
+++ b/dev/bots/test/fake_process_manager.dart
@@ -55,6 +55,7 @@ class FakeProcessManager extends Mock implements ProcessManager {
 
   ProcessResult _popResult(List<String> command) {
     final String key = command.join(' ');
+    expect(key, 'blah');
     expect(fakeResults, isNotEmpty);
     expect(fakeResults, contains(key));
     expect(fakeResults[key], isNotEmpty);

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -367,6 +367,73 @@ void main() {
         expect(() async => await publisher.publishArchive(false), throwsException);
         processManager.verifyCalls(calls.keys.toList());
       });
+
+      test('publishArchive does not throw if forceUpload is true and artifact '
+           'already exists on cloud storage', () async {
+        final String archiveName = platform.isLinux ? 'archive.tar.xz' : 'archive.zip';
+        final File outputFile = File(path.join(tempDir.absolute.path, archiveName));
+        final ArchivePublisher publisher = ArchivePublisher(
+          tempDir,
+          testRef,
+          Branch.stable,
+          'v1.2.3',
+          outputFile,
+          processManager: processManager,
+          subprocessOutput: false,
+          platform: platform,
+        );
+        final String archivePath = path.join(tempDir.absolute.path, archiveName);
+        final String jsonPath = path.join(tempDir.absolute.path, releasesName);
+        final String gsJsonPath = 'gs://flutter_infra/releases/$releasesName';
+        final String releasesJson = '''
+{
+  "base_url": "https://storage.googleapis.com/flutter_infra/releases",
+  "current_release": {
+    "beta": "3ea4d06340a97a1e9d7cae97567c64e0569dcaa2",
+    "dev": "5a58b36e36b8d7aace89d3950e6deb307956a6a0"
+  },
+  "releases": [
+    {
+      "hash": "5a58b36e36b8d7aace89d3950e6deb307956a6a0",
+      "channel": "dev",
+      "version": "v0.2.3",
+      "release_date": "2018-03-20T01:47:02.851729Z",
+      "archive": "dev/$platformName/flutter_${platformName}_v0.2.3-dev.zip",
+      "sha256": "4fe85a822093e81cb5a66c7fc263f68de39b5797b294191b6d75e7afcc86aff8"
+    },
+    {
+      "hash": "b9bd51cc36b706215915711e580851901faebb40",
+      "channel": "beta",
+      "version": "v0.2.2",
+      "release_date": "2018-03-16T18:48:13.375013Z",
+      "archive": "dev/$platformName/flutter_${platformName}_v0.2.2-dev.zip",
+      "sha256": "6073331168cdb37a4637a5dc073d6a7ef4e466321effa2c529fa27d2253a4d4b"
+    },
+    {
+      "hash": "$testRef",
+      "channel": "stable",
+      "version": "v0.0.0",
+      "release_date": "2018-03-20T01:47:02.851729Z",
+      "archive": "stable/$platformName/flutter_${platformName}_v0.0.0-dev.zip",
+      "sha256": "5dd34873b3a3e214a32fd30c2c319a0f46e608afb72f0d450b2d621a6d02aebd"
+    }
+  ]
+}
+''';
+        File(jsonPath).writeAsStringSync(releasesJson);
+        File(archivePath).writeAsStringSync('archive contents');
+        final Map<String, List<ProcessResult>> calls = <String, List<ProcessResult>>{
+          '$gsutilCall -- rm $gsArchivePath': null,
+          '$gsutilCall -- -h Content-Type:$archiveMime cp $archivePath $gsArchivePath': null,
+          '$gsutilCall -- cp $gsJsonPath $jsonPath': null,
+          '$gsutilCall -- rm $gsJsonPath': null,
+          '$gsutilCall -- -h Content-Type:application/json cp $jsonPath $gsJsonPath': null,
+        };
+        processManager.fakeResults = calls;
+        assert(tempDir.existsSync());
+        await publisher.publishArchive(true);
+        processManager.verifyCalls(calls.keys.toList());
+      });
     });
   }
 }

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -345,8 +345,7 @@ void main() {
         expect(contents, equals(encoder.convert(jsonData)));
       });
 
-      test('publishArchive throws if forceUpload is false and artifact '
-           'already exists on cloud storage', () async {
+      test('publishArchive throws if forceUpload is false and artifact already exists on cloud storage', () async {
         final String archiveName = platform.isLinux ? 'archive.tar.xz' : 'archive.zip';
         final File outputFile = File(path.join(tempDir.absolute.path, archiveName));
         final ArchivePublisher publisher = ArchivePublisher(
@@ -368,8 +367,7 @@ void main() {
         processManager.verifyCalls(calls.keys.toList());
       });
 
-      test('publishArchive does not throw if forceUpload is true and artifact '
-           'already exists on cloud storage', () async {
+      test('publishArchive does not throw if forceUpload is true and artifact already exists on cloud storage', () async {
         final String archiveName = platform.isLinux ? 'archive.tar.xz' : 'archive.zip';
         final File outputFile = File(path.join(tempDir.absolute.path, archiveName));
         final ArchivePublisher publisher = ArchivePublisher(

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -359,11 +359,12 @@ void main() {
           subprocessOutput: false,
           platform: platform,
         );
-        await publisher.publishArchive(false);
         final Map<String, List<ProcessResult>> calls = <String, List<ProcessResult>>{
           // This process returns 0 because file already exists
           '$gsutilCall -- stat $gsArchivePath': <ProcessResult>[ProcessResult(0, 0, '', '')],
         };
+        processManager.fakeResults = calls;
+        expect(() async => await publisher.publishArchive(false), throwsException);
         processManager.verifyCalls(calls.keys.toList());
       });
     });


### PR DESCRIPTION
## Description

Ensure the packaging script does not overwrite a previous upload.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55082

## Tests

I added two new tests to ensure duplicate packages will fail without the -f flag and pass with it.