### PR TITLE
[dev] Don't use await for on stdout and stdin; pass local engine argument

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -51,7 +51,8 @@ Future<int> runTest({bool coverage = false, bool noPub = false}) async {
   );
   int badLines = 0;
   TestStep step = TestStep.starting;
-  await for (final String entry in analysis.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter())) {
+
+  analysis.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen((String entry) {
     print('test stdout ($step): $entry');
     if (step == TestStep.starting && entry == 'Building flutter tool...') {
       // ignore this line
@@ -83,11 +84,11 @@ Future<int> runTest({bool coverage = false, bool noPub = false}) async {
         }
       }
     }
-  }
-  await for (final String entry in analysis.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter())) {
+  });
+  analysis.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen((String entry) {
     print('test stderr: $entry');
     badLines += 1;
-  }
+  });
   final int result = await analysis.exitCode;
   clock.stop();
   if (result != 0)

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -110,7 +110,8 @@ class _TaskRunner {
         '--enable-macos-desktop',
         '--enable-windows-desktop',
         '--enable-linux-desktop',
-        '--enable-web'
+        '--enable-web',
+        if (localEngine != null) ...['--local-engine', localEngine],
       ], canFail: true);
       if (configResult != 0) {
         print('Failed to enable configuration, tasks may not run.');

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -111,7 +111,7 @@ class _TaskRunner {
         '--enable-windows-desktop',
         '--enable-linux-desktop',
         '--enable-web',
-        if (localEngine != null) ...['--local-engine', localEngine],
+        if (localEngine != null) ...<String>['--local-engine', localEngine],
       ], canFail: true);
       if (configResult != 0) {
         print('Failed to enable configuration, tasks may not run.');


### PR DESCRIPTION
1) Don't use await for on stdout followd by await for on stderr. This can cause nothing to happen. E.g. if one didn't do something like `flutter pub upgrade` dev/automated_tests and the version in the old one was pre-nnbd (but flutter itself use lots of nnbd stuff) lots of errors would be emitted, but because we basically only listen to stdout nothing will happen (deadlock once stderr buffer runs out). Note that it still awaits the exit-code below.

2) Pass --local-engine (if given) so there won't be any crashes because of that.