### PR TITLE
Allow flavors and build types when using plugins

### DIFF
--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -282,7 +282,7 @@ subprojects {
 
   /// Adds a plugin to the pubspec.
   /// In pubpsec, each dependency is expressed as key, value pair joined by a colon `:`.
-  /// such as `plugin_a`:`^0.0.1` or `path`:`\npath: /some/path`.
+  /// such as `plugin_a`:`^0.0.1` or `plugin_a`:`\npath: /some/path`.
   Future<void> addPlugin(String plugin, { String value = '' }) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -280,12 +280,15 @@ subprojects {
     ''');
   }
 
-  Future<void> addPlugin(String plugin) async {
+  /// Adds a plugin to the pubspec.
+  /// In pubpsec, each dependency is expressed as key, value pair joined by a colon `:`.
+  /// such as `plugin_a`:`^0.0.1` or `path`:`\npath: /some/path`.
+  Future<void> addPlugin(String plugin, { String value = '' }) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
     String content = await pubspec.readAsString();
     content = content.replaceFirst(
       '${platformLineSep}dependencies:$platformLineSep',
-      '${platformLineSep}dependencies:$platformLineSep  $plugin:$platformLineSep',
+      '${platformLineSep}dependencies:$platformLineSep  $plugin:$value$platformLineSep',
     );
     await pubspec.writeAsString(content, flush: true);
   }

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -281,7 +281,7 @@ subprojects {
   }
 
   /// Adds a plugin to the pubspec.
-  /// In pubpsec, each dependency is expressed as key, value pair joined by a colon `:`.
+  /// In pubspec, each dependency is expressed as key, value pair joined by a colon `:`.
   /// such as `plugin_a`:`^0.0.1` or `plugin_a`:`\npath: /some/path`.
   Future<void> addPlugin(String plugin, { String value = '' }) async {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -149,19 +149,16 @@ class FlutterPlugin implements Plugin<Project> {
         String flutterExecutableName = Os.isFamily(Os.FAMILY_WINDOWS) ? "flutter.bat" : "flutter"
         flutterExecutable = Paths.get(flutterRoot.absolutePath, "bin", flutterExecutableName).toFile();
 
-        // Add custom build types.
+        String flutterProguardRules = Paths.get(flutterRoot.absolutePath, "packages", "flutter_tools",
+                "gradle", "flutter_proguard_rules.pro")
         project.android.buildTypes {
+            // Add profile build type.
             profile {
                 initWith debug
                 if (it.hasProperty("matchingFallbacks")) {
                     matchingFallbacks = ["debug", "release"]
                 }
             }
-        }
-
-        String flutterProguardRules = Paths.get(flutterRoot.absolutePath, "packages", "flutter_tools",
-                "gradle", "flutter_proguard_rules.pro")
-        project.android.buildTypes {
             release {
                 // Enables code shrinking, obfuscation, and optimization for only
                 // your project's release build type.
@@ -304,8 +301,10 @@ class FlutterPlugin implements Plugin<Project> {
             return
         }
         // Add plugin dependency to the app project.
+        // Use the default configuration, so the app project can define custom configurations
+        // (such as those created after adding a flavor or a custom build type).
         project.dependencies {
-            implementation pluginProject
+            implementation project(path: ":$pluginName", configuration: 'default')
         }
         Closure addEmbeddingCompileOnlyDependency = { buildType ->
             String flutterBuildMode = buildModeFor(buildType)

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -315,18 +315,16 @@ class FlutterPlugin implements Plugin<Project> {
             // Copy build types from the app to the plugin.
             // This allows to build apps with plugins and custom build types or flavors.
             pluginProject.android.buildTypes {
-              "${buildType.name}" {}
+                "${buildType.name}" {}
             }
-            addApiDependencies(
-                pluginProject,
-                buildType.name,
-                "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion"
-            )
+            pluginProject.dependencies.add(
+                "${buildType.name}CompileOnly",
+                "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion")
         }
         // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
-          project.android.buildTypes.each addEmbeddingCompileOnlyDependency
-          project.android.buildTypes.whenObjectAdded addEmbeddingCompileOnlyDependency
+            project.android.buildTypes.each addEmbeddingCompileOnlyDependency
+            project.android.buildTypes.whenObjectAdded addEmbeddingCompileOnlyDependency
         }
     }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -301,10 +301,8 @@ class FlutterPlugin implements Plugin<Project> {
             return
         }
         // Add plugin dependency to the app project.
-        // Use the default configuration, so the app project can define custom configurations
-        // (such as those created after adding a flavor or a custom build type).
         project.dependencies {
-            implementation project(path: ":$pluginName", configuration: 'default')
+            implementation pluginProject
         }
         Closure addEmbeddingCompileOnlyDependency = { buildType ->
             String flutterBuildMode = buildModeFor(buildType)
@@ -314,20 +312,21 @@ class FlutterPlugin implements Plugin<Project> {
             if (!supportsBuildMode(flutterBuildMode)) {
                 return
             }
+            // Copy build types from the app to the plugin.
+            // This allows to build apps with plugins and custom build types or flavors.
+            pluginProject.android.buildTypes {
+              "${buildType.name}" {}
+            }
             addApiDependencies(
                 pluginProject,
                 buildType.name,
                 "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion"
             )
         }
+        // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
-          pluginProject.android.buildTypes {
-              profile {
-                  initWith debug
-              }
-          }
-          pluginProject.android.buildTypes.each addEmbeddingCompileOnlyDependency
-          pluginProject.android.buildTypes.whenObjectAdded addEmbeddingCompileOnlyDependency
+          project.android.buildTypes.each addEmbeddingCompileOnlyDependency
+          project.android.buildTypes.whenObjectAdded addEmbeddingCompileOnlyDependency
         }
     }
 


### PR DESCRIPTION
## Description

Currently, a project doesn't build if it includes a plugin and also defines a flavor or custom build type.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71694

## Tests

I added the following tests: e2e

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
