### PR TITLE
Use cached Xcode build settings during iOS build

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -701,8 +701,9 @@ String getAssetBuildDirectory() {
 }
 
 /// Returns the iOS build output directory.
-String getIosBuildDirectory() {
-  return globals.fs.path.join(getBuildDirectory(), 'ios');
+String getIosBuildDirectory([Config config, FileSystem fileSystem]) {
+  fileSystem ??= globals.fs;
+  return fileSystem.path.join(getBuildDirectory(config, fileSystem), 'ios');
 }
 
 /// Returns the macOS build output directory.

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -322,6 +322,7 @@ Future<T> runInContext<T>(
         fileSystem: globals.fs,
         terminal: globals.terminal,
         usage: globals.flutterUsage,
+        config: globals.config,
       ),
     },
   );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -346,43 +346,8 @@ Future<XcodeBuildResult> buildXcodeProject({
   );
   globals.flutterUsage.sendTiming(buildAction.name, 'xcode-ios', Duration(milliseconds: sw.elapsedMilliseconds));
 
-  // Run -showBuildSettings again but with the exact same parameters as the
-  // build. showBuildSettings is reported to occasionally timeout. Here, we give
-  // it a lot of wiggle room (locally on Flutter Gallery, this takes ~1s).
-  // When there is a timeout, we retry once. See issue #35988.
-  final List<String> showBuildSettingsCommand = (List<String>
-      .of(buildCommands)
-      ..add('-showBuildSettings'))
-      // Undocumented behavior: xcodebuild craps out if -showBuildSettings
-      // is used together with -allowProvisioningUpdates or
-      // -allowProvisioningDeviceRegistration and freezes forever.
-      .where((String buildCommand) {
-        return !const <String>[
-          '-allowProvisioningUpdates',
-          '-allowProvisioningDeviceRegistration',
-        ].contains(buildCommand);
-      }).toList();
-  const Duration showBuildSettingsTimeout = Duration(minutes: 1);
-  Map<String, String> buildSettings;
-  try {
-    final RunResult showBuildSettingsResult = await globals.processUtils.run(
-      showBuildSettingsCommand,
-      throwOnError: true,
-      workingDirectory: app.project.hostAppRoot.path,
-      timeout: showBuildSettingsTimeout,
-      timeoutRetries: 1,
-    );
-    final String showBuildSettings = showBuildSettingsResult.stdout.trim();
-    buildSettings = parseXcodeBuildSettings(showBuildSettings);
-  } on ProcessException catch (e) {
-    if (e.toString().contains('timed out')) {
-      BuildEvent('xcode-show-build-settings-timeout',
-        command: showBuildSettingsCommand.join(' '),
-        flutterUsage: globals.flutterUsage,
-      ).send();
-    }
-    rethrow;
-  }
+  Map<String, String> buildSettings = await app.project.buildSettingsForBuildInfo(buildInfo);
+  buildSettings ??= <String, String>{};
 
   if (buildResult.exitCode != 0) {
     globals.printStatus('Failed to build iOS app');

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -554,7 +554,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       info.reportFlavorNotFoundAndExit();
     }
 
-    return _buildSettingsByScheme[scheme] ??= await _xcodeProjectBuildSettings(scheme);
+    return _buildSettingsByScheme[scheme] ??= await _xcodeProjectBuildSettings(
+      scheme,
+      buildInfo,
+    );
   }
   Map<String, Map<String, String>> _buildSettingsByScheme;
 
@@ -566,12 +569,20 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   }
   XcodeProjectInfo _projectInfo;
 
-  Future<Map<String, String>> _xcodeProjectBuildSettings(String scheme) async {
+  Future<Map<String, String>> _xcodeProjectBuildSettings(String scheme, BuildInfo buildInfo) async {
     if (!globals.xcodeProjectInterpreter.isInstalled) {
       return null;
     }
+    String configuration;
+    if (buildInfo != null) {
+      configuration = (await projectInfo()).buildConfigurationFor(
+        buildInfo,
+        scheme,
+      );
+    }
     final Map<String, String> buildSettings = await globals.xcodeProjectInterpreter.getBuildSettings(
-      xcodeProject.path,
+      xcodeWorkspace.path,
+      configuration: configuration,
       scheme: scheme,
     );
     if (buildSettings != null && buildSettings.isNotEmpty) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -20,6 +20,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
   @override
   Future<Map<String, String>> getBuildSettings(
       String projectPath, {
+        String configuration,
         String scheme,
         Duration timeout = const Duration(minutes: 1),
       }) async {
@@ -80,7 +81,7 @@ void main() {
 
   // Creates a FakeCommand for the xcodebuild call to build the app
   // in the given configuration.
-  FakeCommand setUpMockXcodeBuildHandler({ bool verbose = false, bool showBuildSettings = false, void Function() onRun }) {
+  FakeCommand setUpMockXcodeBuildHandler({ bool verbose = false, void Function() onRun }) {
     return FakeCommand(
       command: <String>[
         'xcrun',
@@ -98,8 +99,6 @@ void main() {
         'COMPILER_INDEX_STORE_ENABLE=NO',
         '-archivePath', '/build/ios/archive/Runner',
         'archive',
-        if (showBuildSettings)
-          '-showBuildSettings',
       ],
       stdout: 'STDOUT STUFF',
       onRun: onRun,
@@ -209,7 +208,6 @@ void main() {
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
       setUpMockXcodeBuildHandler(),
-      setUpMockXcodeBuildHandler(showBuildSettings: true),
     ]),
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
@@ -227,7 +225,6 @@ void main() {
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
       xattrCommand,
       setUpMockXcodeBuildHandler(verbose: true),
-      setUpMockXcodeBuildHandler(verbose: true, showBuildSettings: true),
     ]),
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
@@ -270,7 +267,6 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync('{}');
       }),
-      setUpMockXcodeBuildHandler(showBuildSettings: true),
     ]),
     Platform: () => macosPlatform,
     FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
@@ -302,7 +298,6 @@ void main() {
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
           xattrCommand,
           setUpMockXcodeBuildHandler(),
-          setUpMockXcodeBuildHandler(showBuildSettings: true),
           exportArchiveCommand,
         ]),
     Platform: () => macosPlatform,

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/build.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
@@ -208,6 +209,11 @@ void main() {
             fileSystem: fileSystem,
             terminal: Terminal.test(),
             usage: Usage.test(),
+            config: Config.test(
+              'test',
+              logger: logger,
+              directory: fileSystem.directory('/'),
+            ),
           ),
         ),
         artifacts: artifacts,

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -359,8 +359,11 @@ apply plugin: 'kotlin-android'
       testWithMocks('from build settings, if no plist', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -390,8 +393,11 @@ apply plugin: 'kotlin-android'
       testWithMocks('from build settings and plist, if default variable', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -409,8 +415,11 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
         project.ios.defaultHostInfoPlist.createSync(recursive: true);
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-          (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
             return Future<Map<String,String>>.value(<String, String>{
               'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               'SUFFIX': 'suffix',
@@ -440,8 +449,10 @@ apply plugin: 'kotlin-android'
       testWithMocks('handles case insensitive flavor', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -512,7 +523,11 @@ apply plugin: 'kotlin-android'
       testUsingContext('app product name xcodebuild settings', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer((_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
           return Future<Map<String,String>>.value(<String, String>{
             'FULL_PRODUCT_NAME': 'My App.app'
           });
@@ -629,8 +644,11 @@ apply plugin: 'kotlin-android'
 
     group('with bundle identifier', () {
       setUp(() {
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-            (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
             return Future<Map<String,String>>.value(<String, String>{
               'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
             });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -394,6 +394,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   @override
   Future<Map<String, String>> getBuildSettings(
     String projectPath, {
+    String configuration,
     String scheme,
     Duration timeout = const Duration(minutes: 1),
   }) async {


### PR DESCRIPTION
## Description

`flutter build ios` was calling `xcodebuild -showBuildSettings` multiple times, which can take several seconds to run.  Instead, only run it once with the correct flags, and use that cache elsewhere.

The first time it wasn't using the `--flavor` scheme, which caused [confusing output](https://github.com/flutter/flutter/issues/70576#issuecomment-736196704).  Always use the passed in scheme.

## Related Issues

https://github.com/flutter/flutter/issues/9199
https://github.com/flutter/flutter/issues/70576#issuecomment-736196704
