### PR TITLE
Deal with infinity in intrinsics of RenderConstrainedBox

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -234,7 +234,11 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMinIntrinsicWidth(double height) {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth)
       return _additionalConstraints.minWidth;
-    final double width = super.computeMinIntrinsicWidth(_additionalConstraints.constrainHeight(height));
+    final double width = super.computeMinIntrinsicWidth(
+      _additionalConstraints.hasInfiniteHeight
+          ? height
+          : additionalConstraints.constrainHeight(height),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth)
       return _additionalConstraints.constrainWidth(width);
@@ -245,7 +249,11 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMaxIntrinsicWidth(double height) {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth)
       return _additionalConstraints.minWidth;
-    final double width = super.computeMaxIntrinsicWidth(_additionalConstraints.constrainHeight(height));
+    final double width = super.computeMaxIntrinsicWidth(
+      _additionalConstraints.hasInfiniteHeight
+          ? height
+          : additionalConstraints.constrainHeight(height),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth)
       return _additionalConstraints.constrainWidth(width);
@@ -256,7 +264,11 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMinIntrinsicHeight(double width) {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight)
       return _additionalConstraints.minHeight;
-    final double height = super.computeMinIntrinsicHeight(_additionalConstraints.constrainWidth(width));
+    final double height = super.computeMinIntrinsicHeight(
+      _additionalConstraints.hasInfiniteWidth
+          ? width
+          : _additionalConstraints.constrainWidth(width),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight)
       return _additionalConstraints.constrainHeight(height);
@@ -267,7 +279,11 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMaxIntrinsicHeight(double width) {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight)
       return _additionalConstraints.minHeight;
-    final double height = super.computeMaxIntrinsicHeight(_additionalConstraints.constrainWidth(width));
+    final double height = super.computeMaxIntrinsicHeight(
+      _additionalConstraints.hasInfiniteWidth
+          ? width
+          : _additionalConstraints.constrainWidth(width),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight)
       return _additionalConstraints.constrainHeight(height);

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -209,4 +209,27 @@ void main() {
 
     expect(tester.getSize(find.text('This is a multi-line text.')).height, greaterThan(16));
   });
+
+  testWidgets('SizedBox constrains intrinsics correctly when one dimension is infinity', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Center(
+        child: SizedBox(
+          width: 100,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: IntrinsicHeight(
+                child: SizedBox(
+                  width: double.infinity,
+                  child: Text('This is a multi-line text.', style: TextStyle(height: 1.0, fontSize: 16)),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.text('This is a multi-line text.')).height, greaterThan(16));
+  });
 }


### PR DESCRIPTION
## Description

Follow-up to https://github.com/flutter/flutter/pull/71880. I missed the case where _additionalConstraints specify a min width/height of infinity (meaning that the box should be as big as the parent allows).

## Related Issues

#27293
b/175263631

## Tests

I added the following tests:

* test when dimension is infinity

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
