### PR TITLE
[flutter_tool] fix incorrect coverage file generation

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -251,7 +251,8 @@ class TestCommand extends FlutterCommand {
         verbose: !machine,
         libraryPredicate: (String libraryName) => libraryName.contains(projectName),
         // TODO(jonahwilliams): file bug for incorrect URI handling on windows
-        packagesPath: globals.fs.path.absolute('.packages'),
+        packagesPath: globals.fs.file(buildInfo.packagesPath)
+          .parent.parent.childFile('.packages').path
       );
     }
 

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -117,7 +117,6 @@ class CoverageCollector extends TestWatcher {
   Future<String> finalizeCoverage({
     coverage.Formatter formatter,
     Directory coverageDirectory,
-    String packagesPath,
   }) async {
     if (_globalHitmap == null) {
       return null;

--- a/packages/flutter_tools/test/integration.shard/coverage_collection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/coverage_collection_test.dart
@@ -32,6 +32,6 @@ void main() {
     final File lcovFile = tempDir.childDirectory('coverage').childFile('lcov.info');
 
     expect(lcovFile, exists);
-    expect(lcovFile.readAsStringSync(), contains('SF:lib/main.dart'));
+    expect(lcovFile.readAsStringSync(), contains('main.dart')); // either 'SF:lib/main.dart or SF:lib\\main.dart
   });
 }

--- a/packages/flutter_tools/test/integration.shard/coverage_collection_test.dart
+++ b/packages/flutter_tools/test/integration.shard/coverage_collection_test.dart
@@ -29,6 +29,9 @@ void main() {
     await flutter.test(coverage: true);
     await flutter.done;
 
-    expect(tempDir.childDirectory('coverage').childFile('lcov.info'), exists);
+    final File lcovFile = tempDir.childDirectory('coverage').childFile('lcov.info');
+
+    expect(lcovFile, exists);
+    expect(lcovFile.readAsStringSync(), contains('SF:lib/main.dart'));
   });
 }


### PR DESCRIPTION
## Description

The refactor to mostly use package config broke this, because the cwd is changed for tests so .packages is incorrect. Really the long term fix is to track down the bug in package:coverage that makes the package_config.json not work on windows.

Updates an integration test to confirm the coverage file is non-empty.

Fixes https://github.com/flutter/flutter/issues/71467