### PR TITLE
[devicelab] Add upload metrics test builder as flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -121,6 +121,12 @@
          "flaky": true
       },
       {
+         "name": "Linux web_benchmarks_canvaskit",
+         "repo": "flutter",
+         "task_name": "linux_web_benchmarks_canvaskit",
+         "flaky": true
+      },
+      {
          "name": "Linux web_benchmarks_html",
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_html",


### PR DESCRIPTION
## Description

We're going to use this as a test builder to validate the end to end process of uploading metrics on LUCI. This will be marked as flaky on the dashboard to not block the tree.

This will allow us to validate what is happening in Datastore before moving as blocking functionality.

## Related Issues

https://github.com/flutter/flutter/issues/71749