### PR TITLE
let NOTICES be double gzip wrapped to reduce on-disk installed space

### DIFF
--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -319,7 +319,11 @@ Future<void> main() async {
       section('Check the NOTICE file is correct');
 
       await inDirectory(hostApp, () async {
-        await exec('unzip', <String>[releaseHostApk, 'assets/flutter_assets/NOTICES.Z']);
+        if (Platform.isWindows) {
+          await exec('7za', <String>['x', releaseHostApk, 'assets/flutter_assets/NOTICES.Z']);
+        } else {
+          await exec('unzip', <String>[releaseHostApk, 'assets/flutter_assets/NOTICES.Z']);
+        }
         checkFileExists(path.join(hostApp.path, 'assets', 'flutter_assets', 'NOTICES.Z'));
 
         final Uint8List licenseData = File(path.join(hostApp.path, 'assets', 'flutter_assets', 'NOTICES.Z')).readAsBytesSync();

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
@@ -212,6 +214,8 @@ Future<void> main() async {
 
       final File objectiveCAnalyticsOutputFile = File(path.join(tempDir.path, 'analytics-objc.log'));
       final Directory objectiveCBuildDirectory = Directory(path.join(tempDir.path, 'build-objc'));
+
+      section('Build iOS Objective-C host app');
       await inDirectory(objectiveCHostApp, () async {
         await exec(
           'pod',
@@ -267,6 +271,28 @@ Future<void> main() async {
         'flutter_assets',
         'isolate_snapshot_data',
       ));
+
+      section('Check the NOTICE file is correct');
+
+      final String licenseFilePath = path.join(
+        objectiveCBuildDirectory.path,
+        'Host.app',
+        'Frameworks',
+        'App.framework',
+        'flutter_assets',
+        'NOTICES.Z',
+      );
+      checkFileExists(licenseFilePath);
+
+      await inDirectory(objectiveCBuildDirectory, () async {
+        final Uint8List licenseData = File(licenseFilePath).readAsBytesSync();
+        final String licenseString = utf8.decode(gzip.decode(licenseData));
+        if (!licenseString.contains('skia') || !licenseString.contains('Flutter Authors')) {
+          return TaskResult.failure('License content missing');
+        }
+      });
+
+      section('Check that the host build sends the correct analytics');
 
       final String objectiveCAnalyticsOutput = objectiveCAnalyticsOutputFile.readAsStringSync();
       if (!objectiveCAnalyticsOutput.contains('cd24: ios')

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -13,7 +13,7 @@ final String platformLineSep = Platform.isWindows ? '\r\n' : '\n';
 
 final List<String> flutterAssets = <String>[
   'assets/flutter_assets/AssetManifest.json',
-  'assets/flutter_assets/NOTICES.gz',
+  'assets/flutter_assets/NOTICES.Z',
   'assets/flutter_assets/fonts/MaterialIcons-Regular.otf',
   'assets/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf',
 ];

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -13,7 +13,7 @@ final String platformLineSep = Platform.isWindows ? '\r\n' : '\n';
 
 final List<String> flutterAssets = <String>[
   'assets/flutter_assets/AssetManifest.json',
-  'assets/flutter_assets/NOTICES',
+  'assets/flutter_assets/NOTICES.gz',
   'assets/flutter_assets/fonts/MaterialIcons-Regular.otf',
   'assets/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf',
 ];

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1070,7 +1070,7 @@ class CompileTest {
 
     final _UnzipListEntry libflutter = fileToMetadata['lib/armeabi-v7a/libflutter.so'];
     final _UnzipListEntry libapp = fileToMetadata['lib/armeabi-v7a/libapp.so'];
-    final _UnzipListEntry license = fileToMetadata['assets/flutter_assets/NOTICES'];
+    final _UnzipListEntry license = fileToMetadata['assets/flutter_assets/NOTICES.gz'];
 
     return <String, dynamic>{
       'libflutter_uncompressed_bytes': libflutter.uncompressedSize,

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1070,7 +1070,7 @@ class CompileTest {
 
     final _UnzipListEntry libflutter = fileToMetadata['lib/armeabi-v7a/libflutter.so'];
     final _UnzipListEntry libapp = fileToMetadata['lib/armeabi-v7a/libapp.so'];
-    final _UnzipListEntry license = fileToMetadata['assets/flutter_assets/NOTICES.gz'];
+    final _UnzipListEntry license = fileToMetadata['assets/flutter_assets/NOTICES.Z'];
 
     return <String, dynamic>{
       'libflutter_uncompressed_bytes': libflutter.uncompressedSize,

--- a/dev/integration_tests/flutter_gallery/test/example_code_parser_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/example_code_parser_test.dart
@@ -46,7 +46,7 @@ class TestAssetBundle extends AssetBundle {
   }
 
   @override
-  Future<String> loadString(String key, { bool cache = true }) async {
+  Future<String> loadString(String key, { bool cache = true, bool unzip = false }) async {
     if (key == 'lib/gallery/example_code.dart')
       return testCodeFile;
     return '';

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -64,6 +64,9 @@ abstract class AssetBundle {
   /// caller is going to be doing its own caching. (It might not be cached if
   /// it's set to true either, that depends on the asset bundle
   /// implementation.)
+  ///
+  /// If the `unzip` argument is set to true, it would first unzip file at the
+  /// specified location before retrieving the string content.
   Future<String> loadString(
     String key,
     {
@@ -82,12 +85,13 @@ abstract class AssetBundle {
     if (data.lengthInBytes < 50 * 1024 && !unzip) {
       return _utf8Decode(data);
     }
+
     // For strings larger than 50 KB, run the computation in an isolate to
     // avoid causing main thread jank.
     return compute(
       unzip ? _utf8ZipDecode : _utf8Decode,
       data,
-      debugLabel: 'UTF8 decode for "$key"',
+      debugLabel: '${unzip ? "Unzip and ": ""}UTF8 decode for "$key"',
     );
   }
 
@@ -181,7 +185,7 @@ abstract class CachingAssetBundle extends AssetBundle {
   @override
   Future<String> loadString(String key, { bool cache = true, bool unzip = false }) {
     if (cache)
-      return _stringCache.putIfAbsent(key, () => super.loadString(key));
+      return _stringCache.putIfAbsent(key, () => super.loadString(key, unzip: unzip));
     return super.loadString(key, unzip: unzip);
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -64,7 +64,13 @@ abstract class AssetBundle {
   /// caller is going to be doing its own caching. (It might not be cached if
   /// it's set to true either, that depends on the asset bundle
   /// implementation.)
-  Future<String> loadString(String key, { bool cache = true }) async {
+  Future<String> loadString(
+    String key,
+    {
+      bool cache = true,
+      bool unzip = false,
+    }
+  ) async {
     final ByteData data = await load(key);
     // Note: data has a non-nullable type, but might be null when running with
     // weak checking, so we need to null check it anyway (and ignore the warning
@@ -73,15 +79,25 @@ abstract class AssetBundle {
       throw FlutterError('Unable to load asset: $key'); // ignore: dead_code
     // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
     // on a Pixel 4.
-    if (data.lengthInBytes < 50 * 1024) {
-      return utf8.decode(data.buffer.asUint8List());
+    if (data.lengthInBytes < 50 * 1024 && !unzip) {
+      return _utf8Decode(data);
     }
     // For strings larger than 50 KB, run the computation in an isolate to
     // avoid causing main thread jank.
-    return compute(_utf8decode, data, debugLabel: 'UTF8 decode for "$key"');
+    return compute(
+      unzip ? _utf8ZipDecode : _utf8Decode,
+      data,
+      debugLabel: 'UTF8 decode for "$key"',
+    );
   }
 
-  static String _utf8decode(ByteData data) {
+  static String _utf8ZipDecode(ByteData data) {
+    List<int> bytes = data.buffer.asUint8List();
+    bytes = gzip.decode(bytes);
+    return utf8.decode(bytes);
+  }
+
+  static String _utf8Decode(ByteData data) {
     return utf8.decode(data.buffer.asUint8List());
   }
 
@@ -163,10 +179,10 @@ abstract class CachingAssetBundle extends AssetBundle {
   final Map<String, Future<dynamic>> _structuredDataCache = <String, Future<dynamic>>{};
 
   @override
-  Future<String> loadString(String key, { bool cache = true }) {
+  Future<String> loadString(String key, { bool cache = true, bool unzip = false }) {
     if (cache)
       return _stringCache.putIfAbsent(key, () => super.loadString(key));
-    return super.loadString(key);
+    return super.loadString(key, unzip: unzip);
   }
 
   /// Retrieve a string from the asset bundle, parse it with the given function,

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -104,7 +104,9 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     // TODO(ianh): Remove this complexity once these bugs are fixed.
     final Completer<String> rawLicenses = Completer<String>();
     scheduleTask(() async {
-      rawLicenses.complete(await rootBundle.loadString('NOTICES', cache: false));
+      rawLicenses.complete(
+        await rootBundle.loadString('NOTICES.gz', cache: false, unzip: true)
+      );
     }, Priority.animation);
     await rawLicenses.future;
     final Completer<List<LicenseEntry>> parsedLicenses = Completer<List<LicenseEntry>>();

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -105,7 +105,14 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     final Completer<String> rawLicenses = Completer<String>();
     scheduleTask(() async {
       rawLicenses.complete(
-        await rootBundle.loadString('NOTICES.gz', cache: false, unzip: true)
+        await rootBundle.loadString(
+          // NOTICES for web isn't compressed since we don't have access to
+          // dart:io on the client side and it's already compressed between
+          // the server and client.
+          kIsWeb ? 'NOTICES' : 'NOTICES.gz',
+          cache: false,
+          unzip: !kIsWeb,
+        )
       );
     }, Priority.animation);
     await rawLicenses.future;

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -109,7 +109,10 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
           // NOTICES for web isn't compressed since we don't have access to
           // dart:io on the client side and it's already compressed between
           // the server and client.
-          kIsWeb ? 'NOTICES' : 'NOTICES.gz',
+          //
+          // The compressed version doesn't have a common .gz extension because
+          // gradle for Android non-transparently manipulates .gz files.
+          kIsWeb ? 'NOTICES' : 'NOTICES.Z',
           cache: false,
           unzip: !kIsWeb,
         )

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -110,8 +110,8 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
           // dart:io on the client side and it's already compressed between
           // the server and client.
           //
-          // The compressed version doesn't have a common .gz extension because
-          // gradle for Android non-transparently manipulates .gz files.
+          // The compressed version doesn't have a more common .gz extension
+          // because gradle for Android non-transparently manipulates .gz files.
           kIsWeb ? 'NOTICES' : 'NOTICES.Z',
           cache: false,
           unzip: !kIsWeb,

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -15,10 +16,13 @@ class TestAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
+    loadCallCount[key] = loadCallCount[key] ?? 0 + 1;
     if (key == 'AssetManifest.json')
       return ByteData.view(Uint8List.fromList(const Utf8Encoder().convert('{"one": ["one"]}')).buffer);
 
-    loadCallCount[key] = loadCallCount[key] ?? 0 + 1;
+    if (key == 'NOTICES.Z')
+      return ByteData.view(Uint8List.fromList(gzip.encode(utf8.encode('All your base are belong to us'))).buffer);
+
     if (key == 'one')
       return ByteData(1)..setInt8(0, 49);
     throw FlutterError('key not found');
@@ -46,6 +50,21 @@ void main() {
       loadException = e;
     }
     expect(loadException, isFlutterError);
+  });
+
+  test('Test loading zipped strings', () async {
+    final TestAssetBundle bundle = TestAssetBundle();
+
+    String assetString = await bundle.loadString('NOTICES.Z', unzip: true);
+    expect(assetString, equals('All your base are belong to us'));
+
+    expect(bundle.loadCallCount['NOTICES.Z'], 1);
+
+    assetString = await bundle.loadString('NOTICES.Z', unzip: true);
+    expect(assetString, equals('All your base are belong to us'));
+
+    // Should have been cached and shouldn't retrieve and decode another time.
+    expect(bundle.loadCallCount['NOTICES.Z'], 1);
   });
 
   test('AssetImage.obtainKey succeeds with ImageConfiguration.empty', () async {

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -65,6 +65,11 @@ void main() {
 
     // Should have been cached and shouldn't retrieve and decode another time.
     expect(bundle.loadCallCount['NOTICES.Z'], 1);
+  }, onPlatform: <String, dynamic>{
+    'browser': const Skip(
+      'Skip the NOTICES unzipping test because NOTICES are'
+      'not zipped for the web'
+    ),
   });
 
   test('AssetImage.obtainKey succeeds with ImageConfiguration.empty', () async {

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -44,8 +46,8 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
   BinaryMessenger createBinaryMessenger() {
     return super.createBinaryMessenger()
       ..setMockMessageHandler('flutter/assets', (ByteData? message) async {
-        if (const StringCodec().decodeMessage(message) == 'NOTICES') {
-          return const StringCodec().encodeMessage(licenses);
+        if (const StringCodec().decodeMessage(message) == 'NOTICES.gz') {
+          return Uint8List.fromList(gzip.encode(utf8.encode(licenses))).buffer.asByteData();
         }
         return null;
       });

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -46,8 +46,11 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
   BinaryMessenger createBinaryMessenger() {
     return super.createBinaryMessenger()
       ..setMockMessageHandler('flutter/assets', (ByteData? message) async {
-        if (const StringCodec().decodeMessage(message) == 'NOTICES.gz') {
+        if (const StringCodec().decodeMessage(message) == 'NOTICES.Z' && !kIsWeb) {
           return Uint8List.fromList(gzip.encode(utf8.encode(licenses))).buffer.asByteData();
+        }
+        if (const StringCodec().decodeMessage(message) == 'NOTICES' && kIsWeb) {
+          return const StringCodec().encodeMessage(licenses);
         }
         return null;
       });

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -66,7 +66,7 @@ class TestAssetBundle extends CachingAssetBundle {
   }
 
   @override
-  Future<String> loadString(String key, { bool cache = true }) {
+  Future<String> loadString(String key, { bool cache = true, bool unzip = false }) {
     if (key == 'AssetManifest.json')
       return SynchronousFuture<String>(manifest);
     return SynchronousFuture<String>('');

--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -7,6 +7,7 @@ import 'package:flutter_tools/src/asset.dart' hide defaultManifestPath;
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart' as libfs;
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/devfs.dart';
@@ -59,6 +60,7 @@ Future<void> run(List<String> args) async {
     manifestPath: argResults[_kOptionManifest] as String ?? defaultManifestPath,
     assetDirPath: assetDir,
     packagesPath: argResults[_kOptionPackages] as String,
+    targetPlatform: TargetPlatform.fuchsia_arm64 // This is not arch specific.
   );
 
   if (assets == null) {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -124,7 +124,13 @@ class ManifestAssetBundle implements AssetBundle {
 
   static const String _kAssetManifestJson = 'AssetManifest.json';
   static const String _kNoticeFile = 'NOTICES';
-  static const String _kNoticeZippedFile = 'NOTICES.gz';
+  // Comically, this can't be name with the more common .gz file extension
+  // because when it's part of an AAR and brought into another APK via gradle,
+  // gradle individually traverses all the files of the AAR and unzips .gz
+  // files (b/37117906). A less common .Z extension still describes how the
+  // file is formatted if users want to manually inspect the application
+  // bundle and is recognized by default file handlers on OS such as macOS.˚
+  static const String _kNoticeZippedFile = 'NOTICES.Z';
 
   @override
   bool wasBuiltOnce() => _lastBuildTimestamp != null;

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -358,6 +358,9 @@ class ManifestAssetBundle implements AssetBundle {
               != licenseBytes) {
         entries[_kNoticeZippedFile] = DevFSByteContent(
           ZLibEncoder(
+            // A zlib dictionary is a hinting string sequence with the most
+            // likely string occurrences at the end. This ends up just being
+            // common English words with domain specific words like copyright.
             dictionary: utf8.encode('copyrightsoftwaretothisinandorofthe'),
             gzip: true,
             level: 9,

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -102,7 +102,8 @@ export 'dart:io'
         systemEncoding,
         WebSocket,
         WebSocketException,
-        WebSocketTransformer;
+        WebSocketTransformer,
+        ZLibEncoder;
 
 /// Exits the process with the given [exitCode].
 typedef ExitFunction = void Function(int exitCode);

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -54,6 +54,7 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
     manifestPath: pubspecFile.path,
     packagesPath: environment.projectDir.childFile('.packages').path,
     assetDirPath: null,
+    targetPlatform: targetPlatform,
   );
   if (resultCode != 0) {
     throw Exception('Failed to bundle asset files.');

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -192,6 +192,7 @@ Future<AssetBundle> buildAssets({
   String manifestPath,
   String assetDirPath,
   @required String packagesPath,
+  TargetPlatform targetPlatform,
 }) async {
   assetDirPath ??= getAssetBuildDirectory();
   packagesPath ??= globals.fs.path.absolute(packagesPath);
@@ -202,6 +203,7 @@ Future<AssetBundle> buildAssets({
     manifestPath: manifestPath,
     assetDirPath: assetDirPath,
     packagesPath: packagesPath,
+    targetPlatform: targetPlatform,
   );
   if (result != 0) {
     return null;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -705,7 +705,10 @@ class _ResidentWebRunner extends ResidentWebRunner {
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
       globals.printTrace('Updating assets');
-      final int result = await assetBundle.build(packagesPath: debuggingOptions.buildInfo.packagesPath);
+      final int result = await assetBundle.build(
+        packagesPath: debuggingOptions.buildInfo.packagesPath,
+        targetPlatform: TargetPlatform.web_javascript,
+      );
       if (result != 0) {
         return UpdateFSReport(success: false);
       }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -88,7 +88,7 @@ flutter:
 
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/AssetManifest.json'), exists);
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/FontManifest.json'), exists);
-    expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/NOTICES.gz'), exists);
+    expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/NOTICES.Z'), exists);
     // See https://github.com/flutter/flutter/issues/35293
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/assets/foo/bar.png'), exists);
     // See https://github.com/flutter/flutter/issues/46163

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -88,7 +88,7 @@ flutter:
 
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/AssetManifest.json'), exists);
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/FontManifest.json'), exists);
-    expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/NOTICES'), exists);
+    expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/NOTICES.gz'), exists);
     // See https://github.com/flutter/flutter/issues/35293
     expect(fileSystem.file('${environment.buildDir.path}/flutter_assets/assets/foo/bar.png'), exists);
     // See https://github.com/flutter/flutter/issues/46163


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/71102. It doesn't quite deduplicate the contents of NOTICES while in transport, but just leaves it compressed on disk until it's actually read since it's an uncommonly used file. Reduces uncompressed (.ipa perspective, not this file's perspective) size from ~800kB before to ~60kB after. 

It leaves web as is since the client doesn't have dart:io or any "native" abilities to unzip. It also has a .Z extension instead of a .gz extension because there are logic baked in in gradle that traverses all the files of an APK and unzips the .gz files. Checked with the gradle team. Our usage here isn't circumventing any meaningful optimizations. It was just originally meant to avoid people thinking this reduces network size (which this doesn't and doesn't intend to) and costing unzip CPU cost (which doesn't affect this since it's uncommonly used). 

Added some new tests but https://github.com/flutter/flutter/pull/71899/files#diff-7e359e27713e3f080b4385c7e6b690e7aa3ab982c98855a088ed00e07bfaa6e5R16 actually ends up making this get tested everywhere. 

----------------------

For future rollers, this will break g3. Subclasses will need to implement the new signature to match. 