### PR TITLE
Cupertino text selection on long press

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1000,7 +1000,7 @@ class TextSelectionGestureDetectorBuilder {
   /// Handler for [TextSelectionGestureDetector.onSingleLongTapStart].
   ///
   /// By default, it selects text position specified in [details] if selection
-  /// is enabled.
+  /// is enabled. If widget is not focused, it selects the word that is tapped on.
   ///
   /// See also:
   ///
@@ -1009,17 +1009,26 @@ class TextSelectionGestureDetectorBuilder {
   @protected
   void onSingleLongTapStart(LongPressStartDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditable.selectPositionAt(
-        from: details.globalPosition,
-        cause: SelectionChangedCause.longPress,
-      );
+      if (!renderEditable.hasFocus) {
+        renderEditable.selectWordsInRange(
+          from: details.globalPosition,
+          to: details.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        );
+      } else {
+        renderEditable.selectPositionAt(
+          from: details.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        );
+      }
     }
   }
 
   /// Handler for [TextSelectionGestureDetector.onSingleLongTapMoveUpdate].
   ///
   /// By default, it updates the selection location specified in [details] if
-  /// selection is enabled.
+  /// selection is enabled. If there are characters already selected, it extends
+  /// the selection.
   ///
   /// See also:
   ///
@@ -1028,10 +1037,22 @@ class TextSelectionGestureDetectorBuilder {
   @protected
   void onSingleLongTapMoveUpdate(LongPressMoveUpdateDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditable.selectPositionAt(
-        from: details.globalPosition,
-        cause: SelectionChangedCause.longPress,
-      );
+      final int selectionCharacterCount = ((renderEditable.selection?.start ?? 0) - (renderEditable.selection?.end ?? 0)).abs();
+      
+      // This checks to make sure it only selects words if there's already some
+      // characters selected.
+      if (selectionCharacterCount > 0) {
+        renderEditable.selectWordsInRange(
+          from: details.globalPosition - details.offsetFromOrigin,
+          to: details.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        );
+      } else {
+        renderEditable.selectPositionAt(
+          from: details.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Per https://github.com/flutter/flutter/issues/35010, modified text selection to occur on long press.

- If text is not focused, the word long pressed on will be selected and dragging will selected more/less.
- If text is focused, the cursor is moved upon long press dragging.

Demo video: https://github.com/DanielEdrisian/SharedStorage/blob/main/long%20press%20demo.mov

## Problems

Extending the word selection seems to not scroll along. Whereas when dragging the start/end of the text selection, the text scrolls to match the start/end even if it goes past the visible characters. What could be the problem here?

Problem demo video: https://github.com/DanielEdrisian/SharedStorage/blob/main/problem%20demo.mov

## Related Issues

https://github.com/flutter/flutter/issues/35010

## Tests

No tests yet.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ]  All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
