### PR TITLE
[devicelab] Use git branch to pull current branch during test

### DIFF
--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -66,7 +66,7 @@ class Cocoon {
 
   /// Parse the local repo for the current running branch.
   String _readCommitBranch() {
-    final ProcessResult result = processRunSync('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']);
+    final ProcessResult result = processRunSync('git', <String>['branch', '--show-current']);
     if (result.exitCode != 0) {
       throw CocoonException(result.stderr as String);
     }


### PR DESCRIPTION
## Description

Switch from `git rev-parse --abbrev-ref HEAD` to `git branch --show-current`. Currently the test runner is reading in `HEAD ` from the existing command.

## Related Issues

https://github.com/flutter/flutter/issues/71749

## Tests

This gets run in the DeviceLab tests on LUCI. We currently have one flaky builder to validate the full end to end process.
