### PR TITLE
[flutter_tools] update message for `flutter create -t plugin` when no `--platforms` specified

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -294,7 +294,7 @@ class CreateCommand extends CreateBase {
       if (!creatingNewProject && requestedPlatforms.isNotEmpty) {
         _printPluginUpdatePubspecMessage(relativePluginPath, platformsString);
       } else if (_getSupportedPlatformsInPlugin(projectDir).isEmpty){
-        globals.printError(_kNoPlatformsArgMessage);
+        _printNoPluginMessage(relativePluginPath);
       }
     } else  {
       // Tell the user the next steps.
@@ -491,13 +491,18 @@ void _printPluginUpdatePubspecMessage(String pluginPath, String platformsString)
   globals.printStatus('''
 
 You need to update $pluginPath/pubspec.yaml to support $platformsString.
-For more information, see https://flutter.dev/go/developing-plugins.
+For more information, see https://flutter.dev/go/plugin-platforms.
 
 ''', emphasis: true, color: TerminalColor.red);
 }
 
-const String _kNoPlatformsArgMessage = '''
+void _printNoPluginMessage(String pluginPath) {
+    globals.printError('''
 
 Must specify at least one platform using --platforms.
-For more information, see https://flutter.dev/go/developing-plugins.
-''';
+If you want to add new platforms to this plugin, run `flutter create -t plugin --platforms <platforms> .` under $pluginPath.
+For more information, see https://flutter.dev/go/plugin-platforms.
+
+''');
+}
+

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -505,4 +505,3 @@ For more information, see https://flutter.dev/go/plugin-platforms.
 
 ''');
 }
-

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -500,7 +500,7 @@ void _printNoPluginMessage(String pluginPath) {
     globals.printError('''
 
 Must specify at least one platform using --platforms.
-If you want to add new platforms to this plugin, run `flutter create -t plugin --platforms <platforms> .` under $pluginPath.
+To add platforms, run `flutter create -t plugin --platforms <platforms> .` under $pluginPath.
 For more information, see https://flutter.dev/go/plugin-platforms.
 
 ''');

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -294,8 +294,9 @@ class CreateCommand extends CreateBase {
       if (!creatingNewProject && requestedPlatforms.isNotEmpty) {
         _printPluginUpdatePubspecMessage(relativePluginPath, platformsString);
       } else if (_getSupportedPlatformsInPlugin(projectDir).isEmpty){
-        _printNoPluginMessage(relativePluginPath);
+        _printNoPluginMessage();
       }
+      _printAddPlatformMessage(relativePluginPath);
     } else  {
       // Tell the user the next steps.
       final FlutterProject project = FlutterProject.fromPath(projectDirPath);
@@ -489,17 +490,20 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
 
 void _printPluginUpdatePubspecMessage(String pluginPath, String platformsString) {
   globals.printStatus('''
-
 You need to update $pluginPath/pubspec.yaml to support $platformsString.
-For more information, see https://flutter.dev/go/plugin-platforms.
 
 ''', emphasis: true, color: TerminalColor.red);
 }
 
-void _printNoPluginMessage(String pluginPath) {
+void _printNoPluginMessage() {
     globals.printError('''
+You've created a plugin project that doesn't yet support any platforms.
 
-Must specify at least one platform using --platforms.
+''');
+}
+
+void _printAddPlatformMessage(String pluginPath) {
+  globals.printStatus('''
 To add platforms, run `flutter create -t plugin --platforms <platforms> .` under $pluginPath.
 For more information, see https://flutter.dev/go/plugin-platforms.
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2316,6 +2316,7 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.errorText, contains(_kNoPlatformsMessage));
     expect(logger.errorText, contains('If you want to add new platforms to this plugin, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
+    expect(logger.errorText, contains('For more information, see https://flutter.dev/go/plugin-platforms.'));
 
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -32,7 +32,7 @@ import '../../src/context.dart';
 import '../../src/pubspec_schema.dart';
 import '../../src/testbed.dart';
 
-const String _kNoPlatformsMessage = 'Must specify at least one platform using --platforms.\n';
+const String _kNoPlatformsMessage = 'You\'ve created a plugin project that doesn\'t yet support any platforms.\n';
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 // TODO(fujino): replace FakePlatform.fromPlatform() with FakePlatform()
@@ -2315,8 +2315,8 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.errorText, contains(_kNoPlatformsMessage));
-    expect(logger.errorText, contains('To add platforms, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
-    expect(logger.errorText, contains('For more information, see https://flutter.dev/go/plugin-platforms.'));
+    expect(logger.statusText, contains('To add platforms, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
+    expect(logger.statusText, contains('For more information, see https://flutter.dev/go/plugin-platforms.'));
 
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2315,6 +2315,7 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.errorText, contains(_kNoPlatformsMessage));
+    expect(logger.errorText, contains('If you want to add new platforms to this plugin, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
 
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2315,7 +2315,7 @@ void main() {
 
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.errorText, contains(_kNoPlatformsMessage));
-    expect(logger.errorText, contains('If you want to add new platforms to this plugin, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
+    expect(logger.errorText, contains('To add platforms, run `flutter create -t plugin --platforms <platforms> .` under ${globals.fs.path.normalize(globals.fs.path.relative(projectDir.path))}.'));
     expect(logger.errorText, contains('For more information, see https://flutter.dev/go/plugin-platforms.'));
 
   }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

* Added an additional sentence for tips to add platforms when `--platforms` are not specified when running the command.
* Updated the link to a more accurate place.

This update is per offline discussion with @csells @amirh 

## Related Issues

N/A

## Tests

I added the following tests:

`created plugin supports no platforms should print `no platforms` message` was updated to reflect the change.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
