### PR TITLE
Move ios_content_validation_test from devicelab to LUCI

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -479,13 +479,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  ios_content_validation_test:
-    description: >
-      Builds an obfuscated app and verifies contents and structure
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-    on_luci: true
-
   tiles_scroll_perf_ios__timeline_summary:
     description: >
       Measures the runtime performance of the tiles tab in the Complex Layout sample app on iPhone 6.

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -247,6 +247,12 @@
          "flaky": false
       },
       {
+         "name": "Mac ios_content_validation_test",
+         "repo": "flutter",
+         "task_name": "mac_ios_content_validation_test",
+         "flaky": true
+      },
+      {
          "name": "Mac plugin_lint_mac",
          "repo": "flutter",
          "task_name": "mac_plugin_lint_mac",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -277,11 +277,18 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
+         "name":"Mac ios_content_validation_test",
+         "repo":"flutter",
+         "task_name":"mac_ios_content_validation_test",
+         "enabled":true,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
+      },
+      {
          "name":"Mac plugin_lint_mac",
          "repo":"flutter",
          "task_name":"mac_plugin_lint_mac",
          "enabled":true,
-         "run_if":["dev/**", "bin/**"]
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name":"Mac plugin_test",


### PR DESCRIPTION
## Description

`ios_content_validation_test` doesn't need to run against a real device and can be moved from the devicelab to a LUCI builder like the other previous `hostonly_devicelab_tests` tests.

## Related Issues

https://github.com/flutter/infra/pull/287