### PR TITLE
ignore sliver underflow if the last children is no longer at the previous last index

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1188,7 +1188,15 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
-      // We don't worry about underflow if any child has been updated.
+      // A element rebuild only updates existing children. The underflow check
+      // is here to make sure we look ahead one more child if we were at the end
+      // of the child list before the update. By doing so, we can update the max
+      // scroll offset during the layout phase. Otherwise, the scroll view will
+      // be stuck at the previous max scroll offset and never gets update even
+      // if there are new children added at the end.
+      //
+      // This logic however is not needed if any existing children has been
+      // updated, because we will not skip the layout phase after the rebuild.
       if (!childrenUpdated && _didUnderflow) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1135,7 +1135,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     try {
       final SplayTreeMap<int, Element?> newChildren = SplayTreeMap<int, Element?>();
       final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
-
+      final int oldLastIndex = _childElements.lastKey() ?? -1;
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;
         if (_childElements[index] != null && _childElements[index] != newChildren[index]) {
@@ -1185,7 +1185,10 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
-      if (_didUnderflow) {
+      final int newLastIndex = _childElements.lastKey() ?? -1;
+      // We only don't worry about underflow if we are not at the end of the
+      // child list after the update.
+      if (_didUnderflow && newLastIndex >= oldLastIndex) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;
         newChildren[rightBoundary] = _childElements[rightBoundary];

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1186,8 +1186,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
       final int newLastIndex = _childElements.lastKey() ?? -1;
-      // We only don't worry about underflow if we are not at the end of the
-      // child list after the update.
+      // We don't worry about underflow if the last child is not longer at the
+      // end of the child list.
       if (_didUnderflow && newLastIndex >= oldLastIndex) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1131,6 +1131,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   void performRebuild() {
     super.performRebuild();
     _currentBeforeChild = null;
+    bool childrenUpdated = false;
     assert(_currentlyUpdatingChildIndex == null);
     try {
       final SplayTreeMap<int, Element?> newChildren = SplayTreeMap<int, Element?>();
@@ -1141,9 +1142,11 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
         if (_childElements[index] != null && _childElements[index] != newChildren[index]) {
           // This index has an old child that isn't used anywhere and should be deactivated.
           _childElements[index] = updateChild(_childElements[index], null, index);
+          childrenUpdated = true;
         }
         final Element? newChild = updateChild(newChildren[index], _build(index), index);
         if (newChild != null) {
+          childrenUpdated = childrenUpdated || _childElements[index] != newChild;
           _childElements[index] = newChild;
           final SliverMultiBoxAdaptorParentData parentData = newChild.renderObject!.parentData! as SliverMultiBoxAdaptorParentData;
           if (index == 0) {
@@ -1154,6 +1157,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           if (!parentData.keptAlive)
             _currentBeforeChild = newChild.renderObject as RenderBox?;
         } else {
+          childrenUpdated = true;
           _childElements.remove(index);
         }
       }
@@ -1188,7 +1192,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       final int newLastIndex = _childElements.lastKey() ?? -1;
       // We don't worry about underflow if the last child is not longer at the
       // end of the child list.
-      if (_didUnderflow && newLastIndex >= oldLastIndex) {
+      if (!childrenUpdated && _didUnderflow) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;
         newChildren[rightBoundary] = _childElements[rightBoundary];

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1136,7 +1136,6 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     try {
       final SplayTreeMap<int, Element?> newChildren = SplayTreeMap<int, Element?>();
       final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
-      final int oldLastIndex = _childElements.lastKey() ?? -1;
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;
         if (_childElements[index] != null && _childElements[index] != newChildren[index]) {
@@ -1189,7 +1188,6 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
-      final int newLastIndex = _childElements.lastKey() ?? -1;
       // We don't worry about underflow if the last child is not longer at the
       // end of the child list.
       if (!childrenUpdated && _didUnderflow) {

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1191,12 +1191,12 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       // A element rebuild only updates existing children. The underflow check
       // is here to make sure we look ahead one more child if we were at the end
       // of the child list before the update. By doing so, we can update the max
-      // scroll offset during the layout phase. Otherwise, the scroll view will
-      // be stuck at the previous max scroll offset and never gets update even
-      // if there are new children added at the end.
+      // scroll offset during the layout phase. Otherwise, the layout phase may
+      // be skipped, and the scroll view may be stuck at the previous max
+      // scroll offset.
       //
-      // This logic however is not needed if any existing children has been
-      // updated, because we will not skip the layout phase after the rebuild.
+      // This logic is not needed if any existing children has been updated,
+      // because we will not skip the layout phase if that happens.
       if (!childrenUpdated && _didUnderflow) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1188,8 +1188,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
-      // We don't worry about underflow if the last child is not longer at the
-      // end of the child list.
+      // We don't worry about underflow if any child has been updated.
       if (!childrenUpdated && _didUnderflow) {
         final int lastKey = _childElements.lastKey() ?? -1;
         final int rightBoundary = lastKey + 1;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1188,7 +1188,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
       renderObject.debugChildIntegrityEnabled = false; // Moving children will temporary violate the integrity.
       newChildren.keys.forEach(processElement);
-      // A element rebuild only updates existing children. The underflow check
+      // An element rebuild only updates existing children. The underflow check
       // is here to make sure we look ahead one more child if we were at the end
       // of the child list before the update. By doing so, we can update the max
       // scroll offset during the layout phase. Otherwise, the layout phase may

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -29,11 +30,12 @@ Future<void> test(WidgetTester tester, double offset, { double anchor = 0.0 }) {
   );
 }
 
-Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items) {
+Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items, { ScrollController? controller }) {
   return tester.pumpWidget(
     Directionality(
       textDirection: TextDirection.ltr,
       child: CustomScrollView(
+        controller: controller,
         slivers: <Widget>[
           SliverFixedExtentList(
             itemExtent: 900,
@@ -269,6 +271,71 @@ void main() {
     expect(find.text('2'), findsNothing);
     expect(find.text('3'), findsOneWidget);
     expect(find.text('4'), findsOneWidget);
+  });
+
+  testWidgets('SliverFixedExtentList handles underflow when its children changes', (WidgetTester tester) async {
+    final List<String> items = <String>['1', '2', '3', '4', '5', '6'];
+    final List<String> initializedChild = <String>[];
+    List<Widget> children = <Widget>[];
+    for (final String item in items) {
+      children.add(
+          StateInitSpy(
+            item, () => initializedChild.add(item), key: ValueKey<String>(item),
+          )
+      );
+    }
+    final ScrollController controller = ScrollController(initialScrollOffset: 5400);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverFixedExtentList(
+              itemExtent: 900,
+              delegate: SliverChildListDelegate(children),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('1'), findsNothing);
+    expect(find.text('2'), findsNothing);
+    expect(find.text('3'), findsNothing);
+    expect(find.text('4'), findsNothing);
+    expect(find.text('5'), findsNothing);
+    expect(find.text('6'), findsOneWidget);
+    expect(const ListEquality<String>().equals(initializedChild, <String>['6']), isTrue);
+
+    // move to item 1 and swap the children at the same time
+    controller.jumpTo(0);
+    final Widget temp = children[5];
+    children[5] = children[0];
+    children[0] = temp;
+    children = List<Widget>.from(children);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverFixedExtentList(
+              itemExtent: 900,
+              delegate: SliverChildListDelegate(children),
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(find.text('1'), findsNothing);
+    expect(find.text('2'), findsNothing);
+    expect(find.text('3'), findsNothing);
+    expect(find.text('4'), findsNothing);
+    expect(find.text('5'), findsNothing);
+    expect(find.text('6'), findsOneWidget);
+    // None of the children should be built.
+    expect(const ListEquality<String>().equals(initializedChild, <String>['6']), isTrue);
   });
 
   testWidgets(
@@ -1018,6 +1085,29 @@ class TestSliverFixedExtentList extends StatelessWidget {
           ],
         ),
     );
+  }
+}
+
+class StateInitSpy extends StatefulWidget {
+  const StateInitSpy(this.data, this.onStateInit, { Key? key }) : super(key: key);
+
+  final String data;
+  final VoidCallback onStateInit;
+
+  @override
+  StateInitSpyState createState() => StateInitSpyState();
+}
+
+class StateInitSpyState extends State<StateInitSpy> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onStateInit();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(widget.data);
   }
 }
 

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -305,7 +305,7 @@ void main() {
     expect(find.text('4'), findsNothing);
     expect(find.text('5'), findsNothing);
     expect(find.text('6'), findsOneWidget);
-    expect(const ListEquality<String>().equals(initializedChild, <String>['6']), isTrue);
+    expect(listEquals<String>(initializedChild, <String>['6']), isTrue);
 
     // move to item 1 and swap the children at the same time
     controller.jumpTo(0);
@@ -334,7 +334,7 @@ void main() {
     expect(find.text('5'), findsNothing);
     expect(find.text('6'), findsOneWidget);
     // None of the children should be built.
-    expect(const ListEquality<String>().equals(initializedChild, <String>['6']), isTrue);
+    expect(listEquals<String>(initializedChild, <String>['6']), isTrue);
   });
 
   testWidgets(

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -30,12 +30,11 @@ Future<void> test(WidgetTester tester, double offset, { double anchor = 0.0 }) {
   );
 }
 
-Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items, { ScrollController? controller }) {
+Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items) {
   return tester.pumpWidget(
     Directionality(
       textDirection: TextDirection.ltr,
       child: CustomScrollView(
-        controller: controller,
         slivers: <Widget>[
           SliverFixedExtentList(
             itemExtent: 900,


### PR DESCRIPTION

## Description

When sliver underflow, it will try to build one more child after the current last child. If the last child got moved to other place, the sliver will still try to build one more child after the new location. This PR fixes it.

Open Question: is the current underflow logic still valid? the sliver render object marks sliver element underflow, but it only gets picked on the next rebuild. if the sliver does not rebuild, nothing will change. and if the sliver does rebuild, the information may be outdated due to children reorder. I am not familiar with the underflow to make an improvement. Any advice?

## Related Issues

fixes https://github.com/flutter/flutter/issues/71273

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
