### PR TITLE
Revert "Pass --local-engine* flags from dev/bots/test.dart down to ` pub test` via env variables (#71721)"

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -56,8 +56,6 @@ final String flutterTester = path.join(flutterRoot, 'bin', 'cache', 'artifacts',
 /// configuration) -- prefilled with the arguments passed to test.dart.
 final List<String> flutterTestArgs = <String>[];
 
-final Map<String, String> localEngineEnv = <String, String>{};
-
 final bool useFlutterTestFormatter = Platform.environment['FLUTTER_TEST_FORMATTER'] == 'true';
 
 
@@ -107,13 +105,6 @@ Future<void> main(List<String> args) async {
   print('$clock STARTING ANALYSIS');
   try {
     flutterTestArgs.addAll(args);
-    for (final String arg in args) {
-      if (arg.startsWith('--local-engine='))
-        localEngineEnv['FLUTTER_LOCAL_ENGINE'] = arg.substring('--local-engine='.length);
-      if (arg.startsWith('--local-engine-src-path='))
-        localEngineEnv['FLUTTER_LOCAL_ENGINE_SRC_PATH'] = arg.substring('--local-engine-src-path='.length);
-    }
-
     if (Platform.environment.containsKey(CIRRUS_TASK_NAME))
       print('Running task: ${Platform.environment[CIRRUS_TASK_NAME]}');
     print('═' * 80);
@@ -1240,7 +1231,6 @@ Future<void> _pubRunTest(String workingDirectory, {
   ];
   final Map<String, String> pubEnvironment = <String, String>{
     'FLUTTER_ROOT': flutterRoot,
-    ...localEngineEnv
   };
   if (Directory(pubCache).existsSync()) {
     pubEnvironment['PUB_CACHE'] = pubCache;


### PR DESCRIPTION
This reverts commit 4300226a50670cff49693dfa26a2d6844238718d.

Reason for revert: The original PR correctly passes down the local
engine flags to subprocesses of the tests. Though this causes issues
because some tests assume a specific target but do not modify the
value for `--local-engine` (which is set to `host_debug`) to reflect
that.

See more discussion here:

    https://github.com/flutter/flutter/pull/71721#issuecomment-743218994