### PR TITLE
Remove Flutter Authors from macOS project organization name

### DIFF
--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -195,7 +195,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = "The Flutter Authors";
+				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
 						CreatedOnToolsVersion = 9.2;


### PR DESCRIPTION
## Description

New macOS projects shouldn't claim `The Flutter Authors` organization.

## Related Issues

This was done in iOS project with https://github.com/flutter/flutter/pull/45373/files?file-filters%5B%5D=.tmpl#diff-3c9acc0841476c06e8695edabae66654092a03757d49cbbea6be29f353b75f01R155