### PR TITLE
RefreshIndicator should not be shown when overscroll occurs due to inertia

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -218,7 +218,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   bool _shouldStart(ScrollNotification notification) {
     // The indicator will be pulled out in two cases,
     // 1, Begin drag when the scrollable widget at the edge with zero scroll position.
-    // 2, Keep drag before overscroll occurs when the scrollable widget have
+    // 2, Keep drag before overscroll occurs when the scrollable widget has
     //    a non-zero scroll position(do not release finger before overscroll).
     return (notification is ScrollStartNotification || (notification is ScrollUpdateNotification && notification.dragDetails != null))
       && notification.metrics.extentBefore == 0.0

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -215,12 +215,21 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     super.dispose();
   }
 
+  bool _shouldStart(ScrollNotification notification) {
+    // The indicator will be pulled out in two cases,
+    // 1, Begin drag when the scrollable widget at the edge with zero scroll position.
+    // 2, Keep drag before overscroll occurs when the scrollable widget have
+    //    a non-zero scroll position(do not release finger before overscroll).
+    return (notification is ScrollStartNotification || (notification is ScrollUpdateNotification && notification.dragDetails != null))
+      && notification.metrics.extentBefore == 0.0
+      && _mode == null
+      && _start(notification.metrics.axisDirection);
+  }
+
   bool _handleScrollNotification(ScrollNotification notification) {
     if (!widget.notificationPredicate(notification))
       return false;
-    if ((notification is ScrollStartNotification || notification is ScrollUpdateNotification) &&
-        notification.metrics.extentBefore == 0.0 &&
-        _mode == null && _start(notification.metrics.axisDirection)) {
+    if (_shouldStart(notification)) {
       setState(() {
         _mode = _RefreshIndicatorMode.drag;
       });

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -47,14 +47,14 @@ enum _RefreshIndicatorMode {
   canceled, // Animating the indicator's fade-out after not arming.
 }
 
-/// Used to configure the [RefreshIndicator] trigger mode.
+/// Used to configure how [RefreshIndicator] can be triggered.
 enum RefreshIndicatorTriggerMode {
-  /// The indicator can trigger when the child's [Scrollable] descendant overscrolls
-  /// by drag(not inertia), regardless of whether its initial scroll position is on the edge or not.
+  /// The indicator can be triggered regardless of the scroll position
+  /// of the [Scrollable] when the drag starts.
   loose,
 
-  /// The indicator can only trigger when the child's [Scrollable] descendant overscrolls
-  /// by drag and its initial scroll position is on the edge.
+  /// The indicator can only be triggered if the [Scrollable] is at the edge
+  /// when the drag starts.
   strict,
 }
 
@@ -175,9 +175,19 @@ class RefreshIndicator extends StatefulWidget {
   /// By default, the value of `strokeWidth` is 2.0 pixels.
   final double strokeWidth;
 
-  /// Defines `triggerMode` for `RefreshIndicator`.
+  /// Defines how this [RefreshIndicator] can be triggered when users overscroll.
   ///
-  /// By default, the value of `triggerMode` is [RefreshIndicatorTriggerMode.strict].
+  /// The [RefreshIndicator] can be pulled out in two cases,
+  /// 1, Keep dragging if the scrollable widget at the edge with zero scroll position
+  ///    when the drag starts.
+  /// 2, Keep dragging after overscroll occurs if the scrollable widget has
+  ///    a non-zero scroll position when the drag starts.
+  ///
+  /// If this is [RefreshIndicatorTriggerMode.loose], both of the cases above can be triggered.
+  ///
+  /// If this is [RefreshIndicatorTriggerMode.strict], only case 1 can be triggered.
+  ///
+  /// Defaults to [RefreshIndicatorTriggerMode.strict].
   final RefreshIndicatorTriggerMode triggerMode;
 
   @override
@@ -236,10 +246,6 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _shouldStart(ScrollNotification notification) {
-    // The indicator will be pulled out in two cases depend on [widget.triggerMode],
-    // 1, Begin drag when the scrollable widget at the edge with zero scroll position.
-    // 2, Keep drag before overscroll occurs when the scrollable widget has
-    //    a non-zero scroll position(do not release finger before overscroll).
     return (notification is ScrollStartNotification || (notification is ScrollUpdateNotification && notification.dragDetails != null && widget.triggerMode == RefreshIndicatorTriggerMode.loose))
       && notification.metrics.extentBefore == 0.0
       && _mode == null

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -51,11 +51,11 @@ enum _RefreshIndicatorMode {
 enum RefreshIndicatorTriggerMode {
   /// The indicator can be triggered regardless of the scroll position
   /// of the [Scrollable] when the drag starts.
-  loose,
+  anywhere,
 
   /// The indicator can only be triggered if the [Scrollable] is at the edge
   /// when the drag starts.
-  strict,
+  onEdge,
 }
 
 /// A widget that supports the Material "swipe to refresh" idiom.
@@ -120,7 +120,7 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsLabel,
     this.semanticsValue,
     this.strokeWidth = 2.0,
-    this.triggerMode = RefreshIndicatorTriggerMode.strict,
+    this.triggerMode = RefreshIndicatorTriggerMode.onEdge,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
@@ -183,11 +183,11 @@ class RefreshIndicator extends StatefulWidget {
   /// 2, Keep dragging after overscroll occurs if the scrollable widget has
   ///    a non-zero scroll position when the drag starts.
   ///
-  /// If this is [RefreshIndicatorTriggerMode.loose], both of the cases above can be triggered.
+  /// If this is [RefreshIndicatorTriggerMode.anywhere], both of the cases above can be triggered.
   ///
-  /// If this is [RefreshIndicatorTriggerMode.strict], only case 1 can be triggered.
+  /// If this is [RefreshIndicatorTriggerMode.onEdge], only case 1 can be triggered.
   ///
-  /// Defaults to [RefreshIndicatorTriggerMode.strict].
+  /// Defaults to [RefreshIndicatorTriggerMode.onEdge].
   final RefreshIndicatorTriggerMode triggerMode;
 
   @override
@@ -246,7 +246,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _shouldStart(ScrollNotification notification) {
-    return (notification is ScrollStartNotification || (notification is ScrollUpdateNotification && notification.dragDetails != null && widget.triggerMode == RefreshIndicatorTriggerMode.loose))
+    return (notification is ScrollStartNotification || (notification is ScrollUpdateNotification && notification.dragDetails != null && widget.triggerMode == RefreshIndicatorTriggerMode.anywhere))
       && notification.metrics.extentBefore == 0.0
       && _mode == null
       && _start(notification.metrics.axisDirection);

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -501,12 +501,13 @@ void main() {
     );
   });
 
-  testWidgets('Top RefreshIndicator should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Top RefreshIndicator(loose mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
+          triggerMode: RefreshIndicatorTriggerMode.loose,
           onRefresh: holdRefresh,
           child: ListView(
             controller: scrollController,
@@ -535,12 +536,13 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('Bottom RefreshIndicator should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Bottom RefreshIndicator(loose mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
+          triggerMode: RefreshIndicatorTriggerMode.loose,
           onRefresh: holdRefresh,
           child: ListView(
             reverse: true,
@@ -571,12 +573,13 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/71936
-  testWidgets('RefreshIndicator should not be shown when overscroll occurs due to inertia', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator(loose mode) should not be shown when overscroll occurs due to inertia', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
+          triggerMode: RefreshIndicatorTriggerMode.loose,
           onRefresh: holdRefresh,
           child: ListView(
             controller: scrollController,
@@ -600,6 +603,75 @@ void main() {
 
     // Release finger before reach the edge.
     await tester.fling(find.text('X'), const Offset(0.0, 99.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+  });
+
+  testWidgets('Top RefreshIndicator(strict mode) should not be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+    refreshCalled = false;
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          child: ListView(
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('X'),
+              ),
+              SizedBox(
+                height: 800.0,
+                child: Text('Y'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(50.0);
+
+    await tester.fling(find.text('X'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+  });
+
+  testWidgets('Bottom RefreshIndicator(strict mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+    refreshCalled = false;
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: holdRefresh,
+          child: ListView(
+            reverse: true,
+            controller: scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('X'),
+              ),
+              SizedBox(
+                height: 800.0,
+                child: Text('Y'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(50.0);
+
+    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -501,7 +501,7 @@ void main() {
     );
   });
 
-  testWidgets('Top RefreshIndicator shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Top RefreshIndicator be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -535,7 +535,7 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('Bottom RefreshIndicator shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Bottom RefreshIndicator be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -501,7 +501,7 @@ void main() {
     );
   });
 
-  testWidgets('Top RefreshIndicator be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Top RefreshIndicator should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -535,7 +535,7 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('Bottom RefreshIndicator be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Bottom RefreshIndicator should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -507,7 +507,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
-          triggerMode: RefreshIndicatorTriggerMode.loose,
+          triggerMode: RefreshIndicatorTriggerMode.anywhere,
           onRefresh: holdRefresh,
           child: ListView(
             controller: scrollController,
@@ -542,7 +542,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
-          triggerMode: RefreshIndicatorTriggerMode.loose,
+          triggerMode: RefreshIndicatorTriggerMode.anywhere,
           onRefresh: holdRefresh,
           child: ListView(
             reverse: true,
@@ -579,7 +579,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: RefreshIndicator(
-          triggerMode: RefreshIndicatorTriggerMode.loose,
+          triggerMode: RefreshIndicatorTriggerMode.anywhere,
           onRefresh: holdRefresh,
           child: ListView(
             controller: scrollController,

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -501,7 +501,7 @@ void main() {
     );
   });
 
-  testWidgets('Top RefreshIndicator(loose mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Top RefreshIndicator(anywhere mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -536,7 +536,7 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('Bottom RefreshIndicator(loose mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Bottom RefreshIndicator(anywhere mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -573,7 +573,7 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/71936
-  testWidgets('RefreshIndicator(loose mode) should not be shown when overscroll occurs due to inertia', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator(anywhere mode) should not be shown when overscroll occurs due to inertia', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -609,7 +609,7 @@ void main() {
     expect(find.byType(RefreshProgressIndicator), findsNothing);
   });
 
-  testWidgets('Top RefreshIndicator(strict mode) should not be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Top RefreshIndicator(onEdge mode) should not be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -643,7 +643,7 @@ void main() {
     expect(find.byType(RefreshProgressIndicator), findsNothing);
   });
 
-  testWidgets('Bottom RefreshIndicator(strict mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Bottom RefreshIndicator(onEdge mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

#71303 let the `RefreshIndicator` can be pulled out from the non-zero scroll position no matter the overscroll occurs due to drag or inertia.

This change cancel shows the `RefreshIndicator` when overscroll occurs due to inertia. I think this is intended to make it so that someone who is just scrolling to the top of your list doesn't accidentally start a refresh.

After this change, The indicator will be pulled out in two cases,
    // 1, Begin drag when the scrollable widget at the edge with zero scroll position.
    // 2, Keep drag before overscroll occurs when the scrollable widget has
    //    a non-zero scroll position(do not release finger before overscroll).

This behavior is consistent with the Android native app(Test with Microsoft Outlook APP).

@Hixie suggested that this behavior can opt-in and tracked by #9690 

### Drag form edge
![20201211_175624](https://user-images.githubusercontent.com/61075224/101889342-41560d80-3bda-11eb-9d5f-41ed8fccefe5.gif)

### Keep drag when overscroll occurs from non-zero scroll position
![20201211_175836](https://user-images.githubusercontent.com/61075224/101889615-92660180-3bda-11eb-8518-6c2d15345986.gif)

### Release finger before overscroll occurs(OverscrllIndicator is shown instead of RefreshIndicator)
![20201211_175931](https://user-images.githubusercontent.com/61075224/101889711-b1649380-3bda-11eb-8a1b-5a1e5c5ad8c4.gif)




## Related Issues

Fixes #71936
Fixes #9690

## Tests

I added the following tests:

See files.
