### PR TITLE
Update macOS Xcode compatibilityVersion

### DIFF
--- a/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -235,7 +235,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/dev/integration_tests/ui/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ui/macos/Runner.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/dev/manual_tests/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/manual_tests/macos/Runner.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -214,7 +214,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/packages/integration_test/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/integration_test/example/macos/Runner.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (


### PR DESCRIPTION
## Description

Update Xcode compatibility mode in new macOS projects to the current default.  In the past older versions of this have caused issues with Swift Package Manager and legacy build locations.

## Related Issues

iOS upgraded from 3.2 to 9.2 in #49654.  See that PR for details.

> I don't think this warrants a migration since most users are not going to be importing Swift packages. The manual migration is to go into the File inspector and swap Project Format from "Xcode 3.2-compatible" to "Xcode 9.3-compatible".