### PR TITLE
Remove duplicate code in Element.rebuild() and BuildOwner.buildScope()

### DIFF
--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -75,6 +75,7 @@ class PointerRouter {
   ///
   /// This is valid in debug builds only. In release builds, this will throw an
   /// [UnsupportedError].
+  @visibleForTesting
   int get debugGlobalRouteCount {
     int? count;
     assert(() {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2651,6 +2651,25 @@ class BuildOwner {
   /// Only valid when asserts are enabled.
   bool get debugBuilding => _debugBuilding;
   bool _debugBuilding = false;
+
+  /// The element currently being built, or null if no element is actively
+  /// being built.
+  ///
+  /// This is valid in debug builds only. In release builds, this will throw an
+  /// [UnsupportedError].
+  Element? get debugCurrentBuildTarget {
+    Element? result;
+    bool isSupportedOperation = false;
+    assert(() {
+      result = _debugCurrentBuildTarget;
+      isSupportedOperation = true;
+      return true;
+    }());
+    if (isSupportedOperation) {
+      return result;
+    }
+    throw UnsupportedError('debugCurrentBuildTarget is not supported in release builds');
+  }
   Element? _debugCurrentBuildTarget;
 
   /// Establishes a scope in which calls to [State.setState] are forbidden, and
@@ -2674,6 +2693,25 @@ class BuildOwner {
       }());
     }
     assert(_debugStateLockLevel >= 0);
+  }
+
+  void _runWithCurrentBuildTarget(Element element, VoidCallback callback) {
+    assert(_debugStateLocked);
+    Element? debugPreviousBuildTarget;
+    assert(() {
+      debugPreviousBuildTarget = _debugCurrentBuildTarget;
+      _debugCurrentBuildTarget = element;
+      return true;
+    }());
+    try {
+      callback();
+    } finally {
+      assert(() {
+        assert(_debugCurrentBuildTarget == element);
+        _debugCurrentBuildTarget = debugPreviousBuildTarget;
+        return true;
+      }());
+    }
   }
 
   /// Establishes a scope for updating the widget tree, and calls the given
@@ -2718,26 +2756,22 @@ class BuildOwner {
     try {
       _scheduledFlushDirtyElements = true;
       if (callback != null) {
-        assert(_debugStateLocked);
-        Element? debugPreviousBuildTarget;
-        assert(() {
-          context._debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-          debugPreviousBuildTarget = _debugCurrentBuildTarget;
-          _debugCurrentBuildTarget = context;
-          return true;
-        }());
-        _dirtyElementsNeedsResorting = false;
-        try {
-          callback();
-        } finally {
+        _runWithCurrentBuildTarget(context, () {
           assert(() {
-            context._debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
-            assert(_debugCurrentBuildTarget == context);
-            _debugCurrentBuildTarget = debugPreviousBuildTarget;
-            _debugElementWasRebuilt(context);
+            context._debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
             return true;
           }());
-        }
+          _dirtyElementsNeedsResorting = false;
+          try {
+            callback();
+          } finally {
+            assert(() {
+              context._debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
+              _debugElementWasRebuilt(context);
+              return true;
+            }());
+          }
+        });
       }
       _dirtyElements.sort(Element._sort);
       _dirtyElementsNeedsResorting = false;
@@ -4369,19 +4403,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       return true;
     }());
     assert(_lifecycleState == _ElementLifecycle.active);
-    assert(owner!._debugStateLocked);
-    Element? debugPreviousBuildTarget;
-    assert(() {
-      debugPreviousBuildTarget = owner!._debugCurrentBuildTarget;
-      owner!._debugCurrentBuildTarget = this;
-      return true;
-    }());
-    performRebuild();
-    assert(() {
-      assert(owner!._debugCurrentBuildTarget == this);
-      owner!._debugCurrentBuildTarget = debugPreviousBuildTarget;
-      return true;
-    }());
+    owner!._runWithCurrentBuildTarget(this, performRebuild);
     assert(!_dirty);
   }
 
@@ -5586,6 +5608,7 @@ abstract class RenderObjectElement extends Element {
   }
 
   @override
+  @mustCallSuper
   void performRebuild() {
     assert(() {
       _debugDoingBuild = true;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2657,6 +2657,7 @@ class BuildOwner {
   ///
   /// This is valid in debug builds only. In release builds, this will throw an
   /// [UnsupportedError].
+  @visibleForTesting
   Element? get debugCurrentBuildTarget {
     Element? result;
     bool isSupportedOperation = false;

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1494,6 +1494,44 @@ void main() {
     expect(GestureBinding.instance!.pointerRouter.debugGlobalRouteCount, pointerRouterCount);
     expect(RawKeyboard.instance.keyEventHandler, same(rawKeyEventHandler));
   });
+
+  testWidgets('Errors in build', (WidgetTester tester) async {
+    final ErrorWidgetBuilder oldErrorBuilder = ErrorWidget.builder;
+    ErrorWidget.builder = (FlutterErrorDetails detail) => throw AssertionError();
+    try {
+      final FlutterExceptionHandler? oldErrorHandler = FlutterError.onError;
+      FlutterError.onError = (FlutterErrorDetails detail) {};
+      try {
+        int buildCount = 0;
+        void handleBuild() => buildCount++;
+        expect(tester.binding.buildOwner!.debugCurrentBuildTarget, isNull);
+        await tester.pumpWidget(_WidgetThatCanThrowInBuild(onBuild: handleBuild));
+        expect(buildCount, 1);
+        await tester.pumpWidget(_WidgetThatCanThrowInBuild(onBuild: handleBuild, shouldThrow: true));
+        tester.takeException();
+        expect(buildCount, 2);
+        expect(tester.binding.buildOwner!.debugCurrentBuildTarget, isNull);
+      } finally {
+        FlutterError.onError = oldErrorHandler;
+      }
+    } finally {
+      ErrorWidget.builder = oldErrorBuilder;
+    }
+  });
+}
+
+class _WidgetThatCanThrowInBuild extends StatelessWidget {
+  const _WidgetThatCanThrowInBuild({required this.onBuild, this.shouldThrow = false});
+
+  final VoidCallback onBuild;
+  final bool shouldThrow;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild();
+    assert(!shouldThrow);
+    return Container();
+  }
 }
 
 class _FakeFocusManager implements FocusManager {


### PR DESCRIPTION
## Description

Element.rebuild() and BuildOwner.buildScope() both had code to
manager the `BuildOwner._debugCurrentBuildTarget` state variable.
Unfortunately, only one of the two places was using a try/finally
to ensure that the state variable was restored even if an error
was thrown.

This creates a private method to unify the copy/pasted code.

## Tests

I added the following tests:

* A test that verifies that `BuildOwner._debugCurrentBuildTarget` is properly managed even in the face of errors.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
