### PR TITLE
Remove unused local from xcode_backend

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -275,11 +275,6 @@ ThinAppFrameworks() {
 # Adds the App.framework as an embedded binary and the flutter_assets as
 # resources.
 EmbedFlutterFrameworks() {
-  local project_path="${SOURCE_ROOT}/.."
-  if [[ -n "$FLUTTER_APPLICATION_PATH" ]]; then
-    project_path="${FLUTTER_APPLICATION_PATH}"
-  fi
-
   # Embed App.framework from Flutter into the app (after creating the Frameworks directory
   # if it doesn't already exist).
   local xcode_frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"


### PR DESCRIPTION
## Description

The last usage of `project_path ` was removed in #70224.  Remove the local from the script.

## Related Issues

https://github.com/flutter/flutter/pull/70224/files#diff-cf570f69a008f028e95cfad7690ee32b3acbbc88379d340ea08ef67c0a3aff69L302