### PR TITLE
Cleanup nullability for ImplicitlyAnimatedWidgetState

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -777,8 +777,8 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
 
   @override
   Widget build(BuildContext context) {
-    final ShapeBorder shape = _border!.evaluate(animation!)!;
-    final double elevation = _elevation!.evaluate(animation!);
+    final ShapeBorder shape = _border!.evaluate(animation)!;
+    final double elevation = _elevation!.evaluate(animation);
     return PhysicalShape(
       child: _ShapeBorderPaint(
         child: widget.child,
@@ -792,7 +792,7 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
       clipBehavior: widget.clipBehavior,
       elevation: elevation,
       color: ElevationOverlay.applyOverlay(context, widget.color, elevation),
-      shadowColor: _shadowColor!.evaluate(animation!)!,
+      shadowColor: _shadowColor!.evaluate(animation)!,
     );
   }
 }

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -230,7 +230,7 @@ class _AnimatedThemeState extends AnimatedWidgetBaseState<AnimatedTheme> {
   Widget build(BuildContext context) {
     return Theme(
       child: widget.child,
-      data: _data!.evaluate(animation!),
+      data: _data!.evaluate(animation),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -463,7 +463,7 @@ class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<_Animate
 
   @override
   void didUpdateTweens() {
-    _placeholderOpacityAnimation = animation!.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
+    _placeholderOpacityAnimation = animation.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
       TweenSequenceItem<double>(
         tween: _placeholderOpacity!.chain(CurveTween(curve: widget.fadeOutCurve)),
         weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
@@ -479,7 +479,7 @@ class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<_Animate
       }
     });
 
-    _targetOpacityAnimation = animation!.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
+    _targetOpacityAnimation = animation.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
       TweenSequenceItem<double>(
         tween: ConstantTween<double>(0),
         weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
@@ -492,7 +492,7 @@ class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<_Animate
     if (!widget.isTargetLoaded && _isValid(_placeholderOpacity!) && _isValid(_targetOpacity!)) {
       // Jump (don't fade) back to the placeholder image, so as to be ready
       // for the full animation when the new target image becomes ready.
-      controller!.value = controller!.upperBound;
+      controller.value = controller.upperBound;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -353,10 +353,10 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   @protected
   AnimationController get controller => _controller;
   late final AnimationController _controller = AnimationController(
-      duration: widget.duration,
-      debugLabel: kDebugMode ? widget.toStringShort() : null,
-      vsync: this,
-    );
+    duration: widget.duration,
+    debugLabel: kDebugMode ? widget.toStringShort() : null,
+    vsync: this,
+  );
 
   /// The animation driving this widget's implicit animations.
   Animation<double> get animation => _animation;

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -351,22 +351,21 @@ typedef TweenVisitor<T extends Object> = Tween<T>? Function(Tween<T>? tween, T t
 abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin<T> {
   /// The animation controller driving this widget's implicit animations.
   @protected
-  AnimationController? get controller => _controller;
-  AnimationController? _controller;
-
-  /// The animation driving this widget's implicit animations.
-  Animation<double>? get animation => _animation;
-  Animation<double>? _animation;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = AnimationController(
+  AnimationController get controller => _controller;
+  late final AnimationController _controller = AnimationController(
       duration: widget.duration,
       debugLabel: kDebugMode ? widget.toStringShort() : null,
       vsync: this,
     );
-    _controller!.addStatusListener((AnimationStatus status) {
+
+  /// The animation driving this widget's implicit animations.
+  Animation<double> get animation => _animation;
+  late Animation<double> _animation = _createCurve();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addStatusListener((AnimationStatus status) {
       switch (status) {
         case AnimationStatus.completed:
           if (widget.onEnd != null)
@@ -377,7 +376,6 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
         case AnimationStatus.reverse:
       }
     });
-    _updateCurve();
     _constructTweens();
     didUpdateTweens();
   }
@@ -386,27 +384,27 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   void didUpdateWidget(T oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.curve != oldWidget.curve)
-      _updateCurve();
-    _controller!.duration = widget.duration;
+      _animation = _createCurve();
+    _controller.duration = widget.duration;
     if (_constructTweens()) {
       forEachTween((Tween<dynamic>? tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
         _updateTween(tween, targetValue);
         return tween;
       });
-      _controller!
+      _controller
         ..value = 0.0
         ..forward();
       didUpdateTweens();
     }
   }
 
-  void _updateCurve() {
-    _animation = CurvedAnimation(parent: _controller!, curve: widget.curve);
+  CurvedAnimation _createCurve() {
+    return CurvedAnimation(parent: _controller, curve: widget.curve);
   }
 
   @override
   void dispose() {
-    _controller!.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -418,7 +416,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
     if (tween == null)
       return;
     tween
-      ..begin = tween.evaluate(_animation!)
+      ..begin = tween.evaluate(_animation)
       ..end = targetValue;
   }
 
@@ -551,7 +549,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
   @override
   void initState() {
     super.initState();
-    controller!.addListener(_handleAnimationChanged);
+    controller.addListener(_handleAnimationChanged);
   }
 
   void _handleAnimationChanged() {
@@ -775,7 +773,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 
   @override
   Widget build(BuildContext context) {
-    final Animation<double> animation = this.animation!;
+    final Animation<double> animation = this.animation;
     return Container(
       child: widget.child,
       alignment: _alignment?.evaluate(animation),
@@ -906,7 +904,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
   Widget build(BuildContext context) {
     return Padding(
       padding: _padding!
-        .evaluate(animation!)
+        .evaluate(animation)
         .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
       child: widget.child,
     );
@@ -1057,9 +1055,9 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   @override
   Widget build(BuildContext context) {
     return Align(
-      alignment: _alignment!.evaluate(animation!)!,
-      heightFactor: _heightFactorTween?.evaluate(animation!),
-      widthFactor: _widthFactorTween?.evaluate(animation!),
+      alignment: _alignment!.evaluate(animation)!,
+      heightFactor: _heightFactorTween?.evaluate(animation),
+      widthFactor: _widthFactorTween?.evaluate(animation),
       child: widget.child,
     );
   }
@@ -1254,12 +1252,12 @@ class _AnimatedPositionedState extends AnimatedWidgetBaseState<AnimatedPositione
   Widget build(BuildContext context) {
     return Positioned(
       child: widget.child,
-      left: _left?.evaluate(animation!),
-      top: _top?.evaluate(animation!),
-      right: _right?.evaluate(animation!),
-      bottom: _bottom?.evaluate(animation!),
-      width: _width?.evaluate(animation!),
-      height: _height?.evaluate(animation!),
+      left: _left?.evaluate(animation),
+      top: _top?.evaluate(animation),
+      right: _right?.evaluate(animation),
+      bottom: _bottom?.evaluate(animation),
+      width: _width?.evaluate(animation),
+      height: _height?.evaluate(animation),
     );
   }
 
@@ -1391,12 +1389,12 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
     return Positioned.directional(
       textDirection: Directionality.of(context),
       child: widget.child,
-      start: _start?.evaluate(animation!),
-      top: _top?.evaluate(animation!),
-      end: _end?.evaluate(animation!),
-      bottom: _bottom?.evaluate(animation!),
-      width: _width?.evaluate(animation!),
-      height: _height?.evaluate(animation!),
+      start: _start?.evaluate(animation),
+      top: _top?.evaluate(animation),
+      end: _end?.evaluate(animation),
+      bottom: _bottom?.evaluate(animation),
+      width: _width?.evaluate(animation),
+      height: _height?.evaluate(animation),
     );
   }
 
@@ -1528,7 +1526,7 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 
   @override
   void didUpdateTweens() {
-    _opacityAnimation = animation!.drive(_opacity!);
+    _opacityAnimation = animation.drive(_opacity!);
   }
 
   @override
@@ -1661,7 +1659,7 @@ class _SliverAnimatedOpacityState extends ImplicitlyAnimatedWidgetState<SliverAn
 
   @override
   void didUpdateTweens() {
-    _opacityAnimation = animation!.drive(_opacity!);
+    _opacityAnimation = animation.drive(_opacity!);
   }
 
   @override
@@ -1791,7 +1789,7 @@ class _AnimatedDefaultTextStyleState extends AnimatedWidgetBaseState<AnimatedDef
   @override
   Widget build(BuildContext context) {
     return DefaultTextStyle(
-      style: _style!.evaluate(animation!),
+      style: _style!.evaluate(animation),
       textAlign: widget.textAlign,
       softWrap: widget.softWrap,
       overflow: widget.overflow,
@@ -1924,11 +1922,11 @@ class _AnimatedPhysicalModelState extends AnimatedWidgetBaseState<AnimatedPhysic
       child: widget.child,
       shape: widget.shape,
       clipBehavior: widget.clipBehavior,
-      borderRadius: _borderRadius!.evaluate(animation!),
-      elevation: _elevation!.evaluate(animation!),
-      color: widget.animateColor ? _color!.evaluate(animation!)! : widget.color,
+      borderRadius: _borderRadius!.evaluate(animation),
+      elevation: _elevation!.evaluate(animation),
+      color: widget.animateColor ? _color!.evaluate(animation)! : widget.color,
       shadowColor: widget.animateShadowColor
-          ? _shadowColor!.evaluate(animation!)!
+          ? _shadowColor!.evaluate(animation)!
           : widget.shadowColor,
     );
   }

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -203,7 +203,7 @@ class _TweenAnimationBuilderState<T extends Object> extends AnimatedWidgetBaseSt
     _currentTween!.begin ??= _currentTween!.end;
     super.initState();
     if (_currentTween!.begin != _currentTween!.end) {
-      controller!.forward();
+      controller.forward();
     }
   }
 
@@ -221,6 +221,6 @@ class _TweenAnimationBuilderState<T extends Object> extends AnimatedWidgetBaseSt
 
   @override
   Widget build(BuildContext context) {
-    return widget.builder(context, _currentTween!.evaluate(animation!), widget.child);
+    return widget.builder(context, _currentTween!.evaluate(animation), widget.child);
   }
 }


### PR DESCRIPTION
## Description

Every usage of `animation` and `controller` had to use a bang, while both could be made non-nullable with a late initializer. This cleans that up, making it more obvious we know these fields are never `null`.

Fixes #72090 .

## Tests

N/A

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] ~I updated/added relevant documentation (doc comments with `///`).~
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
