### PR TITLE
Fix a ConstantTween's clerical error and Add some Tween testcases.

### DIFF
--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -436,7 +436,7 @@ class ConstantTween<T> extends Tween<T> {
   T lerp(double t) => begin as T;
 
   @override
-  String toString() => '${objectRuntimeType(this, 'ReverseTween')}(value: $begin)';
+  String toString() => '${objectRuntimeType(this, 'ConstantTween')}(value: $begin)';
 }
 
 /// Transforms the value of the given animation by the given curve.

--- a/packages/flutter/test/animation/tween_test.dart
+++ b/packages/flutter/test/animation/tween_test.dart
@@ -93,4 +93,34 @@ void main() {
     expect(tween.lerp(0.5), 100.0);
     expect(tween.lerp(1.0), 100.0);
   });
+
+  test('ReverseTween', () {
+    final ReverseTween<int> tween = ReverseTween<int>(IntTween(begin: 5, end: 9));
+    expect(tween.lerp(0.5), 7);
+    expect(tween.lerp(0.7), 6);
+  });
+
+  test('ColorTween', () {
+    final ColorTween tween = ColorTween(
+      begin: const Color(0xff000000),
+      end: const Color(0xffffffff)
+    );
+    expect(tween.lerp(0.0), const Color(0xff000000));
+    expect(tween.lerp(0.5), const Color(0xff7f7f7f));
+    expect(tween.lerp(0.7), const Color(0xffb2b2b2));
+    expect(tween.lerp(1.0), const Color(0xffffffff));
+  });
+
+  test('StepTween', () {
+    final StepTween tween = StepTween(begin: 5, end: 9);
+    expect(tween.lerp(0.5), 7);
+    expect(tween.lerp(0.7), 7);
+  });
+
+  test('CurveTween', () {
+    final CurveTween tween = CurveTween(curve: Curves.easeIn);
+    expect(tween.transform(0.0), 0.0);
+    expect(tween.transform(0.5), 0.31640625);
+    expect(tween.transform(1.0), 1.0);
+  });
 }


### PR DESCRIPTION
## Description

The **ReverseTween** in  "ConstantTween.toString"  might be a clerical error here, right?

I think it may be **ConstantTween**.

```
/// A tween with a constant value.
class ConstantTween<T> extends Tween<T> {
  /// Create a tween whose [begin] and [end] values equal [value].
  ConstantTween(T value) : super(begin: value, end: value);

  /// This tween doesn't interpolate, it always returns the same value.
  @override
  T lerp(double t) => begin as T;

  @override
  String toString() => '${objectRuntimeType(this, 'ReverseTween')}(value: $begin)';
}
```

I fixed it and Added some Tween testcases.

## Tests

I added the following tests:

test/animation/tween_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
