### PR TITLE
Do not add CI build settings to macOS

### DIFF
--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -97,7 +97,6 @@ Future<void> buildMacOS({
         '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
       'EXCLUDED_ARCHS=arm64', // TODO(jmagman): Allow ARM https://github.com/flutter/flutter/issues/69221
-      ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ],
     trace: true,
     stdoutErrorMatcher: verboseLogging ? null : _anyOutput,


### PR DESCRIPTION
## Description

#43553 added the ability to set Xcode build settings from environment variables so the devicelab could set up provisioning profiles.  Using the same settings for iOS and macOS is causing macOS builds to fail.  We think it is related to newer versions of CocoaPods incorrectly signing frameworks? (only executables like apps or extensions should be signed).

## Related Issues

Workaround https://github.com/flutter/flutter/issues/71613