### PR TITLE
Remove isMaterialAppTheme property

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -739,7 +739,6 @@ class _MaterialAppState extends State<MaterialApp> {
       key: widget.scaffoldMessengerKey,
       child: AnimatedTheme(
         data: theme,
-        isMaterialAppTheme: true,
         child: widget.builder != null
           ? Builder(
               builder: (BuildContext context) {

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -42,7 +42,7 @@ class Theme extends StatelessWidget {
     required this.data,
     required this.child,
   }) : assert(child != null),
-       assert(data != null)
+       assert(data != null),
        super(key: key);
 
   /// Specifies the color and typography values for descendant widgets.

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -40,25 +40,13 @@ class Theme extends StatelessWidget {
   const Theme({
     Key? key,
     required this.data,
-    this.isMaterialAppTheme = false,
     required this.child,
   }) : assert(child != null),
-       assert(data != null),
+       assert(data != null)
        super(key: key);
 
   /// Specifies the color and typography values for descendant widgets.
   final ThemeData data;
-
-  /// True if this theme was installed by the [MaterialApp].
-  ///
-  /// When an app uses the [Navigator] to push a route, the route's widgets
-  /// will only inherit from the app's theme, even though the widget that
-  /// triggered the push may inherit from a theme that "shadows" the app's
-  /// theme because it's deeper in the widget tree. Apps can find the shadowing
-  /// theme with `Theme.of(context, shadowThemeOnly: true)` and pass it along
-  /// to the class that creates a route's widgets. Material widgets that push
-  /// routes, like [PopupMenuButton] and [DropdownButton], do this.
-  final bool isMaterialAppTheme;
 
   /// The widget below this widget in the tree.
   ///
@@ -209,7 +197,6 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
   const AnimatedTheme({
     Key? key,
     required this.data,
-    this.isMaterialAppTheme = false,
     Curve curve = Curves.linear,
     Duration duration = kThemeAnimationDuration,
     VoidCallback? onEnd,
@@ -220,9 +207,6 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
 
   /// Specifies the color and typography values for descendant widgets.
   final ThemeData data;
-
-  /// True if this theme was created by the [MaterialApp]. See [Theme.isMaterialAppTheme].
-  final bool isMaterialAppTheme;
 
   /// The widget below this widget in the tree.
   ///
@@ -245,7 +229,6 @@ class _AnimatedThemeState extends AnimatedWidgetBaseState<AnimatedTheme> {
   @override
   Widget build(BuildContext context) {
     return Theme(
-      isMaterialAppTheme: widget.isMaterialAppTheme,
       child: widget.child,
       data: _data!.evaluate(animation!),
     );

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -556,7 +556,6 @@ void main() {
               selectionHandleColor: Color(0x550000AA),
             ),
           ),
-          isMaterialAppTheme: true,
           child: Builder(
             builder: (BuildContext context) {
               return Container(


### PR DESCRIPTION
## Description

The `isMaterialAppTheme` property was only used by the `shadowThemeOnly` flag of `Theme.of`. The `shadowThemeOnly` has since been removed, making the `isMaterialAppTheme` property obsolete. This PR removes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/70981

## Tests

I added the following tests:

* updated existing test

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
