### PR TITLE
enableFlutterDriverExtension: optionally disable text entry emulation

### DIFF
--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -79,6 +79,11 @@ class _DriverBinding extends BindingBase with SchedulerBinding, ServicesBinding,
 /// will still be returned in the `response` field of the result JSON along
 /// with an `isError` boolean.
 ///
+/// `enableTextEntryEmulation` will enable text entry emulation.
+/// Defaults to true. False can be used to enable manual testing
+/// with automation builds, otherwise text entry isn't working
+/// (see [FlutterDriver.setTextEntryEmulation]).
+///
 /// The `finders` and `commands` parameters are optional and used to add custom
 /// finders or commands, as in the following example.
 ///

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -79,10 +79,11 @@ class _DriverBinding extends BindingBase with SchedulerBinding, ServicesBinding,
 /// will still be returned in the `response` field of the result JSON along
 /// with an `isError` boolean.
 ///
-/// `enableTextEntryEmulation` will enable text entry emulation.
-/// Defaults to true. False can be used to enable manual testing
-/// with automation builds, otherwise text entry isn't working
-/// (see [FlutterDriver.setTextEntryEmulation]).
+/// The `enableTextEntryEmulation` parameter controls whether the application interacts
+/// with the system's text entry methods or a mocked out version used by Flutter Driver.
+/// If it is set to false, [FlutterDriver.enterText] will fail,
+/// but testing the application with real keyboard input is possible.
+/// This value may be updated during a test by calling [FlutterDriver.setTextEntryEmulation].
 ///
 /// The `finders` and `commands` parameters are optional and used to add custom
 /// finders or commands, as in the following example.

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -44,7 +44,7 @@ void main() {
 
     setUp(() {
       result = null;
-      driverExtension = FlutterDriverExtension((String message) async { log.add(message); return (messageId += 1).toString(); }, false);
+      driverExtension = FlutterDriverExtension((String message) async { log.add(message); return (messageId += 1).toString(); }, false, true);
     });
 
     testWidgets('returns immediately when transient callback queue is empty', (WidgetTester tester) async {
@@ -105,7 +105,7 @@ void main() {
 
     setUp(() {
       result = null;
-      driverExtension = FlutterDriverExtension((String message) async { log.add(message); return (messageId += 1).toString(); }, false);
+      driverExtension = FlutterDriverExtension((String message) async { log.add(message); return (messageId += 1).toString(); }, false, true);
     });
 
     testWidgets('waiting for NoTransientCallbacks returns immediately when transient callback queue is empty', (WidgetTester tester) async {
@@ -471,7 +471,7 @@ void main() {
   group('getSemanticsId', () {
     FlutterDriverExtension driverExtension;
     setUp(() {
-      driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
     });
 
     testWidgets('works when semantics are enabled', (WidgetTester tester) async {
@@ -520,7 +520,7 @@ void main() {
   });
 
   testWidgets('getOffset', (WidgetTester tester) async {
-    final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+    final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
     Future<Offset> getOffset(OffsetType offset) async {
       final Map<String, String> arguments = GetOffset(ByValueKey(1), offset).serialize();
@@ -552,7 +552,7 @@ void main() {
 
   testWidgets('getText', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
-      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
       Future<String> getTextInternal(SerializableFinder search) async {
         final Map<String, String> arguments = GetText(search, timeout: const Duration(seconds: 1)).serialize();
@@ -622,7 +622,7 @@ void main() {
 
   testWidgets('descendant finder', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
-      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
       Future<String> getDescendantText({ String of, bool matchRoot = false}) async {
         final Map<String, String> arguments = GetText(Descendant(
@@ -667,7 +667,7 @@ void main() {
 
   testWidgets('descendant finder firstMatchOnly', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
-      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
       Future<String> getDescendantText() async {
         final Map<String, String> arguments = GetText(Descendant(
@@ -701,7 +701,7 @@ void main() {
 
   testWidgets('ancestor finder', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
-      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
       Future<Offset> getAncestorTopLeft({ String of, String matching, bool matchRoot = false}) async {
         final Map<String, String> arguments = GetOffset(Ancestor(
@@ -771,7 +771,7 @@ void main() {
 
   testWidgets('ancestor finder firstMatchOnly', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
-      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
       Future<Offset> getAncestorTopLeft() async {
         final Map<String, String> arguments = GetOffset(Ancestor(
@@ -819,7 +819,7 @@ void main() {
   });
 
   testWidgets('GetDiagnosticsTree', (WidgetTester tester) async {
-    final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true);
+    final FlutterDriverExtension driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
 
     Future<Map<String, Object>> getDiagnosticsTree(DiagnosticsType type, SerializableFinder finder, { int depth = 0, bool properties = true }) async {
       final Map<String, String> arguments = GetDiagnosticsTree(finder, type, subtreeDepth: depth, includeProperties: properties).serialize();
@@ -884,6 +884,45 @@ void main() {
     expect(children.single['children'], isEmpty);
   });
 
+  group('enableTextEntryEmulation', () {
+    FlutterDriverExtension driverExtension;
+
+    Future<Map<String, dynamic>> enterText() async {
+      final Map<String, String> arguments = const EnterText('foo').serialize();
+      final Map<String, dynamic> result = await driverExtension.call(arguments);
+      return result;
+    }
+
+    const Widget testWidget = MaterialApp(
+      home: Material(
+        child: Center(
+          child: TextField(
+            key: ValueKey<String>('foo'),
+            autofocus: true,
+          ),
+        ),
+      ),
+    );
+
+    testWidgets('enableTextEntryEmulation false', (WidgetTester tester) async {
+      driverExtension = FlutterDriverExtension((String arg) async => '', true, false);
+
+      await tester.pumpWidget(testWidget);
+
+      final Map<String, dynamic> enterTextResult = await enterText();
+      expect(enterTextResult['isError'], isTrue);
+    });
+
+    testWidgets('enableTextEntryEmulation true', (WidgetTester tester) async {
+      driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
+
+      await tester.pumpWidget(testWidget);
+
+      final Map<String, dynamic> enterTextResult = await enterText();
+      expect(enterTextResult['isError'], isFalse);
+    });
+  });
+
   group('extension finders', () {
     final Widget debugTree = Directionality(
       textDirection: TextDirection.ltr,
@@ -907,6 +946,7 @@ void main() {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
         true,
+        true,
         finders: <FinderExtension>[],
       );
 
@@ -926,6 +966,7 @@ void main() {
     testWidgets('simple extension finder', (WidgetTester tester) async {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
+        true,
         true,
         finders: <FinderExtension>[
           StubFinderExtension(),
@@ -948,6 +989,7 @@ void main() {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
         true,
+        true,
         finders: <FinderExtension>[
           StubFinderExtension(),
         ],
@@ -968,6 +1010,7 @@ void main() {
     testWidgets('extension finder with command', (WidgetTester tester) async {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
+        true,
         true,
         finders: <FinderExtension>[
           StubFinderExtension(),
@@ -1013,6 +1056,7 @@ void main() {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
         true,
+        true,
         commands: <CommandExtension>[],
       );
 
@@ -1032,6 +1076,7 @@ void main() {
     testWidgets('nested command', (WidgetTester tester) async {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
+        true,
         true,
         commands: <CommandExtension>[
           StubNestedCommandExtension(),
@@ -1057,6 +1102,7 @@ void main() {
     testWidgets('prober command', (WidgetTester tester) async {
       final FlutterDriverExtension driverExtension = FlutterDriverExtension(
         (String arg) async => '',
+        true,
         true,
         commands: <CommandExtension>[
           StubProberCommandExtension(),
@@ -1085,7 +1131,7 @@ void main() {
     Map<String, dynamic> result;
 
     setUp(() {
-      driverExtension = FlutterDriverExtension((String arg) async => '', true);
+      driverExtension = FlutterDriverExtension((String arg) async => '', true, true);
       result = null;
     });
 


### PR DESCRIPTION
## Description

Added option to `enableFlutterDriverExtension` so that it can be built without text entry emulation.
Default selection remains as is (enabled text entry emulation).

The change is needed because we want to test also manually the builds that we deploy to test environments. With text entry emulation enabled it is impossible for us to do so.
In tests side having text entry emulation disabled by default causes no harm, as simply running `await driver.setTextEntryEmulation(enabled: true);` enables it for testing.

In short: it will unblock manual testing with automation builds.

## Related Issues

Issue that the change is alleviating/fixing: #9383

## Tests

Conformed existing tests in `packages/flutter_driver/test/src/real_tests/extension_test.dart` and added 2 new tests to cover new parameter behavior:
- `enableTextEntryEmulation false` verifies that `EnterText` fails when `enableTextEntryEmulation` is set as `false`
- `enableTextEntryEmulation true` verifies that `EnterText` fails when `enableTextEntryEmulation` is set as `true`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
