### PR TITLE
Improve the performances of ChangeNotifier

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection';
-
 import 'package:meta/meta.dart';
 
 import 'assertions.dart';
@@ -94,11 +92,6 @@ abstract class ValueListenable<T> extends Listenable {
   T get value;
 }
 
-class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
-  _ListenerEntry(this.listener);
-  final VoidCallback listener;
-}
-
 /// A class that can be extended or mixed in that provides a change notification
 /// API using [VoidCallback] for notifications.
 ///
@@ -109,11 +102,15 @@ class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
-  LinkedList<_ListenerEntry>? _listeners = LinkedList<_ListenerEntry>();
+  int _length = 0;
+  List<VoidCallback?> _listeners = List<VoidCallback?>.filled(0, null);
+  int _notificationCallStackDepth = 0;
+  int _removedListeners = 0;
+  bool _disposed = false;
 
   bool _debugAssertNotDisposed() {
     assert(() {
-      if (_listeners == null) {
+      if (_disposed) {
         throw FlutterError(
           'A $runtimeType was used after being disposed.\n'
           'Once you have called dispose() on a $runtimeType, it can no longer be used.',
@@ -142,7 +139,7 @@ class ChangeNotifier implements Listenable {
   @protected
   bool get hasListeners {
     assert(_debugAssertNotDisposed());
-    return _listeners!.isNotEmpty;
+    return _length > 0;
   }
 
   /// Register a closure to be called when the object changes.
@@ -174,7 +171,37 @@ class ChangeNotifier implements Listenable {
   @override
   void addListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
-    _listeners!.add(_ListenerEntry(listener));
+    if (_length == _listeners.length) {
+      if (_length == 0) {
+        _listeners = List<VoidCallback?>.filled(1, null);
+      } else {
+        final List<VoidCallback?> newListeners =
+            List<VoidCallback?>.filled(_listeners.length * 2, null);
+        for (int i = 0; i < _length; i++) {
+          newListeners[i] = _listeners[i];
+        }
+        _listeners = newListeners;
+      }
+    }
+    _listeners[_length++] = listener;
+  }
+
+  void _removeAt(int index) {
+    _length--;
+    if (_length * 2 <= _listeners.length) {
+      final List<VoidCallback?> newListeners = List<VoidCallback?>.filled(_length, null);
+
+      for (int i = 0; i < index; i++)
+        newListeners[i] = _listeners[i];
+
+      for (int i = index; i < _length; i++)
+        newListeners[i] = _listeners[i + 1];
+
+      _listeners = newListeners;
+    } else {
+      for (int i = index; i < _length; i++)
+        _listeners[i] = _listeners[i + 1];
+    }
   }
 
   /// Remove a previously registered closure from the list of closures that are
@@ -193,10 +220,16 @@ class ChangeNotifier implements Listenable {
   @override
   void removeListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
-    for (final _ListenerEntry entry in _listeners!) {
-      if (entry.listener == listener) {
-        entry.unlink();
-        return;
+    for (int i = 0; i < _length; i++) {
+      final VoidCallback? _listener = _listeners[i];
+      if (_listener == listener) {
+        if (_notificationCallStackDepth > 0) {
+          _listeners[i] = null;
+          _removedListeners++;
+        } else {
+          _removeAt(i);
+        }
+        break;
       }
     }
   }
@@ -210,7 +243,8 @@ class ChangeNotifier implements Listenable {
   @mustCallSuper
   void dispose() {
     assert(_debugAssertNotDisposed());
-    _listeners = null;
+    _listeners = List<VoidCallback?>.filled(0, null);
+    _disposed = true;
   }
 
   /// Call all the registered listeners.
@@ -232,15 +266,15 @@ class ChangeNotifier implements Listenable {
   @visibleForTesting
   void notifyListeners() {
     assert(_debugAssertNotDisposed());
-    if (_listeners!.isEmpty)
+    if (_length == 0)
       return;
 
-    final List<_ListenerEntry> localListeners = List<_ListenerEntry>.from(_listeners!);
+    _notificationCallStackDepth++;
 
-    for (final _ListenerEntry entry in localListeners) {
+    final int end = _length;
+    for (int i = 0; i < end; i++) {
       try {
-        if (entry.list != null)
-          entry.listener();
+        _listeners[i]?.call();
       } catch (exception, stack) {
         FlutterError.reportError(FlutterErrorDetails(
           exception: exception,
@@ -256,6 +290,26 @@ class ChangeNotifier implements Listenable {
           },
         ));
       }
+    }
+
+    _notificationCallStackDepth--;
+
+    if (_notificationCallStackDepth == 0 && _removedListeners > 0) {
+      // We really remove the listeners when all notifications are done.
+      final int newLength = _length - _removedListeners;
+      final List<VoidCallback?> newListeners = List<VoidCallback?>.filled(newLength, null);
+
+      int newIndex = 0;
+      for (int i = 0; i < _length; i++) {
+        final VoidCallback? listener = _listeners[i];
+        if (listener != null) {
+          newListeners[newIndex++] = listener;
+        }
+      }
+
+      _removedListeners = 0;
+      _length = newLength;
+      _listeners = newListeners;
     }
   }
 }

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -31,6 +31,21 @@ class B extends A with ChangeNotifier {
   }
 }
 
+class Counter with ChangeNotifier {
+  int get value => _value;
+  int _value = 0;
+  set value(int value) {
+    if (_value != value) {
+      _value = value;
+      notifyListeners();
+    }
+  }
+
+  void notify() {
+    notifyListeners();
+  }
+}
+
 void main() {
   testWidgets('ChangeNotifier', (WidgetTester tester) async {
     final List<String> log = <String>[];
@@ -396,4 +411,28 @@ void main() {
     ));
   });
 
+  test('notifyListener can be called recursively', () {
+    final Counter counter = Counter();
+    final List<String> log = <String>[];
+
+    final VoidCallback listener1 = () {
+      log.add('listener1');
+      if (counter.value < 0) {
+        counter.value = 0;
+      }
+    };
+
+    counter.addListener(listener1);
+    counter.notify();
+    expect(log, <String>['listener1']);
+    log.clear();
+
+    counter.value = 3;
+    expect(log, <String>['listener1']);
+    log.clear();
+
+    counter.value = -2;
+    expect(log, <String>['listener1', 'listener1']);
+    log.clear();
+  });
 }

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -20,7 +20,9 @@ class HasListenersTester<T> extends ValueNotifier<T> {
 
 class A {
   bool result = false;
-  void test() { result = true; }
+  void test() {
+    result = true;
+  }
 }
 
 class B extends A with ChangeNotifier {
@@ -49,9 +51,18 @@ class Counter with ChangeNotifier {
 void main() {
   testWidgets('ChangeNotifier', (WidgetTester tester) async {
     final List<String> log = <String>[];
-    void listener() { log.add('listener'); }
-    void listener1() { log.add('listener1'); }
-    void listener2() { log.add('listener2'); }
+    void listener() {
+      log.add('listener');
+    }
+
+    void listener1() {
+      log.add('listener1');
+    }
+
+    void listener2() {
+      log.add('listener2');
+    }
+
     void badListener() {
       log.add('badListener');
       throw ArgumentError();
@@ -126,9 +137,18 @@ void main() {
     final TestNotifier test = TestNotifier();
     final List<String> log = <String>[];
 
-    void listener1() { log.add('listener1'); }
-    void listener3() { log.add('listener3'); }
-    void listener4() { log.add('listener4'); }
+    void listener1() {
+      log.add('listener1');
+    }
+
+    void listener3() {
+      log.add('listener3');
+    }
+
+    void listener4() {
+      log.add('listener4');
+    }
+
     void listener2() {
       log.add('listener2');
       test.removeListener(listener1);
@@ -152,12 +172,19 @@ void main() {
     log.clear();
   });
 
-  test('During notifyListeners, a listener was added and removed immediately', () {
+  test('During notifyListeners, a listener was added and removed immediately',
+      () {
     final TestNotifier source = TestNotifier();
     final List<String> log = <String>[];
 
-    void listener3() { log.add('listener3'); }
-    void listener2() { log.add('listener2'); }
+    void listener3() {
+      log.add('listener3');
+    }
+
+    void listener2() {
+      log.add('listener2');
+    }
+
     void listener1() {
       log.add('listener1');
       source.addListener(listener2);
@@ -182,7 +209,10 @@ void main() {
       log.add('selfRemovingListener');
       source.removeListener(selfRemovingListener);
     }
-    void listener1() { log.add('listener1'); }
+
+    void listener1() {
+      log.add('listener1');
+    }
 
     source.addListener(listener1);
     source.addListener(selfRemovingListener);
@@ -193,7 +223,9 @@ void main() {
     expect(log, <String>['listener1', 'selfRemovingListener', 'listener1']);
   });
 
-  test('If the first listener removes itself, notifyListeners still notify all listeners', () {
+  test(
+      'If the first listener removes itself, notifyListeners still notify all listeners',
+      () {
     final TestNotifier source = TestNotifier();
     final List<String> log = <String>[];
 
@@ -201,6 +233,7 @@ void main() {
       log.add('selfRemovingListener');
       source.removeListener(selfRemovingListener);
     }
+
     void listener1() {
       log.add('listener1');
     }
@@ -220,8 +253,13 @@ void main() {
     final List<String> log = <String>[];
 
     final Listenable merged = Listenable.merge(<Listenable>[source1, source2]);
-    void listener1() { log.add('listener1'); }
-    void listener2() { log.add('listener2'); }
+    void listener1() {
+      log.add('listener1');
+    }
+
+    void listener2() {
+      log.add('listener2');
+    }
 
     merged.addListener(listener1);
     source1.notify();
@@ -251,8 +289,11 @@ void main() {
     final TestNotifier source2 = TestNotifier();
     final List<String> log = <String>[];
 
-    final Listenable merged = Listenable.merge(<Listenable?>[null, source1, null, source2, null]);
-    void listener() { log.add('listener'); }
+    final Listenable merged =
+        Listenable.merge(<Listenable?>[null, source1, null, source2, null]);
+    void listener() {
+      log.add('listener');
+    }
 
     merged.addListener(listener);
     source1.notify();
@@ -267,7 +308,9 @@ void main() {
     final List<String> log = <String>[];
 
     final Listenable merged = Listenable.merge(<Listenable>[source1, source2]);
-    void listener() { log.add('listener'); }
+    void listener() {
+      log.add('listener');
+    }
 
     merged.addListener(listener);
     source1.notify();
@@ -284,22 +327,32 @@ void main() {
   test('Cannot use a disposed ChangeNotifier', () {
     final TestNotifier source = TestNotifier();
     source.dispose();
-    expect(() { source.addListener(() { }); }, throwsFlutterError);
-    expect(() { source.removeListener(() { }); }, throwsFlutterError);
-    expect(() { source.dispose(); }, throwsFlutterError);
-    expect(() { source.notify(); }, throwsFlutterError);
+    expect(() {
+      source.addListener(() {});
+    }, throwsFlutterError);
+    expect(() {
+      source.removeListener(() {});
+    }, throwsFlutterError);
+    expect(() {
+      source.dispose();
+    }, throwsFlutterError);
+    expect(() {
+      source.notify();
+    }, throwsFlutterError);
   });
 
   test('Value notifier', () {
     final ValueNotifier<double> notifier = ValueNotifier<double>(2.0);
 
     final List<double> log = <double>[];
-    void listener() { log.add(notifier.value); }
+    void listener() {
+      log.add(notifier.value);
+    }
 
     notifier.addListener(listener);
     notifier.value = 3.0;
 
-    expect(log, equals(<double>[ 3.0 ]));
+    expect(log, equals(<double>[3.0]));
     log.clear();
 
     notifier.value = 3.0;
@@ -340,9 +393,10 @@ void main() {
 
     final TestNotifier source1 = TestNotifier();
     final TestNotifier source2 = TestNotifier();
-    void fakeListener() { }
+    void fakeListener() {}
 
-    final Listenable listenableUnderTest = Listenable.merge(<Listenable>[source1, source2]);
+    final Listenable listenableUnderTest =
+        Listenable.merge(<Listenable>[source1, source2]);
     expect(source1.isListenedTo, isFalse);
     expect(source2.isListenedTo, isFalse);
     listenableUnderTest.addListener(fakeListener);
@@ -354,12 +408,11 @@ void main() {
     expect(source2.isListenedTo, isFalse);
   });
 
-
   test('hasListeners', () {
     final HasListenersTester<bool> notifier = HasListenersTester<bool>(true);
     expect(notifier.testHasListeners, isFalse);
-    void test1() { }
-    void test2() { }
+    void test1() {}
+    void test2() {}
     notifier.addListener(test1);
     expect(notifier.testHasListeners, isTrue);
     notifier.addListener(test1);
@@ -403,12 +456,12 @@ void main() {
     }
     expect(error, isNotNull);
     expect(error!, isFlutterError);
-    expect(error.toStringDeep(), equalsIgnoringHashCodes(
-      'FlutterError\n'
-      '   A TestNotifier was used after being disposed.\n'
-      '   Once you have called dispose() on a TestNotifier, it can no\n'
-      '   longer be used.\n'
-    ));
+    expect(
+        error.toStringDeep(),
+        equalsIgnoringHashCodes('FlutterError\n'
+            '   A TestNotifier was used after being disposed.\n'
+            '   Once you have called dispose() on a TestNotifier, it can no\n'
+            '   longer be used.\n'));
   });
 
   test('notifyListener can be called recursively', () {
@@ -420,7 +473,7 @@ void main() {
       if (counter.value < 0) {
         counter.value = 0;
       }
-    };
+    }
 
     counter.addListener(listener1);
     counter.notify();
@@ -441,7 +494,7 @@ void main() {
     final List<String> log = <String>[];
     final List<VoidCallback> listeners = <VoidCallback>[];
 
-    void autoRemove(){
+    void autoRemove() {
       // We remove 4 listeners.
       // We will end up with (13-4 = 9) listeners.
       test.removeListener(listeners[1]);
@@ -454,13 +507,27 @@ void main() {
 
     // We add 12 more listeners.
     for (int i = 0; i < 12; i++) {
-      void listener () { log.add('listener$i'); }
+      void listener() {
+        log.add('listener$i');
+      }
+
       listeners.add(listener);
       test.addListener(listener);
     }
 
-    final List<int> remainingListenerIndexes = <int>[0,2,5,6,7,8,9,10,11];
-    final List<String> expectedLog = remainingListenerIndexes.map((int i) => 'listener$i').toList();
+    final List<int> remainingListenerIndexes = <int>[
+      0,
+      2,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11
+    ];
+    final List<String> expectedLog =
+        remainingListenerIndexes.map((int i) => 'listener$i').toList();
 
     test.notify();
     expect(log, expectedLog);

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -415,7 +415,7 @@ void main() {
     final Counter counter = Counter();
     final List<String> log = <String>[];
 
-    final VoidCallback listener1 = () {
+    void listener1() {
       log.add('listener1');
       if (counter.value < 0) {
         counter.value = 0;
@@ -454,7 +454,7 @@ void main() {
 
     // We add 12 more listeners.
     for (int i = 0; i < 12; i++) {
-      final VoidCallback listener = () { log.add('listener$i'); };
+      void listener () { log.add('listener$i'); }
       listeners.add(listener);
       test.addListener(listener);
     }

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -459,7 +459,7 @@ void main() {
       test.addListener(listener);
     }
 
-    final List<int> remainingListenerIndexes = [0,2,5,6,7,8,9,10,11];
+    final List<int> remainingListenerIndexes = <int>[0,2,5,6,7,8,9,10,11];
     final List<String> expectedLog = remainingListenerIndexes.map((int i) => 'listener$i').toList();
 
     test.notify();


### PR DESCRIPTION
## Description

This PR improves the performances of `ChangeNotifier` as described in #71900.

## Related Issues

#71900

## Tests

I added the following tests:

- **notifyListener can be called recursively** to verify that we can call `notifyListeners` while we are already notifying. 

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
