### PR TITLE
Mark hot_mode_dev_cycle_macos_target__benchmark flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -677,6 +677,7 @@ tasks:
       Checks the functionality and performance of hot reload on a macOS target platform
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
+    flaky: true # https://github.com/flutter/flutter/issues/71613
 
   ios_app_with_extensions_test:
     description: >


### PR DESCRIPTION
This is breaking the tree, diagnosing in https://github.com/flutter/flutter/issues/71613
Marking flaky in the meantime