### PR TITLE
[devicelab] Migrate web_benchmarks_canvaskit to LUCI

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -890,12 +890,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux-vm"]
 
-  web_benchmarks_canvaskit:
-    description: >
-      Runs Web benchmarks on Chrome on a Linux machine using the CanvasKit rendering backend.
-    stage: devicelab
-    required_agent_capabilities: ["linux-vm"]
-
   # android_splash_screen_integration_test:
   #   description: >
   #     Runs end-to-end test of Flutter's Android splash behavior.

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -124,7 +124,7 @@
          "name": "Linux web_benchmarks_canvaskit",
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_canvaskit",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux web_benchmarks_html",


### PR DESCRIPTION
## Description

This builder has had a few green runs. We can migrate it over to only run on LUCI.

https://ci.chromium.org/p/flutter/builders/prod/Linux%20web_benchmarks_canvaskit

## Related Issues

https://github.com/flutter/flutter/issues/66225
