### PR TITLE
[flutter_tool] Report analytics as disabled when suppressed

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -84,9 +84,11 @@ class ConfigCommand extends FlutterCommand {
     if (values.isEmpty) {
       values = '  No settings have been configured.';
     }
+    final bool analyticsEnabled = globals.flutterUsage.enabled &&
+                                  !globals.flutterUsage.suppressAnalytics;
     return
       '\nSettings:\n$values\n\n'
-      'Analytics reporting is currently ${globals.flutterUsage.enabled ? 'enabled' : 'disabled'}.';
+      'Analytics reporting is currently ${analyticsEnabled ? 'enabled' : 'disabled'}.';
   }
 
   /// Return null to disable analytics recording of the `config` command.

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -288,6 +288,24 @@ void main() {
     }, overrides: <Type, Generator>{
       Usage: () => mockUsage,
     });
+
+    testUsingContext('analytics reported disabled when suppressed', () async {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      mockUsage.suppressAnalytics = true;
+
+      await commandRunner.run(<String>[
+        'config',
+      ]);
+
+      expect(
+        testLogger.statusText,
+        containsIgnoringWhitespace('Analytics reporting is currently disabled'),
+      );
+    }, overrides: <Type, Generator>{
+      Usage: () => mockUsage,
+    });
   });
 }
 
@@ -306,4 +324,7 @@ class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockUsage extends Mock implements Usage {
   @override
   bool enabled = true;
+
+  @override
+  bool suppressAnalytics = false;
 }


### PR DESCRIPTION
## Description

`AnalyticsMock` from the usage package reports analytics as enabled, which caused the tool to report analytics as enabled even when using `AnalyticsMock` and not the real thing. This PR checks whether analytics are suppressed, which we do whenever using `AnalyticsMock`.

## Related Issues

https://github.com/flutter/flutter/issues/59429

## Tests

I added the following tests:

Test in config_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.