### PR TITLE
Turn on dependabot to roll bundler dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
     labels:
       - "team"
       - "team: infra"
+      - "waiting for tree to go green"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       interval: "weekly"
     reviewers:
       - "jmagman"
+      - "keyonghan"
+      - "yusufm"
     labels:
       - "team"
       - "team: infra"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# See Dependabot documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/dev/ci"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "jmagman"
+    labels:
+      - "team"
+      - "team: infra"


### PR DESCRIPTION
## Description

Turn on [GitHub dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) to keep the `dev/ci` `Gemfile.lock` files up to date.  Run it weekly.

## Related Issues

See https://github.com/flutter/flutter/pull/71531 where this was done manually.
It's now opt-in, but for a brief window we were getting dependabot PRs, see https://github.com/flutter/flutter/pull/62379

## Tests

Might not know if this works until next Monday.