### PR TITLE
[flutter_tools] enable CK restart tests

### DIFF
--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -77,7 +77,7 @@ String getFlutterRoot() {
       throw invalidScript();
   }
 
-  final List<String> parts = path.split(globals.fs.path.fromUri(scriptUri));
+  final List<String> parts = path.split(LocalFileSystem.instance.path.fromUri(scriptUri));
   final int toolsIndex = parts.indexOf('flutter_tools');
   if (toolsIndex == -1) {
     throw invalidScript();

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -68,5 +68,5 @@ void main() {
     } finally {
       await subscription.cancel();
     }
-  }, skip: true); // https://github.com/flutter/flutter/issues/70486
+  });
 }


### PR DESCRIPTION
## Description

Canvaskit hot restart is fixed, so re-enable the tests
