### PR TITLE
[flutter_tools] use 1-based index for device selection

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -305,11 +305,11 @@ abstract class DeviceManager {
     if (userInput.toLowerCase() == 'q') {
       throwToolExit('');
     }
-    return devices[int.parse(userInput)];
+    return devices[int.parse(userInput) - 1];
   }
 
   void _displayDeviceOptions(List<Device> devices) {
-    int count = 0;
+    int count = 1;
     for (final Device device in devices) {
       _logger.printStatus(_userMessages.flutterChooseDevice(count, device.name, device.id));
       count++;
@@ -319,7 +319,7 @@ abstract class DeviceManager {
   Future<String> _readUserInput(int deviceCount) async {
     _terminal.usesTerminalUi = true;
     final String result = await _terminal.promptForCharInput(
-      <String>[ for (int i = 0; i < deviceCount; i++) '$i', 'q', 'Q'],
+      <String>[ for (int i = 0; i < deviceCount; i++) '${i + 1}', 'q', 'Q'],
       displayAcceptedCharacters: false,
       logger: _logger,
       prompt: _userMessages.flutterChooseOne,

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -183,11 +183,11 @@ void main() {
       ];
       final MockTerminal mockTerminal = MockTerminal();
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),
-      )).thenAnswer((Invocation invocation) async => '0');
+      )).thenAnswer((Invocation invocation) async => '1');
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
@@ -209,11 +209,11 @@ void main() {
       final MockTerminal mockTerminal = MockTerminal();
 
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),
-      )).thenAnswer((Invocation invocation) async => '1');
+      )).thenAnswer((Invocation invocation) async => '2');
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
@@ -236,11 +236,11 @@ void main() {
       final MockTerminal mockTerminal = MockTerminal();
 
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),
-      )).thenAnswer((Invocation invocation) async => '0');
+      )).thenAnswer((Invocation invocation) async => '1');
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
@@ -262,11 +262,11 @@ void main() {
       final MockTerminal mockTerminal = MockTerminal();
 
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),
-      )).thenAnswer((Invocation invocation) async => '1');
+      )).thenAnswer((Invocation invocation) async => '2');
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
@@ -291,11 +291,11 @@ void main() {
       final MockTerminal mockTerminal = MockTerminal();
 
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', '2', '3', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', '3', '4', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),
-      )).thenAnswer((Invocation invocation) async => '2');
+      )).thenAnswer((Invocation invocation) async => '3');
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
@@ -319,7 +319,7 @@ void main() {
       final MockTerminal mockTerminal = MockTerminal();
 
       when(mockTerminal.stdinHasTerminal).thenReturn(true);
-      when(mockTerminal.promptForCharInput(<String>['0', '1', 'q', 'Q'],
+      when(mockTerminal.promptForCharInput(<String>['1', '2', 'q', 'Q'],
         displayAcceptedCharacters: false,
         logger: anyNamed('logger'),
         prompt: anyNamed('prompt'),


### PR DESCRIPTION
## Description

The Flutter tool uses a 0-based index for device selection. Consequently, the first device is inconveniently on the other side of the keyboard than the next device. This PR changes the device selection to use a 1-based index which is a) more convenient because the device selection keys are side-by-side and b) 1-based index is arguably more appropriate for a human interface.

### Before

```
$ flutter run
Multiple devices found:
Linux (desktop) • linux  • linux-x64      • Linux
Chrome (web)    • chrome • web-javascript • Google Chrome 87.0.4280.88
[0]: Linux (linux)
[1]: Chrome (chrome)
Please choose one (To quit, press "q/Q"): 0

Launching lib/main.dart on Linux in debug mode...
[...]
```

### After

```
$ flutter run
Multiple devices found:
Linux (desktop) • linux  • linux-x64      • Linux
Chrome (web)    • chrome • web-javascript • Google Chrome 87.0.4280.88
[1]: Linux (linux)
[2]: Chrome (chrome)
Please choose one (To quit, press "q/Q"): 1

Launching lib/main.dart on Linux in debug mode...
[...]
```

## Related Issues

#64565

## Tests

I updated the following tests:

- `test/general.shard/device_test.dart`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

At least both Android Studio and VS Code select the correct device. I'm a bit unsure if any automated scripts could fail, even though it would be a pretty fragile way to select the device...

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
