### PR TITLE
Stop using the List constructor

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/heavy_grid_view.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/heavy_grid_view.dart
@@ -19,7 +19,7 @@ class HeavyWidget extends StatelessWidget {
   HeavyWidget(this.index) : super(key: ValueKey<int>(index));
 
   final int index;
-  final List<int> _weight = List<int>(1000000);
+  final List<int> _weight = List<int>.filled(1000000, null);
 
   @override
   Widget build(BuildContext context) {

--- a/dev/tools/vitool/lib/vitool.dart
+++ b/dev/tools/vitool/lib/vitool.dart
@@ -77,7 +77,7 @@ class PathAnimation {
     final List<PathCommandAnimation> commands = <PathCommandAnimation>[];
     for (int commandIdx = 0; commandIdx < frames[0].paths[pathIdx].commands.length; commandIdx += 1) {
       final int numPointsInCommand = frames[0].paths[pathIdx].commands[commandIdx].points.length;
-      final List<List<Point<double>>> points = List<List<Point<double>>>(numPointsInCommand);
+      final List<List<Point<double>>> points = List<List<Point<double>>>.filled(numPointsInCommand, null);
       for (int j = 0; j < numPointsInCommand; j += 1)
         points[j] = <Point<double>>[];
       final String commandType = frames[0].paths[pathIdx].commands[commandIdx].type;
@@ -422,7 +422,7 @@ class SvgPathCommandBuilder {
 }
 
 List<double> _pointsToVector3Array(List<Point<double>> points) {
-  final List<double> result = List<double>(points.length * 3);
+  final List<double> result = List<double>.filled(points.length * 3, null);
   for (int i = 0; i < points.length; i += 1) {
     result[i * 3] = points[i].x;
     result[i * 3 + 1] = points[i].y;
@@ -433,7 +433,7 @@ List<double> _pointsToVector3Array(List<Point<double>> points) {
 
 List<Point<double>> _vector3ArrayToPoints(List<double> vector) {
   final int numPoints = (vector.length / 3).floor();
-  final List<Point<double>> points = List<Point<double>>(numPoints);
+  final List<Point<double>> points = List<Point<double>>.filled(numPoints, null);
   for (int i = 0; i < numPoints; i += 1) {
     points[i] = Point<double>(vector[i*3], vector[i*3 + 1]);
   }

--- a/examples/image_list/lib/main.dart
+++ b/examples/image_list/lib/main.dart
@@ -178,14 +178,14 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    final List<AnimationController> controllers = List<AnimationController>(IMAGES);
+    final List<AnimationController> controllers = List<AnimationController>.filled(IMAGES, null);
     for (int i = 0; i < IMAGES; i++) {
       controllers[i] = AnimationController(
         duration: const Duration(milliseconds: 3600),
         vsync: this,
       )..repeat();
     }
-    final List<Completer<bool>> completers = List<Completer<bool>>(IMAGES);
+    final List<Completer<bool>> completers = List<Completer<bool>>.filled(IMAGES, null);
     for (int i = 0; i < IMAGES; i++) {
       completers[i] = Completer<bool>();
     }


### PR DESCRIPTION
The List constructor will be deprecated in the Dart platform libraries.
It cannot be used in null safe code, and it's deprecated to give users a fair warning
to stop using it in legacy code.

See: https://dart-review.googlesource.com/c/sdk/+/173261

This removes uses of the List constructor which are detected by the Dart continuous build system.
It does not attempt to find further uses in other packages.

Equivalent engine PR is at https://github.com/flutter/engine/pull/22793