### PR TITLE
Rename IOSMigrator -> ProjectMigrator

### DIFF
--- a/packages/flutter_tools/lib/src/base/project_migrator.dart
+++ b/packages/flutter_tools/lib/src/base/project_migrator.dart
@@ -4,14 +4,14 @@
 
 import 'package:meta/meta.dart';
 
-import '../../base/file_system.dart';
-import '../../base/logger.dart';
+import 'file_system.dart';
+import 'logger.dart';
 
-/// iOS project is generated from a template on Flutter project creation.
-/// Sometimes (due to behavior changes in Xcode, CocoaPods, etc) these files need to be altered
+/// Project is generated from a template on Flutter project creation.
+/// Sometimes (due to behavior changes in Xcode, Gradle, etc) these files need to be altered
 /// from the original template.
-abstract class IOSMigrator {
-  IOSMigrator(this.logger);
+abstract class ProjectMigrator {
+  ProjectMigrator(this.logger);
 
   @protected
   final Logger logger;
@@ -58,13 +58,13 @@ abstract class IOSMigrator {
   }
 }
 
-class IOSMigration {
-  IOSMigration(this.migrators);
+class ProjectMigration {
+  ProjectMigration(this.migrators);
 
-  final List<IOSMigrator> migrators;
+  final List<ProjectMigrator> migrators;
 
   bool run() {
-    for (final IOSMigrator migrator in migrators) {
+    for (final ProjectMigrator migrator in migrators) {
       if (!migrator.migrate()) {
         // Migration failures should be more robust, with transactions and fallbacks.
         // See https://github.com/flutter/flutter/issues/12573 and

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -12,6 +12,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
+import '../base/project_migrator.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -23,7 +24,6 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import 'code_signing.dart';
 import 'devices.dart';
-import 'migrations/ios_migrator.dart';
 import 'migrations/project_base_configuration_migration.dart';
 import 'migrations/remove_framework_link_and_embedding_migration.dart';
 import 'migrations/xcode_build_system_migration.dart';
@@ -102,13 +102,13 @@ Future<XcodeBuildResult> buildXcodeProject({
     return XcodeBuildResult(success: false);
   }
 
-  final List<IOSMigrator> migrators = <IOSMigrator>[
+  final List<ProjectMigrator> migrators = <ProjectMigrator>[
     RemoveFrameworkLinkAndEmbeddingMigration(app.project, globals.logger, globals.xcode, globals.flutterUsage),
     XcodeBuildSystemMigration(app.project, globals.logger),
     ProjectBaseConfigurationMigration(app.project, globals.logger),
   ];
 
-  final IOSMigration migration = IOSMigration(migrators);
+  final ProjectMigration migration = ProjectMigration(migrators);
   if (!migration.run()) {
     return XcodeBuildResult(success: false);
   }

--- a/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
@@ -4,13 +4,13 @@
 
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
+import '../../base/project_migrator.dart';
 import '../../project.dart';
-import 'ios_migrator.dart';
 
 // The Runner target should inherit its build configuration from Generated.xcconfig.
 // However the top-level Runner project should not inherit any build configuration so
 // the Flutter build settings do not stomp on non-Flutter targets.
-class ProjectBaseConfigurationMigration extends IOSMigrator {
+class ProjectBaseConfigurationMigration extends ProjectMigrator {
   ProjectBaseConfigurationMigration(IosProject project, Logger logger)
     : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
       super(logger);

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -5,15 +5,15 @@
 import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
+import '../../base/project_migrator.dart';
 import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../../reporting/reporting.dart';
-import 'ios_migrator.dart';
 
 // Xcode 11.4 requires linked and embedded frameworks to contain all targeted architectures before build phases are run.
 // This caused issues switching between a real device and simulator due to architecture mismatch.
 // Remove the linking and embedding logic from the Xcode project to give the tool more control over these.
-class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
+class RemoveFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   RemoveFrameworkLinkAndEmbeddingMigration(
     IosProject project,
     Logger logger,

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -4,13 +4,13 @@
 
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
+import '../../base/project_migrator.dart';
 import '../../project.dart';
-import 'ios_migrator.dart';
 
 // Xcode legacy build system no longer supported by Xcode.
 // Set in https://github.com/flutter/flutter/pull/21901/.
 // Removed in https://github.com/flutter/flutter/pull/33684.
-class XcodeBuildSystemMigration extends IOSMigrator {
+class XcodeBuildSystemMigration extends ProjectMigrator {
   XcodeBuildSystemMigration(
     IosProject project,
     Logger logger,

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -7,7 +7,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/ios/migrations/ios_migrator.dart';
+import 'package:flutter_tools/src/base/project_migrator.dart';
 import 'package:flutter_tools/src/ios/migrations/project_base_configuration_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/remove_framework_link_and_embedding_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/xcode_build_system_migration.dart';
@@ -28,13 +28,13 @@ void main () {
 
     testWithoutContext('migrators succeed', () {
       final FakeIOSMigrator fakeIOSMigrator = FakeIOSMigrator(succeeds: true);
-      final IOSMigration migration = IOSMigration(<IOSMigrator>[fakeIOSMigrator]);
+      final ProjectMigration migration = ProjectMigration(<ProjectMigrator>[fakeIOSMigrator]);
       expect(migration.run(), isTrue);
     });
 
     testWithoutContext('migrators fail', () {
       final FakeIOSMigrator fakeIOSMigrator = FakeIOSMigrator(succeeds: false);
-      final IOSMigration migration = IOSMigration(<IOSMigrator>[fakeIOSMigrator]);
+      final ProjectMigration migration = ProjectMigration(<ProjectMigrator>[fakeIOSMigrator]);
       expect(migration.run(), isFalse);
     });
 
@@ -506,7 +506,7 @@ class MockIosProject extends Mock implements IosProject {}
 class MockXcode extends Mock implements Xcode {}
 class MockUsage extends Mock implements Usage {}
 
-class FakeIOSMigrator extends IOSMigrator {
+class FakeIOSMigrator extends ProjectMigrator {
   FakeIOSMigrator({@required this.succeeds})
     : super(null);
 


### PR DESCRIPTION
## Description

I'm about to create a macOS project migration.  Rename `IOSMigrator` to `ProjectMigrator` and move from `ios/migrations` to `base/project_migrator.dart` to make it more generic.

## Related Issues

Will be used to migrate https://github.com/flutter/flutter/issues/56581.