### PR TITLE
Avoid null check operator failure in RenderFlex._hasOverflow

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -483,10 +483,10 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 
   // Set during layout if overflow occurred on the main axis.
-  double? _overflow;
+  double _overflow = 0;
   // Check whether any meaningful overflow is present. Values below an epsilon
   // are treated as not overflowing.
-  bool get _hasOverflow => _overflow! > precisionErrorTolerance;
+  bool get _hasOverflow => _overflow > precisionErrorTolerance;
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
@@ -1125,10 +1125,10 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       final Rect overflowChildRect;
       switch (_direction) {
         case Axis.horizontal:
-          overflowChildRect = Rect.fromLTWH(0.0, 0.0, size.width + _overflow!, 0.0);
+          overflowChildRect = Rect.fromLTWH(0.0, 0.0, size.width + _overflow, 0.0);
           break;
         case Axis.vertical:
-          overflowChildRect = Rect.fromLTWH(0.0, 0.0, 0.0, size.height + _overflow!);
+          overflowChildRect = Rect.fromLTWH(0.0, 0.0, 0.0, size.height + _overflow);
           break;
       }
       paintOverflowIndicator(context, offset, Offset.zero & size, overflowChildRect, overflowHints: debugOverflowHints);
@@ -1144,7 +1144,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   @override
   String toStringShort() {
     String header = super.toStringShort();
-    if (_overflow != null && _hasOverflow)
+    if (_hasOverflow)
       header += ' OVERFLOWING';
     return header;
   }

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -632,4 +632,20 @@ void main() {
     expect(() => flex.getMaxIntrinsicWidth(100), cannotCalculateIntrinsics);
     expect(() => flex.getMinIntrinsicWidth(100), cannotCalculateIntrinsics);
   });
+
+  test('Can call methods that check overflow even if overflow value is not set', () {
+    final List<dynamic> exceptions = <dynamic>[];
+    final RenderFlex flex = RenderFlex(children: const <RenderBox>[]);
+    // This forces a check for _hasOverflow
+    expect(flex.toStringShort(), isNot(contains('OVERFLOWING')));
+    layout(flex, phase: EnginePhase.paint, onErrors: () {
+      exceptions.addAll(renderer.takeAllFlutterExceptions());
+    });
+    // We expect the RenderFlex to throw during performLayout() for not having
+    // a text direction, thus leaving it with a null overflow value. It'll then
+    // try to paint(), which also checks _hasOverflow, and it should be able to
+    // do so without an ancillary error.
+    expect(exceptions, hasLength(1));
+    expect(exceptions.first.message, isNot(contains('Null check operator')));
+  });
 }


### PR DESCRIPTION
## Description

This gracefully handles a null `_overflow` value in `RenderFlex._hasOverflow`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71972

## Tests

I added the following tests:

* A test for the case outlined in the issue.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
