### PR TITLE
Update data_table.dart

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1170,7 +1170,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
         _opacityController.reverse();
       }
     }
-    if ((_up != newUp) && !skipArrow) {
+    if ((_up != newUp) && (newUp == false || _up != null) && !skipArrow) {
       if (_orientationController.status == AnimationStatus.dismissed) {
         _orientationController.forward();
       } else {

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -13,6 +13,43 @@ import 'package:vector_math/vector_math_64.dart' show Matrix3;
 import '../rendering/mock_canvas.dart';
 import 'data_table_test_utils.dart';
 
+
+// onSort must remain empty in this widget
+class TestStateWithoutSorting extends StatefulWidget {
+  @override
+  _TestStateWithoutSortingState createState() => _TestStateWithoutSortingState();
+}
+
+class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        home: Material(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              RaisedButton(
+                onPressed: () => setState(() => {}),
+                child: Text('Test'),
+              ),
+              DataTable(
+                  sortColumnIndex: 0,
+                  sortAscending: true,
+                  columns: [
+                    DataColumn(
+                      label: Text('Column 1'),
+                      onSort: (a, i) {},
+                    ),
+                  ],
+                  rows: []
+              )
+            ],
+          ),
+        )
+    );
+  }
+}
+
 void main() {
   testWidgets('DataTable control test', (WidgetTester tester) async {
     final List<String> log = <String>[];
@@ -1495,5 +1532,25 @@ void main() {
       tester.getBottomRight(find.byType(Table)),
       const Offset(width - borderVertical, height - borderHorizontal),
     );
+  });
+
+  testWidgets('Check that arrow stays up when no sort action triggered.', (WidgetTester tester) async {
+    // Use stateful widget with data table in ascending order
+    await tester.pumpWidget(TestStateWithoutSorting());
+
+    // Capture upward arrow prior to button being pressed
+    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+
+    // Press button with setState action (no sort action triggered)
+    await tester.tap(find.text('Test'));
+    await tester.pumpAndSettle();
+
+    // Verify arrow is still in upward direction
+    Transform newTransformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    expect(
+        transformOfArrow.transform.getRotation(),
+        equals(newTransformOfArrow.transform.getRotation())
+    );
+
   });
 }

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -21,6 +21,9 @@ class TestStateWithoutSorting extends StatefulWidget {
 }
 
 class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
+  static const String _buttonText = 'Test';
+  static const String _columnText = 'Column 1';
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -29,15 +32,15 @@ class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               RaisedButton(
-                onPressed: () => setState(() => {}),
-                child: Text('Test'),
+                onPressed: () => setState((){}),
+                child: Text(_buttonText),
               ),
               DataTable(
                   sortColumnIndex: 0,
                   sortAscending: true,
                   columns: [
                     DataColumn(
-                      label: Text('Column 1'),
+                      label: Text(_columnText),
                       onSort: (a, i) {},
                     ),
                   ],

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -21,9 +21,7 @@ class TestStateWithoutSorting extends StatefulWidget {
 }
 
 class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
-  static const String _buttonText = 'Test';
-  static const String _columnText = 'Column 1';
-
+  
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -33,14 +31,14 @@ class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
             children: <Widget>[
               RaisedButton(
                 onPressed: () => setState((){}),
-                child: Text(_buttonText),
+                child: Text('Test'),
               ),
               DataTable(
                   sortColumnIndex: 0,
                   sortAscending: true,
                   columns: [
                     DataColumn(
-                      label: Text(_columnText),
+                      label: Text('Column 1'),
                       onSort: (a, i) {},
                     ),
                   ],
@@ -52,6 +50,7 @@ class _TestStateWithoutSortingState extends State<TestStateWithoutSorting> {
     );
   }
 }
+
 
 void main() {
   testWidgets('DataTable control test', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This change fixed a bug I was experiencing while using DataTable in conjunction with the showDatePicker calendar widget.  When selecting a different date to populate the data table and not doing an initial sort of the data, the _orientationcontroller would run without a sort being called and the arrow would switch to "down" in the first column while the data set was still sorted in ascending order.  By adding this additional condition, it maintained its original functionality, while also fixing this bug and keeping the arrow in the "up" position after the new dataset was selected.

## Related Issues

https://github.com/flutter/flutter/issues/43724

## Tests

I added the following tests:

flutter test --merge-coverage test/material/data_table_test.dart

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [] Yes, this is a breaking change. *If not, delete the remainder of this section.*


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
