### PR TITLE
Add text to --analyze-size command output to launch DevTools with size data

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -540,6 +540,11 @@ Future<void> _performCodeSizeAnalysis(
   globals.printStatus(
     'A summary of your ${kind.toUpperCase()} analysis can be found at: ${outputFile.path}',
   );
+  globals.printStatus(
+    '\nTo analyze your app size in Dart DevTools, run the following command:\n'
+    'pub global activate devtools; pub global run devtools '
+    '--appSizeBase=${outputFile.path}'
+  );
 }
 
 /// Builds AAR and POM files.

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -542,7 +542,7 @@ Future<void> _performCodeSizeAnalysis(
   );
   globals.printStatus(
     '\nTo analyze your app size in Dart DevTools, run the following command:\n'
-    'pub global activate devtools; pub global run devtools '
+    'flutter pub global activate devtools; flutter pub global run devtools '
     '--appSizeBase=${outputFile.path}'
   );
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -540,10 +540,13 @@ Future<void> _performCodeSizeAnalysis(
   globals.printStatus(
     'A summary of your ${kind.toUpperCase()} analysis can be found at: ${outputFile.path}',
   );
+
+  // DevTools expects a file path relative to the .flutter-devtools/ dir.
+  final String relativeAppSizePath = outputFile.path.split('.flutter-devtools/').last.trim();
   globals.printStatus(
     '\nTo analyze your app size in Dart DevTools, run the following command:\n'
     'flutter pub global activate devtools; flutter pub global run devtools '
-    '--appSizeBase=${outputFile.path}'
+    '--appSizeBase=$relativeAppSizePath'
   );
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -294,6 +294,11 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       globals.printStatus(
         'A summary of your iOS bundle analysis can be found at: ${outputFile.path}',
       );
+      globals.printStatus(
+        '\nTo analyze your app size in Dart DevTools, run the following command:\n'
+        'flutter pub global activate devtools; flutter pub global run devtools '
+        '--appSizeBase=${outputFile.path}'
+      );
     }
 
     if (result.output != null) {

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -294,10 +294,13 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       globals.printStatus(
         'A summary of your iOS bundle analysis can be found at: ${outputFile.path}',
       );
+
+      // DevTools expects a file path relative to the .flutter-devtools/ dir.
+      final String relativeAppSizePath = outputFile.path.split('.flutter-devtools/').last.trim();
       globals.printStatus(
         '\nTo analyze your app size in Dart DevTools, run the following command:\n'
         'flutter pub global activate devtools; flutter pub global run devtools '
-        '--appSizeBase=${outputFile.path}'
+        '--appSizeBase=$relativeAppSizePath'
       );
     }
 

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -84,6 +84,11 @@ Future<void> buildLinux(
     globals.printStatus(
       'A summary of your Linux bundle analysis can be found at: ${outputFile.path}',
     );
+    globals.printStatus(
+      '\nTo analyze your app size in Dart DevTools, run the following command:\n'
+      'flutter pub global activate devtools; flutter pub global run devtools '
+      '--appSizeBase=${outputFile.path}'
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -84,10 +84,13 @@ Future<void> buildLinux(
     globals.printStatus(
       'A summary of your Linux bundle analysis can be found at: ${outputFile.path}',
     );
+
+    // DevTools expects a file path relative to the .flutter-devtools/ dir.
+    final String relativeAppSizePath = outputFile.path.split('.flutter-devtools/').last.trim();
     globals.printStatus(
       '\nTo analyze your app size in Dart DevTools, run the following command:\n'
       'flutter pub global activate devtools; flutter pub global run devtools '
-      '--appSizeBase=${outputFile.path}'
+      '--appSizeBase=$relativeAppSizePath'
     );
   }
 }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -140,10 +140,13 @@ Future<void> buildMacOS({
     globals.printStatus(
       'A summary of your macOS bundle analysis can be found at: ${outputFile.path}',
     );
+
+    // DevTools expects a file path relative to the .flutter-devtools/ dir.
+    final String relativeAppSizePath = outputFile.path.split('.flutter-devtools/').last.trim();
     globals.printStatus(
       '\nTo analyze your app size in Dart DevTools, run the following command:\n'
       'flutter pub global activate devtools; flutter pub global run devtools '
-      '--appSizeBase=${outputFile.path}'
+      '--appSizeBase=$relativeAppSizePath'
     );
   }
   globals.flutterUsage.sendTiming('build', 'xcode-macos', Duration(milliseconds: sw.elapsedMilliseconds));

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -140,6 +140,11 @@ Future<void> buildMacOS({
     globals.printStatus(
       'A summary of your macOS bundle analysis can be found at: ${outputFile.path}',
     );
+    globals.printStatus(
+      '\nTo analyze your app size in Dart DevTools, run the following command:\n'
+      'flutter pub global activate devtools; flutter pub global run devtools '
+      '--appSizeBase=${outputFile.path}'
+    );
   }
   globals.flutterUsage.sendTiming('build', 'xcode-macos', Duration(milliseconds: sw.elapsedMilliseconds));
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -86,10 +86,13 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
     globals.printStatus(
       'A summary of your Windows bundle analysis can be found at: ${outputFile.path}',
     );
+
+    // DevTools expects a file path relative to the .flutter-devtools/ dir.
+    final String relativeAppSizePath = outputFile.path.split('.flutter-devtools/').last.trim();
     globals.printStatus(
       '\nTo analyze your app size in Dart DevTools, run the following command:\n'
       'flutter pub global activate devtools; flutter pub global run devtools '
-      '--appSizeBase=${outputFile.path}'
+      '--appSizeBase=$relativeAppSizePath'
     );
   }
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -86,6 +86,11 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
     globals.printStatus(
       'A summary of your Windows bundle analysis can be found at: ${outputFile.path}',
     );
+    globals.printStatus(
+      '\nTo analyze your app size in Dart DevTools, run the following command:\n'
+      'flutter pub global activate devtools; flutter pub global run devtools '
+      '--appSizeBase=${outputFile.path}'
+    );
   }
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -249,6 +249,7 @@ void main() {
     );
 
     expect(testLogger.statusText, contains('A summary of your iOS bundle analysis can be found at'));
+    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
     expect(buffer.toString(), contains('event {category: code-size-analysis, action: ios, label: null, value: null, cd33: '));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -459,6 +459,7 @@ set(BINARY_NAME "fizz_bar")
     );
 
     expect(testLogger.statusText, contains('A summary of your Linux bundle analysis can be found at'));
+    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
     expect(buffer.toString(), contains('event {category: code-size-analysis, action: linux, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -345,6 +345,7 @@ void main() {
     );
 
     expect(testLogger.statusText, contains('A summary of your macOS bundle analysis can be found at'));
+    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
     expect(buffer.toString(), contains('event {category: code-size-analysis, action: macos, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -407,6 +407,7 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
     );
 
     expect(testLogger.statusText, contains('A summary of your Windows bundle analysis can be found at'));
+    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
     expect(buffer.toString(), contains('event {category: code-size-analysis, action: windows, label: null, value: null, cd33:'));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -10,6 +10,7 @@ import 'test_utils.dart';
 
 const String apkDebugMessage = 'A summary of your APK analysis can be found at: ';
 const String iosDebugMessage = 'A summary of your iOS bundle analysis can be found at: ';
+const String runDevToolsMessage = 'flutter pub global activate devtools; flutter pub global run devtools ';
 
 void main() {
   testWithoutContext('--analyze-size flag produces expected output on hello_world for Android', () async {
@@ -35,6 +36,13 @@ void main() {
     final String outputFilePath = line.split(apkDebugMessage).last.trim();
     expect(fileSystem.file(fileSystem.path.join(woringDirectory, outputFilePath)), exists);
     expect(outputFilePath, contains('.flutter-devtools'));
+
+    final String devToolsCommand = result.stdout.toString()
+        .split('\n')
+        .firstWhere((String line) => line.contains(runDevToolsMessage));
+    final String commandArguments = devToolsCommand.split(runDevToolsMessage).last.trim();
+    expect(commandArguments.contains('--appSizeBase=$outputFilePath'), isTrue);
+
     expect(result.exitCode, 0);
   });
 
@@ -60,6 +68,13 @@ void main() {
 
     final String outputFilePath = line.split(iosDebugMessage).last.trim();
     expect(fileSystem.file(fileSystem.path.join(woringDirectory, outputFilePath)), exists);
+
+    final String devToolsCommand = result.stdout.toString()
+        .split('\n')
+        .firstWhere((String line) => line.contains(runDevToolsMessage));
+    final String commandArguments = devToolsCommand.split(runDevToolsMessage).last.trim();
+    expect(commandArguments.contains('--appSizeBase=$outputFilePath'), isTrue);
+
     expect(result.exitCode, 0);
   }, skip: true); // Extremely flaky due to https://github.com/flutter/flutter/issues/68144
 

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -14,7 +14,7 @@ const String runDevToolsMessage = 'flutter pub global activate devtools; flutter
 
 void main() {
   testWithoutContext('--analyze-size flag produces expected output on hello_world for Android', () async {
-    final String woringDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -23,7 +23,7 @@ void main() {
       'apk',
       '--analyze-size',
       '--target-platform=android-arm64'
-    ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
+    ], workingDirectory: workingDirectory);
 
     print(result.stdout);
     print(result.stderr);
@@ -34,20 +34,21 @@ void main() {
       .firstWhere((String line) => line.contains(apkDebugMessage));
 
     final String outputFilePath = line.split(apkDebugMessage).last.trim();
-    expect(fileSystem.file(fileSystem.path.join(woringDirectory, outputFilePath)), exists);
+    expect(fileSystem.file(fileSystem.path.join(workingDirectory, outputFilePath)), exists);
     expect(outputFilePath, contains('.flutter-devtools'));
 
     final String devToolsCommand = result.stdout.toString()
         .split('\n')
         .firstWhere((String line) => line.contains(runDevToolsMessage));
     final String commandArguments = devToolsCommand.split(runDevToolsMessage).last.trim();
-    expect(commandArguments.contains('--appSizeBase=$outputFilePath'), isTrue);
+    final String relativeAppSizePath = outputFilePath.split('.flutter-devtools/').last.trim();
+    expect(commandArguments.contains('--appSizeBase=$relativeAppSizePath'), isTrue);
 
     expect(result.exitCode, 0);
   });
 
   testWithoutContext('--analyze-size flag produces expected output on hello_world for iOS', () async {
-    final String woringDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -56,7 +57,7 @@ void main() {
       'ios',
       '--analyze-size',
       '--no-codesign',
-    ], workingDirectory: woringDirectory);
+    ], workingDirectory: workingDirectory);
 
     print(result.stdout);
     print(result.stderr);
@@ -67,13 +68,14 @@ void main() {
       .firstWhere((String line) => line.contains(iosDebugMessage));
 
     final String outputFilePath = line.split(iosDebugMessage).last.trim();
-    expect(fileSystem.file(fileSystem.path.join(woringDirectory, outputFilePath)), exists);
+    expect(fileSystem.file(fileSystem.path.join(workingDirectory, outputFilePath)), exists);
 
     final String devToolsCommand = result.stdout.toString()
         .split('\n')
         .firstWhere((String line) => line.contains(runDevToolsMessage));
     final String commandArguments = devToolsCommand.split(runDevToolsMessage).last.trim();
-    expect(commandArguments.contains('--appSizeBase=$outputFilePath'), isTrue);
+    final String relativeAppSizePath = outputFilePath.split('.flutter-devtools/').last.trim();
+    expect(commandArguments.contains('--appSizeBase=$relativeAppSizePath'), isTrue);
 
     expect(result.exitCode, 0);
   }, skip: true); // Extremely flaky due to https://github.com/flutter/flutter/issues/68144


### PR DESCRIPTION
Example output for `flutter build <platform bundle> --analyze-size`(see bottom 2 lines for new text):

<img width="838" alt="Screen Shot 2020-12-14 at 4 03 36 PM" src="https://user-images.githubusercontent.com/43759233/102150706-0fd18200-3e26-11eb-8a5a-b4670664b52f.png">

