### PR TITLE
Add footer to CupertinoFormSection and fix CupertinoFormSection margins.

### DIFF
--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -10,7 +10,7 @@ import 'theme.dart';
 
 // Content padding determined via SwiftUI's `Form` view in the iOS 14.2 SDK.
 const EdgeInsetsGeometry _kDefaultPadding =
-    EdgeInsetsDirectional.fromSTEB(16.0, 6.0, 6.0, 6.0);
+    EdgeInsetsDirectional.fromSTEB(20.0, 6.0, 6.0, 6.0);
 
 /// An iOS-style form row.
 ///
@@ -149,22 +149,7 @@ class CupertinoFormRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CupertinoThemeData themeData = CupertinoTheme.of(context);
-    final TextStyle textStyle = themeData.textTheme.textStyle;
-
-    final List<Widget> rowChildren = <Widget>[
-      if (prefix != null)
-        DefaultTextStyle(
-          style: textStyle,
-          child: prefix!,
-        ),
-      Flexible(
-        child: Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: child,
-        ),
-      ),
-    ];
+    final TextStyle textStyle = CupertinoTheme.of(context).textTheme.textStyle;
 
     return Padding(
       padding: padding ?? _kDefaultPadding,
@@ -172,7 +157,19 @@ class CupertinoFormRow extends StatelessWidget {
         children: <Widget>[
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: rowChildren,
+            children: <Widget>[
+              if (prefix != null)
+                DefaultTextStyle(
+                  style: textStyle,
+                  child: prefix!,
+                ),
+              Flexible(
+                child: Align(
+                  alignment: AlignmentDirectional.centerEnd,
+                  child: child,
+                ),
+              ),
+            ],
           ),
           if (helper != null)
             Align(

--- a/packages/flutter/lib/src/cupertino/form_section.dart
+++ b/packages/flutter/lib/src/cupertino/form_section.dart
@@ -9,12 +9,16 @@ import 'colors.dart';
 
 // Standard header margin, determined from SwiftUI's Forms in iOS 14.2 SDK.
 const EdgeInsetsDirectional _kDefaultHeaderMargin =
-    EdgeInsetsDirectional.fromSTEB(16.5, 16.0, 16.5, 10.0);
+    EdgeInsetsDirectional.fromSTEB(20.0, 16.0, 20.0, 10.0);
+
+// Standard footer margin, determined from SwiftUI's Forms in iOS 14.2 SDK.
+const EdgeInsetsDirectional _kDefaultFooterMargin =
+    EdgeInsetsDirectional.fromSTEB(20.0, 0.0, 20.0, 10.0);
 
 // Used for iOS "Inset Grouped" margin, determined from SwiftUI's Forms in
 // iOS 14.2 SDK.
 const EdgeInsetsDirectional _kDefaultInsetGroupedRowsMargin =
-    EdgeInsetsDirectional.fromSTEB(16.5, 0.0, 16.5, 16.5);
+    EdgeInsetsDirectional.fromSTEB(20.0, 0.0, 20.0, 10.0);
 
 // Used for iOS "Inset Grouped" border radius, estimated from SwiftUI's Forms in
 // iOS 14.2 SDK.
@@ -38,6 +42,9 @@ enum _CupertinoFormSectionType { base, insetGrouped }
 ///
 /// The [header] parameter sets the form section header. The section header lies
 /// above the [children] rows, with margins that match the iOS style.
+///
+/// The [footer] parameter sets the form section footer. The section footer
+/// lies below the [children] rows.
 ///
 /// The [children] parameter is required and sets the list of rows shown in
 /// the section. The [children] parameter takes a list, as opposed to a more
@@ -69,6 +76,9 @@ class CupertinoFormSection extends StatelessWidget {
   /// The [header] parameter sets the form section header. The section header
   /// lies above the [children] rows, with margins that match the iOS style.
   ///
+  /// The [footer] parameter sets the form section footer. The section footer
+  /// lies below the [children] rows.
+  ///
   /// The [children] parameter is required and sets the list of rows shown in
   /// the section. The [children] parameter takes a list, as opposed to a more
   /// efficient builder function that lazy builds, because forms are intended to
@@ -93,6 +103,7 @@ class CupertinoFormSection extends StatelessWidget {
     Key? key,
     required this.children,
     this.header,
+    this.footer,
     this.margin = EdgeInsets.zero,
     this.backgroundColor = CupertinoColors.systemGroupedBackground,
     this.decoration,
@@ -110,6 +121,9 @@ class CupertinoFormSection extends StatelessWidget {
   ///
   /// The [header] parameter sets the form section header. The section header
   /// lies above the [children] rows, with margins that match the iOS style.
+  ///
+  /// The [footer] parameter sets the form section footer. The section footer
+  /// lies below the [children] rows.
   ///
   /// The [children] parameter is required and sets the list of rows shown in
   /// the section. The [children] parameter takes a list, as opposed to a more
@@ -136,6 +150,7 @@ class CupertinoFormSection extends StatelessWidget {
     Key? key,
     required this.children,
     this.header,
+    this.footer,
     this.margin = _kDefaultInsetGroupedRowsMargin,
     this.backgroundColor = CupertinoColors.systemGroupedBackground,
     this.decoration,
@@ -149,6 +164,10 @@ class CupertinoFormSection extends StatelessWidget {
   /// Sets the form section header. The section header lies above the
   /// [children] rows.
   final Widget? header;
+
+  /// Sets the form section footer. The section footer lies below the
+  /// [children] rows.
+  final Widget? footer;
 
   /// Margin around the content area of the section encapsulating [children].
   ///
@@ -228,6 +247,11 @@ class CupertinoFormSection extends StatelessWidget {
       childrenWithDividers.add(longDivider);
     }
 
+    final BorderRadius childrenGroupBorderRadius =
+        _type == _CupertinoFormSectionType.insetGrouped
+            ? _kDefaultInsetGroupedBorderRadius
+            : BorderRadius.zero;
+
     // Refactored the decorate children group in one place to avoid repeating it
     // twice down bellow in the returned widget.
     final DecoratedBox decoratedChildrenGroup = DecoratedBox(
@@ -237,7 +261,7 @@ class CupertinoFormSection extends StatelessWidget {
                 decoration?.color ??
                     CupertinoColors.secondarySystemGroupedBackground,
                 context),
-            borderRadius: _kDefaultInsetGroupedBorderRadius,
+            borderRadius: childrenGroupBorderRadius,
           ),
       child: Column(
         children: childrenWithDividers,
@@ -256,7 +280,7 @@ class CupertinoFormSection extends StatelessWidget {
                 ? null
                 : DefaultTextStyle(
                     style: TextStyle(
-                      fontSize: 13.5,
+                      fontSize: 13.0,
                       color:
                           CupertinoColors.secondaryLabel.resolveFrom(context),
                     ),
@@ -271,9 +295,25 @@ class CupertinoFormSection extends StatelessWidget {
             child: clipBehavior == Clip.none
                 ? decoratedChildrenGroup
                 : ClipRRect(
-                    borderRadius: _kDefaultInsetGroupedBorderRadius,
+                    borderRadius: childrenGroupBorderRadius,
                     clipBehavior: clipBehavior,
                     child: decoratedChildrenGroup),
+          ),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: footer == null
+                ? null
+                : DefaultTextStyle(
+                    style: TextStyle(
+                      fontSize: 13.0,
+                      color:
+                          CupertinoColors.secondaryLabel.resolveFrom(context),
+                    ),
+                    child: Padding(
+                      padding: _kDefaultFooterMargin,
+                      child: footer!,
+                    ),
+                  ),
           ),
         ],
       ),

--- a/packages/flutter/lib/src/cupertino/form_section.dart
+++ b/packages/flutter/lib/src/cupertino/form_section.dart
@@ -249,10 +249,10 @@ class CupertinoFormSection extends StatelessWidget {
 
     final BorderRadius childrenGroupBorderRadius;
     switch (_type) {
-      case _CupertinoFormSectionType.base:
+      case _CupertinoFormSectionType.insetGrouped:
         childrenGroupBorderRadius = _kDefaultInsetGroupedBorderRadius;
         break;
-      case _CupertinoFormSectionType.insetGrouped:
+      case _CupertinoFormSectionType.base:
         childrenGroupBorderRadius = BorderRadius.zero;
         break;
     }

--- a/packages/flutter/lib/src/cupertino/form_section.dart
+++ b/packages/flutter/lib/src/cupertino/form_section.dart
@@ -247,10 +247,15 @@ class CupertinoFormSection extends StatelessWidget {
       childrenWithDividers.add(longDivider);
     }
 
-    final BorderRadius childrenGroupBorderRadius =
-        _type == _CupertinoFormSectionType.insetGrouped
-            ? _kDefaultInsetGroupedBorderRadius
-            : BorderRadius.zero;
+    final BorderRadius childrenGroupBorderRadius;
+    switch (_type) {
+      case _CupertinoFormSectionType.base:
+        childrenGroupBorderRadius = _kDefaultInsetGroupedBorderRadius;
+        break;
+      case _CupertinoFormSectionType.insetGrouped:
+        childrenGroupBorderRadius = BorderRadius.zero;
+        break;
+    }
 
     // Refactored the decorate children group in one place to avoid repeating it
     // twice down bellow in the returned widget.
@@ -274,22 +279,20 @@ class CupertinoFormSection extends StatelessWidget {
       ),
       child: Column(
         children: <Widget>[
-          Align(
-            alignment: AlignmentDirectional.centerStart,
-            child: header == null
-                ? null
-                : DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 13.0,
-                      color:
-                          CupertinoColors.secondaryLabel.resolveFrom(context),
-                    ),
-                    child: Padding(
-                      padding: _kDefaultHeaderMargin,
-                      child: header!,
-                    ),
-                  ),
-          ),
+          if (header != null)
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: DefaultTextStyle(
+                style: TextStyle(
+                  fontSize: 13.0,
+                  color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                ),
+                child: Padding(
+                  padding: _kDefaultHeaderMargin,
+                  child: header!,
+                ),
+              ),
+            ),
           Padding(
             padding: margin,
             child: clipBehavior == Clip.none
@@ -299,22 +302,20 @@ class CupertinoFormSection extends StatelessWidget {
                     clipBehavior: clipBehavior,
                     child: decoratedChildrenGroup),
           ),
-          Align(
-            alignment: AlignmentDirectional.centerStart,
-            child: footer == null
-                ? null
-                : DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 13.0,
-                      color:
-                          CupertinoColors.secondaryLabel.resolveFrom(context),
-                    ),
-                    child: Padding(
-                      padding: _kDefaultFooterMargin,
-                      child: footer!,
-                    ),
-                  ),
-          ),
+          if (footer != null)
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: DefaultTextStyle(
+                style: TextStyle(
+                  fontSize: 13.0,
+                  color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                ),
+                child: Padding(
+                  padding: _kDefaultFooterMargin,
+                  child: footer!,
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/packages/flutter/test/cupertino/form_section_test.dart
+++ b/packages/flutter/test/cupertino/form_section_test.dart
@@ -8,37 +8,33 @@ import 'package:flutter/rendering.dart';
 
 void main() {
   testWidgets('Shows header', (WidgetTester tester) async {
-    const Widget header = Text('Enter Value');
-
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(
           child: CupertinoFormSection(
-            header: header,
+            header: const Text('Header'),
             children: <Widget>[CupertinoTextFormFieldRow()],
           ),
         ),
       ),
     );
 
-    expect(header, tester.widget(find.byType(Text)));
+    expect(find.text('Header'), findsOneWidget);
   });
 
   testWidgets('Shows footer', (WidgetTester tester) async {
-    const Widget footer = Text('Footer');
-
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(
           child: CupertinoFormSection(
-            header: footer,
+            footer: const Text('Footer'),
             children: <Widget>[CupertinoTextFormFieldRow()],
           ),
         ),
       ),
     );
 
-    expect(footer, tester.widget(find.byType(Text)));
+    expect(find.text('Footer'), findsOneWidget);
   });
 
   testWidgets('Shows long dividers in edge-to-edge section part 1',

--- a/packages/flutter/test/cupertino/form_section_test.dart
+++ b/packages/flutter/test/cupertino/form_section_test.dart
@@ -24,6 +24,23 @@ void main() {
     expect(header, tester.widget(find.byType(Text)));
   });
 
+  testWidgets('Shows footer', (WidgetTester tester) async {
+    const Widget footer = Text('Footer');
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoFormSection(
+            header: footer,
+            children: <Widget>[CupertinoTextFormFieldRow()],
+          ),
+        ),
+      ),
+    );
+
+    expect(footer, tester.widget(find.byType(Text)));
+  });
+
   testWidgets('Shows long dividers in edge-to-edge section part 1',
       (WidgetTester tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

- Added footer widget shown underneath children rows in `CupertinoFormSection`.

<img width="433" alt="Screen Shot 2020-12-09 at 5 46 55 PM" src="https://user-images.githubusercontent.com/11810973/101710602-a973ea80-3a46-11eb-9d2c-860a3e5932ee.png">

- Fixed `CupertinoFormSection` margins to match SwiftUI `Form` sections and `CupertinoFormRow` margins to match SwiftUI `Form` rows.

- Fixed border radius issue that existed in the standard `CupertinoFormSection()` constructor.

- Refactored code for `CupertinoFormSection` and `CupertinoFormRow`.

## Related Issues

Related PR: https://github.com/flutter/flutter/pull/70676

## Tests

Added documentation and tests for footer.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
