### PR TITLE
Remove left-overs from causal async stacks.

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -180,8 +180,6 @@ class AOTSnapshotter {
     // Optimization arguments.
     genSnapshotArgs.addAll(<String>[
       // Faster async/await
-      '--no-causal-async-stacks',
-      '--lazy-async-stacks',
       if (shouldSplitDebugInfo) ...<String>[
         '--dwarf-stack-traces',
         '--save-debugging-info=${_fileSystem.path.join(splitDebugInfo, debugFilename)}'

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -241,7 +241,6 @@ class KernelCompiler {
       sdkRoot,
       '--target=$targetModel',
       '--no-print-incremental-dependencies',
-      '-Ddart.developer.causal_async_stacks=${buildMode == BuildMode.debug}',
       for (final Object dartDefine in dartDefines)
         '-D$dartDefine',
       ...buildModeOptions(buildMode, dartDefines),
@@ -660,7 +659,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
       // in the frontend_server.
       // https://github.com/flutter/flutter/issues/59902
       '--experimental-emit-debug-metadata',
-      '-Ddart.developer.causal_async_stacks=${buildMode == BuildMode.debug}',
       for (final Object dartDefine in dartDefines)
         '-D$dartDefine',
       if (outputPath != null) ...<String>[

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -91,8 +91,6 @@ Future<void> _genSnapshot(
 
   final List<String> command = <String>[
     genSnapshot,
-    '--no-causal-async-stacks',
-    '--lazy-async-stacks',
     '--deterministic',
     '--snapshot_kind=app-aot-elf',
     '--elf=$elf',

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -115,7 +115,6 @@ class FuchsiaKernelCompiler {
         '-Ddart.vm.profile=false',
         '-Ddart.vm.product=true',
       ],
-      '-Ddart.developer.causal_async_stacks=${buildInfo.isDebug}',
 
       for (final String dartDefine in buildInfo.dartDefines)
         '-D$dartDefine',

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -264,8 +264,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));
@@ -324,8 +322,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           '--dwarf-stack-traces',
           '--save-debugging-info=$debugPath',
           'main.dill',
@@ -384,8 +380,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           '--obfuscate',
           'main.dill',
         ]
@@ -443,8 +437,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));
@@ -498,8 +490,6 @@ void main() {
           '--snapshot_kind=app-aot-assembly',
           '--assembly=${fileSystem.path.join(outputPath, 'snapshot_assembly.S')}',
           '--strip',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));
@@ -555,8 +545,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));
@@ -587,8 +575,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           '--dwarf-stack-traces',
           '--save-debugging-info=$debugPath',
           'main.dill',
@@ -620,8 +606,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           '--obfuscate',
           'main.dill',
         ]
@@ -652,8 +636,6 @@ void main() {
           '--strip',
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));
@@ -681,8 +663,6 @@ void main() {
           '--snapshot_kind=app-aot-elf',
           '--elf=build/foo/app.so',
           '--strip',
-          '--no-causal-async-stacks',
-          '--lazy-async-stacks',
           'main.dill',
         ]
       ));

--- a/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
@@ -191,8 +191,6 @@ void main() {
       '--snapshot_kind=app-aot-elf',
       '--elf=${environment.buildDir.childDirectory('arm64-v8a').childFile('app.so').path}',
       '--strip',
-      '--no-causal-async-stacks',
-      '--lazy-async-stacks',
       environment.buildDir.childFile('app.dill').path,
       ],
     ));
@@ -235,8 +233,6 @@ void main() {
       '--snapshot_kind=app-aot-elf',
       '--elf=${environment.buildDir.childDirectory('arm64-v8a').childFile('app.so').path}',
       '--strip',
-      '--no-causal-async-stacks',
-      '--lazy-async-stacks',
       environment.buildDir.childFile('app.dill').path,
       ],
     ));
@@ -282,8 +278,6 @@ void main() {
         '--snapshot_kind=app-aot-elf',
         '--elf=${environment.buildDir.childDirectory('arm64-v8a').childFile('app.so').path}',
         '--strip',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         environment.buildDir.childFile('app.dill').path
       ],
     ));

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -89,7 +89,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=false',
         ...buildModeOptions(BuildMode.profile, <String>[]),
         '--aot',
         '--tfa',
@@ -126,7 +125,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=false',
         ...buildModeOptions(BuildMode.profile, <String>[]),
         '--aot',
         '--tfa',
@@ -163,7 +161,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=false',
         ...buildModeOptions(BuildMode.profile, <String>[]),
         '--aot',
         '--tfa',
@@ -201,7 +198,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=false',
         ...buildModeOptions(BuildMode.profile, <String>[]),
         '--aot',
         '--tfa',
@@ -241,7 +237,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=true',
         ...buildModeOptions(BuildMode.debug, <String>[]),
         '--no-link-platform',
         '--packages',
@@ -279,7 +274,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=true',
         ...buildModeOptions(BuildMode.debug, <String>[]),
         '--packages',
         '/.dart_tool/package_config.json',
@@ -329,7 +323,6 @@ void main() {
         ) + '/',
         '--target=flutter',
         '--no-print-incremental-dependencies',
-        '-Ddart.developer.causal_async_stacks=true',
         ...buildModeOptions(BuildMode.debug, <String>[]),
         '--track-widget-creation',
         '--no-link-platform',
@@ -363,8 +356,6 @@ void main() {
         '--strip',
         '--no-sim-use-hardfp',
         '--no-use-integer-division',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ])
     ]);
@@ -393,8 +384,6 @@ void main() {
         '--strip',
         '--no-sim-use-hardfp',
         '--no-use-integer-division',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ])
     ]);
@@ -463,8 +452,6 @@ void main() {
         '--strip',
         '--no-sim-use-hardfp',
         '--no-use-integer-division',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ]),
       FakeCommand(command: <String>[
@@ -474,8 +461,6 @@ void main() {
         kAssemblyAot,
         '--assembly=$build/arm64/snapshot_assembly.S',
         '--strip',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ]),
       FakeCommand(command: <String>[
@@ -582,8 +567,6 @@ void main() {
         kAssemblyAot,
         '--assembly=$build/arm64/snapshot_assembly.S',
         '--strip',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ]),
       FakeCommand(command: <String>[
@@ -659,8 +642,6 @@ void main() {
         kAssemblyAot,
         '--assembly=$build/arm64/snapshot_assembly.S',
         '--strip',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ]),
       FakeCommand(command: <String>[
@@ -741,8 +722,6 @@ void main() {
         '--strip',
         '--no-sim-use-hardfp',
         '--no-use-integer-division',
-        '--no-causal-async-stacks',
-        '--lazy-async-stacks',
         '$build/app.dill',
       ]),
     ]);

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -75,7 +75,6 @@ void main() {
     expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
     expect(logger.errorText, equals('line1\nline2\n'));
     expect(output.outputFilename, equals('/path/to/main.dart.dill'));
-    final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
   });
 
   testWithoutContext('passes correct AOT config to kernel compiler in aot/profile mode', () async {

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -76,9 +76,6 @@ void main() {
     expect(logger.errorText, equals('line1\nline2\n'));
     expect(output.outputFilename, equals('/path/to/main.dart.dill'));
     final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
-    expect(argVerification.captured.single, containsAll(<String>[
-      '-Ddart.developer.causal_async_stacks=true',
-    ]));
   });
 
   testWithoutContext('passes correct AOT config to kernel compiler in aot/profile mode', () async {
@@ -113,7 +110,6 @@ void main() {
       '--tfa',
       '-Ddart.vm.profile=true',
       '-Ddart.vm.product=false',
-      '-Ddart.developer.causal_async_stacks=false',
     ]));
   });
 
@@ -149,7 +145,6 @@ void main() {
       '--tfa',
       '-Ddart.vm.profile=false',
       '-Ddart.vm.product=true',
-      '-Ddart.developer.causal_async_stacks=false',
     ]));
   });
 


### PR DESCRIPTION
All embedders of the Dart VM have been using `--lazy-async-stacks
--no-causal-async-stacks` for some time. The default in the VM has been
changed to this as well now.

The support for causal async stacks has now be removed entirely
from the Dart VM. So we can remove any left-overs in the flutter
repository related to causal async stacks.

Issue https://github.com/flutter/flutter/issues/51001
