### PR TITLE
Pass --local-engine* flags from dev/bots/test.dart down to `pub test` via env variables

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -56,6 +56,8 @@ final String flutterTester = path.join(flutterRoot, 'bin', 'cache', 'artifacts',
 /// configuration) -- prefilled with the arguments passed to test.dart.
 final List<String> flutterTestArgs = <String>[];
 
+final Map<String, String> localEngineEnv = <String, String>{};
+
 final bool useFlutterTestFormatter = Platform.environment['FLUTTER_TEST_FORMATTER'] == 'true';
 
 
@@ -105,6 +107,13 @@ Future<void> main(List<String> args) async {
   print('$clock STARTING ANALYSIS');
   try {
     flutterTestArgs.addAll(args);
+    for (final String arg in args) {
+      if (arg.startsWith('--local-engine='))
+        localEngineEnv['FLUTTER_LOCAL_ENGINE'] = arg.substring('--local-engine='.length);
+      if (arg.startsWith('--local-engine-src-path='))
+        localEngineEnv['FLUTTER_LOCAL_ENGINE_SRC_PATH'] = arg.substring('--local-engine-src-path='.length);
+    }
+
     if (Platform.environment.containsKey(CIRRUS_TASK_NAME))
       print('Running task: ${Platform.environment[CIRRUS_TASK_NAME]}');
     print('═' * 80);
@@ -1242,6 +1251,7 @@ Future<void> _pubRunTest(String workingDirectory, {
   ];
   final Map<String, String> pubEnvironment = <String, String>{
     'FLUTTER_ROOT': flutterRoot,
+    ...localEngineEnv
   };
   if (Directory(pubCache).existsSync()) {
     pubEnvironment['PUB_CACHE'] = pubCache;


### PR DESCRIPTION
We are seeing issues on HHH configuration of dart-lang/sdk,
flutter/engine and flutter/flutter where the web tests are using new
frontend_server tooling (which expects current kernel version) but is
given kernel file from an older version.

This is an indication that the web tests are not fully using the local
engine. By reading through dev/bots/test.dart it appears like that
script will correctly pass down --local-engine* flags when it runs
`flutter test` (via the same --local-engine* arguments) but not when
it runs `pub test` (which doesn't accept --local-engine* arguments).

This PR is an attempt to set corresponding environment variables when
invoking pub.