### PR TITLE
Flutter clean Flutter.podspec

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -52,6 +52,7 @@ class CleanCommand extends FlutterCommand {
     deleteFile(flutterProject.ios.generatedEnvironmentVariableExportScript);
     deleteFile(flutterProject.ios.deprecatedCompiledDartFramework);
     deleteFile(flutterProject.ios.deprecatedProjectFlutterFramework);
+    deleteFile(flutterProject.ios.flutterPodspec);
 
     deleteFile(flutterProject.linux.ephemeralDirectory);
     deleteFile(flutterProject.macos.ephemeralDirectory);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -692,6 +692,11 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       .childDirectory('Flutter')
       .childDirectory('Flutter.framework');
 
+  /// Used only for "flutter clean" to remove old references.
+  File get flutterPodspec => _flutterLibRoot
+      .childDirectory('Flutter')
+      .childFile('Flutter.podspec');
+
   Directory get pluginRegistrantHost {
     return isModule
         ? _flutterLibRoot

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -50,6 +50,7 @@ void main() {
         projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
         projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
         projectUnderTest.ios.deprecatedProjectFlutterFramework.createSync(recursive: true);
+        projectUnderTest.ios.flutterPodspec.createSync(recursive: true);
 
         projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
@@ -71,6 +72,7 @@ void main() {
         expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
         expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);
         expect(projectUnderTest.ios.deprecatedProjectFlutterFramework.existsSync(), isFalse);
+        expect(projectUnderTest.ios.flutterPodspec.existsSync(), isFalse);
 
         expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/70224 (on master/dev) purposely writes a bogus file to `ios/Flutter/Flutter.podspec` because the CocoaPods linking logic was moved into the flutter tool.  However, when users switch back to beta/stable, that bogus podspec is still present, but the flutter tool linking logic has been reverted.

At the moment this change isn't "necessary" on master, but it's a good idea in case we ever change it again.

## Related Issues

Once cherry-picked to stable/release, will resolve https://github.com/flutter/flutter/issues/70895 by running `flutter clean`.

## Tests

clean_test