### PR TITLE
[flutter_tools] mode code size output to ~/.flutter-devtools

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -532,7 +532,9 @@ Future<void> _performCodeSizeAnalysis(
     kind: kind,
   );
   final File outputFile = globals.fsUtils.getUniqueFile(
-    globals.fs.directory(getBuildDirectory()),'$kind-code-size-analysis', 'json',
+    globals.fs
+      .directory(globals.fsUtils.homeDirPath)
+      .childDirectory('.flutter-devtools'), '$kind-code-size-analysis', 'json',
   )..writeAsStringSync(jsonEncode(output));
   // This message is used as a sentinel in analyze_apk_size_test.dart
   globals.printStatus(

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -103,6 +103,7 @@ class FileSystemUtils {
       final String name = '${baseName}_${i.toString().padLeft(2, '0')}.$ext';
       final File file = fs.file(_fileSystem.path.join(dir.path, name));
       if (!file.existsSync()) {
+        file.createSync(recursive: true);
         return file;
       }
       i += 1;

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -286,7 +286,9 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
         type: 'ios',
       );
       final File outputFile = globals.fsUtils.getUniqueFile(
-        globals.fs.directory(getBuildDirectory()),'ios-code-size-analysis', 'json',
+        globals.fs
+          .directory(globals.fsUtils.homeDirPath)
+          .childDirectory('.flutter-devtools'), 'ios-code-size-analysis', 'json',
       )..writeAsStringSync(jsonEncode(output));
       // This message is used as a sentinel in analyze_apk_size_test.dart
       globals.printStatus(

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -70,7 +70,9 @@ Future<void> buildLinux(
       type: 'linux',
     );
     final File outputFile = globals.fsUtils.getUniqueFile(
-      globals.fs.directory(getBuildDirectory()),'linux-code-size-analysis', 'json',
+      globals.fs
+        .directory(globals.fsUtils.homeDirPath)
+        .childDirectory('.flutter-devtools'), 'linux-code-size-analysis', 'json',
     )..writeAsStringSync(jsonEncode(output));
     // This message is used as a sentinel in analyze_apk_size_test.dart
     globals.printStatus(

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -133,7 +133,9 @@ Future<void> buildMacOS({
       excludePath: 'Versions', // Avoid double counting caused by symlinks
     );
     final File outputFile = globals.fsUtils.getUniqueFile(
-      globals.fs.directory(getBuildDirectory()), 'macos-code-size-analysis', 'json',
+      globals.fs
+        .directory(globals.fsUtils.homeDirPath)
+        .childDirectory('.flutter-devtools'), 'macos-code-size-analysis', 'json',
     )..writeAsStringSync(jsonEncode(output));
     // This message is used as a sentinel in analyze_apk_size_test.dart
     globals.printStatus(

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -78,7 +78,9 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
       type: 'windows',
     );
     final File outputFile = globals.fsUtils.getUniqueFile(
-      globals.fs.directory(getBuildDirectory()),'windows-code-size-analysis', 'json',
+      globals.fs
+        .directory(globals.fsUtils.homeDirPath)
+        .childDirectory('.flutter-devtools'), 'windows-code-size-analysis', 'json',
     )..writeAsStringSync(jsonEncode(output));
     // This message is used as a sentinel in analyze_apk_size_test.dart
     globals.printStatus(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -34,6 +34,7 @@ final Platform macosPlatform = FakePlatform(
   operatingSystem: 'macos',
   environment: <String, String>{
     'FLUTTER_ROOT': '/',
+    'HOME': '/',
   }
 );
 final Platform notMacosPlatform = FakePlatform(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -26,7 +26,8 @@ const String _kTestFlutterRoot = '/flutter';
 final Platform linuxPlatform = FakePlatform(
   operatingSystem: 'linux',
   environment: <String, String>{
-    'FLUTTER_ROOT': _kTestFlutterRoot
+    'FLUTTER_ROOT': _kTestFlutterRoot,
+    'HOME': '/',
   }
 );
 final Platform notLinuxPlatform = FakePlatform(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -26,7 +26,7 @@ import '../../src/testbed.dart';
 
 class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter {
   @override
-  Future<XcodeProjectInfo> getInfo(String projectPath, {String projectFilename}) async {
+  Future<XcodeProjectInfo> getInfo(String projectPath, { String projectFilename }) async {
     return XcodeProjectInfo(
       <String>['Runner'],
       <String>['Debug', 'Profile', 'Release'],

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -40,6 +40,7 @@ final Platform macosPlatform = FakePlatform(
   operatingSystem: 'macos',
   environment: <String, String>{
     'FLUTTER_ROOT': '/',
+    'HOME': '/',
   }
 );
 final Platform notMacosPlatform = FakePlatform(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -28,6 +28,7 @@ final Platform windowsPlatform = FakePlatform(
   environment: <String, String>{
     'PROGRAMFILES(X86)':  r'C:\Program Files (x86)\',
     'FLUTTER_ROOT': flutterRoot,
+    'USERPROFILE': '/',
   }
 );
 final Platform notWindowsPlatform = FakePlatform(

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -34,6 +34,7 @@ void main() {
 
     final String outputFilePath = line.split(apkDebugMessage).last.trim();
     expect(fileSystem.file(fileSystem.path.join(woringDirectory, outputFilePath)), exists);
+    expect(outputFilePath, contains('.flutter-devtools'));
     expect(result.exitCode, 0);
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/71585 .

Rather than write the output to the build directory, write to the user's home directory.
