### PR TITLE
Fix dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directory: "/dev/ci"
+    directory: "/dev/ci/mac"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
## Description

Well #71602 didn't work.  Directory either needs to point to the Gemfile location, or there needs to be a `.github/workflows` file.

https://github.com/flutter/flutter/network/updates:

<img width="929" alt="Screen Shot 2020-12-02 at 5 16 00 PM" src="https://user-images.githubusercontent.com/682784/100950858-2bea3080-34c2-11eb-88b7-b951b5e82675.png">

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#directory`