### PR TITLE
Allow iOS plugins to support bitcode

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -59,7 +59,6 @@ def flutter_additional_ios_build_settings(target)
     build_configuration.build_settings['OTHER_LDFLAGS'] = '$(inherited) -framework Flutter'
 
     build_configuration.build_settings['CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER'] = 'NO'
-    build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
     # Suppress warning when pod supports a version lower than the minimum supported by Xcode (Xcode 12 - iOS 9).
     # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
     # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -449,7 +449,6 @@ end
         xcodeBuildConfiguration,
         'SYMROOT=${iPhoneBuildOutput.path}',
         'BITCODE_GENERATION_MODE=$bitcodeGenerationMode',
-        'ENABLE_BITCODE=YES', // Support host apps with bitcode enabled.
         'ONLY_ACTIVE_ARCH=NO', // No device targeted, so build all valid architectures.
         'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
       ];


### PR DESCRIPTION
## Description

Stop overriding `ENABLE_BITCODE` for plugins that can support bitcode.  Apps still set `ENABLE_BITCODE=NO` so this doesn't actually allow users to upload bitcode version of their apps.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39793
Possible as of #70224 which links the plugin directly to the right framework build mode.
https://github.com/flutter/flutter/issues/39356

## Tests

This is already validated in https://github.com/flutter/flutter/blob/d4150d3f6de2fbb82bfea5070bfb35bf03f3199e/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart#L307