### PR TITLE
Stop using Xcode build settings in materialized Info.plist

### DIFF
--- a/packages/flutter_tools/templates/app/ios.tmpl/Flutter/AppFrameworkInfo.plist
+++ b/packages/flutter_tools/templates/app/ios.tmpl/Flutter/AppFrameworkInfo.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>CFBundleDevelopmentRegion</key>
-  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <string>en</string>
   <key>CFBundleExecutable</key>
   <string>App</string>
   <key>CFBundleIdentifier</key>

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/AppFrameworkInfo.plist
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/AppFrameworkInfo.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>CFBundleDevelopmentRegion</key>
-  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <string>en</string>
   <key>CFBundleExecutable</key>
   <string>App</string>
   <key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Description

Xcode build settings can be used in Info.plists, and Xcode will swap them out with values when they are built.  However, `Flutter/AppFrameworkInfo.plist` is not processed by Xcode--it's just copied by the tool into the App.framework next to the compiled dart code to make it look like a real framework bundle.  Because it's not processed by Xcode, build setting substitution doesn't work.

Here's what a built Runner.app/App.framework/Info.plist currently looks like:
<img width="762" alt="Screen Shot 2020-12-07 at 1 08 56 PM" src="https://user-images.githubusercontent.com/682784/101405727-5efb3e00-388d-11eb-8112-b5e54140c154.png">

Stop using `DEVELOPMENT_LANGUAGE` in this context and default to `en`.

This isn't a big deal and hasn't caused any problems I'm aware of, so it's not worth a potentially destructive migration.
