### PR TITLE
showDialog assertion for non-null builder or child property

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -972,6 +972,7 @@ Future<T?> showDialog<T>({
   )
   Widget? child,
 }) {
+  assert(child == null || builder == null);
   assert(child != null || builder != null);
   assert(barrierDismissible != null);
   assert(useSafeArea != null);

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -972,7 +972,7 @@ Future<T?> showDialog<T>({
   )
   Widget? child,
 }) {
-  assert(child == null || builder == null);
+  assert(child != null || builder != null);
   assert(barrierDismissible != null);
   assert(useSafeArea != null);
   assert(useRootNavigator != null);

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -217,6 +217,57 @@ void main() {
     expect(materialWidget.shape, customBorder);
   });
 
+   testWidgets('showDialog child and builder cannot be simultaneously defined', (WidgetTester tester) async {
+    late BuildContext currentBuildContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                currentBuildContext = context;
+                return Container();
+              }
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(() async {
+      showDialog<void>(
+        context: currentBuildContext,
+        child: const Text('Child'),
+        builder: (BuildContext context) {
+          return const Text('Builder');
+        },
+      );
+    }, throwsAssertionError);
+  });
+
+  testWidgets('showDialog child or builder must be defined', (WidgetTester tester) async {
+    late BuildContext currentBuildContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                currentBuildContext = context;
+                return Container();
+              }
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      () => showDialog<void>(context: currentBuildContext),
+      throwsAssertionError,
+    );
+  });
+
   testWidgets('Simple dialog control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -217,7 +217,7 @@ void main() {
     expect(materialWidget.shape, customBorder);
   });
 
-   testWidgets('showDialog child and builder cannot be simultaneously defined', (WidgetTester tester) async {
+  testWidgets('showDialog child and builder cannot be simultaneously defined', (WidgetTester tester) async {
     late BuildContext currentBuildContext;
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

If child and builder are null then

**Expected Exception** (in this PR)
```
The following assertion was thrown while handling a gesture:
'package:flutter/src/material/dialog.dart': 
Failed assertion: line 975 pos 10: 'child != null || builder != null': is not true.
```

<details>
<summary>Logs</summary>

```Dart

════════ Exception caught by gesture ═══════════════════════════════════════════
The following assertion was thrown while handling a gesture:
'package:flutter/src/material/dialog.dart': Failed assertion: line 975 pos 10: 'child != null || builder != null': is not true.

When the exception was thrown, this was the stack
#2      showDialog
package:flutter/…/material/dialog.dart:975
#3      ExampleDialogMaxWidth.build.<anonymous closure>
package:issue_44570_dialog_max_width/main.dart:27
#4      _InkResponseState._handleTap
package:flutter/…/material/ink_well.dart:990```
```
</details>


**Existing Exception**

```Dart
The following _CastError was thrown building Builder(dirty):
Null check operator used on a null value
```

### Special Mention
On providing ```child``` and ```builder``` simultaneously may pass assertion but we only considering ```child``` as both are not-null.  
Refer
https://github.com/flutter/flutter/blob/1aafb3a8b9b0c36241c5f5b34ee914770f015818/packages/flutter/lib/src/material/dialog.dart#L993


## Related Issues

fixes #71834

## Tests

I added the following tests:

None

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
