### PR TITLE
Prepare to migrate API doc samples and snippets to null safety

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -153,7 +153,7 @@ class SampleChecker {
   /// A RegExp that matches a Dart constructor.
   static final RegExp _constructorRegExp = RegExp(r'(const\s+)?_*[A-Z][a-zA-Z0-9<>._]*\(');
 
-  /// A RegExp that matches a dart version specification in a example preamble.
+  /// A RegExp that matches a dart version specification in an example preamble.
   static final RegExp _dartVersionRegExp = RegExp(r'\/\/ \/\/ @dart = ([0-9]+\.[0-9]+)');
 
   /// Whether or not to print verbose output.

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -529,7 +529,7 @@ linter:
     final String sectionId = _createNameFromSource('snippet', section.start.filename, section.start.line);
     final File outputFile = File(path.join(_tempDirectory.path, '$sectionId.dart'))..createSync(recursive: true);
     final List<Line> mainContents = <Line>[
-      if (!section.isNullSafe) const Line('// @dart = 2.9'),
+      if (!section.isNullSafe) const Line('// @dart = 2.9') else const Line(''),
       ...headers,
       const Line(''),
       Line('// From: ${section.start.filename}:${section.start.line}'),
@@ -600,7 +600,7 @@ linter:
       caseSensitive: false,
     );
     bool unknownAnalyzerErrors = false;
-    final int headerLength = headers.length + 2;
+    final int headerLength = headers.length + 3;
     for (final String error in errors) {
       final Match parts = errorPattern.matchAsPrefix(error);
       if (parts != null) {

--- a/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
@@ -35,7 +35,7 @@
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
 /// blabla it when it is blabla:
 ///

--- a/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
@@ -5,8 +5,8 @@
 // This file is used by ../analyze-sample-code_test.dart, which depends on the
 // precise contents (including especially the comments) of this file.
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // bool _visible = true;
 // class _Text extends Text {
 //   const _Text(String text) : super(text);

--- a/dev/bots/test/analyze-sample-code-test-null-safe-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-null-safe-input/known_broken_documentation.dart
@@ -103,3 +103,32 @@
 /// const text1 = _Text('Poor wandering ones!');
 /// ```
 /// {@end-tool}
+///
+/// {@tool snippet}
+/// Snippet with null-safe syntax
+///
+/// ```dart
+/// final String? bar = 'Hello';
+/// final int foo = null;
+/// ```
+/// {@end-tool}
+///
+/// {@tool dartpad --template=stateless_widget_material}
+/// Dartpad with null-safe syntax
+///
+/// ```dart preamble
+/// bool? _visible = true;
+/// final GlobalKey globalKey = GlobalKey();
+/// ```
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   final String title;
+///   return Opacity(
+///     key: globalKey,
+///     opacity: _visible! ? 1.0 : 0.0,
+///     child: Text(title),
+///   );
+/// }
+/// ```
+/// {@end-tool}

--- a/dev/bots/test/analyze-sample-code-test-null-safe-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-null-safe-input/known_broken_documentation.dart
@@ -5,7 +5,6 @@
 // This file is used by ../analyze-sample-code_test.dart, which depends on the
 // precise contents (including especially the comments) of this file.
 
-// Examples are not null safe.
 // Examples can assume:
 // bool _visible = true;
 // class _Text extends Text {
@@ -35,7 +34,7 @@
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material}
 /// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
 /// blabla it when it is blabla:
 ///

--- a/dev/bots/test/analyze-sample-code_test.dart
+++ b/dev/bots/test/analyze-sample-code_test.dart
@@ -42,16 +42,20 @@ void main() {
       ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
+      'In sample starting at known_broken_documentation.dart:117:      child: Text(title),',
+      '>>> The final variable \'title\' can\'t be read because it is potentially unassigned at this point (read_potentially_unassigned_final)',
       'known_broken_documentation.dart:30:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
       'known_broken_documentation.dart:62:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
+      'known_broken_documentation.dart:112:25: final int foo = null;',
+      '>>> A value of type \'Null\' can\'t be assigned to a variable of type \'int\' (invalid_assignment)',
       '',
-      'Found 1 sample code errors.',
-      '',
+      'Found 2 sample code errors.',
+      ''
     ]);
     expect(stdoutLines, <String>[
-      'Found 7 sample code sections.',
+      'Found 8 sample code sections.',
       'Starting analysis of code samples.',
       '',
     ]);

--- a/dev/bots/test/analyze-sample-code_test.dart
+++ b/dev/bots/test/analyze-sample-code_test.dart
@@ -17,6 +17,31 @@ void main() {
       ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
+      'known_broken_documentation.dart:31:9: new Opacity(',
+      '>>> Unnecessary new keyword (unnecessary_new)',
+      'known_broken_documentation.dart:63:9: new Opacity(',
+      '>>> Unnecessary new keyword (unnecessary_new)',
+      '',
+      'Found 1 sample code errors.',
+      '',
+    ]);
+    expect(stdoutLines, <String>[
+      'Found 7 sample code sections.',
+      'Starting analysis of code samples.',
+      '',
+    ]);
+  }, skip: Platform.isWindows);
+
+  test('analyze-sample-code null-safe', () {
+    final ProcessResult process = Process.runSync(
+      '../../bin/cache/dart-sdk/bin/dart',
+      <String>['analyze-sample-code.dart', 'test/analyze-sample-code-test-null-safe-input'],
+    );
+    final List<String> stdoutLines = process.stdout.toString().split('\n');
+    final List<String> stderrLines = process.stderr.toString().split('\n')
+      ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
+    expect(process.exitCode, isNot(equals(0)));
+    expect(stderrLines, <String>[
       'known_broken_documentation.dart:30:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
       'known_broken_documentation.dart:62:9: new Opacity(',
@@ -27,7 +52,7 @@ void main() {
     ]);
     expect(stdoutLines, <String>[
       'Found 7 sample code sections.',
-       'Starting analysis of code samples.',
+      'Starting analysis of code samples.',
       '',
     ]);
   }, skip: Platform.isWindows);

--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -23,7 +23,7 @@
 <div class="snippet-container">
     <div class="snippet" id="longSnippet{{serial}}">
         {{description}}
-        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id={{id}}&sample_channel={{channel}}"></iframe>
+        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&null_safety=true&sample_id={{id}}&sample_channel={{channel}}"></iframe>
         <div class="snippet-description">To create a local project with this code sample, run:<br/>
             <span class="snippet-create-command">flutter create --sample={{id}} mysample</span>
         </div>

--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/freeform_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/freeform_no_null_safety.tmpl
@@ -1,0 +1,12 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+{{code-imports}}
+
+{{code-main}}
+
+{{code-preamble}}
+
+{{code}}

--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -25,7 +24,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -26,7 +25,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_no_null_safety.tmpl
@@ -1,0 +1,38 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/cupertino.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -29,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold_no_null_safety.tmpl
@@ -1,0 +1,41 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/cupertino.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: _title,
+      home: CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(middle: const Text(_title)),
+        child: MyStatefulWidget(),
+      ),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -26,7 +25,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino_ticker_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_ticker_no_null_safety.tmpl
@@ -1,0 +1,39 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/cupertino.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+/// AnimationControllers can be created with `vsync: this` because of TickerProviderStateMixin.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> with TickerProviderStateMixin {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -26,7 +25,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_material_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_no_null_safety.tmpl
@@ -1,0 +1,38 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -26,7 +25,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_material_ticker_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_ticker_no_null_safety.tmpl
@@ -1,0 +1,39 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+/// AnimationControllers can be created with `vsync: this` because of TickerProviderStateMixin.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> with TickerProviderStateMixin {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_no_null_safety.tmpl
@@ -1,0 +1,37 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/widgets.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Flutter Code Sample',
+      home: MyStatefulWidget(),
+      color: const Color(0xffffffff),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_restoration.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_restoration.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -27,9 +26,9 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key, this.restorationId}) : super(key: key);
+  MyStatefulWidget({Key? key, this.restorationId}) : super(key: key);
 
-  final String restorationId;
+  final String? restorationId;
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
@@ -41,7 +40,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> with RestorationMix
   // In this example, the restoration ID for the mixin is passed in through
   // the [StatefulWidget]'s constructor.
   @override
-  String get restorationId => widget.restorationId;
+  String? get restorationId => widget.restorationId;
 
 {{code}}
 }

--- a/dev/snippets/config/templates/stateful_widget_restoration_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration_no_null_safety.tmpl
@@ -1,0 +1,47 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Flutter Code Sample',
+      home: Center(
+        child: MyStatefulWidget(restorationId: 'main'),
+      ),
+      color: const Color(0xffffffff),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key, this.restorationId}) : super(key: key);
+
+  final String restorationId;
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+/// RestorationProperty objects can be used because of RestorationMixin.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> with RestorationMixin {
+  // In this example, the restoration ID for the mixin is passed in through
+  // the [StatefulWidget]'s constructor.
+  @override
+  String get restorationId => widget.restorationId;
+
+{{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -29,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -31,7 +30,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -31,7 +30,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state_no_null_safety.tmpl
@@ -1,0 +1,41 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: Center(
+          child: MyStatefulWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+{{code}}

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_no_null_safety.tmpl
@@ -1,0 +1,43 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: Center(
+          child: MyStatefulWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_scaffold_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_no_null_safety.tmpl
@@ -1,0 +1,41 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: MyStatefulWidget(),
+      ),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateful_widget_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_ticker.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateful_widget_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_ticker.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -25,7 +24,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key key}) : super(key: key);
+  MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_ticker_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_ticker_no_null_safety.tmpl
@@ -1,0 +1,38 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/widgets.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Flutter Code Sample',
+      home: MyStatefulWidget(),
+      color: const Color(0xffffffff),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateful widget that the main application instantiates.
+class MyStatefulWidget extends StatefulWidget {
+  MyStatefulWidget({Key key}) : super(key: key);
+
+  @override
+  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+}
+
+/// This is the private State class that goes with MyStatefulWidget.
+/// AnimationControllers can be created with `vsync: this` because of TickerProviderStateMixin.
+class _MyStatefulWidgetState extends State<MyStatefulWidget> with TickerProviderStateMixin {
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget.tmpl
+++ b/dev/snippets/config/templates/stateless_widget.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -27,7 +26,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget.tmpl
+++ b/dev/snippets/config/templates/stateless_widget.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -27,7 +26,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_cupertino_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino_no_null_safety.tmpl
@@ -1,0 +1,34 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/cupertino.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -30,7 +29,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold_no_null_safety.tmpl
@@ -1,0 +1,37 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/cupertino.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      title: _title,
+      home: CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(middle: const Text(_title)),
+        body: MyStatelessWidget(),
+      ),
+    );
+  }
+}
+
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -27,7 +26,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_material_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material_no_null_safety.tmpl
@@ -1,0 +1,34 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_no_null_safety.tmpl
@@ -1,0 +1,34 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/widgets.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      title: 'Flutter Code Sample',
+      builder: (BuildContext context, Widget navigator) {
+        return MyStatelessWidget();
+      },
+      color: const Color(0xffffffff),
+    );
+  }
+}
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -30,7 +29,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
@@ -1,5 +1,4 @@
 /// Flutter code sample for {{element}}
-{{dart-version-header}}
 
 {{description}}
 
@@ -32,7 +31,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
+  MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
@@ -1,5 +1,5 @@
 /// Flutter code sample for {{element}}
-// @dart = 2.9
+{{dart-version-header}}
 
 {{description}}
 

--- a/dev/snippets/config/templates/stateless_widget_scaffold_center_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold_center_no_null_safety.tmpl
@@ -1,0 +1,39 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: Center(
+          child: MyStatelessWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/config/templates/stateless_widget_scaffold_no_null_safety.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold_no_null_safety.tmpl
@@ -1,0 +1,37 @@
+/// Flutter code sample for {{element}}
+// @dart = 2.9
+
+{{description}}
+
+import 'package:flutter/material.dart';
+
+{{code-imports}}
+
+void main() => runApp(new MyApp());
+
+/// This is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: MyStatelessWidget(),
+      ),
+    );
+  }
+}
+
+
+{{code-preamble}}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  {{code}}
+}

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -18,6 +18,7 @@ const String _kLibraryOption = 'library';
 const String _kOutputOption = 'output';
 const String _kPackageOption = 'package';
 const String _kTemplateOption = 'template';
+const String _kNullSafetyOption = 'null-safety';
 const String _kTypeOption = 'type';
 const String _kShowDartPad = 'dartpad';
 
@@ -104,6 +105,12 @@ void main(List<String> argList) {
         'final HTML output. This flag only applies when the type parameter is '
         '"sample".',
   );
+  parser.addFlag(
+    _kNullSafetyOption,
+    defaultsTo: true,
+    negatable: true,
+    help: 'Indicates whether the null-safety language features should be enabled.',
+  );
 
   final ArgResults args = parser.parse(argList);
 
@@ -176,6 +183,7 @@ void main(List<String> argList) {
     input,
     snippetType,
     showDartPad: args[_kShowDartPad] as bool,
+    enableNullSafety: args[_kNullSafetyOption] as bool,
     template: template,
     output: args[_kOutputOption] != null ? File(args[_kOutputOption] as String) : null,
     metadata: <String, Object>{

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -18,7 +18,6 @@ const String _kLibraryOption = 'library';
 const String _kOutputOption = 'output';
 const String _kPackageOption = 'package';
 const String _kTemplateOption = 'template';
-const String _kNullSafetyOption = 'null-safety';
 const String _kTypeOption = 'type';
 const String _kShowDartPad = 'dartpad';
 
@@ -105,12 +104,6 @@ void main(List<String> argList) {
         'final HTML output. This flag only applies when the type parameter is '
         '"sample".',
   );
-  parser.addFlag(
-    _kNullSafetyOption,
-    defaultsTo: true,
-    negatable: true,
-    help: 'Indicates whether the null-safety language features should be enabled.',
-  );
 
   final ArgResults args = parser.parse(argList);
 
@@ -183,7 +176,6 @@ void main(List<String> argList) {
     input,
     snippetType,
     showDartPad: args[_kShowDartPad] as bool,
-    enableNullSafety: args[_kNullSafetyOption] as bool,
     template: template,
     output: args[_kOutputOption] != null ? File(args[_kOutputOption] as String) : null,
     metadata: <String, Object>{

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -248,7 +248,6 @@ class SnippetGenerator {
               'The template $template was not found in the templates directory ${templatesDir.path}');
           exit(1);
         }
-
         final String templateContents = _loadFileAsUtf8(templateFile);
         String app = interpolateTemplate(snippetData, templateContents, metadata);
 

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -226,6 +226,7 @@ class SnippetGenerator {
     File input,
     SnippetType type, {
     bool showDartPad = false,
+    bool enableNullSafety = true,
     String template,
     File output,
     @required Map<String, Object> metadata,
@@ -248,6 +249,10 @@ class SnippetGenerator {
               'The template $template was not found in the templates directory ${templatesDir.path}');
           exit(1);
         }
+        if (!enableNullSafety) {
+          snippetData.add(_ComponentTuple('dart-version-header', <String>['// @dart = 2.9']));
+        }
+
         final String templateContents = _loadFileAsUtf8(templateFile);
         String app = interpolateTemplate(snippetData, templateContents, metadata);
 

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -226,7 +226,6 @@ class SnippetGenerator {
     File input,
     SnippetType type, {
     bool showDartPad = false,
-    bool enableNullSafety = true,
     String template,
     File output,
     @required Map<String, Object> metadata,
@@ -248,9 +247,6 @@ class SnippetGenerator {
           stderr.writeln(
               'The template $template was not found in the templates directory ${templatesDir.path}');
           exit(1);
-        }
-        if (!enableNullSafety) {
-          snippetData.add(_ComponentTuple('dart-version-header', <String>['// @dart = 2.9']));
         }
 
         final String templateContents = _loadFileAsUtf8(templateFile);

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -19,6 +19,7 @@ export 'package:meta/meta.dart' show
   required,
   visibleForTesting;
 
+// Examples are not null safe.
 // Examples can assume:
 // String _name;
 // bool _first;

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -19,8 +19,8 @@ export 'package:meta/meta.dart' show
   required,
   visibleForTesting;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // String _name;
 // bool _first;
 // bool _lights;

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 
 import 'tween.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController _controller;
 

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -7,8 +7,8 @@ import 'package:flutter/foundation.dart';
 
 import 'tween.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController _controller;
 
 /// The status of an animation.

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -16,8 +16,8 @@ import 'listener_helpers.dart';
 
 export 'package:flutter/scheduler.dart' show TickerFuture, TickerCanceled;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController _controller, fadeAnimationController, sizeAnimationController;
 // bool dismissed;
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -16,6 +16,7 @@ import 'listener_helpers.dart';
 
 export 'package:flutter/scheduler.dart' show TickerFuture, TickerCanceled;
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController _controller, fadeAnimationController, sizeAnimationController;
 // bool dismissed;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -11,6 +11,7 @@ import 'animation.dart';
 import 'curves.dart';
 import 'listener_helpers.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController controller;
 

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -11,8 +11,8 @@ import 'animation.dart';
 import 'curves.dart';
 import 'listener_helpers.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController controller;
 
 class _AlwaysCompleteAnimation extends Animation<double> {

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -319,7 +319,7 @@ class Cubic extends Curve {
 /// part of the curve, or hardly at all in another part of the curve, depending
 /// on the definition of the curve.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to use a [Curve2D] to modify the position of a widget
 /// so that it can follow an arbitrary path.
 ///

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -319,7 +319,7 @@ class Cubic extends Curve {
 /// part of the curve, or hardly at all in another part of the curve, depending
 /// on the definition of the curve.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to use a [Curve2D] to modify the position of a widget
 /// so that it can follow an arbitrary path.
 ///

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -11,8 +11,8 @@ import 'animation.dart';
 import 'animations.dart';
 import 'curves.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // Animation<Offset> _animation;
 // AnimationController _controller;
 

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -11,6 +11,7 @@ import 'animation.dart';
 import 'animations.dart';
 import 'curves.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // Animation<Offset> _animation;
 // AnimationController _controller;

--- a/packages/flutter/lib/src/animation/tween_sequence.dart
+++ b/packages/flutter/lib/src/animation/tween_sequence.dart
@@ -6,8 +6,8 @@
 import 'animation.dart';
 import 'tween.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController myAnimationController;
 
 /// Enables creating an [Animation] whose value is defined by a sequence of

--- a/packages/flutter/lib/src/animation/tween_sequence.dart
+++ b/packages/flutter/lib/src/animation/tween_sequence.dart
@@ -6,6 +6,7 @@
 import 'animation.dart';
 import 'tween.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController myAnimationController;
 

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -13,6 +13,8 @@ import 'localizations.dart';
 import 'route.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
+
 /// An application that uses Cupertino design.
 ///
 /// A convenience widget that wraps a number of widgets that are commonly

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -13,7 +13,8 @@ import 'localizations.dart';
 import 'route.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// An application that uses Cupertino design.
 ///

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -11,6 +11,7 @@ import '../widgets/media_query.dart';
 import 'interface_level.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // Widget child;
 // BuildContext context;

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -11,8 +11,8 @@ import '../widgets/media_query.dart';
 import 'interface_level.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // Widget child;
 // BuildContext context;
 

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -75,7 +75,7 @@ enum _ContextMenuLocation {
 /// child's corners and allowing its aspect ratio to expand, similar to the
 /// Photos app on iOS.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows a very simple CupertinoContextMenu for an empty red
 /// 100x100 Container. Simply long press on it to open.

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -75,7 +75,7 @@ enum _ContextMenuLocation {
 /// child's corners and allowing its aspect ratio to expand, similar to the
 /// Photos app on iOS.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This sample shows a very simple CupertinoContextMenu for an empty red
 /// 100x100 Container. Simply long press on it to open.

--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -8,6 +8,8 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
+
 // Content padding determined via SwiftUI's `Form` view in the iOS 14.2 SDK.
 const EdgeInsetsGeometry _kDefaultPadding =
     EdgeInsetsDirectional.fromSTEB(20.0, 6.0, 6.0, 6.0);

--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -8,7 +8,8 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // Content padding determined via SwiftUI's `Form` view in the iOS 14.2 SDK.
 const EdgeInsetsGeometry _kDefaultPadding =

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -267,7 +267,7 @@ typedef RefreshCallback = Future<void> Function();
 /// sliver such as [CupertinoSliverNavigationBar] and your main scrollable
 /// content's sliver.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// When the user scrolls past [refreshTriggerPullDistance],
 /// this sample shows the default iOS pull to refresh indicator for 1 second and

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -267,7 +267,7 @@ typedef RefreshCallback = Future<void> Function();
 /// sliver such as [CupertinoSliverNavigationBar] and your main scrollable
 /// content's sliver.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// When the user scrolls past [refreshTriggerPullDistance],
 /// this sample shows the default iOS pull to refresh indicator for 1 second and

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -12,7 +12,8 @@ import 'icons.dart';
 import 'localizations.dart';
 import 'text_field.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A [CupertinoTextField] that mimics the look and behavior of UIKit's
 /// `UISearchTextField`.

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -12,6 +12,8 @@ import 'icons.dart';
 import 'localizations.dart';
 import 'text_field.dart';
 
+// Examples are not null safe.
+
 /// A [CupertinoTextField] that mimics the look and behavior of UIKit's
 /// `UISearchTextField`.
 ///

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -11,7 +11,8 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // Minimum padding from edges of the segmented control to edges of
 // encompassing widget.

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -11,6 +11,8 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
+// Examples are not null safe.
+
 // Minimum padding from edges of the segmented control to edges of
 // encompassing widget.
 const EdgeInsetsGeometry _kHorizontalItemPadding = EdgeInsets.symmetric(horizontal: 16.0);

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -13,8 +13,8 @@ import 'colors.dart';
 import 'theme.dart';
 import 'thumb_painter.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // int _cupertinoSliderValue = 1;
 // void setState(VoidCallback fn) { }
 

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -13,6 +13,7 @@ import 'colors.dart';
 import 'theme.dart';
 import 'thumb_painter.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // int _cupertinoSliderValue = 1;
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -12,7 +12,8 @@ import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // Extracted from https://developer.apple.com/design/resources/.
 

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -12,6 +12,8 @@ import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
 
+// Examples are not null safe.
+
 // Extracted from https://developer.apple.com/design/resources/.
 
 // Minimum padding from edges of the segmented control to edges of

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -13,8 +13,8 @@ import 'package:flutter/services.dart';
 import 'colors.dart';
 import 'thumb_painter.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // bool _lights;
 // void setState(VoidCallback fn) { }
 

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -13,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'colors.dart';
 import 'thumb_painter.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // bool _lights;
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -16,7 +16,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 const TextStyle _kDefaultPlaceholderStyle = TextStyle(
   fontWeight: FontWeight.w400,

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -16,6 +16,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 
+// Examples are not null safe.
+
 const TextStyle _kDefaultPlaceholderStyle = TextStyle(
   fontWeight: FontWeight.w400,
   color: CupertinoColors.placeholderText,

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -11,6 +11,8 @@ import 'form_row.dart';
 import 'text_field.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
+
 /// Creates a [CupertinoFormRow] containing a [FormField] that wraps
 /// a [CupertinoTextField].
 ///
@@ -72,7 +74,7 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows how to move the focus to the next field when the user
 /// presses the SPACE key.
 ///

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -74,7 +74,7 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows how to move the focus to the next field when the user
 /// presses the SPACE key.
 ///

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -11,7 +11,8 @@ import 'form_row.dart';
 import 'text_field.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Creates a [CupertinoFormRow] containing a [FormField] that wraps
 /// a [CupertinoTextField].

--- a/packages/flutter/lib/src/foundation/annotations.dart
+++ b/packages/flutter/lib/src/foundation/annotations.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class Cat { }
 
 /// A category with which to annotate a class, for documentation

--- a/packages/flutter/lib/src/foundation/annotations.dart
+++ b/packages/flutter/lib/src/foundation/annotations.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Examples are not null safe.
 // Examples can assume:
 // class Cat { }
 

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -10,6 +10,7 @@ import 'diagnostics.dart';
 import 'print.dart';
 import 'stack_frame.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // String runtimeType;
 // bool draconisAlive;

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -10,8 +10,8 @@ import 'diagnostics.dart';
 import 'print.dart';
 import 'stack_frame.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // String runtimeType;
 // bool draconisAlive;
 // bool draconisAmulet;

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -11,8 +11,8 @@ import 'constants.dart';
 import 'debug.dart';
 import 'object.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // int rows, columns;
 // String _name;
 // bool inherit;

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -11,6 +11,7 @@ import 'constants.dart';
 import 'debug.dart';
 import 'object.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // int rows, columns;
 // String _name;

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -43,7 +43,7 @@ import 'theme.dart';
 ///
 /// If your application does not have a [Drawer], you should provide an
 /// affordance to call [showAboutDialog] or (at least) [showLicensePage].
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
 /// uses an [AboutListTile], and the second uses the [showAboutDialog] function.

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -43,7 +43,7 @@ import 'theme.dart';
 ///
 /// If your application does not have a [Drawer], you should provide an
 /// affordance to call [showAboutDialog] or (at least) [showLicensePage].
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
 /// uses an [AboutListTile], and the second uses the [showAboutDialog] function.

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -43,13 +43,13 @@ import 'theme.dart';
 ///
 /// If your application does not have a [Drawer], you should provide an
 /// affordance to call [showAboutDialog] or (at least) [showLicensePage].
+///
 /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
 /// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
 ///
 /// ```dart
-///
 ///  Widget build(BuildContext context) {
 ///    final TextStyle textStyle = Theme.of(context).textTheme.bodyText2;
 ///    final List<Widget> aboutBoxChildren = <Widget>[
@@ -110,10 +110,9 @@ import 'theme.dart';
 ///        ),
 ///      ),
 ///    );
-///}
+/// }
 /// ```
 /// {@end-tool}
-///
 class AboutListTile extends StatelessWidget {
   /// Creates a list tile for showing an about box.
   ///

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -47,7 +47,7 @@ import 'theme.dart';
 /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
-/// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
+/// uses an [AboutListTile], and the second uses the [showAboutDialogE] function.
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -47,7 +47,7 @@ import 'theme.dart';
 /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows two ways to open [AboutDialog]. The first one
-/// uses an [AboutListTile], and the second uses the [showAboutDialogE] function.
+/// uses an [AboutListTile], and the second uses the [showAboutDialog] function.
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -9,6 +9,7 @@ part of material_animated_icons;
 // See: https://github.com/flutter/flutter/issues/1831 for details regarding
 // generic vector graphics support in Flutter.
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController controller;
 

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -9,8 +9,8 @@ part of material_animated_icons;
 // See: https://github.com/flutter/flutter/issues/1831 for details regarding
 // generic vector graphics support in Flutter.
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController controller;
 
 /// Shows an animated icon at a given animation [progress].

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -18,6 +18,8 @@ import 'page.dart';
 import 'scaffold.dart' show ScaffoldMessenger, ScaffoldMessengerState;
 import 'theme.dart';
 
+// Examples are not null safe.
+
 /// [MaterialApp] uses this [TextStyle] as its [DefaultTextStyle] to encourage
 /// developers to be intentional about their [DefaultTextStyle].
 ///

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -18,7 +18,8 @@ import 'page.dart';
 import 'scaffold.dart' show ScaffoldMessenger, ScaffoldMessengerState;
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// [MaterialApp] uses this [TextStyle] as its [DefaultTextStyle] to encourage
 /// developers to be intentional about their [DefaultTextStyle].

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -91,7 +91,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 /// to false. In that case a null leading widget will result in the middle/title widget
 /// stretching to start.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This sample shows an [AppBar] with two simple actions. The first action
 /// opens a [SnackBar], while the second action navigates to a new page.

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -91,7 +91,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 /// to false. In that case a null leading widget will result in the middle/title widget
 /// stretching to start.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This sample shows an [AppBar] with two simple actions. The first action
 /// opens a [SnackBar], while the second action navigates to a new page.

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -18,7 +18,7 @@ import 'theme.dart';
 /// They are persistent and non-modal, allowing the user to either ignore them or
 /// interact with them at any time.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -18,7 +18,7 @@ import 'theme.dart';
 /// They are persistent and non-modal, allowing the user to either ignore them or
 /// interact with them at any time.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -12,8 +12,8 @@ import 'material.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // Widget bottomAppBarContents;
 
 /// A container that is typically used with [Scaffold.bottomNavigationBar], and

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -12,6 +12,7 @@ import 'material.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // Widget bottomAppBarContents;
 

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -63,7 +63,7 @@ enum BottomNavigationBarType {
 ///    case it's assumed that each item will have a different background color
 ///    and that background color will contrast well with white.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows a [BottomNavigationBar] as it is used within a [Scaffold]
 /// widget. The [BottomNavigationBar] has three [BottomNavigationBarItem]
 /// widgets and the [currentIndex] is set to index 0. The selected item is

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -63,7 +63,7 @@ enum BottomNavigationBarType {
 ///    case it's assumed that each item will have a different background color
 ///    and that background color will contrast well with white.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows a [BottomNavigationBar] as it is used within a [Scaffold]
 /// widget. The [BottomNavigationBar] has three [BottomNavigationBarItem]
 /// widgets and the [currentIndex] is set to index 0. The selected item is

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -596,7 +596,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This example demonstrates how to use `showModalBottomSheet` to display a
 /// bottom sheet that obscures the content behind it when a user taps a button.

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -596,7 +596,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// Returns a `Future` that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the modal bottom sheet was closed.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This example demonstrates how to use `showModalBottomSheet` to display a
 /// bottom sheet that obscures the content behind it when a user taps a button.

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -20,7 +20,7 @@ import 'theme.dart';
 /// some text describing a musical, and the other with buttons for buying
 /// tickets or listening to the show.](https://flutter.github.io/assets-for-api-docs/assets/material/card.png)
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows creation of a [Card] widget that shows album information
 /// and two actions.
@@ -63,7 +63,7 @@ import 'theme.dart';
 /// Sometimes the primary action area of a card is the card itself. Cards can be
 /// one large touch target that shows a detail screen when tapped.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows creation of a [Card] widget that can be tapped. When
 /// tapped this [Card]'s [InkWell] displays an "ink splash" that fills the

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -20,7 +20,7 @@ import 'theme.dart';
 /// some text describing a musical, and the other with buttons for buying
 /// tickets or listening to the show.](https://flutter.github.io/assets-for-api-docs/assets/material/card.png)
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows creation of a [Card] widget that shows album information
 /// and two actions.
@@ -63,7 +63,7 @@ import 'theme.dart';
 /// Sometimes the primary action area of a card is the card itself. Cards can be
 /// one large touch target that shows a detail screen when tapped.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows creation of a [Card] widget that can be tapped. When
 /// tapped this [Card]'s [InkWell] displays an "ink splash" that fills the

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -9,8 +9,8 @@ import 'list_tile.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // void setState(VoidCallback fn) { }
 
 /// A [ListTile] with a [Checkbox]. In other words, a checkbox with a label.

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -9,6 +9,7 @@ import 'list_tile.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // void setState(VoidCallback fn) { }
 
@@ -39,7 +40,7 @@ import 'theme_data.dart';
 /// To show the [CheckboxListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![CheckboxListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile.png)
 ///
@@ -84,7 +85,7 @@ import 'theme_data.dart';
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool sample --template=stateful_widget_scaffold_center}
+/// {@tool sample --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![Checkbox list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile_semantics.png)
 ///
@@ -168,7 +169,7 @@ import 'theme_data.dart';
 /// combining [Checkbox] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![Custom checkbox list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile_custom.png)
 ///

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -40,7 +40,7 @@ import 'theme_data.dart';
 /// To show the [CheckboxListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![CheckboxListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile.png)
 ///
@@ -85,7 +85,7 @@ import 'theme_data.dart';
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool sample --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool sample --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![Checkbox list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile_semantics.png)
 ///
@@ -169,7 +169,7 @@ import 'theme_data.dart';
 /// combining [Checkbox] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![Custom checkbox list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/checkbox_list_tile_custom.png)
 ///

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -23,7 +23,8 @@ import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // Some design constants
 const double _kChipHeight = 32.0;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -23,6 +23,8 @@ import 'theme.dart';
 import 'theme_data.dart';
 import 'tooltip.dart';
 
+// Examples are not null safe.
+
 // Some design constants
 const double _kChipHeight = 32.0;
 const double _kDeleteIconSize = 18.0;
@@ -221,7 +223,7 @@ abstract class DeletableChipAttributes {
   /// that the user tapped the delete button. In order to delete the chip, you
   /// have to do something similar to the following sample:
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
   ///
   /// This sample shows how to use [onDeleted] to remove an entry when the
   /// delete button is tapped.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -223,7 +223,7 @@ abstract class DeletableChipAttributes {
   /// that the user tapped the delete button. In order to delete the chip, you
   /// have to do something similar to the following sample:
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
   ///
   /// This sample shows how to use [onDeleted] to remove an entry when the
   /// delete button is tapped.

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -8,8 +8,8 @@ import 'constants.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // String userAvatarUrl;
 
 /// A circle that represents a user.

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -8,6 +8,7 @@ import 'constants.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // String userAvatarUrl;
 

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -6,7 +6,8 @@ import 'dart:ui' show Color;
 
 import 'package:flutter/painting.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Defines a single color as well a color swatch with ten shades of the color.
 ///

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show Color;
 
 import 'package:flutter/painting.dart';
 
+// Examples are not null safe.
+
 /// Defines a single color as well a color swatch with ten shades of the color.
 ///
 /// The color's shades are referred to by index. The greater the index, the

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -260,7 +260,7 @@ class DataCell {
 /// [PaginatedDataTable] which automatically splits the data into
 /// multiple pages.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to display a [DataTable] with three columns: name, age, and
 /// role. The columns are defined by three [DataColumn] objects. The table
@@ -322,7 +322,7 @@ class DataCell {
 /// {@end-tool}
 ///
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to display a [DataTable] with alternate colors per
 /// row, and a custom color for when the row is selected.

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -260,7 +260,7 @@ class DataCell {
 /// [PaginatedDataTable] which automatically splits the data into
 /// multiple pages.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to display a [DataTable] with three columns: name, age, and
 /// role. The columns are defined by three [DataColumn] objects. The table
@@ -322,7 +322,7 @@ class DataCell {
 /// {@end-tool}
 ///
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to display a [DataTable] with alternate colors per
 /// row, and a custom color for when the row is selected.

--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -22,8 +22,8 @@ import 'theme.dart';
 // and it is what most apps would have used).
 
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 const Duration _kMonthScrollDuration = Duration(milliseconds: 200);

--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -22,6 +22,7 @@ import 'theme.dart';
 // and it is what most apps would have used).
 
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -17,8 +17,8 @@ import 'material_localizations.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // enum Department { treasury, state }
 // BuildContext context;
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -17,6 +17,7 @@ import 'material_localizations.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // enum Department { treasury, state }
 // BuildContext context;

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -8,8 +8,8 @@ import 'package:flutter/painting.dart';
 import 'divider_theme.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 /// A thin horizontal line, with padding on either side.

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -25,7 +25,7 @@ import 'theme.dart';
 /// The box's total height is controlled by [height]. The appropriate
 /// padding is automatically computed from the height.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to display a Divider between an orange and blue box
 /// inside a column. The Divider is 20 logical pixels in height and contains a

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -8,6 +8,7 @@ import 'package:flutter/painting.dart';
 import 'divider_theme.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 
@@ -24,7 +25,7 @@ import 'theme.dart';
 /// The box's total height is controlled by [height]. The appropriate
 /// padding is automatically computed from the height.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to display a Divider between an orange and blue box
 /// inside a column. The Divider is 20 logical pixels in height and contains a

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -728,7 +728,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// dropdown's value. It should also call [State.setState] to rebuild the
 /// dropdown with the new value.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// This sample shows a `DropdownButton` with a large arrow icon,
 /// purple text style, and bold purple underline, whose value is one of "One",
@@ -912,7 +912,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// from the list corresponds to the [DropdownMenuItem] of the same index
   /// in [items].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   ///
   /// This sample shows a `DropdownButton` with a button with [Text] that
   /// corresponds to but is unique from [DropdownMenuItem].
@@ -963,7 +963,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// To use a separate text style for selected item when it's displayed within
   /// the dropdown button, consider using [selectedItemBuilder].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   ///
   /// This sample shows a `DropdownButton` with a dropdown button text style
   /// that is different than its menu items.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -728,7 +728,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// dropdown's value. It should also call [State.setState] to rebuild the
 /// dropdown with the new value.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// This sample shows a `DropdownButton` with a large arrow icon,
 /// purple text style, and bold purple underline, whose value is one of "One",
@@ -912,7 +912,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// from the list corresponds to the [DropdownMenuItem] of the same index
   /// in [items].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   ///
   /// This sample shows a `DropdownButton` with a button with [Text] that
   /// corresponds to but is unique from [DropdownMenuItem].
@@ -963,7 +963,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// To use a separate text style for selected item when it's displayed within
   /// the dropdown button, consider using [selectedItemBuilder].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   ///
   /// This sample shows a `DropdownButton` with a dropdown button text style
   /// that is different than its menu items.

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -148,7 +148,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
 /// Note that [expansionCallback] behaves differently for [ExpansionPanelList]
 /// and [ExpansionPanelList.radio].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// Here is a simple example of how to implement ExpansionPanelList.
 ///
@@ -252,7 +252,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// arguments must not be null. The [children] objects must be instances
   /// of [ExpansionPanelRadio].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   ///
   /// Here is a simple example of how to implement ExpansionPanelList.radio.
   ///

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -148,7 +148,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
 /// Note that [expansionCallback] behaves differently for [ExpansionPanelList]
 /// and [ExpansionPanelList.radio].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// Here is a simple example of how to implement ExpansionPanelList.
 ///
@@ -252,7 +252,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// arguments must not be null. The [children] objects must be instances
   /// of [ExpansionPanelRadio].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   ///
   /// Here is a simple example of how to implement ExpansionPanelList.radio.
   ///

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -53,7 +53,7 @@ enum StretchMode {
 /// [FlexibleSpaceBar.createSettings], to convey sizing information down to the
 /// [FlexibleSpaceBar].
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This sample application demonstrates the different features of the
 /// [FlexibleSpaceBar] when used in a [SliverAppBar]. This app bar is configured
 /// to stretch into the overscroll space, and uses the

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -53,7 +53,7 @@ enum StretchMode {
 /// [FlexibleSpaceBar.createSettings], to convey sizing information down to the
 /// [FlexibleSpaceBar].
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This sample application demonstrates the different features of the
 /// [FlexibleSpaceBar] when used in a [SliverAppBar]. This app bar is configured
 /// to stretch into the overscroll space, and uses the

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -58,7 +58,7 @@ class _DefaultHeroTag {
 /// disabled. Consider changing the [backgroundColor] if disabling the floating
 /// action button.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to display a [FloatingActionButton] in a
 /// [Scaffold], with a pink [backgroundColor] and a thumbs up [Icon].
 ///
@@ -85,7 +85,7 @@ class _DefaultHeroTag {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to make an extended [FloatingActionButton] in a
 /// [Scaffold], with a  pink [backgroundColor], a thumbs up [Icon] and a
 /// [Text] label that reads "Approve".

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -58,7 +58,7 @@ class _DefaultHeroTag {
 /// disabled. Consider changing the [backgroundColor] if disabling the floating
 /// action button.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to display a [FloatingActionButton] in a
 /// [Scaffold], with a pink [backgroundColor] and a thumbs up [Icon].
 ///
@@ -85,7 +85,7 @@ class _DefaultHeroTag {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to make an extended [FloatingActionButton] in a
 /// [Scaffold], with a  pink [backgroundColor], a thumbs up [Icon] and a
 /// [Text] label that reads "Approve".

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -431,7 +431,7 @@ abstract class FloatingActionButtonLocation {
 /// You can create your own subclass of [StandardFabLocation]
 /// to implement a custom [FloatingActionButtonLocation].
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This is an example of a user-defined [FloatingActionButtonLocation].
 ///

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -431,7 +431,7 @@ abstract class FloatingActionButtonLocation {
 /// You can create your own subclass of [StandardFabLocation]
 /// to implement a custom [FloatingActionButtonLocation].
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This is an example of a user-defined [FloatingActionButtonLocation].
 ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -40,7 +40,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// requirements in the Material Design specification. The [alignment] controls
 /// how the icon itself is positioned within the hit region.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// This sample shows an `IconButton` that uses the Material icon "volume_up" to
 /// increase the volume.
@@ -84,7 +84,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// the underlying [Material] along with the splash and highlight
 /// [InkResponse] contributed by descendant widgets.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// In this sample the icon button's background color is defined with an [Ink]
 /// widget whose child is an [IconButton]. The icon button's filled background

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -40,7 +40,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// requirements in the Material Design specification. The [alignment] controls
 /// how the icon itself is positioned within the hit region.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// This sample shows an `IconButton` that uses the Material icon "volume_up" to
 /// increase the volume.
@@ -84,7 +84,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// the underlying [Material] along with the splash and highlight
 /// [InkResponse] contributed by descendant widgets.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// In this sample the icon button's background color is defined with an [Ink]
 /// widget whose child is an [IconButton]. The icon button's filled background

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1170,7 +1170,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 ///
 /// An example of this situation is as follows:
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// Tap the container to cause it to grow. Then, tap it again and hold before
 /// the widget reaches its maximum size to observe the clipped ink splash.

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1170,7 +1170,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 ///
 /// An example of this situation is as follows:
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// Tap the container to cause it to grow. Then, tap it again and hold before
 /// the widget reaches its maximum size to observe the clipped ink splash.

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2389,7 +2389,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// to describe their decoration. (In fact, this class is merely the
 /// configuration of an [InputDecorator], which does all the heavy lifting.)
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to style a `TextField` using an `InputDecorator`. The
 /// TextField displays a "send message" icon to the left of the input area,
@@ -2414,7 +2414,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to style a "collapsed" `TextField` using an
 /// `InputDecorator`. The collapsed `TextField` surrounds the hint text and
@@ -2434,7 +2434,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to create a `TextField` with hint text, a red border
 /// on all sides, and an error message. To display a red border and error
@@ -2455,7 +2455,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to style a `TextField` with a round border and
 /// additional text before and after the input area. It displays "Prefix" before
@@ -2836,7 +2836,7 @@ class InputDecoration {
   /// setting the constraints' minimum height and width to a value lower than
   /// 48px.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
   /// This example shows the differences between two `TextField` widgets when
   /// [prefixIconConstraints] is set to the default value and when one is not.
   ///
@@ -3004,7 +3004,7 @@ class InputDecoration {
   /// If null, a [BoxConstraints] with a minimum width and height of 48px is
   /// used.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
   /// This example shows the differences between two `TextField` widgets when
   /// [suffixIconConstraints] is set to the default value and when one is not.
   ///

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2389,7 +2389,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// to describe their decoration. (In fact, this class is merely the
 /// configuration of an [InputDecorator], which does all the heavy lifting.)
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to style a `TextField` using an `InputDecorator`. The
 /// TextField displays a "send message" icon to the left of the input area,
@@ -2414,7 +2414,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to style a "collapsed" `TextField` using an
 /// `InputDecorator`. The collapsed `TextField` surrounds the hint text and
@@ -2434,7 +2434,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to create a `TextField` with hint text, a red border
 /// on all sides, and an error message. To display a red border and error
@@ -2455,7 +2455,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to style a `TextField` with a round border and
 /// additional text before and after the input area. It displays "Prefix" before
@@ -2836,7 +2836,7 @@ class InputDecoration {
   /// setting the constraints' minimum height and width to a value lower than
   /// 48px.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold}
+  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
   /// This example shows the differences between two `TextField` widgets when
   /// [prefixIconConstraints] is set to the default value and when one is not.
   ///
@@ -3004,7 +3004,7 @@ class InputDecoration {
   /// If null, a [BoxConstraints] with a minimum width and height of 48px is
   /// used.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold}
+  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
   /// This example shows the differences between two `TextField` widgets when
   /// [suffixIconConstraints] is set to the default value and when one is not.
   ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -416,7 +416,7 @@ enum ListTileControlAffinity {
 /// you're looking for, it's easy to create custom list items with a
 /// combination of other widgets, such as [Row]s and [Column]s.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// Here is an example of a custom list item that resembles a YouTube-related
 /// video list item created with [Expanded] and [Container] widgets.
@@ -537,7 +537,7 @@ enum ListTileControlAffinity {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// Here is an example of an article list item with multiline titles and
 /// subtitles. It utilizes [Row]s and [Column]s, as well as [Expanded] and
@@ -889,7 +889,7 @@ class ListTile extends StatelessWidget {
   /// By default the selected color is the theme's primary color. The selected color
   /// can be overridden with a [ListTileTheme].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   ///
   /// Here is an example of using a [StatefulWidget] to keep track of the
   /// selected index, and using that to set the `selected` property on the

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -416,7 +416,7 @@ enum ListTileControlAffinity {
 /// you're looking for, it's easy to create custom list items with a
 /// combination of other widgets, such as [Row]s and [Column]s.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// Here is an example of a custom list item that resembles a YouTube-related
 /// video list item created with [Expanded] and [Container] widgets.
@@ -537,7 +537,7 @@ enum ListTileControlAffinity {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// Here is an example of an article list item with multiline titles and
 /// subtitles. It utilizes [Row]s and [Column]s, as well as [Expanded] and
@@ -889,7 +889,7 @@ class ListTile extends StatelessWidget {
   /// By default the selected color is the theme's primary color. The selected color
   /// can be overridden with a [ListTileTheme].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   ///
   /// Here is an example of using a [StatefulWidget] to keep track of the
   /// selected index, and using that to set the `selected` property on the

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -179,7 +179,7 @@ class _MaterialStateColor extends MaterialStateColor {
 /// To use a [MaterialStateMouseCursor], you should create a subclass of
 /// [MaterialStateMouseCursor] and implement the abstract `resolve` method.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// This example defines a mouse cursor that resolves to
 /// [SystemMouseCursors.forbidden] when its widget is disabled.
@@ -294,7 +294,7 @@ class _EnabledAndDisabledMouseCursor extends MaterialStateMouseCursor {
 /// To use a [MaterialStateBorderSide], you should create a subclass of a
 /// [MaterialStateBorderSide] and override the abstract `resolve` method.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This example defines a subclass of [MaterialStateBorderSide], that resolves
 /// to a red border side when its widget is selected.
@@ -352,7 +352,7 @@ abstract class MaterialStateBorderSide extends BorderSide implements MaterialSta
 /// [OutlinedBorder] and implement [MaterialStateOutlinedBorder]'s abstract
 /// `resolve` method.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This example defines a subclass of [RoundedRectangleBorder] and an
 /// implementation of [MaterialStateOutlinedBorder], that resolves to
@@ -423,7 +423,7 @@ abstract class MaterialStateOutlinedBorder extends OutlinedBorder implements Mat
 /// of their current material state and [resolve] the button style's
 /// material state properties when their value is needed.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// This example shows how you can override the default text and icon
 /// color (the "foreground color") of a [TextButton] with a

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -179,7 +179,7 @@ class _MaterialStateColor extends MaterialStateColor {
 /// To use a [MaterialStateMouseCursor], you should create a subclass of
 /// [MaterialStateMouseCursor] and implement the abstract `resolve` method.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// This example defines a mouse cursor that resolves to
 /// [SystemMouseCursors.forbidden] when its widget is disabled.
@@ -294,7 +294,7 @@ class _EnabledAndDisabledMouseCursor extends MaterialStateMouseCursor {
 /// To use a [MaterialStateBorderSide], you should create a subclass of a
 /// [MaterialStateBorderSide] and override the abstract `resolve` method.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This example defines a subclass of [MaterialStateBorderSide], that resolves
 /// to a red border side when its widget is selected.
@@ -352,7 +352,7 @@ abstract class MaterialStateBorderSide extends BorderSide implements MaterialSta
 /// [OutlinedBorder] and implement [MaterialStateOutlinedBorder]'s abstract
 /// `resolve` method.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This example defines a subclass of [RoundedRectangleBorder] and an
 /// implementation of [MaterialStateOutlinedBorder], that resolves to
@@ -423,7 +423,7 @@ abstract class MaterialStateOutlinedBorder extends OutlinedBorder implements Mat
 /// of their current material state and [resolve] the button style's
 /// material state properties when their value is needed.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// This example shows how you can override the default text and icon
 /// color (the "foreground color") of a [TextButton] with a

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -16,7 +16,8 @@ import 'navigation_rail_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A material widget that is meant to be displayed at the left or right of an
 /// app to navigate between a small number of views, typically between three and

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -16,6 +16,8 @@ import 'navigation_rail_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
+
 /// A material widget that is meant to be displayed at the left or right of an
 /// app to navigate between a small number of views, typically between three and
 /// five.
@@ -38,7 +40,7 @@ import 'theme_data.dart';
 /// [https://github.com/flutter/samples/blob/master/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart]
 /// for an example.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This example shows a [NavigationRail] used within a Scaffold with 3
 /// [NavigationRailDestination]s. The main content is separated by a divider

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -40,7 +40,7 @@ import 'theme_data.dart';
 /// [https://github.com/flutter/samples/blob/master/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart]
 /// for an example.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This example shows a [NavigationRail] used within a Scaffold with 3
 /// [NavigationRailDestination]s. The main content is separated by a divider

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -57,7 +57,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 /// Outline buttons have a minimum size of 88.0 by 36.0 which can be overridden
 /// with [ButtonTheme].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// Here is an example of a basic [OutlineButton].
 ///

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -57,7 +57,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 /// Outline buttons have a minimum size of 88.0 by 36.0 which can be overridden
 /// with [ButtonTheme].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// Here is an example of a basic [OutlineButton].
 ///

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -20,6 +20,7 @@ import 'popup_menu_theme.dart';
 import 'theme.dart';
 import 'tooltip.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // enum Commands { heroAndScholar, hurricaneCame }
 // dynamic _heroAndScholar;

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -20,8 +20,8 @@ import 'popup_menu_theme.dart';
 import 'theme.dart';
 import 'tooltip.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // enum Commands { heroAndScholar, hurricaneCame }
 // dynamic _heroAndScholar;
 // dynamic _selection;

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -243,7 +243,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 /// The minimum height of the indicator can be specified using [minHeight].
 /// The indicator can be made taller by wrapping the widget with a [SizedBox].
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This example shows a [LinearProgressIndicator] with a changing value.
 ///
@@ -481,7 +481,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 /// The indicator arc is displayed with [valueColor], an animated value. To
 /// specify a constant color use: `AlwaysStoppedAnimation<Color>(color)`.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This example shows a [CircularProgressIndicator] with a changing value.
 ///

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -243,7 +243,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 /// The minimum height of the indicator can be specified using [minHeight].
 /// The indicator can be made taller by wrapping the widget with a [SizedBox].
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This example shows a [LinearProgressIndicator] with a changing value.
 ///
@@ -481,7 +481,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 /// The indicator arc is displayed with [valueColor], an animated value. To
 /// specify a constant color use: `AlwaysStoppedAnimation<Color>(color)`.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This example shows a [CircularProgressIndicator] with a changing value.
 ///

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -30,7 +30,7 @@ const double _kInnerRadius = 4.5;
 /// will respond to [onChanged] by calling [State.setState] to update the
 /// radio button's [groupValue].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// Here is an example of Radio widgets wrapped in ListTiles, which is similar
 /// to what you could get with the RadioListTile widget.
@@ -202,7 +202,7 @@ class Radio<T> extends StatefulWidget {
   ///
   /// The default is false.
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   /// This example shows how to enable deselecting a radio button by setting the
   /// [toggleable] attribute.
   ///

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -30,7 +30,7 @@ const double _kInnerRadius = 4.5;
 /// will respond to [onChanged] by calling [State.setState] to update the
 /// radio button's [groupValue].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// Here is an example of Radio widgets wrapped in ListTiles, which is similar
 /// to what you could get with the RadioListTile widget.
@@ -202,7 +202,7 @@ class Radio<T> extends StatefulWidget {
   ///
   /// The default is false.
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   /// This example shows how to enable deselecting a radio button by setting the
   /// [toggleable] attribute.
   ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -9,6 +9,7 @@ import 'radio.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // void setState(VoidCallback fn) { }
 
@@ -40,7 +41,7 @@ import 'theme_data.dart';
 /// To show the [RadioListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ![RadioListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile.png)
 ///
@@ -92,7 +93,7 @@ import 'theme_data.dart';
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ![Radio list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile_semantics.png)
 ///
@@ -196,7 +197,7 @@ import 'theme_data.dart';
 /// combining [Radio] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ![Custom radio list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile_custom.png)
 ///
@@ -386,7 +387,7 @@ class RadioListTile<T> extends StatelessWidget {
   ///
   /// The default is false.
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold}
+  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
   /// This example shows how to enable deselecting a radio button by setting the
   /// [toggleable] attribute.
   ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -41,7 +41,7 @@ import 'theme_data.dart';
 /// To show the [RadioListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ![RadioListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile.png)
 ///
@@ -93,7 +93,7 @@ import 'theme_data.dart';
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ![Radio list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile_semantics.png)
 ///
@@ -197,7 +197,7 @@ import 'theme_data.dart';
 /// combining [Radio] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ![Custom radio list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/radio_list_tile_custom.png)
 ///
@@ -387,7 +387,7 @@ class RadioListTile<T> extends StatelessWidget {
   ///
   /// The default is false.
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
   /// This example shows how to enable deselecting a radio button by setting the
   /// [toggleable] attribute.
   ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -9,8 +9,8 @@ import 'radio.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // void setState(VoidCallback fn) { }
 
 /// A [ListTile] with a [Radio]. In other words, a radio button with a label.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -43,7 +43,7 @@ import 'theme_data.dart';
 /// Raised buttons have a minimum size of 88.0 by 36.0 which can be overridden
 /// with [ButtonTheme].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how to render a disabled RaisedButton, an enabled RaisedButton
 /// and lastly a RaisedButton with gradient background.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -43,7 +43,7 @@ import 'theme_data.dart';
 /// Raised buttons have a minimum size of 88.0 by 36.0 which can be overridden
 /// with [ButtonTheme].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how to render a disabled RaisedButton, an enabled RaisedButton
 /// and lastly a RaisedButton with gradient background.

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -34,7 +34,7 @@ typedef PaintRangeValueIndicator = void Function(PaintingContext context, Offset
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the default
 /// value indicator.](https://flutter.github.io/assets-for-api-docs/assets/material/range_slider.png)

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -17,8 +17,8 @@ import 'debug.dart';
 import 'slider_theme.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // RangeValues _rangeValues = RangeValues(0.3, 0.7);
 // RangeValues _dollarsRange = RangeValues(50, 100);
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -17,6 +17,7 @@ import 'debug.dart';
 import 'slider_theme.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // RangeValues _rangeValues = RangeValues(0.3, 0.7);
 // RangeValues _dollarsRange = RangeValues(50, 100);
@@ -33,7 +34,7 @@ typedef PaintRangeValueIndicator = void Function(PaintingContext context, Offset
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ![A range slider widget, consisting of 5 divisions and showing the default
 /// value indicator.](https://flutter.github.io/assets-for-api-docs/assets/material/range_slider.png)

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -11,8 +11,8 @@ import 'debug.dart';
 import 'material.dart';
 import 'material_localizations.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class MyDataObject { }
 
 /// The callback used by [ReorderableListView] to move an item to a new

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -60,7 +60,7 @@ typedef ReorderCallback = void Function(int oldIndex, int newIndex);
 /// The [onReorder] parameter is required and will be called when a child
 /// widget is dragged to a new position.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ```dart
 /// List<String> _list = List.generate(5, (i) => "${i}");

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -11,6 +11,7 @@ import 'debug.dart';
 import 'material.dart';
 import 'material_localizations.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // class MyDataObject { }
 
@@ -59,7 +60,7 @@ typedef ReorderCallback = void Function(int oldIndex, int newIndex);
 /// The [onReorder] parameter is required and will be called when a child
 /// widget is dragged to a new position.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ```dart
 /// List<String> _list = List.generate(5, (i) => "${i}");

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -29,6 +29,7 @@ import 'snack_bar_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // TabController tabController;
 // void setState(VoidCallback fn) { }
@@ -68,7 +69,7 @@ enum _ScaffoldSlot {
 /// [BuildContext] via [ScaffoldMessenger.of] and use the
 /// [ScaffoldMessengerState.showSnackBar] function.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// Here is an example of showing a [SnackBar] when the user presses a button.
 ///
@@ -111,7 +112,7 @@ class ScaffoldMessenger extends StatefulWidget {
   /// The state from the closest instance of this class that encloses the given
   /// context.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
   /// Typical usage of the [ScaffoldMessenger.of] function is to call it in
   /// response to a user gesture or an application state change.
   ///
@@ -137,7 +138,7 @@ class ScaffoldMessenger extends StatefulWidget {
   /// function. The [MaterialApp.scaffoldMessengerKey] refers to the root
   /// ScaffoldMessenger that is provided by default.
   ///
-  /// {@tool dartpad --template=freeform}
+  /// {@tool dartpad --template=freeform --no-null-safety}
   /// Sometimes [SnackBar]s are produced by code that doesn't have ready access
   /// to a valid [BuildContext]. One such example of this is when you show a
   /// SnackBar from a method outside of the `build` function. In these
@@ -303,7 +304,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// See [ScaffoldMessenger.of] for information about how to obtain the
   /// [ScaffoldMessengerState].
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
   ///
   /// Here is an example of showing a [SnackBar] when the user presses a button.
   ///
@@ -1258,7 +1259,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// [ScaffoldState] for the current [BuildContext] via [Scaffold.of] and use the
 /// [ScaffoldState.showBottomSheet] function.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows a [Scaffold] with a [body] and [FloatingActionButton].
 /// The [body] is a [Text] placed in a [Center] in order to center the text
 /// within the [Scaffold]. The [FloatingActionButton] is connected to a
@@ -1287,7 +1288,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows a [Scaffold] with a blueGrey [backgroundColor], [body]
 /// and [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in
 /// order to center the text within the [Scaffold]. The [FloatingActionButton]
@@ -1317,7 +1318,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a
 /// [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order
 /// to center the text within the [Scaffold]. The [FloatingActionButton] is
@@ -1559,7 +1560,7 @@ class Scaffold extends StatefulWidget {
   ///
   /// To close the drawer, use [Navigator.pop].
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   /// To disable the drawer edge swipe, set the
   /// [Scaffold.drawerEnableOpenDragGesture] to false. Then, use
   /// [ScaffoldState.openDrawer] to open the drawer and [Navigator.pop] to close
@@ -1622,7 +1623,7 @@ class Scaffold extends StatefulWidget {
   ///
   /// To close the drawer, use [Navigator.pop].
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   /// To disable the drawer edge swipe, set the
   /// [Scaffold.endDrawerEnableOpenDragGesture] to false. Then, use
   /// [ScaffoldState.openEndDrawer] to open the drawer and [Navigator.pop] to
@@ -1789,7 +1790,7 @@ class Scaffold extends StatefulWidget {
   /// If no instance of this class encloses the given context, will cause an
   /// assert in debug mode, and throw an exception in release mode.
   ///
-  /// {@tool dartpad --template=freeform}
+  /// {@tool dartpad --template=freeform --no-null-safety}
   /// Typical usage of the [Scaffold.of] function is to call it from within the
   /// `build` method of a child of a [Scaffold].
   ///
@@ -1860,7 +1861,7 @@ class Scaffold extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@tool dartpad --template=stateless_widget_material}
+  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
   /// When the [Scaffold] is actually created in the same `build` function, the
   /// `context` argument to the `build` function can't be used to find the
   /// [Scaffold] (since it's "above" the widget being returned in the widget
@@ -2172,7 +2173,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// See [ScaffoldMessenger.of] for information about how to obtain the
   /// [ScaffoldMessengerState].
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
   ///
   /// Here is an example of showing a [SnackBar] when the user presses a button.
   ///
@@ -2546,7 +2547,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// of the app. Modal bottom sheets can be created and displayed with the
   /// [showModalBottomSheet] function.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold}
+  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
   ///
   /// This example demonstrates how to use `showBottomSheet` to display a
   /// bottom sheet when a user taps a button. It also demonstrates how to

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -29,8 +29,8 @@ import 'snack_bar_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // TabController tabController;
 // void setState(VoidCallback fn) { }
 // String appBarTitle;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -69,7 +69,7 @@ enum _ScaffoldSlot {
 /// [BuildContext] via [ScaffoldMessenger.of] and use the
 /// [ScaffoldMessengerState.showSnackBar] function.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// Here is an example of showing a [SnackBar] when the user presses a button.
 ///
@@ -112,7 +112,7 @@ class ScaffoldMessenger extends StatefulWidget {
   /// The state from the closest instance of this class that encloses the given
   /// context.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
   /// Typical usage of the [ScaffoldMessenger.of] function is to call it in
   /// response to a user gesture or an application state change.
   ///
@@ -138,7 +138,7 @@ class ScaffoldMessenger extends StatefulWidget {
   /// function. The [MaterialApp.scaffoldMessengerKey] refers to the root
   /// ScaffoldMessenger that is provided by default.
   ///
-  /// {@tool dartpad --template=freeform --no-null-safety}
+  /// {@tool dartpad --template=freeform_no_null_safety}
   /// Sometimes [SnackBar]s are produced by code that doesn't have ready access
   /// to a valid [BuildContext]. One such example of this is when you show a
   /// SnackBar from a method outside of the `build` function. In these
@@ -304,7 +304,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// See [ScaffoldMessenger.of] for information about how to obtain the
   /// [ScaffoldMessengerState].
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
   ///
   /// Here is an example of showing a [SnackBar] when the user presses a button.
   ///
@@ -1259,7 +1259,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// [ScaffoldState] for the current [BuildContext] via [Scaffold.of] and use the
 /// [ScaffoldState.showBottomSheet] function.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows a [Scaffold] with a [body] and [FloatingActionButton].
 /// The [body] is a [Text] placed in a [Center] in order to center the text
 /// within the [Scaffold]. The [FloatingActionButton] is connected to a
@@ -1288,7 +1288,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows a [Scaffold] with a blueGrey [backgroundColor], [body]
 /// and [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in
 /// order to center the text within the [Scaffold]. The [FloatingActionButton]
@@ -1318,7 +1318,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a
 /// [FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order
 /// to center the text within the [Scaffold]. The [FloatingActionButton] is
@@ -1560,7 +1560,7 @@ class Scaffold extends StatefulWidget {
   ///
   /// To close the drawer, use [Navigator.pop].
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   /// To disable the drawer edge swipe, set the
   /// [Scaffold.drawerEnableOpenDragGesture] to false. Then, use
   /// [ScaffoldState.openDrawer] to open the drawer and [Navigator.pop] to close
@@ -1623,7 +1623,7 @@ class Scaffold extends StatefulWidget {
   ///
   /// To close the drawer, use [Navigator.pop].
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   /// To disable the drawer edge swipe, set the
   /// [Scaffold.endDrawerEnableOpenDragGesture] to false. Then, use
   /// [ScaffoldState.openEndDrawer] to open the drawer and [Navigator.pop] to
@@ -1790,7 +1790,7 @@ class Scaffold extends StatefulWidget {
   /// If no instance of this class encloses the given context, will cause an
   /// assert in debug mode, and throw an exception in release mode.
   ///
-  /// {@tool dartpad --template=freeform --no-null-safety}
+  /// {@tool dartpad --template=freeform_no_null_safety}
   /// Typical usage of the [Scaffold.of] function is to call it from within the
   /// `build` method of a child of a [Scaffold].
   ///
@@ -1861,7 +1861,7 @@ class Scaffold extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
   /// When the [Scaffold] is actually created in the same `build` function, the
   /// `context` argument to the `build` function can't be used to find the
   /// [Scaffold] (since it's "above" the widget being returned in the widget
@@ -2173,7 +2173,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// See [ScaffoldMessenger.of] for information about how to obtain the
   /// [ScaffoldMessengerState].
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
   ///
   /// Here is an example of showing a [SnackBar] when the user presses a button.
   ///
@@ -2547,7 +2547,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   /// of the app. Modal bottom sheets can be created and displayed with the
   /// [showModalBottomSheet] function.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
   ///
   /// This example demonstrates how to use `showBottomSheet` to display a
   /// bottom sheet when a user taps a button. It also demonstrates how to

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -17,6 +17,8 @@ import 'scaffold.dart';
 import 'text_field.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
+
 /// Shows a full screen search page and returns the search result selected by
 /// the user when the page is closed.
 ///

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -17,7 +17,8 @@ import 'scaffold.dart';
 import 'text_field.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Shows a full screen search page and returns the search result selected by
 /// the user when the page is closed.

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -20,8 +20,8 @@ import 'material_state.dart';
 import 'slider_theme.dart';
 import 'theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // int _dollars = 0;
 // int _duelCommandment = 1;
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -40,7 +40,7 @@ enum _SliderType { material, adaptive }
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the default value
 /// indicator.](https://flutter.github.io/assets-for-api-docs/assets/material/slider.png)

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -20,6 +20,7 @@ import 'material_state.dart';
 import 'slider_theme.dart';
 import 'theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // int _dollars = 0;
 // int _duelCommandment = 1;
@@ -39,7 +40,7 @@ enum _SliderType { material, adaptive }
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// ![A slider widget, consisting of 5 divisions and showing the default value
 /// indicator.](https://flutter.github.io/assets-for-api-docs/assets/material/slider.png)

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -13,6 +13,8 @@ import 'colors.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
+
 /// Applies a slider theme to descendant [Slider] widgets.
 ///
 /// A slider theme describes the colors and shape choices of the slider

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -13,7 +13,8 @@ import 'colors.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Applies a slider theme to descendant [Slider] widgets.
 ///

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -158,7 +158,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// A SnackBar with an action will not time out when TalkBack or VoiceOver are
 /// enabled. This is controlled by [AccessibilityFeatures.accessibleNavigation].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// Here is an example of a [SnackBar] with an [action] button implemented using
 /// [SnackBarAction].
@@ -185,7 +185,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// Here is an example of a customized [SnackBar]. It utilizes
 /// [behavior], [shape], [padding], [width], and [duration] to customize the

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -158,7 +158,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// A SnackBar with an action will not time out when TalkBack or VoiceOver are
 /// enabled. This is controlled by [AccessibilityFeatures.accessibleNavigation].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// Here is an example of a [SnackBar] with an [action] button implemented using
 /// [SnackBarAction].
@@ -185,7 +185,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// Here is an example of a customized [SnackBar]. It utilizes
 /// [behavior], [shape], [padding], [width], and [duration] to customize the

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -122,7 +122,7 @@ class Step {
 /// to this widget based on some logic triggered by the three callbacks that it
 /// provides.
 ///
-/// {@tool sample --template=stateful_widget_scaffold_center}
+/// {@tool sample --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ```dart
 /// int _index = 0;
@@ -247,7 +247,7 @@ class Stepper extends StatefulWidget {
   /// For example, keeping track of the [currentStep] within the callback can
   /// change the text of the continue or cancel button depending on which step users are at.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold}
+  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
   /// Creates a stepper control with custom buttons.
   ///
   /// ```dart

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -122,7 +122,7 @@ class Step {
 /// to this widget based on some logic triggered by the three callbacks that it
 /// provides.
 ///
-/// {@tool sample --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool sample --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ```dart
 /// int _index = 0;
@@ -247,7 +247,7 @@ class Stepper extends StatefulWidget {
   /// For example, keeping track of the [currentStep] within the callback can
   /// change the text of the continue or cancel button depending on which step users are at.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
   /// Creates a stepper control with custom buttons.
   ///
   /// ```dart

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -9,6 +9,7 @@ import 'switch.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // void setState(VoidCallback fn) { }
 // bool _isSelected;
@@ -45,7 +46,7 @@ enum _SwitchListTileType { material, adaptive }
 /// To show the [SwitchListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![SwitchListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile.png)
 ///
@@ -84,7 +85,7 @@ enum _SwitchListTileType { material, adaptive }
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![Switch list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile_semantics.png)
 ///
@@ -168,7 +169,7 @@ enum _SwitchListTileType { material, adaptive }
 /// combining [Switch] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// ![Custom switch list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile_custom.png)
 ///

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -9,8 +9,8 @@ import 'switch.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // void setState(VoidCallback fn) { }
 // bool _isSelected;
 

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -46,7 +46,7 @@ enum _SwitchListTileType { material, adaptive }
 /// To show the [SwitchListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![SwitchListTile sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile.png)
 ///
@@ -85,7 +85,7 @@ enum _SwitchListTileType { material, adaptive }
 /// into one. Therefore, it may be necessary to create a custom radio tile
 /// widget to accommodate similar use cases.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![Switch list tile semantics sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile_semantics.png)
 ///
@@ -169,7 +169,7 @@ enum _SwitchListTileType { material, adaptive }
 /// combining [Switch] with other widgets, such as [Text], [Padding] and
 /// [InkWell].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// ![Custom switch list tile sample](https://flutter.github.io/assets-for-api-docs/assets/material/switch_list_tile_custom.png)
 ///

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 
@@ -84,7 +85,7 @@ import 'constants.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This example shows how to listen to page updates in [TabBar] and [TabBarView]
 /// when using [DefaultTabController].

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -8,8 +8,8 @@ import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 /// Coordinates tab selection between a [TabBar] and a [TabBarView].

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -85,7 +85,7 @@ import 'constants.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This example shows how to listen to page updates in [TabBar] and [TabBarView]
 /// when using [DefaultTabController].

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -25,7 +25,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Signature for the [TextField.buildCounter] callback.
 typedef InputCounterWidgetBuilder = Widget? Function(

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -200,7 +200,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// callback. This callback is applied to the text field's current value when
 /// the user finishes editing.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This sample shows how to get a value from a TextField via the [onSubmitted]
 /// callback.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -25,6 +25,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 
+// Examples are not null safe.
+
 /// Signature for the [TextField.buildCounter] callback.
 typedef InputCounterWidgetBuilder = Widget? Function(
   /// The build context for the TextField.
@@ -198,7 +200,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// callback. This callback is applied to the text field's current value when
 /// the user finishes editing.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This sample shows how to get a value from a TextField via the [onSubmitted]
 /// callback.

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -11,6 +11,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 
+// Examples are not null safe.
+
 /// A [FormField] that contains a [TextField].
 ///
 /// This is a convenience widget that wraps a [TextField] widget in a
@@ -67,7 +69,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows how to move the focus to the next field when the user
 /// presses the SPACE key.
 ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -11,7 +11,8 @@ import 'theme.dart';
 
 export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A [FormField] that contains a [TextField].
 ///

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -69,7 +69,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows how to move the focus to the next field when the user
 /// presses the SPACE key.
 ///

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -7,6 +7,8 @@ import 'package:flutter/painting.dart';
 
 import 'typography.dart';
 
+// Examples are not null safe.
+
 /// Material design text theme.
 ///
 /// Definitions for the various typographical styles found in Material Design

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -7,7 +7,8 @@ import 'package:flutter/painting.dart';
 
 import 'typography.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Material design text theme.
 ///

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -33,6 +33,7 @@ import 'theme_data.dart';
 import 'time.dart';
 import 'time_picker_theme.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -33,8 +33,8 @@ import 'theme_data.dart';
 import 'time.dart';
 import 'time_picker_theme.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 const Duration _kDialogSizeAnimationDuration = Duration(milliseconds: 200);

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -30,7 +30,7 @@ import 'tooltip_theme.dart';
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=EeEfD5fI-5Q}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// This example show a basic [Tooltip] which has a [Text] as child.
 /// [message] contains your label to be shown by the tooltip when
@@ -47,7 +47,7 @@ import 'tooltip_theme.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// This example covers most of the attributes available in Tooltip.
 /// `decoration` has been used to give a gradient and borderRadius to Tooltip.

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -30,7 +30,7 @@ import 'tooltip_theme.dart';
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=EeEfD5fI-5Q}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// This example show a basic [Tooltip] which has a [Text] as child.
 /// [message] contains your label to be shown by the tooltip when
@@ -47,7 +47,7 @@ import 'tooltip_theme.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// This example covers most of the attributes available in Tooltip.
 /// `decoration` has been used to give a gradient and borderRadius to Tooltip.

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -10,6 +10,7 @@ import 'border_radius.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -10,8 +10,8 @@ import 'border_radius.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 /// The shape to use when rendering a [Border] or [BoxDecoration].

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -330,7 +330,7 @@ abstract class Gradient {
 /// Typically this class is used with [BoxDecoration], which does the painting.
 /// To use a [LinearGradient] to paint on a canvas directly, see [createShader].
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This sample draws a picture that looks like vertical window shades by having
 /// a [Container] display a [BoxDecoration] with a [LinearGradient].
 ///

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -330,7 +330,7 @@ abstract class Gradient {
 /// Typically this class is used with [BoxDecoration], which does the painting.
 /// To use a [LinearGradient] to paint on a canvas directly, see [createShader].
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This sample draws a picture that looks like vertical window shades by having
 /// a [Container] display a [BoxDecoration] with a [LinearGradient].
 ///

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -17,7 +17,8 @@ import 'binding.dart';
 import 'image_cache.dart';
 import 'image_stream.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Signature for the callback taken by [_createErrorHandlerAndKey].
 typedef _KeyAndErrorHandlerCallback<T> = void Function(T key, ImageErrorListener handleError);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -17,6 +17,8 @@ import 'binding.dart';
 import 'image_cache.dart';
 import 'image_stream.dart';
 
+// Examples are not null safe.
+
 /// Signature for the callback taken by [_createErrorHandlerAndKey].
 typedef _KeyAndErrorHandlerCallback<T> = void Function(T key, ImageErrorListener handleError);
 

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -9,7 +9,8 @@ import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A [dart:ui.Image] object with its corresponding scale.
 ///

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -9,6 +9,8 @@ import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
+// Examples are not null safe.
+
 /// A [dart:ui.Image] object with its corresponding scale.
 ///
 /// ImageInfo objects are used by [ImageStream] objects to represent the

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'dart:ui' as ui show ParagraphBuilder;
 
 import 'package:flutter/foundation.dart';
@@ -13,6 +12,8 @@ import 'basic_types.dart';
 import 'inline_span.dart';
 import 'text_painter.dart';
 import 'text_style.dart';
+
+// Examples are not null safe.
 
 /// An immutable span of text.
 ///

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -13,7 +13,8 @@ import 'inline_span.dart';
 import 'text_painter.dart';
 import 'text_style.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// An immutable span of text.
 ///

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -24,8 +24,8 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 // defaults set in the engine (eg, LibTxt's text_style.h, paragraph_style.h).
 const double _kDefaultFontSize = 14.0;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 /// An immutable style describing how to format and paint text.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -24,6 +24,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 // defaults set in the engine (eg, LibTxt's text_style.h, paragraph_style.h).
 const double _kDefaultFontSize = 14.0;
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 

--- a/packages/flutter/lib/src/physics/gravity_simulation.dart
+++ b/packages/flutter/lib/src/physics/gravity_simulation.dart
@@ -4,8 +4,8 @@
 
 import 'simulation.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // AnimationController _controller;
 
 /// A simulation that applies a constant accelerating force.

--- a/packages/flutter/lib/src/physics/gravity_simulation.dart
+++ b/packages/flutter/lib/src/physics/gravity_simulation.dart
@@ -4,6 +4,7 @@
 
 import 'simulation.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // AnimationController _controller;
 

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -19,8 +19,8 @@ import 'view.dart';
 
 export 'package:flutter/gestures.dart' show HitTestResult;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // dynamic context;
 
 /// The glue between the render tree and the Flutter engine.

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -19,6 +19,7 @@ import 'view.dart';
 
 export 'package:flutter/gestures.dart' show HitTestResult;
 
+// Examples are not null safe.
 // Examples can assume:
 // dynamic context;
 

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -13,6 +13,8 @@ import 'package:vector_math/vector_math_64.dart';
 import 'debug.dart';
 import 'object.dart';
 
+// Examples are not null safe.
+
 // This class should only be used in debug builds.
 class _DebugSize extends Size {
   _DebugSize(Size source, this._owner, this._canBeUsedByParent) : super.copy(source);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -13,7 +13,8 @@ import 'package:vector_math/vector_math_64.dart';
 import 'debug.dart';
 import 'object.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // This class should only be used in debug builds.
 class _DebugSize extends Size {

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -11,6 +11,8 @@ import 'package:flutter/foundation.dart';
 import 'object.dart';
 import 'stack.dart';
 
+// Examples are not null safe.
+
 // Describes which side the region data overflows on.
 enum _OverflowSide {
   left,

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -11,7 +11,8 @@ import 'package:flutter/foundation.dart';
 import 'object.dart';
 import 'stack.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 // Describes which side the region data overflows on.
 enum _OverflowSide {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -28,7 +28,8 @@ export 'package:flutter/gestures.dart' show
   PointerUpEvent,
   PointerCancelEvent;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A base class for render boxes that resemble their children.
 ///

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -28,6 +28,8 @@ export 'package:flutter/gestures.dart' show
   PointerUpEvent,
   PointerCancelEvent;
 
+// Examples are not null safe.
+
 /// A base class for render boxes that resemble their children.
 ///
 /// A proxy box has a single child and simply mimics all the properties of that

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -45,7 +45,7 @@ abstract class KeyboardKey with Diagnosticable {
 /// look at the physical key to make sure that regardless of the character the
 /// key produces, you got the key that is in that location on the keyboard.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 /// This example shows how to detect if the user has selected the logical "Q"
 /// key.
 ///
@@ -1987,7 +1987,7 @@ class LogicalKeyboardKey extends KeyboardKey {
 /// looking for "the key next next to the TAB key", since on a French keyboard,
 /// the key next to the TAB key has an "A" on it.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 /// This example shows how to detect if the user has selected the physical key
 /// to the right of the CAPS LOCK key.
 ///

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -45,7 +45,7 @@ abstract class KeyboardKey with Diagnosticable {
 /// look at the physical key to make sure that regardless of the character the
 /// key produces, you got the key that is in that location on the keyboard.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 /// This example shows how to detect if the user has selected the logical "Q"
 /// key.
 ///
@@ -1987,7 +1987,7 @@ class LogicalKeyboardKey extends KeyboardKey {
 /// looking for "the key next next to the TAB key", since on a French keyboard,
 /// the key next to the TAB key has an "A" on it.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 /// This example shows how to detect if the user has selected the physical key
 /// to the right of the CAPS LOCK key.
 ///

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -12,7 +12,8 @@ import 'binding.dart';
 import 'message_codec.dart';
 import 'message_codecs.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A named channel for communicating with platform plugins using asynchronous
 /// message passing.

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -12,6 +12,8 @@ import 'binding.dart';
 import 'message_codec.dart';
 import 'message_codecs.dart';
 
+// Examples are not null safe.
+
 /// A named channel for communicating with platform plugins using asynchronous
 /// message passing.
 ///

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -344,7 +344,7 @@ class SystemChrome {
   /// navigation bar and synthesize them into a single style. This can be used
   /// to configure the system styles when an app bar is not used.
   ///
-  /// {@tool sample --template=stateful_widget_material --no-null-safety}
+  /// {@tool sample --template=stateful_widget_material_no_null_safety}
   /// The following example creates a widget that changes the status bar color
   /// to a random value on Android.
   ///

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -344,7 +344,7 @@ class SystemChrome {
   /// navigation bar and synthesize them into a single style. This can be used
   /// to configure the system styles when an app bar is not used.
   ///
-  /// {@tool sample --template=stateful_widget_material}
+  /// {@tool sample --template=stateful_widget_material --no-null-safety}
   /// The following example creates a widget that changes the status bar color
   /// to a random value on Android.
   ///

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -795,7 +795,7 @@ class _ActionsMarker extends InheritedWidget {
 /// widget, and the new control should be enabled for keyboard traversal and
 /// activation.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows how keyboard interaction can be added to a custom control
 /// that changes color when hovered and focused, and can toggle a light when
 /// activated, either by touch or by hitting the `X` key on the keyboard when

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -795,7 +795,7 @@ class _ActionsMarker extends InheritedWidget {
 /// widget, and the new control should be enabled for keyboard traversal and
 /// activation.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows how keyboard interaction can be added to a custom control
 /// that changes color when hovered and focused, and can toggle a light when
 /// activated, either by touch or by hitting the `X` key on the keyboard when

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -10,8 +10,8 @@ import 'framework.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // bool _first;
 
 /// Specifies which of two children to show. See [AnimatedCrossFade].

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -10,6 +10,7 @@ import 'framework.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // bool _first;
 

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -48,7 +48,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ZtfItHwFlZ8}
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This sample application uses an [AnimatedList] to create an effect when
 /// items are removed or added to the list.
 ///
@@ -517,7 +517,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 /// [GlobalKey] or use the static [SliverAnimatedList.of] method from an item's
 /// input callback.
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This sample application uses a [SliverAnimatedList] to create an animated
 /// effect when items are removed or added to the list.
 ///

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -48,7 +48,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ZtfItHwFlZ8}
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This sample application uses an [AnimatedList] to create an effect when
 /// items are removed or added to the list.
 ///
@@ -517,7 +517,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 /// [GlobalKey] or use the static [SliverAnimatedList.of] method from an item's
 /// input callback.
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This sample application uses a [SliverAnimatedList] to create an animated
 /// effect when items are removed or added to the list.
 ///

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -11,7 +11,7 @@ import 'framework.dart';
 /// Animated widget that automatically transitions its size over a given
 /// duration whenever the given child's size changes.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state_no_null_safety}
 /// This example makes a [Container] react to being touched, causing the child
 /// of the [AnimatedSize] widget, here a [FlutterLogo], to animate.
 ///

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -11,7 +11,7 @@ import 'framework.dart';
 /// Animated widget that automatically transitions its size over a given
 /// duration whenever the given child's size changes.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
 /// This example makes a [Container] react to being touched, causing the child
 /// of the [AnimatedSize] widget, here a [FlutterLogo], to animate.
 ///

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -90,7 +90,7 @@ typedef AnimatedSwitcherLayoutBuilder = Widget Function(Widget? currentChild, Li
 /// The type of transition can be changed from a cross-fade to a custom
 /// transition by setting the [transitionBuilder].
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This sample shows a counter that animates the scale of a text widget
 /// whenever the value changes.
 ///

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -90,7 +90,7 @@ typedef AnimatedSwitcherLayoutBuilder = Widget Function(Widget? currentChild, Li
 /// The type of transition can be changed from a cross-fade to a custom
 /// transition by setting the [transitionBuilder].
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This sample shows a counter that animates the scale of a text widget
 /// whenever the value changes.
 ///

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -30,6 +30,8 @@ import 'widget_inspector.dart';
 
 export 'dart:ui' show Locale;
 
+// Examples are not null safe.
+
 /// The signature of [WidgetsApp.localeListResolutionCallback].
 ///
 /// A [LocaleListResolutionCallback] is responsible for computing the locale of the app's

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -30,7 +30,8 @@ import 'widget_inspector.dart';
 
 export 'dart:ui' show Locale;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// The signature of [WidgetsApp.localeListResolutionCallback].
 ///

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -371,7 +371,7 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 /// as the builder will always be called before the stream listener has a chance
 /// to be processed.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This sample shows a [StreamBuilder] that listens to a Stream that emits bids
 /// for an auction. Every time the StreamBuilder receives a bid from the Stream,
@@ -614,7 +614,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// `future?.asStream()`, except that snapshots with `ConnectionState.active`
 /// may appear for the latter, depending on how the stream is implemented.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// This sample shows a [FutureBuilder] that displays a loading spinner while it
 /// loads data. It displays a success icon and text if the [Future] completes

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -12,8 +12,8 @@ import 'package:flutter/foundation.dart';
 
 import 'framework.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // dynamic _lot;
 // Future<String> _calculation;
 

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 
 import 'framework.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // dynamic _lot;
 // Future<String> _calculation;
@@ -370,7 +371,7 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 /// as the builder will always be called before the stream listener has a chance
 /// to be processed.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This sample shows a [StreamBuilder] that listens to a Stream that emits bids
 /// for an auction. Every time the StreamBuilder receives a bid from the Stream,
@@ -613,7 +614,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// `future?.asStream()`, except that snapshots with `ConnectionState.active`
 /// may appear for the latter, depending on how the stream is implemented.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// This sample shows a [FutureBuilder] that displays a loading spinner while it
 /// loads data. It displays a success icon and text if the [Future] completes

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -69,7 +69,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// [fieldViewBuilder] parameter. The options to be displayed are determined
 /// using [optionsBuilder] and rendered with [optionsViewBuilder].
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This example shows how to create a very basic autocomplete widget using the
 /// [fieldViewBuilder] and [optionsViewBuilder] parameters.
 ///
@@ -143,7 +143,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// Options will be compared using `==`, so it may be beneficial to override
 /// [Object.==] and [Object.hashCode] for custom types.
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This example is similar to the previous example, but it uses a custom T data
 /// type instead of directly using String.
 ///
@@ -244,7 +244,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This example shows the use of RawAutocomplete in a form.
 ///
 /// ```dart imports

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -69,7 +69,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// [fieldViewBuilder] parameter. The options to be displayed are determined
 /// using [optionsBuilder] and rendered with [optionsViewBuilder].
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This example shows how to create a very basic autocomplete widget using the
 /// [fieldViewBuilder] and [optionsViewBuilder] parameters.
 ///
@@ -143,7 +143,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// Options will be compared using `==`, so it may be beneficial to override
 /// [Object.==] and [Object.hashCode] for custom types.
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This example is similar to the previous example, but it uses a custom T data
 /// type instead of directly using String.
 ///
@@ -244,7 +244,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This example shows the use of RawAutocomplete in a form.
 ///
 /// ```dart imports

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -51,7 +51,7 @@ enum AutofillContextAction {
 /// autofillable input fields in an [AutofillGroup], so the user input of the
 /// [Form] can be saved for future autofill by the platform.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// An example form with autofillable fields grouped into different
 /// `AutofillGroup`s.

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -51,7 +51,7 @@ enum AutofillContextAction {
 /// autofillable input fields in an [AutofillGroup], so the user input of the
 /// [Form] can be saved for future autofill by the platform.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// An example form with autofillable fields grouped into different
 /// `AutofillGroup`s.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -65,6 +65,7 @@ export 'package:flutter/rendering.dart' show
   WrapAlignment,
   WrapCrossAlignment;
 
+// Examples are not null safe.
 // Examples can assume:
 // class TestWidget extends StatelessWidget { @override Widget build(BuildContext context) => const Placeholder(); }
 // WidgetTester tester;
@@ -1474,7 +1475,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=T4Uehk3_wlY}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// In this example, the image is stretched to fill the entire [Container], which would
 /// not happen normally without using FittedBox.
@@ -2758,7 +2759,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// needed, prefer removing the widget from the tree entirely rather than
 /// keeping it alive in an [Offstage] subtree.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// This example shows a [FlutterLogo] widget when the `_offstage` member field
 /// is false, and hides it without any room in the parent when it is true. When
@@ -2882,7 +2883,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// 16.0/9.0. If the maximum width is infinite, the initial width is determined
 /// by applying the aspect ratio to the maximum height.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This examples shows how AspectRatio sets width when its parent's width
 /// constraint is infinite. Since its parent's allowed height is a fixed value,
@@ -2914,7 +2915,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// the height to be between 0.0 and 100.0. We'll select a width of 100.0 (the
 /// biggest allowed) and a height of 50.0 (to match the aspect ratio).
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
@@ -2948,7 +2949,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// will eventually select a size for the child that meets the layout
 /// constraints but fails to meet the aspect ratio constraints.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
@@ -4809,7 +4810,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=_rnZaagadyo}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to use an [Expanded] widget in a [Column] so that
 /// its middle child, a [Container] here, expands to fill the space.
 ///
@@ -4848,7 +4849,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to use an [Expanded] widget in a [Row] with multiple
 /// children expanded, utilizing the [flex] factor to prioritize available space.
 ///
@@ -5199,7 +5200,7 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 ///
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 ///
 /// This example uses the [Flow] widget to create a menu that opens and closes
 /// as it is interacted with, shown above. The color of the button in the menu
@@ -5967,7 +5968,7 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 /// If it has a child, this widget defers to the child for sizing behavior. If
 /// it does not have a child, it grows to fit the parent instead.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 /// This example makes a [Container] react to being touched, showing a count of
 /// the number of pointer downs and ups.
 ///
@@ -6137,7 +6138,7 @@ class Listener extends SingleChildRenderObjectWidget {
 /// If it has a child, this widget defers to the child for sizing behavior. If
 /// it does not have a child, it grows to fit the parent instead.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 /// This example makes a [Container] react to being entered by a mouse
 /// pointer, showing a count of the number of entries and exits.
 ///
@@ -6306,7 +6307,7 @@ class MouseRegion extends StatefulWidget {
   ///    override [State.dispose] and call [onExit], or create your own widget
   ///    using [RenderMouseRegion].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
   /// The following example shows a blue rectangular that turns yellow when
   /// hovered. Since the hover state is completely contained within a widget
   /// that unconditionally creates the `MouseRegion`, you can ignore the
@@ -6334,7 +6335,7 @@ class MouseRegion extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
   /// The following example shows a widget that hides its content one second
   /// after being hovered, and also exposes the enter and exit callbacks.
   /// Because the widget conditionally creates the `MouseRegion`, and leaks the
@@ -6623,7 +6624,7 @@ class RepaintBoundary extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=qV9pqHWxYgI}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// The following sample has an [IgnorePointer] widget wrapping the `Column`
 /// which contains a button.
 /// When [ignoring] is set to `true` anything inside the `Column` can
@@ -6739,7 +6740,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=65HoWqBboI8}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 /// The following sample has an [AbsorbPointer] widget wrapping the button on
 /// top of the stack, which absorbs pointer events, preventing its child button
 /// __and__ the button below it in the stack from receiving the pointer events.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1475,7 +1475,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=T4Uehk3_wlY}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// In this example, the image is stretched to fill the entire [Container], which would
 /// not happen normally without using FittedBox.
@@ -2759,7 +2759,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// needed, prefer removing the widget from the tree entirely rather than
 /// keeping it alive in an [Offstage] subtree.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// This example shows a [FlutterLogo] widget when the `_offstage` member field
 /// is false, and hides it without any room in the parent when it is true. When
@@ -2883,7 +2883,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// 16.0/9.0. If the maximum width is infinite, the initial width is determined
 /// by applying the aspect ratio to the maximum height.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This examples shows how AspectRatio sets width when its parent's width
 /// constraint is infinite. Since its parent's allowed height is a fixed value,
@@ -2915,7 +2915,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// the height to be between 0.0 and 100.0. We'll select a width of 100.0 (the
 /// biggest allowed) and a height of 50.0 (to match the aspect ratio).
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
@@ -2949,7 +2949,7 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 /// will eventually select a size for the child that meets the layout
 /// constraints but fails to meet the aspect ratio constraints.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
@@ -4810,7 +4810,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=_rnZaagadyo}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to use an [Expanded] widget in a [Column] so that
 /// its middle child, a [Container] here, expands to fill the space.
 ///
@@ -4849,7 +4849,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to use an [Expanded] widget in a [Row] with multiple
 /// children expanded, utilizing the [flex] factor to prioritize available space.
 ///
@@ -5200,7 +5200,7 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 ///
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 ///
 /// This example uses the [Flow] widget to create a menu that opens and closes
 /// as it is interacted with, shown above. The color of the button in the menu
@@ -5968,7 +5968,7 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 /// If it has a child, this widget defers to the child for sizing behavior. If
 /// it does not have a child, it grows to fit the parent instead.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 /// This example makes a [Container] react to being touched, showing a count of
 /// the number of pointer downs and ups.
 ///
@@ -6138,7 +6138,7 @@ class Listener extends SingleChildRenderObjectWidget {
 /// If it has a child, this widget defers to the child for sizing behavior. If
 /// it does not have a child, it grows to fit the parent instead.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 /// This example makes a [Container] react to being entered by a mouse
 /// pointer, showing a count of the number of entries and exits.
 ///
@@ -6307,7 +6307,7 @@ class MouseRegion extends StatefulWidget {
   ///    override [State.dispose] and call [onExit], or create your own widget
   ///    using [RenderMouseRegion].
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
   /// The following example shows a blue rectangular that turns yellow when
   /// hovered. Since the hover state is completely contained within a widget
   /// that unconditionally creates the `MouseRegion`, you can ignore the
@@ -6335,7 +6335,7 @@ class MouseRegion extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
-  /// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
   /// The following example shows a widget that hides its content one second
   /// after being hovered, and also exposes the enter and exit callbacks.
   /// Because the widget conditionally creates the `MouseRegion`, and leaks the
@@ -6624,7 +6624,7 @@ class RepaintBoundary extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=qV9pqHWxYgI}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// The following sample has an [IgnorePointer] widget wrapping the `Column`
 /// which contains a button.
 /// When [ignoring] is set to `true` anything inside the `Column` can
@@ -6740,7 +6740,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=65HoWqBboI8}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 /// The following sample has an [AbsorbPointer] widget wrapping the button on
 /// top of the stack, which absorbs pointer events, preventing its child button
 /// __and__ the button below it in the stack from receiving the pointer events.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -65,8 +65,8 @@ export 'package:flutter/rendering.dart' show
   WrapAlignment,
   WrapCrossAlignment;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class TestWidget extends StatelessWidget { @override Widget build(BuildContext context) => const Placeholder(); }
 // WidgetTester tester;
 // bool _visible;

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -21,7 +21,8 @@ import 'widget_inspector.dart';
 
 export 'dart:ui' show AppLifecycleState, Locale;
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Interface for classes that register with the Widgets layer binding.
 ///

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -21,6 +21,8 @@ import 'widget_inspector.dart';
 
 export 'dart:ui' show AppLifecycleState, Locale;
 
+// Examples are not null safe.
+
 /// Interface for classes that register with the Widgets layer binding.
 ///
 /// When used as a mixin, provides no-op method implementations.

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -10,6 +10,7 @@ import 'basic.dart';
 import 'framework.dart';
 import 'image.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -10,8 +10,8 @@ import 'basic.dart';
 import 'framework.dart';
 import 'image.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 
 /// A widget that paints a [Decoration] either before or after its child paints.

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -65,7 +65,7 @@ enum DismissDirection {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=iEMgjrfuc58}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// This sample shows how you can use the [Dismissible] widget to
 /// remove list items using swipe gestures. Swipe any of the list

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -65,7 +65,7 @@ enum DismissDirection {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=iEMgjrfuc58}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// This sample shows how you can use the [Dismissible] widget to
 /// remove list items using swipe gestures. Swipe any of the list

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -104,7 +104,7 @@ enum DragAnchor {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=QzA4c4QHZCY}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// The following example has a [Draggable] widget along with a [DragTarget]
 /// in a row demonstrating an incremented `acceptedData` integer value when

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -104,7 +104,7 @@ enum DragAnchor {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=QzA4c4QHZCY}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// The following example has a [Draggable] widget along with a [DragTarget]
 /// in a row demonstrating an incremented `acceptedData` integer value when

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -84,7 +84,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 ///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer
 /// needed. This will ensure we discard any resources used by the object.
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example creates a [TextField] with a [TextEditingController] whose
 /// change listener forces the entered text to be lower case and keeps the
 /// cursor at the end of the input.
@@ -926,7 +926,7 @@ class EditableText extends StatefulWidget {
   /// and selection, one can add a listener to its [controller] with
   /// [TextEditingController.addListener].
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// This example shows how onChanged could be used to check the TextField's
   /// current value each time the user inserts or deletes a character.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -84,7 +84,7 @@ const int _kObscureShowLatestCharCursorTicks = 3;
 ///
 /// Remember to [dispose] of the [TextEditingController] when it is no longer
 /// needed. This will ensure we discard any resources used by the object.
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example creates a [TextField] with a [TextEditingController] whose
 /// change listener forces the entered text to be lower case and keeps the
 /// cursor at the end of the input.
@@ -926,7 +926,7 @@ class EditableText extends StatefulWidget {
   /// and selection, one can add a listener to its [controller] with
   /// [TextEditingController.addListener].
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// This example shows how onChanged could be used to check the TextField's
   /// current value each time the user inserts or deletes a character.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -13,6 +13,7 @@ import 'image.dart';
 import 'implicit_animations.dart';
 import 'transitions.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // Uint8List bytes;
 

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -13,8 +13,8 @@ import 'image.dart';
 import 'implicit_animations.dart';
 import 'transitions.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // Uint8List bytes;
 
 /// An image that shows a [placeholder] image while the target [image] is

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -303,7 +303,7 @@ enum UnfocusDisposition {
 /// [DirectionalFocusTraversalPolicyMixin], but custom policies can be built
 /// based upon these policies. See [FocusTraversalPolicy] for more information.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold} This example shows how
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety} This example shows how
 /// a FocusNode should be managed if not using the [Focus] or [FocusScope]
 /// widgets. See the [Focus] widget for a similar example using [Focus] and
 /// [FocusScope] widgets.
@@ -786,7 +786,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// previous node in the enclosing [FocusTraversalGroup], call [nextFocus] or
   /// [previousFocus] instead of calling `unfocus`.
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   /// This example shows the difference between the different [UnfocusDisposition]
   /// values for [unfocus].
   ///

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -303,7 +303,7 @@ enum UnfocusDisposition {
 /// [DirectionalFocusTraversalPolicyMixin], but custom policies can be built
 /// based upon these policies. See [FocusTraversalPolicy] for more information.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety} This example shows how
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety} This example shows how
 /// a FocusNode should be managed if not using the [Focus] or [FocusScope]
 /// widgets. See the [Focus] widget for a similar example using [Focus] and
 /// [FocusScope] widgets.
@@ -786,7 +786,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// previous node in the enclosing [FocusTraversalGroup], call [nextFocus] or
   /// [previousFocus] instead of calling `unfocus`.
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   /// This example shows the difference between the different [UnfocusDisposition]
   /// values for [unfocus].
   ///

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -48,7 +48,7 @@ import 'inherited_notifier.dart';
 /// the focus traversal order, call `Focus.of(context).nextFocus()`. To unfocus
 /// a widget, call `Focus.of(context).unfocus()`.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 /// This example shows how to manage focus using the [Focus] and [FocusScope]
 /// widgets. See [FocusNode] for a similar example that doesn't use [Focus] or
 /// [FocusScope].
@@ -128,7 +128,7 @@ import 'inherited_notifier.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This example shows how to wrap another widget in a [Focus] widget to make it
 /// focusable. It wraps a [Container], and changes the container's color when it
 /// is set as the [FocusManager.primaryFocus].
@@ -186,7 +186,7 @@ import 'inherited_notifier.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example shows how to focus a newly-created widget immediately after it
 /// is created.
 ///
@@ -738,7 +738,7 @@ class _FocusState extends State<Focus> {
 /// the focus traversal order, call `Focus.of(context).nextFocus()`. To unfocus
 /// a widget, call `Focus.of(context).unfocus()`.
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// This example demonstrates using a [FocusScope] to restrict focus to a particular
 /// portion of the app. In this case, restricting focus to the visible part of a
 /// Stack.

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -48,7 +48,7 @@ import 'inherited_notifier.dart';
 /// the focus traversal order, call `Focus.of(context).nextFocus()`. To unfocus
 /// a widget, call `Focus.of(context).unfocus()`.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 /// This example shows how to manage focus using the [Focus] and [FocusScope]
 /// widgets. See [FocusNode] for a similar example that doesn't use [Focus] or
 /// [FocusScope].
@@ -128,7 +128,7 @@ import 'inherited_notifier.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This example shows how to wrap another widget in a [Focus] widget to make it
 /// focusable. It wraps a [Container], and changes the container's color when it
 /// is set as the [FocusManager.primaryFocus].
@@ -186,7 +186,7 @@ import 'inherited_notifier.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example shows how to focus a newly-created widget immediately after it
 /// is created.
 ///
@@ -738,7 +738,7 @@ class _FocusState extends State<Focus> {
 /// the focus traversal order, call `Focus.of(context).nextFocus()`. To unfocus
 /// a widget, call `Focus.of(context).unfocus()`.
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// This example demonstrates using a [FocusScope] to restrict focus to a particular
 /// portion of the app. In this case, restricting focus to the visible part of a
 /// Stack.

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1256,7 +1256,7 @@ class _OrderedFocusInfo {
 ///
 /// {@macro flutter.widgets.FocusOrder.comparable}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 /// This sample shows how to assign a traversal order to a widget. In the
 /// example, the focus order goes from bottom right (the "One" button) to top
 /// left (the "Six" button).
@@ -1466,7 +1466,7 @@ class FocusTraversalOrder extends InheritedWidget {
 /// To prevent the members of the group from being focused, set the
 /// [descendantsAreFocusable] attribute to false.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// This sample shows three rows of buttons, each grouped by a
 /// [FocusTraversalGroup], each with different traversal order policies. Use tab
 /// traversal to see the order they are traversed in.  The first row follows a

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1256,7 +1256,7 @@ class _OrderedFocusInfo {
 ///
 /// {@macro flutter.widgets.FocusOrder.comparable}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 /// This sample shows how to assign a traversal order to a widget. In the
 /// example, the focus order goes from bottom right (the "One" button) to top
 /// left (the "Six" button).
@@ -1466,7 +1466,7 @@ class FocusTraversalOrder extends InheritedWidget {
 /// To prevent the members of the group from being focused, set the
 /// [descendantsAreFocusable] attribute to false.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// This sample shows three rows of buttons, each grouped by a
 /// [FocusTraversalGroup], each with different traversal order policies. Use tab
 /// traversal to see the order they are traversed in.  The first row follows a

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -16,7 +16,7 @@ import 'will_pop_scope.dart';
 /// with a context whose ancestor is the [Form], or pass a [GlobalKey] to the
 /// [Form] constructor and call [GlobalKey.currentState].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 /// This example shows a [Form] with one [TextFormField] to enter an email
 /// address and an [ElevatedButton] to submit the form. A [GlobalKey] is used here
 /// to identify the [Form] and validate input.

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -16,7 +16,7 @@ import 'will_pop_scope.dart';
 /// with a context whose ancestor is the [Form], or pass a [GlobalKey] to the
 /// [Form] constructor and call [GlobalKey.currentState].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 /// This example shows a [Form] with one [TextFormField] to enter an email
 /// address and an [ElevatedButton] to submit the form. A [GlobalKey] is used here
 /// to identify the [Form] and validate input.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -29,11 +29,10 @@ export 'package:flutter/foundation.dart' show DiagnosticsNode, DiagnosticLevel;
 export 'package:flutter/foundation.dart' show Key, LocalKey, ValueKey;
 export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpRenderTree, debugDumpLayerTree;
 
+// Examples are not null safe.
 // Examples can assume:
 // BuildContext context;
 // void setState(VoidCallback fn) { }
-
-// Examples can assume:
 // abstract class RenderFrogJar extends RenderObject { }
 // abstract class FrogJar extends RenderObjectWidget { }
 // abstract class FrogJarParentData extends ParentData { Size size; }
@@ -4437,7 +4436,7 @@ typedef ErrorWidgetBuilder = Widget Function(FlutterErrorDetails details);
 ///
 /// It is possible to override this widget.
 ///
-/// {@tool sample --template=freeform}
+/// {@tool sample --template=freeform --no-null-safety}
 /// ```dart
 /// import 'package:flutter/material.dart';
 ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4436,7 +4436,7 @@ typedef ErrorWidgetBuilder = Widget Function(FlutterErrorDetails details);
 ///
 /// It is possible to override this widget.
 ///
-/// {@tool sample --template=freeform --no-null-safety}
+/// {@tool sample --template=freeform_no_null_safety}
 /// ```dart
 /// import 'package:flutter/material.dart';
 ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -29,8 +29,8 @@ export 'package:flutter/foundation.dart' show DiagnosticsNode, DiagnosticLevel;
 export 'package:flutter/foundation.dart' show Key, LocalKey, ValueKey;
 export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpRenderTree, debugDumpLayerTree;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // BuildContext context;
 // void setState(VoidCallback fn) { }
 // abstract class RenderFrogJar extends RenderObject { }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -47,6 +47,7 @@ export 'package:flutter/gestures.dart' show
   Velocity;
 export 'package:flutter/rendering.dart' show RenderSemanticsGestureHandler;
 
+// Examples are not null safe.
 // Examples can assume:
 // bool _lights;
 // void setState(VoidCallback fn) { }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -47,8 +47,8 @@ export 'package:flutter/gestures.dart' show
   Velocity;
 export 'package:flutter/rendering.dart' show RenderSemanticsGestureHandler;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // bool _lights;
 // void setState(VoidCallback fn) { }
 // String _last;

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -754,7 +754,7 @@ class Image extends StatefulWidget {
   /// ```
   /// {@endtemplate}
   ///
-  /// {@tool dartpad --template=stateless_widget_material}
+  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
   ///
   /// The following sample demonstrates how to use this builder to implement an
   /// image that fades in once it's been loaded.
@@ -820,7 +820,7 @@ class Image extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Image.frameBuilder.chainedBuildersExample}
   ///
-  /// {@tool dartpad --template=stateless_widget_material}
+  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
   ///
   /// The following sample uses [loadingBuilder] to show a
   /// [CircularProgressIndicator] while an image loads over the network.
@@ -865,7 +865,7 @@ class Image extends StatefulWidget {
   /// [FlutterError.onError]. If it is provided, the caller should either handle
   /// the exception by providing a replacement widget, or rethrow the exception.
   ///
-  /// {@tool dartpad --template=stateless_widget_material}
+  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
   ///
   /// The following sample uses [errorBuilder] to show a '😢' in place of the
   /// image that fails to load, and prints the error to the console.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -754,7 +754,7 @@ class Image extends StatefulWidget {
   /// ```
   /// {@endtemplate}
   ///
-  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
   ///
   /// The following sample demonstrates how to use this builder to implement an
   /// image that fades in once it's been loaded.
@@ -820,7 +820,7 @@ class Image extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Image.frameBuilder.chainedBuildersExample}
   ///
-  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
   ///
   /// The following sample uses [loadingBuilder] to show a
   /// [CircularProgressIndicator] while an image loads over the network.
@@ -865,7 +865,7 @@ class Image extends StatefulWidget {
   /// [FlutterError.onError]. If it is provided, the caller should either handle
   /// the exception by providing a replacement widget, or rethrow the exception.
   ///
-  /// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_material_no_null_safety}
   ///
   /// The following sample uses [errorBuilder] to show a '😢' in place of the
   /// image that fails to load, and prints the error to the console.

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -18,8 +18,8 @@ import 'text.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class MyWidget extends ImplicitlyAnimatedWidget {
 //   MyWidget() : super(duration: const Duration(seconds: 1));
 //   final Color targetColor = Colors.black;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -575,7 +575,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=yI-8QHpGIP4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// The following example (depicted above) transitions an AnimatedContainer
 /// between two states. It adjusts the `height`, `width`, `color`, and
@@ -814,7 +814,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 /// of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_padding.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// The following code implements the [AnimatedPadding] widget, using a [curve] of
 /// [Curves.easeInOut].
@@ -935,7 +935,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_no_null_safety}
 ///
 /// The following code implements the [AnimatedAlign] widget, using a [curve] of
 /// [Curves.fastOutSlowIn].
@@ -1100,7 +1100,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// The following example transitions an AnimatedPositioned
 /// between two states. It adjusts the `height`, `width`, and
@@ -1552,7 +1552,7 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 /// Here's an illustration of what using this widget looks like, using a [curve]
 /// of [Curves.fastOutSlowIn].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state_no_null_safety}
 /// Creates a [CustomScrollView] with a [SliverFixedExtentList] and a
 /// [FloatingActionButton]. Pressing the button animates the lists' opacity.
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -18,6 +18,7 @@ import 'text.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // class MyWidget extends ImplicitlyAnimatedWidget {
 //   MyWidget() : super(duration: const Duration(seconds: 1));
@@ -574,7 +575,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=yI-8QHpGIP4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// The following example (depicted above) transitions an AnimatedContainer
 /// between two states. It adjusts the `height`, `width`, `color`, and
@@ -813,7 +814,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 /// of [Curves.fastOutSlowIn].
 /// {@animation 250 266 https://flutter.github.io/assets-for-api-docs/assets/widgets/animated_padding.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// The following code implements the [AnimatedPadding] widget, using a [curve] of
 /// [Curves.easeInOut].
@@ -934,7 +935,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold}
+/// {@tool dartpad --template=stateful_widget_scaffold --no-null-safety}
 ///
 /// The following code implements the [AnimatedAlign] widget, using a [curve] of
 /// [Curves.fastOutSlowIn].
@@ -1099,7 +1100,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 /// it also requires more development overhead as you have to manually manage
 /// the lifecycle of the underlying [AnimationController].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// The following example transitions an AnimatedPositioned
 /// between two states. It adjusts the `height`, `width`, and
@@ -1551,7 +1552,7 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 /// Here's an illustration of what using this widget looks like, using a [curve]
 /// of [Curves.fastOutSlowIn].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
 /// Creates a [CustomScrollView] with a [SliverFixedExtentList] and a
 /// [FloatingActionButton]. Pressing the button animates the lists' opacity.
 ///

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -28,7 +28,7 @@ import 'framework.dart';
 /// changed. When it returns true, the dependents are marked as needing to be
 /// rebuilt this frame.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This example shows three spinning squares that use the value of the notifier
 /// on an ancestor [InheritedNotifier] (`SpinModel`) to give them their

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -28,7 +28,7 @@ import 'framework.dart';
 /// changed. When it returns true, the dependents are marked as needing to be
 /// rebuilt this frame.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This example shows three spinning squares that use the value of the notifier
 /// on an ancestor [InheritedNotifier] (`SpinModel`) to give them their

--- a/packages/flutter/lib/src/widgets/inherited_theme.dart
+++ b/packages/flutter/lib/src/widgets/inherited_theme.dart
@@ -17,7 +17,7 @@ import 'framework.dart';
 /// like the contents of a new route or an overlay, will be able to see the
 /// ancestor inherited themes of the context it was built in.
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This example demonstrates how `InheritedTheme.capture()` can be used
 /// to wrap the contents of a new route with the inherited themes that
 /// are present when the route was built - but are not present when route

--- a/packages/flutter/lib/src/widgets/inherited_theme.dart
+++ b/packages/flutter/lib/src/widgets/inherited_theme.dart
@@ -17,7 +17,7 @@ import 'framework.dart';
 /// like the contents of a new route or an overlay, will be able to see the
 /// ancestor inherited themes of the context it was built in.
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This example demonstrates how `InheritedTheme.capture()` can be used
 /// to wrap the contents of a new route with the inherited themes that
 /// are present when the route was built - but are not present when route

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -34,7 +34,7 @@ import 'ticker_provider.dart';
 ///   * The [Flutter Gallery's transformations demo](https://github.com/flutter/gallery/blob/master/lib/demos/reference/transformations_demo.dart),
 ///     which includes the use of InteractiveViewer.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 /// This example shows a simple Container that can be panned and zoomed.
 ///
 /// ```dart
@@ -151,7 +151,7 @@ class InteractiveViewer extends StatefulWidget {
   ///
   /// Defaults to true.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold}
+  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
   /// This example shows how to create a pannable table. Because the table is
   /// larger than the entire screen, setting `constrained` to false is necessary
   /// to allow it to be drawn to its full size. The parts of the table that
@@ -305,7 +305,7 @@ class InteractiveViewer extends StatefulWidget {
   /// listeners are notified. If the value is set, InteractiveViewer will update
   /// to respect the new value.
   ///
-  /// {@tool dartpad --template=stateful_widget_material_ticker}
+  /// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
   /// This example shows how transformationController can be used to animate the
   /// transformation back to its starting position.
   ///

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -34,7 +34,7 @@ import 'ticker_provider.dart';
 ///   * The [Flutter Gallery's transformations demo](https://github.com/flutter/gallery/blob/master/lib/demos/reference/transformations_demo.dart),
 ///     which includes the use of InteractiveViewer.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 /// This example shows a simple Container that can be panned and zoomed.
 ///
 /// ```dart
@@ -151,7 +151,7 @@ class InteractiveViewer extends StatefulWidget {
   ///
   /// Defaults to true.
   ///
-  /// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+  /// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
   /// This example shows how to create a pannable table. Because the table is
   /// larger than the entire screen, setting `constrained` to false is necessary
   /// to allow it to be drawn to its full size. The parts of the table that
@@ -305,7 +305,7 @@ class InteractiveViewer extends StatefulWidget {
   /// listeners are notified. If the value is set, InteractiveViewer will update
   /// to respect the new value.
   ///
-  /// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
   /// This example shows how transformationController can be used to animate the
   /// transformation back to its starting position.
   ///

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -243,7 +243,7 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
 /// in an [Align] widget. If the child might want to be bigger, consider
 /// wrapping it in a [SingleChildScrollView] or [OverflowBox].
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This example uses a [LayoutBuilder] to build a different widget depending on the available width. Resize the
 /// DartPad window to see [LayoutBuilder] in action!

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -243,7 +243,7 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
 /// in an [Align] widget. If the child might want to be bigger, consider
 /// wrapping it in a [SingleChildScrollView] or [OverflowBox].
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This example uses a [LayoutBuilder] to build a different widget depending on the available width. Resize the
 /// DartPad window to see [LayoutBuilder] in action!

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -14,8 +14,8 @@ import 'debug.dart';
 import 'framework.dart';
 
 // Examples can assume:
-// class Intl { static String message(String s, { String name, String locale }) => ''; }
-// Future<void> initializeMessages(String locale) => null;
+// class Intl { static String message(String s, { String? name, String? locale }) => ''; }
+// Future<void> initializeMessages(String locale) => Future.value();
 
 // Used by loadAll() to record LocalizationsDelegate.load() futures we're
 // waiting for.
@@ -323,7 +323,7 @@ class _LocalizationsScope extends InheritedWidget {
 ///   }
 ///
 ///   static MyLocalizations of(BuildContext context) {
-///     return Localizations.of<MyLocalizations>(context, MyLocalizations);
+///     return Localizations.of<MyLocalizations>(context, MyLocalizations)!;
 ///   }
 ///
 ///   String title() => Intl.message('<title>', name: 'title', locale: locale.toString());

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -250,7 +250,7 @@ class MediaQueryData {
   /// This property is currently only expected to be set to a non-default value
   /// on Android starting with version Q.
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// For apps that might be deployed on Android Q devices with full gesture
   /// navigation enabled, use [systemGestureInsets] with [Padding]

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -250,7 +250,7 @@ class MediaQueryData {
   /// This property is currently only expected to be set to a non-default value
   /// on Android starting with version Q.
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// For apps that might be deployed on Android Q devices with full gesture
   /// navigation enabled, use [systemGestureInsets] with [Padding]

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -25,6 +25,7 @@ import 'restoration_properties.dart';
 import 'routes.dart';
 import 'ticker_provider.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // class MyPage extends Placeholder { MyPage({String title}); }
 // class MyHomePage extends Placeholder { }
@@ -733,7 +734,7 @@ abstract class RouteTransitionRecord {
 ///
 /// To make route transition decisions, subclass must implement [resolve].
 ///
-/// {@tool sample --template=freeform}
+/// {@tool sample --template=freeform --no-null-safety}
 /// The following example demonstrates how to implement a subclass that always
 /// removes or adds routes without animated transitions and puts the removed
 /// routes at the top of the list.
@@ -1266,7 +1267,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// [WidgetsApp] and [CupertinoTabView] widgets and do not need to be explicitly
 /// created or managed.
 ///
-/// {@tool sample --template=freeform}
+/// {@tool sample --template=freeform --no-null-safety}
 /// The following example demonstrates how a nested [Navigator] can be used to
 /// present a standalone user registration journey.
 ///
@@ -2119,7 +2120,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -2214,7 +2215,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -2319,7 +2320,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4363,7 +4364,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4501,7 +4502,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4607,7 +4608,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material}
+  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -5527,7 +5528,7 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 /// When [present] has been called to add a route, it may only be called again
 /// after the previously added route has completed.
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 /// This example uses a [RestorableRouteFuture] in the `_MyHomeState` to push a
 /// new `MyCounter` route and to retrieve its return value.
 ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -734,7 +734,7 @@ abstract class RouteTransitionRecord {
 ///
 /// To make route transition decisions, subclass must implement [resolve].
 ///
-/// {@tool sample --template=freeform --no-null-safety}
+/// {@tool sample --template=freeform_no_null_safety}
 /// The following example demonstrates how to implement a subclass that always
 /// removes or adds routes without animated transitions and puts the removed
 /// routes at the top of the list.
@@ -1267,7 +1267,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// [WidgetsApp] and [CupertinoTabView] widgets and do not need to be explicitly
 /// created or managed.
 ///
-/// {@tool sample --template=freeform --no-null-safety}
+/// {@tool sample --template=freeform_no_null_safety}
 /// The following example demonstrates how a nested [Navigator] can be used to
 /// present a standalone user registration journey.
 ///
@@ -2120,7 +2120,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -2215,7 +2215,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -2320,7 +2320,7 @@ class Navigator extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4364,7 +4364,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4502,7 +4502,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -4608,7 +4608,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// {@macro flutter.widgets.Navigator.restorablePushNamed.returnValue}
   ///
-  /// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+  /// {@tool dartpad --template=stateful_widget_material_no_null_safety}
   ///
   /// Typical usage is as follows:
   ///
@@ -5528,7 +5528,7 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 /// When [present] has been called to add a route, it may only be called again
 /// after the previously added route has completed.
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 /// This example uses a [RestorableRouteFuture] in the `_MyHomeState` to push a
 /// new `MyCounter` route and to retrieve its return value.
 ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -25,8 +25,8 @@ import 'restoration_properties.dart';
 import 'routes.dart';
 import 'ticker_provider.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class MyPage extends Placeholder { MyPage({String title}); }
 // class MyHomePage extends Placeholder { }
 // NavigatorState navigator;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -62,7 +62,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// (those inside the [TabBarView], hooking them together so that they appear,
 /// to the user, as one coherent scroll view.
 ///
-/// {@tool sample --template=stateless_widget_material --no-null-safety}
+/// {@tool sample --template=stateless_widget_material_no_null_safety}
 ///
 /// This example shows a [NestedScrollView] whose header is the combination of a
 /// [TabBar] in a [SliverAppBar] and whose body is a [TabBarView]. It uses a
@@ -224,7 +224,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// configuration, the flexible space of the app bar will open and collapse,
 /// while the primary portion of the app bar remains pinned.
 ///
-/// {@tool sample --template=stateless_widget_material --no-null-safety}
+/// {@tool sample --template=stateless_widget_material_no_null_safety}
 ///
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// floating [SliverAppBar]. By using the [floatHeaderSlivers] property, the
@@ -285,7 +285,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// for the nested "inner" scroll view below to end up under the [SliverAppBar]
 /// even when the inner scroll view thinks it has not been scrolled.
 ///
-/// {@tool sample --template=stateless_widget_material --no-null-safety}
+/// {@tool sample --template=stateless_widget_material_no_null_safety}
 ///
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// snapping, floating [SliverAppBar]. _Without_ setting any additional flags,
@@ -504,7 +504,7 @@ class NestedScrollView extends StatefulWidget {
 /// [NestedScrollView], you can get its [NestedScrollViewState] by supplying a
 /// `GlobalKey<NestedScrollViewState>` to the [NestedScrollView.key] parameter).
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// [NestedScrollViewState] can be obtained using a [GlobalKey].
 /// Using the following setup, you can access the inner scroll controller
 /// using `globalKey.currentState.innerController`.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -26,6 +26,7 @@ import 'sliver_fill.dart';
 import 'ticker_provider.dart';
 import 'viewport.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // List<String> _tabs;
 
@@ -61,7 +62,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// (those inside the [TabBarView], hooking them together so that they appear,
 /// to the user, as one coherent scroll view.
 ///
-/// {@tool sample --template=stateless_widget_material}
+/// {@tool sample --template=stateless_widget_material --no-null-safety}
 ///
 /// This example shows a [NestedScrollView] whose header is the combination of a
 /// [TabBar] in a [SliverAppBar] and whose body is a [TabBarView]. It uses a
@@ -223,7 +224,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// configuration, the flexible space of the app bar will open and collapse,
 /// while the primary portion of the app bar remains pinned.
 ///
-/// {@tool sample --template=stateless_widget_material}
+/// {@tool sample --template=stateless_widget_material --no-null-safety}
 ///
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// floating [SliverAppBar]. By using the [floatHeaderSlivers] property, the
@@ -284,7 +285,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// for the nested "inner" scroll view below to end up under the [SliverAppBar]
 /// even when the inner scroll view thinks it has not been scrolled.
 ///
-/// {@tool sample --template=stateless_widget_material}
+/// {@tool sample --template=stateless_widget_material --no-null-safety}
 ///
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// snapping, floating [SliverAppBar]. _Without_ setting any additional flags,
@@ -503,7 +504,7 @@ class NestedScrollView extends StatefulWidget {
 /// [NestedScrollView], you can get its [NestedScrollViewState] by supplying a
 /// `GlobalKey<NestedScrollViewState>` to the [NestedScrollView.key] parameter).
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// [NestedScrollViewState] can be obtained using a [GlobalKey].
 /// Using the following setup, you can access the inner scroll controller
 /// using `globalKey.currentState.innerController`.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -26,8 +26,8 @@ import 'sliver_fill.dart';
 import 'ticker_provider.dart';
 import 'viewport.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // List<String> _tabs;
 
 /// Signature used by [NestedScrollView] for building its header.

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -17,7 +17,7 @@ import 'framework.dart';
 
 typedef NotificationListenerCallback<T extends Notification> = bool Function(T notification);
 
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 ///
 /// This example shows a [NotificationListener] widget
 /// that listens for [ScrollNotification] notifications. When a scroll

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -17,7 +17,7 @@ import 'framework.dart';
 
 typedef NotificationListenerCallback<T extends Notification> = bool Function(T notification);
 
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 ///
 /// This example shows a [NotificationListener] widget
 /// that listens for [ScrollNotification] notifications. When a scroll

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -44,7 +44,7 @@ enum OverflowBarAlignment {
 /// If the layout overflows, then children's order within their
 /// column is specified by [overflowDirection] instead.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
+/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
 ///
 /// This example defines a simple approximation of a dialog
 /// layout, where the layout of the dialog's action buttons are

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -44,7 +44,7 @@ enum OverflowBarAlignment {
 /// If the layout overflows, then children's order within their
 /// column is specified by [overflowDirection] instead.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_center_no_null_safety}
 ///
 /// This example defines a simple approximation of a dialog
 /// layout, where the layout of the dialog's action buttons are

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -46,7 +46,7 @@ import 'ticker_provider.dart';
 /// [OverscrollIndicatorNotification.paintOffset] to the
 /// notification, or use a [NestedScrollView].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This example demonstrates how to use a [NotificationListener] to manipulate
 /// the placement of a [GlowingOverscrollIndicator] when building a
@@ -81,7 +81,7 @@ import 'ticker_provider.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This example demonstrates how to use a [NestedScrollView] to manipulate the
 /// placement of a [GlowingOverscrollIndicator] when building a

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -46,7 +46,7 @@ import 'ticker_provider.dart';
 /// [OverscrollIndicatorNotification.paintOffset] to the
 /// notification, or use a [NestedScrollView].
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This example demonstrates how to use a [NotificationListener] to manipulate
 /// the placement of a [GlowingOverscrollIndicator] when building a
@@ -81,7 +81,7 @@ import 'ticker_provider.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This example demonstrates how to use a [NestedScrollView] to manipulate the
 /// placement of a [GlowingOverscrollIndicator] when building a

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -136,7 +136,7 @@ class PageStorageBucket {
 /// you should give each of them unique [PageStorageKey]s, or set some of their
 /// `keepScrollOffset` false to prevent saving.
 ///
-/// {@tool dartpad --template=freeform}
+/// {@tool dartpad --template=freeform --no-null-safety}
 ///
 /// This sample shows how to explicitly use a [PageStorage] to
 /// store the states of its children pages. Each page includes a scrollable

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -136,7 +136,7 @@ class PageStorageBucket {
 /// you should give each of them unique [PageStorageKey]s, or set some of their
 /// `keepScrollOffset` false to prevent saving.
 ///
-/// {@tool dartpad --template=freeform --no-null-safety}
+/// {@tool dartpad --template=freeform_no_null_safety}
 ///
 /// This sample shows how to explicitly use a [PageStorage] to
 /// store the states of its children pages. Each page includes a scrollable

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -27,6 +27,8 @@ import 'sliver.dart';
 import 'sliver_fill.dart';
 import 'viewport.dart';
 
+// Examples are not null safe.
+
 /// A controller for [PageView].
 ///
 /// A page controller lets you manipulate which page is visible in a [PageView].

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -27,7 +27,8 @@ import 'sliver.dart';
 import 'sliver_fill.dart';
 import 'viewport.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A controller for [PageView].
 ///

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -625,9 +625,9 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///
 /// ```dart
 /// class RestorableCounter extends StatefulWidget {
-///   RestorableCounter({Key key, this.restorationId}) : super(key: key);
+///   RestorableCounter({Key? key, this.restorationId}) : super(key: key);
 ///
-///   final String restorationId;
+///   final String? restorationId;
 ///
 ///   @override
 ///   _RestorableCounterState createState() => _RestorableCounterState();
@@ -645,10 +645,10 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///   // In this example, the restoration ID for the mixin is passed in through
 ///   // the [StatefulWidget]'s constructor.
 ///   @override
-///   String get restorationId => widget.restorationId;
+///   String? get restorationId => widget.restorationId;
 ///
 ///   @override
-///   void restoreState(RestorationBucket oldBucket, bool initialRestore) {
+///   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
 ///     // All restorable properties must be registered with the mixin. After
 ///     // registration, the counter either has its old value restored or is
 ///     // initialized to its default value.

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -10,7 +10,8 @@ import 'package:flutter/services.dart';
 import 'editable_text.dart';
 import 'restoration.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// A [RestorableProperty] that makes the wrapped value accessible to the owning
 /// [State] object via the [value] getter and setter.

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -10,6 +10,8 @@ import 'package:flutter/services.dart';
 import 'editable_text.dart';
 import 'restoration.dart';
 
+// Examples are not null safe.
+
 /// A [RestorableProperty] that makes the wrapped value accessible to the owning
 /// [State] object via the [value] getter and setter.
 ///
@@ -19,7 +21,7 @@ import 'restoration.dart';
 ///
 /// ## Using a RestorableValue
 ///
-/// {@tool dartpad --template=stateful_widget_restoration}
+/// {@tool dartpad --template=stateful_widget_restoration --no-null-safety}
 /// A [StatefulWidget] that has a restorable [int] property.
 ///
 /// ```dart

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -21,7 +21,7 @@ import 'restoration.dart';
 ///
 /// ## Using a RestorableValue
 ///
-/// {@tool dartpad --template=stateful_widget_restoration --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_restoration_no_null_safety}
 /// A [StatefulWidget] that has a restorable [int] property.
 ///
 /// ```dart

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -23,6 +23,7 @@ import 'restoration.dart';
 import 'scroll_controller.dart';
 import 'transitions.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // dynamic routeObserver;
 // NavigatorState navigator;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -23,8 +23,8 @@ import 'restoration.dart';
 import 'scroll_controller.dart';
 import 'transitions.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // dynamic routeObserver;
 // NavigatorState navigator;
 

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -274,8 +274,8 @@ class ScrollController extends ChangeNotifier {
   }
 }
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // TrackingScrollController _trackingScrollController;
 
 /// A [ScrollController] whose [initialScrollOffset] tracks its most recently

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -274,6 +274,7 @@ class ScrollController extends ChangeNotifier {
   }
 }
 
+// Examples are not null safe.
 // Examples can assume:
 // TrackingScrollController _trackingScrollController;
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -16,8 +16,8 @@ import 'scroll_simulation.dart';
 
 export 'package:flutter/physics.dart' show Simulation, ScrollSpringSimulation, Tolerance;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // class FooScrollPhysics extends ScrollPhysics {
 //   const FooScrollPhysics({ ScrollPhysics parent }): super(parent: parent);
 // }

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -16,6 +16,7 @@ import 'scroll_simulation.dart';
 
 export 'package:flutter/physics.dart' show Simulation, ScrollSpringSimulation, Tolerance;
 
+// Examples are not null safe.
 // Examples can assume:
 // class FooScrollPhysics extends ScrollPhysics {
 //   const FooScrollPhysics({ ScrollPhysics parent }): super(parent: parent);

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -22,8 +22,8 @@ import 'scrollable.dart';
 import 'sliver.dart';
 import 'viewport.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // int itemCount;
 
 /// A representation of how a [ScrollView] should dismiss the on-screen

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -468,7 +468,7 @@ abstract class ScrollView extends StatelessWidget {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 ///
 /// By default, if items are inserted at the "top" of a scrolling container like
 /// [ListView] or [CustomScrollView], the top item and all of the items below it

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -22,6 +22,7 @@ import 'scrollable.dart';
 import 'sliver.dart';
 import 'viewport.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // int itemCount;
 
@@ -467,7 +468,7 @@ abstract class ScrollView extends StatelessWidget {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 ///
 /// By default, if items are inserted at the "top" of a scrolling container like
 /// [ListView] or [CustomScrollView], the top item and all of the items below it

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -386,7 +386,7 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
 /// when invoking an [Action] via a keyboard key combination that maps to an
 /// [Intent].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 ///
 /// Here, we will use a [Shortcuts] and [Actions] widget to add and remove from a counter.
 /// This can be done by creating a child widget that is focused and pressing the logical key

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -386,7 +386,7 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
 /// when invoking an [Action] via a keyboard key combination that maps to an
 /// [Intent].
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 ///
 /// Here, we will use a [Shortcuts] and [Actions] widget to add and remove from a counter.
 /// This can be done by creating a child widget that is focused and pressing the logical key

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -80,7 +80,7 @@ import 'scrollable.dart';
 /// with some remaining space to allocate as specified by its
 /// [Column.mainAxisAlignment] argument.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// In this example, the children are spaced out equally, unless there's no more
 /// room, in which case they stack vertically and scroll.
 ///
@@ -154,7 +154,7 @@ import 'scrollable.dart';
 /// so that the intrinsic sizing algorithm can short-circuit the computation when it
 /// reaches those parts of the subtree.
 ///
-/// {@tool dartpad --template=stateless_widget_material}
+/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
 /// In this example, the column becomes either as big as viewport, or as big as
 /// the contents, whichever is biggest.
 ///

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -80,7 +80,7 @@ import 'scrollable.dart';
 /// with some remaining space to allocate as specified by its
 /// [Column.mainAxisAlignment] argument.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// In this example, the children are spaced out equally, unless there's no more
 /// room, in which case they stack vertically and scroll.
 ///
@@ -154,7 +154,7 @@ import 'scrollable.dart';
 /// so that the intrinsic sizing algorithm can short-circuit the computation when it
 /// reaches those parts of the subtree.
 ///
-/// {@tool dartpad --template=stateless_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_material_no_null_safety}
 /// In this example, the column becomes either as big as viewport, or as big as
 /// the contents, whichever is biggest.
 ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -16,6 +16,7 @@ export 'package:flutter/rendering.dart' show
   SliverGridDelegateWithFixedCrossAxisCount,
   SliverGridDelegateWithMaxCrossAxisExtent;
 
+// Examples are not null safe.
 // Examples can assume:
 // SliverGridDelegateWithMaxCrossAxisExtent _gridDelegate;
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -16,8 +16,8 @@ export 'package:flutter/rendering.dart' show
   SliverGridDelegateWithFixedCrossAxisCount,
   SliverGridDelegateWithMaxCrossAxisExtent;
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // SliverGridDelegateWithMaxCrossAxisExtent _gridDelegate;
 
 /// A callback which produces a semantic index given a widget and the local index.

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -203,7 +203,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// of space that has been scrolled beforehand has not exceeded the main axis
 /// extent of the viewport.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// In this sample the [SliverFillRemaining] sizes its [child] to fill the
 /// remaining extent of the viewport in both axes. The icon is centered in the
@@ -239,7 +239,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// [SliverFillRemaining] will defer to the size of its [child] if the
 /// child's size exceeds the remaining space in the viewport.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// In this sample the [SliverFillRemaining] defers to the size of its [child]
 /// because the child's extent exceeds that of the remaining extent of the
@@ -281,7 +281,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// [SliverFillRemaining] will defer to the size of its [child] if the
 /// [SliverConstraints.precedingScrollExtent] exceeded the length of the viewport's main axis.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// In this sample the [SliverFillRemaining] defers to the size of its [child]
 /// because the [SliverConstraints.precedingScrollExtent] has gone
@@ -330,7 +330,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///
 /// {@animation 250 500 https://flutter.github.io/assets-for-api-docs/assets/widgets/sliver_fill_remaining_fill_overscroll.mp4}
 ///
-/// {@tool sample --template=stateless_widget_scaffold}
+/// {@tool sample --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// In this sample the [SliverFillRemaining]'s child stretches to fill the
 /// overscroll area when [fillOverscroll] is true. This sample also features a

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -203,7 +203,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// of space that has been scrolled beforehand has not exceeded the main axis
 /// extent of the viewport.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// In this sample the [SliverFillRemaining] sizes its [child] to fill the
 /// remaining extent of the viewport in both axes. The icon is centered in the
@@ -239,7 +239,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// [SliverFillRemaining] will defer to the size of its [child] if the
 /// child's size exceeds the remaining space in the viewport.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// In this sample the [SliverFillRemaining] defers to the size of its [child]
 /// because the child's extent exceeds that of the remaining extent of the
@@ -281,7 +281,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 /// [SliverFillRemaining] will defer to the size of its [child] if the
 /// [SliverConstraints.precedingScrollExtent] exceeded the length of the viewport's main axis.
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// In this sample the [SliverFillRemaining] defers to the size of its [child]
 /// because the [SliverConstraints.precedingScrollExtent] has gone
@@ -330,7 +330,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///
 /// {@animation 250 500 https://flutter.github.io/assets-for-api-docs/assets/widgets/sliver_fill_remaining_fill_overscroll.mp4}
 ///
-/// {@tool sample --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool sample --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// In this sample the [SliverFillRemaining]'s child stretches to fill the
 /// overscroll area when [fillOverscroll] is true. This sample also features a

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -81,7 +81,7 @@ class _TableElementRow {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=_lbE0wsVZSw}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
 ///
 /// This sample shows a `Table` with borders, multiple types of column widths and different vertical cell alignments.
 ///

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -81,7 +81,7 @@ class _TableElementRow {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=_lbE0wsVZSw}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold --no-null-safety}
+/// {@tool dartpad --template=stateless_widget_scaffold_no_null_safety}
 ///
 /// This sample shows a `Table` with borders, multiple types of column widths and different vertical cell alignments.
 ///

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -12,6 +12,7 @@ import 'framework.dart';
 import 'inherited_theme.dart';
 import 'media_query.dart';
 
+// Examples are not null safe.
 // Examples can assume:
 // String _name;
 

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -12,8 +12,8 @@ import 'framework.dart';
 import 'inherited_theme.dart';
 import 'media_query.dart';
 
-// Examples are not null safe.
 // Examples can assume:
+// // @dart = 2.9
 // String _name;
 
 /// The text style to apply to descendant [Text] widgets which don't have an

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -25,7 +25,7 @@ export 'package:flutter/rendering.dart' show RelativeRect;
 /// [AnimatedWidget] is most useful for widgets that are otherwise stateless. To
 /// use [AnimatedWidget], simply subclass it and implement the build function.
 ///
-///{@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+///{@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This code defines a widget called `Spinner` that spins a green square
 /// continually. It is built with an [AnimatedWidget].
@@ -195,7 +195,7 @@ class _AnimatedState extends State<AnimatedWidget> {
 /// animated by a [CurvedAnimation] set to [Curves.elasticIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/slide_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state_no_null_safety}
 /// The following code implements the [SlideTransition] as seen in the video
 /// above:
 ///
@@ -313,7 +313,7 @@ class SlideTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/scale_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [ScaleTransition] as seen in the video
 /// above:
@@ -416,7 +416,7 @@ class ScaleTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.elasticOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/rotation_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [RotationTransition] as seen in the video
 /// above:
@@ -525,7 +525,7 @@ class RotationTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/size_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This code defines a widget that uses [SizeTransition] to change the size
 /// of [FlutterLogo] continually. It is built with a [Scaffold]
@@ -658,7 +658,7 @@ class SizeTransition extends AnimatedWidget {
 /// Here's an illustration of the [FadeTransition] widget, with it's [opacity]
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [FadeTransition] using
 /// the Flutter logo:
@@ -762,7 +762,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 
 /// Animates the opacity of a sliver widget.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state_no_null_safety}
 /// Creates a [CustomScrollView] with a [SliverFixedExtentList] that uses a
 /// [SliverFadeTransition] to fade the list in and out.
 ///
@@ -904,7 +904,7 @@ class RelativeRectTween extends Tween<RelativeRect> {
 /// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/positioned_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [PositionedTransition] as seen in the video
 /// above:
@@ -1010,7 +1010,7 @@ class PositionedTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/relative_positioned_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [RelativePositionedTransition] as seen in the video
 /// above:
@@ -1130,7 +1130,7 @@ class RelativePositionedTransition extends AnimatedWidget {
 /// [decoration] animated by a [CurvedAnimation] set to [Curves.decelerate]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/decorated_box_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 /// The following code implements the [DecoratedBoxTransition] as seen in the video
 /// above:
 ///
@@ -1310,7 +1310,7 @@ class AlignTransition extends AnimatedWidget {
 /// Animated version of a [DefaultTextStyle] that animates the different properties
 /// of its [TextStyle].
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// The following code implements the [DefaultTextStyleTransition] that shows
 /// a transition between thick blue font and thin red font.
@@ -1438,7 +1438,7 @@ class DefaultTextStyleTransition extends AnimatedWidget {
 /// Using this pre-built child is entirely optional, but can improve
 /// performance significantly in some cases and is therefore a good practice.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_ticker_no_null_safety}
 ///
 /// This code defines a widget that spins a green square continually. It is
 /// built with an [AnimatedBuilder] and makes use of the [child] feature to

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -25,7 +25,7 @@ export 'package:flutter/rendering.dart' show RelativeRect;
 /// [AnimatedWidget] is most useful for widgets that are otherwise stateless. To
 /// use [AnimatedWidget], simply subclass it and implement the build function.
 ///
-///{@tool dartpad --template=stateful_widget_material_ticker}
+///{@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This code defines a widget called `Spinner` that spins a green square
 /// continually. It is built with an [AnimatedWidget].
@@ -195,7 +195,7 @@ class _AnimatedState extends State<AnimatedWidget> {
 /// animated by a [CurvedAnimation] set to [Curves.elasticIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/slide_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
 /// The following code implements the [SlideTransition] as seen in the video
 /// above:
 ///
@@ -313,7 +313,7 @@ class SlideTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/scale_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [ScaleTransition] as seen in the video
 /// above:
@@ -416,7 +416,7 @@ class ScaleTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.elasticOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/rotation_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [RotationTransition] as seen in the video
 /// above:
@@ -525,7 +525,7 @@ class RotationTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/size_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This code defines a widget that uses [SizeTransition] to change the size
 /// of [FlutterLogo] continually. It is built with a [Scaffold]
@@ -658,7 +658,7 @@ class SizeTransition extends AnimatedWidget {
 /// Here's an illustration of the [FadeTransition] widget, with it's [opacity]
 /// animated by a [CurvedAnimation] set to [Curves.fastOutSlowIn]:
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [FadeTransition] using
 /// the Flutter logo:
@@ -762,7 +762,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 
 /// Animates the opacity of a sliver widget.
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_freeform_state --no-null-safety}
 /// Creates a [CustomScrollView] with a [SliverFixedExtentList] that uses a
 /// [SliverFadeTransition] to fade the list in and out.
 ///
@@ -904,7 +904,7 @@ class RelativeRectTween extends Tween<RelativeRect> {
 /// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/positioned_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [PositionedTransition] as seen in the video
 /// above:
@@ -1010,7 +1010,7 @@ class PositionedTransition extends AnimatedWidget {
 /// animated by a [CurvedAnimation] set to [Curves.elasticInOut]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/relative_positioned_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [RelativePositionedTransition] as seen in the video
 /// above:
@@ -1130,7 +1130,7 @@ class RelativePositionedTransition extends AnimatedWidget {
 /// [decoration] animated by a [CurvedAnimation] set to [Curves.decelerate]:
 /// {@animation 300 378 https://flutter.github.io/assets-for-api-docs/assets/widgets/decorated_box_transition.mp4}
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 /// The following code implements the [DecoratedBoxTransition] as seen in the video
 /// above:
 ///
@@ -1310,7 +1310,7 @@ class AlignTransition extends AnimatedWidget {
 /// Animated version of a [DefaultTextStyle] that animates the different properties
 /// of its [TextStyle].
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// The following code implements the [DefaultTextStyleTransition] that shows
 /// a transition between thick blue font and thin red font.
@@ -1438,7 +1438,7 @@ class DefaultTextStyleTransition extends AnimatedWidget {
 /// Using this pre-built child is entirely optional, but can improve
 /// performance significantly in some cases and is therefore a good practice.
 ///
-/// {@tool dartpad --template=stateful_widget_material_ticker}
+/// {@tool dartpad --template=stateful_widget_material_ticker --no-null-safety}
 ///
 /// This code defines a widget that spins a green square continually. It is
 /// built with an [AnimatedBuilder] and makes use of the [child] feature to

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -61,7 +61,7 @@ import 'value_listenable_builder.dart';
 ///
 /// ## Example Code
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center}
+/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
 /// This example shows an [IconButton] that "zooms" in when the widget first
 /// builds (its size smoothly increases from 0 to 24) and whenever the button
 /// is pressed, it smoothly changes its size to the new target value of either

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -61,7 +61,7 @@ import 'value_listenable_builder.dart';
 ///
 /// ## Example Code
 ///
-/// {@tool dartpad --template=stateful_widget_scaffold_center --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_scaffold_center_no_null_safety}
 /// This example shows an [IconButton] that "zooms" in when the widget first
 /// builds (its size smoothly increases from 0 to 24) and whenever the button
 /// is pressed, it smoothly changes its size to the new target value of either

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -6,7 +6,8 @@ import 'package:flutter/foundation.dart';
 
 import 'framework.dart';
 
-// Examples are not null safe.
+// Examples can assume:
+// // @dart = 2.9
 
 /// Builds a [Widget] when given a concrete value of a [ValueListenable<T>].
 ///

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 
 import 'framework.dart';
 
+// Examples are not null safe.
+
 /// Builds a [Widget] when given a concrete value of a [ValueListenable<T>].
 ///
 /// If the `child` parameter provided to the [ValueListenableBuilder] is not

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,7 +29,7 @@ import 'routes.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
 /// ```dart
 /// bool shouldPop = true;
 /// @override

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -29,7 +29,7 @@ import 'routes.dart';
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material --no-null-safety}
+/// {@tool dartpad --template=stateful_widget_material_no_null_safety}
 /// ```dart
 /// bool shouldPop = true;
 /// @override


### PR DESCRIPTION
## Description

With this PR landed, we can one-by-one migrate the samples and snippets in our API docs to null safety using the new interactive analyzer mode for snippets and samples (see below).

This PR:

* Adds sample template versions that have been migrated to null safety. The unmigrated templates have been renamed to end in `_no_null_safety` and will be deleted once the migration is complete.
* Extends the snippet generator and analyzer to support snippets and sample code that have been migrated to NNBD:
  - Samples can opt out of null safety by using a template that ends in `_no_null_safety`.
  - Snippets can be opted out of null safety for an entire fill by placing `// Examples are not null safe.` near the top of the file, similar to the `// Examples can assume:` feature. (Snippet opt-out is for entire file because snippets share the `// Examples can assume:` section)
* Migrates one sample and one snippet to NNBD
* Opts out all other samples and snippets from NNBD (for now).
* Adds an interactive analyzer mode for snippets and samples to `dev/bots/analyze-sample-code.dart`, launched via `dart dev/bots/analyze-sample-code.dart -i <path to dart file>` it will watch the file and whenever it changes, re-analyze the snippets/samples in that file. Analyzer errors are displayed interactively in the console. This will make migration of snippets and samples faster/easier.

## Related Issues

https://github.com/flutter/flutter/issues/69123

## Tests

I added the following tests:

* Tests for the NNBD mode of the snippet/sample generator.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
