### PR TITLE
Add --dart-define option support to build aar command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -40,6 +40,7 @@ class BuildAarCommand extends BuildSubCommand {
     usesPubOption();
     addSplitDebugInfoOption();
     addDartObfuscationOption();
+    usesDartDefineOption();
     usesTrackWidgetCreation(verboseHelp: false);
     addNullSafetyModeOptions(hide: !verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -176,6 +176,7 @@ void main() {
           '--split-debug-info',
           '/project-name/v1.2.3/',
           '--obfuscate',
+          '--dart-define=foo=bar'
         ],
       );
 
@@ -196,6 +197,8 @@ void main() {
       expect(buildInfo.flavor, 'free');
       expect(buildInfo.splitDebugInfoPath, '/project-name/v1.2.3/');
       expect(buildInfo.dartObfuscation, isTrue);
+      expect(buildInfo.dartDefines.isNotEmpty, isTrue);
+      expect(buildInfo.dartDefines.contains('foo=bar'), isTrue);
     }, overrides: <Type, Generator>{
       AndroidBuilder: () => mockAndroidBuilder,
     });

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -197,7 +197,6 @@ void main() {
       expect(buildInfo.flavor, 'free');
       expect(buildInfo.splitDebugInfoPath, '/project-name/v1.2.3/');
       expect(buildInfo.dartObfuscation, isTrue);
-      expect(buildInfo.dartDefines.isNotEmpty, isTrue);
       expect(buildInfo.dartDefines.contains('foo=bar'), isTrue);
     }, overrides: <Type, Generator>{
       AndroidBuilder: () => mockAndroidBuilder,


### PR DESCRIPTION
## Description
Add --dart-define option support to `flutter build aar` command

## Related Issues
https://github.com/flutter/flutter/issues/71827
