### PR TITLE
Include Xcode configuration to initial showBuildSettings cache

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -342,8 +342,8 @@ class XcodeProjectInterpreter {
   ///
   /// If [scheme] is null, xcodebuild will return build settings for the first discovered
   /// target (by default this is Runner).
-  Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+  Future<Map<String, String>> getBuildSettings(String workspacePath, {
+    String configuration,
     String scheme,
     Duration timeout = const Duration(minutes: 1),
   }) async {
@@ -354,10 +354,12 @@ class XcodeProjectInterpreter {
     final List<String> showBuildSettingsCommand = <String>[
       ...xcrunCommand(),
       'xcodebuild',
-      '-project',
-      _fileSystem.path.absolute(projectPath),
+      '-workspace',
+      _fileSystem.path.absolute(workspacePath),
       if (scheme != null)
         ...<String>['-scheme', scheme],
+      if (configuration != null)
+        ...<String>['-configuration', configuration],
       '-showBuildSettings',
       ...environmentVariablesAsXcodeBuildSettings(_platform)
     ];
@@ -368,7 +370,7 @@ class XcodeProjectInterpreter {
       final RunResult result = await _processUtils.run(
         showBuildSettingsCommand,
         throwOnError: true,
-        workingDirectory: projectPath,
+        workingDirectory: workspacePath,
         timeout: timeout,
         timeoutRetries: 1,
       );

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -554,7 +554,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       info.reportFlavorNotFoundAndExit();
     }
 
-    return _buildSettingsByScheme[scheme] ??= await _xcodeProjectBuildSettings(scheme);
+    return _buildSettingsByScheme[scheme] ??= await _xcodeProjectBuildSettings(
+      scheme,
+      buildInfo,
+    );
   }
   Map<String, Map<String, String>> _buildSettingsByScheme;
 
@@ -566,12 +569,20 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   }
   XcodeProjectInfo _projectInfo;
 
-  Future<Map<String, String>> _xcodeProjectBuildSettings(String scheme) async {
+  Future<Map<String, String>> _xcodeProjectBuildSettings(String scheme, BuildInfo buildInfo) async {
     if (!globals.xcodeProjectInterpreter.isInstalled) {
       return null;
     }
+    String configuration;
+    if (buildInfo != null) {
+      configuration = (await projectInfo()).buildConfigurationFor(
+        buildInfo,
+        scheme,
+      );
+    }
     final Map<String, String> buildSettings = await globals.xcodeProjectInterpreter.getBuildSettings(
-      xcodeProject.path,
+      xcodeWorkspace.path,
+      configuration: configuration,
       scheme: scheme,
     );
     if (buildSettings != null && buildSettings.isNotEmpty) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -19,7 +19,8 @@ import '../../src/testbed.dart';
 class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInterpreter {
   @override
   Future<Map<String, String>> getBuildSettings(
-      String projectPath, {
+      String workspacePath, {
+        String configuration,
         String scheme,
         Duration timeout = const Duration(minutes: 1),
       }) async {

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -74,7 +74,7 @@ void main() {
           .thenReturn(ProcessResult(0, 1, '', ''));
 
       expect(await xcodeProjectInterpreter.getBuildSettings(
-        '', scheme: 'Runner', timeout: delay),
+        '', configuration: 'Profile', scheme: 'Runner', timeout: delay),
         const <String, String>{});
       // build settings times out and is killed once, then succeeds.
       verify(processManager.killPid(any)).called(1);
@@ -321,17 +321,26 @@ void main() {
         command: <String>[
           'xcrun',
           'xcodebuild',
-          '-project',
+          '-workspace',
           '/',
           '-scheme',
           'Free',
-          '-showBuildSettings'
+          '-configuration',
+          'Release (Free)',
+          '-showBuildSettings',
         ],
         exitCode: 1,
       ),
     ]);
 
-    expect(await xcodeProjectInterpreter.getBuildSettings('', scheme: 'Free'), const <String, String>{});
+    expect(
+      await xcodeProjectInterpreter.getBuildSettings(
+        '',
+        configuration: 'Release (Free)',
+        scheme: 'Free',
+      ),
+      const <String, String>{},
+    );
     expect(fakeProcessManager.hasRemainingExpectations, isFalse);
   });
 
@@ -345,15 +354,23 @@ void main() {
         command: <String>[
           'xcrun',
           'xcodebuild',
-          '-project',
+          '-workspace',
           '/',
-          '-showBuildSettings'
+          '-configuration',
+          'Profile',
+          '-showBuildSettings',
         ],
         exitCode: 1,
       ),
     ]);
 
-    expect(await xcodeProjectInterpreter.getBuildSettings(''), const <String, String>{});
+    expect(
+      await xcodeProjectInterpreter.getBuildSettings(
+        '',
+        configuration: 'Profile',
+      ),
+      const <String, String>{},
+    );
     expect(fakeProcessManager.hasRemainingExpectations, isFalse);
   });
 
@@ -369,17 +386,26 @@ void main() {
         command: <String>[
           'xcrun',
           'xcodebuild',
-          '-project',
+          '-workspace',
           fileSystem.path.separator,
           '-scheme',
           'Free',
+          '-configuration',
+          'Release (Free)',
           '-showBuildSettings',
           'CODE_SIGN_STYLE=Manual',
-          'ARCHS=arm64'
+          'ARCHS=arm64',
         ],
       ),
     ]);
-    expect(await xcodeProjectInterpreter.getBuildSettings('', scheme: 'Free'), const <String, String>{});
+    expect(
+      await xcodeProjectInterpreter.getBuildSettings(
+        '',
+        configuration: 'Release (Free)',
+        scheme: 'Free',
+      ),
+      const <String, String>{},
+    );
     expect(fakeProcessManager.hasRemainingExpectations, isFalse);
   });
 

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -359,8 +359,11 @@ apply plugin: 'kotlin-android'
       testWithMocks('from build settings, if no plist', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -390,8 +393,11 @@ apply plugin: 'kotlin-android'
       testWithMocks('from build settings and plist, if default variable', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -409,8 +415,11 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
         project.ios.defaultHostInfoPlist.createSync(recursive: true);
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-          (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
             return Future<Map<String,String>>.value(<String, String>{
               'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               'SUFFIX': 'suffix',
@@ -440,8 +449,10 @@ apply plugin: 'kotlin-android'
       testWithMocks('handles case insensitive flavor', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-                (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
               return Future<Map<String,String>>.value(<String, String>{
                 'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
               });
@@ -512,7 +523,11 @@ apply plugin: 'kotlin-android'
       testUsingContext('app product name xcodebuild settings', () async {
         final FlutterProject project = await someProject();
         project.ios.xcodeProject.createSync();
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer((_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
           return Future<Map<String,String>>.value(<String, String>{
             'FULL_PRODUCT_NAME': 'My App.app'
           });
@@ -629,8 +644,11 @@ apply plugin: 'kotlin-android'
 
     group('with bundle identifier', () {
       setUp(() {
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, scheme: anyNamed('scheme'))).thenAnswer(
-            (_) {
+        when(mockXcodeProjectInterpreter.getBuildSettings(
+          any,
+          configuration: anyNamed('configuration'),
+          scheme: anyNamed('scheme'),
+        )).thenAnswer((_) {
             return Future<Map<String,String>>.value(<String, String>{
               'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
             });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -393,7 +393,8 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<Map<String, String>> getBuildSettings(
-    String projectPath, {
+    String workspacePath, {
+    String configuration,
     String scheme,
     Duration timeout = const Duration(minutes: 1),
   }) async {


### PR DESCRIPTION
## Description

`flutter build ios` was calling `xcodebuild -showBuildSettings` multiple times, which can take several seconds to run.  Instead, only run it once with the correct flags, and use that cache elsewhere.

The first time `xcodebuild -showBuildSettings` is called, it doesn't pass along the specified configuration (Release, Debug, custom flavor configuration), which causes [confusing output](https://github.com/flutter/flutter/issues/70576#issuecomment-736196704).  Always use the passed in configuration.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/72916