### PR TITLE
Revert "Constrain width/hight when asking child for intrinsics"

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -234,7 +234,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMinIntrinsicWidth(double height) {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth)
       return _additionalConstraints.minWidth;
-    final double width = super.computeMinIntrinsicWidth(_additionalConstraints.constrainHeight(height));
+    final double width = super.computeMinIntrinsicWidth(height);
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth)
       return _additionalConstraints.constrainWidth(width);
@@ -245,7 +245,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMaxIntrinsicWidth(double height) {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth)
       return _additionalConstraints.minWidth;
-    final double width = super.computeMaxIntrinsicWidth(_additionalConstraints.constrainHeight(height));
+    final double width = super.computeMaxIntrinsicWidth(height);
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth)
       return _additionalConstraints.constrainWidth(width);
@@ -256,7 +256,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMinIntrinsicHeight(double width) {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight)
       return _additionalConstraints.minHeight;
-    final double height = super.computeMinIntrinsicHeight(_additionalConstraints.constrainWidth(width));
+    final double height = super.computeMinIntrinsicHeight(width);
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight)
       return _additionalConstraints.constrainHeight(height);
@@ -267,7 +267,7 @@ class RenderConstrainedBox extends RenderProxyBox {
   double computeMaxIntrinsicHeight(double width) {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight)
       return _additionalConstraints.minHeight;
-    final double height = super.computeMaxIntrinsicHeight(_additionalConstraints.constrainWidth(width));
+    final double height = super.computeMaxIntrinsicHeight(width);
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight)
       return _additionalConstraints.constrainHeight(height);

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -190,23 +190,4 @@ void main() {
     );
     expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
   });
-
-  testWidgets('SizedBox constrains intrinsics', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/27293.
-    await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: IntrinsicHeight(
-            child: SizedBox(
-              width: 100,
-              child: Text('This is a multi-line text.', style: TextStyle(height: 1.0, fontSize: 16)),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(tester.getSize(find.text('This is a multi-line text.')).height, greaterThan(16));
-  });
 }


### PR DESCRIPTION
Reverts flutter/flutter#71880

Reopens https://github.com/flutter/flutter/issues/27293

It's breaking tests in google and needs more investigation.