### PR TITLE
Update dartdoc to 0.38.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.37.0
+    "$PUB" global activate dartdoc 0.38.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
## Description

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.38.0

TL;DR:  For Flutter SDK docs you can expect a ~25-30% overall performance improvement in runtime for 0.38 vs 0.37, plus some minor bugfixes.

## Tests

Tested by hand and compared performance.