### PR TITLE
[flutter_tools] improve error surfacing from Linux builds

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -29,6 +29,7 @@ Future<void> main(List<String> arguments) async {
   final bool trackWidgetCreation = Platform.environment['TRACK_WIDGET_CREATION'] == 'true';
   final bool treeShakeIcons = Platform.environment['TREE_SHAKE_ICONS'] == 'true';
   final bool verbose = Platform.environment['VERBOSE_SCRIPT_LOGGING'] == 'true';
+  final bool prefixedErrors = Platform.environment['PREFIXED_ERROR_LOGGING'] == 'true';
 
   Directory.current = projectDirectory;
 
@@ -61,6 +62,8 @@ or
     <String>[
       if (verbose)
         '--verbose',
+      if (prefixedErrors)
+        '--prefixed-errors',
       if (flutterEngine != null) '--local-engine-src-path=$flutterEngine',
       if (localEngine != null) '--local-engine=$localEngine',
       'assemble',

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -61,6 +61,7 @@ import 'src/web/web_runner.dart';
 Future<void> main(List<String> args) async {
   final bool veryVerbose = args.contains('-vv');
   final bool verbose = args.contains('-v') || args.contains('--verbose') || veryVerbose;
+  final bool prefixedErrors = args.contains('--prefixed-errors');
   // Support the -? Powershell help idiom.
   final int powershellHelpIndex = args.indexOf('-?');
   if (powershellHelpIndex != -1) {
@@ -166,6 +167,7 @@ Future<void> main(List<String> args) async {
           daemon: daemon,
           machine: runMachine,
           verbose: verbose && !muteCommandLogging,
+          prefixedErrors: prefixedErrors,
           windows: globals.platform.isWindows,
         );
        }
@@ -194,6 +196,7 @@ class LoggerFactory {
   /// Create the appropriate logger for the current platform and configuration.
   Logger createLogger({
     @required bool verbose,
+    @required bool prefixedErrors,
     @required bool machine,
     @required bool daemon,
     @required bool windows,
@@ -216,6 +219,9 @@ class LoggerFactory {
     }
     if (verbose) {
       logger = VerboseLogger(logger, stopwatchFactory: _stopwatchFactory);
+    }
+    if (prefixedErrors) {
+      logger = PrefixedErrorLogger(logger);
     }
     if (daemon) {
       return NotifyingLogger(verbose: verbose, parent: logger);

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -676,6 +676,34 @@ class VerboseLogger extends DelegatingLogger {
   void sendEvent(String name, [Map<String, dynamic> args]) { }
 }
 
+class PrefixedErrorLogger extends DelegatingLogger {
+  PrefixedErrorLogger(Logger parent) : super(parent);
+
+  @override
+  void printError(
+    String message, {
+    StackTrace stackTrace,
+    bool emphasis,
+    TerminalColor color,
+    int indent,
+    int hangingIndent,
+    bool wrap,
+  }) {
+    if (message?.trim()?.isNotEmpty == true) {
+      message = 'ERROR: $message';
+    }
+    super.printError(
+      message,
+      stackTrace: stackTrace,
+      emphasis: emphasis,
+      color: color,
+      indent: indent,
+      hangingIndent: hangingIndent,
+      wrap: wrap,
+    );
+  }
+}
+
 enum _LogType { error, status, trace }
 
 typedef SlowWarningCallback = String Function();

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -22,7 +22,8 @@ import '../project.dart';
 // - <file path>:<line>:<column>: (fatal) error: <error...>
 // - <file path>:<line>:<column>: warning: <warning...>
 // - clang: error: <link error...>
-final RegExp errorMatcher = RegExp(r'(?:.*:\d+:\d+|clang):\s?(fatal\s)?(?:error|warning):\s.*', caseSensitive: false);
+// - Error: <tool error...>
+final RegExp errorMatcher = RegExp(r'(?:(?:.*:\d+:\d+|clang):\s)?(fatal\s)?(?:error|warning):\s.*', caseSensitive: false);
 
 /// Builds the Linux project through the Makefile.
 Future<void> buildLinux(
@@ -152,7 +153,9 @@ Future<void> _runBuild(Directory buildDir) async {
       ],
       environment: <String, String>{
         if (globals.logger.isVerbose)
-          'VERBOSE_SCRIPT_LOGGING': 'true'
+          'VERBOSE_SCRIPT_LOGGING': 'true',
+        if (!globals.logger.isVerbose)
+          'PREFIXED_ERROR_LOGGING': 'true',
       },
       trace: true,
       stdoutErrorMatcher: errorMatcher,

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -44,6 +44,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
         negatable: false,
         help: 'Noisy logging, including all shell commands executed.\n'
               'If used with --help, shows hidden options.');
+    argParser.addFlag('prefixed-errors',
+        negatable: false,
+        hide: true,
+        defaultsTo: false);
     argParser.addFlag('quiet',
         negatable: false,
         hide: !verboseHelp,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -231,6 +231,7 @@ lib/main.dart:4:3: Error: Method not found: 'foo'.
 main.cc:(.text+0x13): undefined reference to `Foo::bar()'
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ninja: build stopped: subcommand failed.
+ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
 ''';
 
     processManager = FakeProcessManager.list(<FakeCommand>[
@@ -252,6 +253,7 @@ lib/main.dart:4:3: Error: Method not found: 'foo'.
 /foo/linux/main.cc:12:7: error: 'bar' is a private member of 'Foo'
 /foo/linux/my_application.h:4:10: fatal error: 'gtk/gtk.h' file not found
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
+ERROR: No file or variants found for asset: images/a_dot_burr.jpeg
 ''');
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -36,36 +36,49 @@ void main() {
 
     expect(loggerFactory.createLogger(
       verbose: false,
+      prefixedErrors: false,
       machine: false,
       daemon: false,
       windows: false,
     ), isA<StdoutLogger>());
     expect(loggerFactory.createLogger(
       verbose: false,
+      prefixedErrors: false,
       machine: false,
       daemon: false,
       windows: true,
     ), isA<WindowsStdoutLogger>());
     expect(loggerFactory.createLogger(
       verbose: true,
+      prefixedErrors: false,
       machine: false,
       daemon: false,
       windows: true,
     ), isA<VerboseLogger>());
     expect(loggerFactory.createLogger(
       verbose: true,
+      prefixedErrors: false,
       machine: false,
       daemon: false,
       windows: false,
     ), isA<VerboseLogger>());
     expect(loggerFactory.createLogger(
       verbose: false,
+      prefixedErrors: true,
+      machine: false,
+      daemon: false,
+      windows: false,
+    ), isA<PrefixedErrorLogger>());
+    expect(loggerFactory.createLogger(
+      verbose: false,
+      prefixedErrors: false,
       machine: false,
       daemon: true,
       windows: false,
     ), isA<NotifyingLogger>());
     expect(loggerFactory.createLogger(
       verbose: false,
+      prefixedErrors: false,
       machine: true,
       daemon: false,
       windows: false,


### PR DESCRIPTION
## Description

For example, with a missing asset in pubspec.yaml:

### Before
```
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
Exception: Build process failed
```

### After
```
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
ERROR: No file or variants found for asset: images/a_dot_burr.jpeg.
Exception: Build process failed
```

## Related Issues

#33584

## Tests

I updated the following tests:

- `test/general.shard/base/logger_test.dart`
- `test/commands.shard/hermetic/build_linux_test.dart`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
