### PR TITLE
Launch named iOS simulators

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -142,7 +142,7 @@ class AndroidEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  PlatformType get platformType => PlatformType.android;
+  String get platformDisplay => PlatformType.android.toString();
 
   String _prop(String name) => _properties != null ? _properties[name] : null;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -933,7 +933,7 @@ Map<String, dynamic> _emulatorToMap(Emulator emulator) {
     'id': emulator.id,
     'name': emulator.name,
     'category': emulator.category?.toString(),
-    'platformType': emulator.platformType?.toString(),
+    'platformType': emulator.platformDisplay,
   };
 }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -27,7 +27,7 @@ class EmulatorsCommand extends FlutterCommand {
   final String description = 'List, launch and create emulators.';
 
   @override
-  final List<String> aliases = <String>['emulator'];
+  final List<String> aliases = <String>['emulator', 'simulators', 'simulator'];
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -614,10 +614,6 @@ abstract class Device {
   /// Check if the device is supported by Flutter.
   bool isSupported();
 
-  // String meant to be displayed to the user indicating if the device is
-  // supported by Flutter, and, if not, why.
-  String supportMessage() => isSupported() ? 'Supported' : 'Unsupported';
-
   /// The device's platform.
   Future<TargetPlatform> get targetPlatform;
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -252,7 +252,7 @@ abstract class Emulator {
   String get name;
   String get manufacturer;
   Category get category;
-  PlatformType get platformType;
+  String get platformDisplay;
 
   @override
   int get hashCode => id.hashCode;
@@ -283,7 +283,7 @@ abstract class Emulator {
           emulator.id ?? '',
           emulator.name ?? '',
           emulator.manufacturer ?? '',
-          emulator.platformType?.toString() ?? '',
+          emulator.platformDisplay ?? '',
         ],
     ];
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -44,7 +44,9 @@ class IOSEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  PlatformType get platformType => PlatformType.ios;
+  String get platformDisplay =>
+      // com.apple.CoreSimulator.SimRuntime.iOS-10-3 => iOS-10-3
+      _simulator.simulatorCategory?.split('.')?.last ?? 'ios';
 
   @override
   Future<void> launch() async {

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -16,17 +16,28 @@ class IOSEmulators extends EmulatorDiscovery {
   bool get canListAnything => globals.iosWorkflow.canListEmulators;
 
   @override
-  Future<List<Emulator>> get emulators async => getEmulators();
+  Future<List<Emulator>> get emulators async {
+    final List<IOSSimulator> simulators = await globals.iosSimulatorUtils.getAvailableDevices();
+    final List<Emulator> discoveredEmulators = simulators.map<Emulator>((IOSSimulator device) {
+      return IOSEmulator(device);
+    }).toList();
+    discoveredEmulators.add(const PlaceholderIOSEmulator());
+    return discoveredEmulators;
+  }
 
   @override
   bool get canLaunchAnything => canListAnything;
 }
 
 class IOSEmulator extends Emulator {
-  const IOSEmulator(String id) : super(id, true);
+  IOSEmulator(IOSSimulator simulator)
+      : _simulator = simulator,
+        super(simulator.id, true);
+
+  final IOSSimulator _simulator;
 
   @override
-  String get name => 'iOS Simulator';
+  String get name => _simulator.name;
 
   @override
   String get manufacturer => 'Apple';
@@ -39,22 +50,29 @@ class IOSEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    Future<bool> launchSimulator(List<String> additionalArgs) async {
-      final List<String> args = <String>[
-        'open',
-        ...additionalArgs,
-        '-a',
-        globals.xcode.getSimulatorPath(),
-      ];
+    await launchSimulator(<String>[]);
+    return _simulator.boot();
+  }
+}
 
-      final RunResult launchResult = await globals.processUtils.run(args);
-      if (launchResult.exitCode != 0) {
-        globals.printError('$launchResult');
-        return false;
-      }
-      return true;
-    }
+/// Used by IDEs to "Open iOS Simulator" without a specific simulator.
+class PlaceholderIOSEmulator extends Emulator {
+  const PlaceholderIOSEmulator() : super(iosSimulatorId, true);
 
+  @override
+  String get name => 'iOS Simulator (launch app only)';
+
+  @override
+  String get manufacturer => 'Apple';
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  PlatformType get platformType => PlatformType.ios;
+
+  @override
+  Future<void> launch() async {
     // First run with `-n` to force a device to boot if there isn't already one
     if (!await launchSimulator(<String>['-n'])) {
       return;
@@ -66,12 +84,18 @@ class IOSEmulator extends Emulator {
   }
 }
 
-/// Return the list of iOS Simulators (there can only be zero or one).
-List<IOSEmulator> getEmulators() {
-  final String simulatorPath = globals.xcode.getSimulatorPath();
-  if (simulatorPath == null) {
-    return <IOSEmulator>[];
-  }
+Future<bool> launchSimulator(List<String> additionalArgs) async {
+  final List<String> args = <String>[
+    'open',
+    ...additionalArgs,
+    '-a',
+    globals.xcode.getSimulatorPath(),
+  ];
 
-  return <IOSEmulator>[const IOSEmulator(iosSimulatorId)];
+  final RunResult launchResult = await globals.processUtils.run(args);
+  if (launchResult.exitCode != 0) {
+    globals.printError('$launchResult');
+    return false;
+  }
+  return true;
 }

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -18,11 +18,9 @@ class IOSEmulators extends EmulatorDiscovery {
   @override
   Future<List<Emulator>> get emulators async {
     final List<IOSSimulator> simulators = await globals.iosSimulatorUtils.getAvailableDevices();
-    final List<Emulator> discoveredEmulators = simulators.map<Emulator>((IOSSimulator device) {
+    return simulators.map<Emulator>((IOSSimulator device) {
       return IOSEmulator(device);
     }).toList();
-    discoveredEmulators.add(const PlaceholderIOSEmulator());
-    return discoveredEmulators;
   }
 
   @override
@@ -50,52 +48,14 @@ class IOSEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    await launchSimulator(<String>[]);
+    final RunResult launchResult = await globals.processUtils.run(<String>[
+      'open',
+      '-a',
+      globals.xcode.getSimulatorPath(),
+    ]);
+    if (launchResult.exitCode != 0) {
+      globals.printError('$launchResult');
+    }
     return _simulator.boot();
   }
-}
-
-/// Used by IDEs to "Open iOS Simulator" without a specific simulator.
-class PlaceholderIOSEmulator extends Emulator {
-  const PlaceholderIOSEmulator() : super(iosSimulatorId, true);
-
-  @override
-  String get name => 'iOS Simulator (launch app only)';
-
-  @override
-  String get manufacturer => 'Apple';
-
-  @override
-  Category get category => Category.mobile;
-
-  @override
-  PlatformType get platformType => PlatformType.ios;
-
-  @override
-  Future<void> launch() async {
-    // First run with `-n` to force a device to boot if there isn't already one
-    if (!await launchSimulator(<String>['-n'])) {
-      return;
-    }
-
-    // Run again to force it to Foreground (using -n doesn't force existing
-    // devices to the foreground)
-    await launchSimulator(<String>[]);
-  }
-}
-
-Future<bool> launchSimulator(List<String> additionalArgs) async {
-  final List<String> args = <String>[
-    'open',
-    ...additionalArgs,
-    '-a',
-    globals.xcode.getSimulatorPath(),
-  ];
-
-  final RunResult launchResult = await globals.processUtils.run(args);
-  if (launchResult.exitCode != 0) {
-    globals.printError('$launchResult');
-    return false;
-  }
-  return true;
 }

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(emulator.name, displayName);
       expect(emulator.manufacturer, manufacturer);
       expect(emulator.category, Category.mobile);
-      expect(emulator.platformType, PlatformType.android);
+      expect(emulator.platformDisplay, 'android');
     });
 
     testWithoutContext('prefers displayname for name', () {

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
@@ -336,32 +333,6 @@ void main() {
 
       expect(emulator.id, '1234');
       expect(emulator.name, 'iPhone 12');
-      await emulator.launch();
-      expect(fakeProcessManager.hasRemainingExpectations, false);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => fakeProcessManager,
-      Xcode: () => mockXcode,
-    });
-
-    testUsingContext('launches app with placeholder emulator ID', () async {
-      fakeProcessManager.addCommands(<FakeCommand>[
-        const FakeCommand(command: <String>[
-          'open',
-          '-n',
-          '-a',
-          '/fake/simulator.app',
-        ]),
-        const FakeCommand(command: <String>[
-          'open',
-          '-a',
-          '/fake/simulator.app',
-        ]),
-      ]);
-
-      final PlaceholderIOSEmulator emulator = PlaceholderIOSEmulator();
-
-      expect(emulator.id, 'apple_ios_simulator');
-      expect(emulator.name, 'iOS Simulator (launch app only)');
       await emulator.launch();
       expect(fakeProcessManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
+import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -45,14 +46,10 @@ const FakeCommand kListEmulatorsCommand = FakeCommand(
 );
 
 void main() {
-  MockProcessManager mockProcessManager;
   MockAndroidSdk mockSdk;
-  MockXcode mockXcode;
 
   setUp(() {
-    mockProcessManager = MockProcessManager();
     mockSdk = MockAndroidSdk();
-    mockXcode = MockXcode();
 
     when(mockSdk.avdManagerPath).thenReturn('avdmanager');
     when(mockSdk.getAvdManagerPath()).thenReturn('avdmanager');
@@ -299,24 +296,76 @@ void main() {
   });
 
   group('ios_emulators', () {
-    bool didAttemptToRunSimulator = false;
+    MockXcode mockXcode;
+    FakeProcessManager fakeProcessManager;
+
     setUp(() {
-      when(mockXcode.xcodeSelectPath).thenReturn('/fake/Xcode.app/Contents/Developer');
-      when(mockXcode.getSimulatorPath()).thenAnswer((_) => '/fake/simulator.app');
-      when(mockProcessManager.run(any)).thenAnswer((Invocation invocation) async {
-        final List<String> args = invocation.positionalArguments[0] as List<String>;
-        if (args.length >= 3 && args[0] == 'open' && args[1] == '-a' && args[2] == '/fake/simulator.app') {
-          didAttemptToRunSimulator = true;
-        }
-        return ProcessResult(101, 0, '', '');
-      });
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
+      mockXcode = MockXcode();
+      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
+      when(mockXcode.getSimulatorPath())
+          .thenAnswer((_) => '/fake/simulator.app');
     });
+
     testUsingContext('runs correct launch commands', () async {
-      const Emulator emulator = IOSEmulator('ios');
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          'open',
+          '-a',
+          '/fake/simulator.app',
+        ]),
+        const FakeCommand(command: <String>[
+          'xcrun',
+          'simctl',
+          'boot',
+          '1234',
+        ]),
+      ]);
+      final SimControl simControl = SimControl.test(
+        processManager: fakeProcessManager,
+        xcode: mockXcode,
+      );
+
+      final IOSSimulator simulator = IOSSimulator(
+        '1234',
+        name: 'iPhone 12',
+        simControl: simControl,
+        xcode: mockXcode,
+      );
+      final IOSEmulator emulator = IOSEmulator(simulator);
+
+      expect(emulator.id, '1234');
+      expect(emulator.name, 'iPhone 12');
       await emulator.launch();
-      expect(didAttemptToRunSimulator, equals(true));
+      expect(fakeProcessManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
+      Xcode: () => mockXcode,
+    });
+
+    testUsingContext('launches app with placeholder emulator ID', () async {
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          'open',
+          '-n',
+          '-a',
+          '/fake/simulator.app',
+        ]),
+        const FakeCommand(command: <String>[
+          'open',
+          '-a',
+          '/fake/simulator.app',
+        ]),
+      ]);
+
+      final PlaceholderIOSEmulator emulator = PlaceholderIOSEmulator();
+
+      expect(emulator.id, 'apple_ios_simulator');
+      expect(emulator.name, 'iOS Simulator (launch app only)');
+      await emulator.launch();
+      expect(fakeProcessManager.hasRemainingExpectations, false);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => fakeProcessManager,
       Xcode: () => mockXcode,
     });
   });
@@ -354,28 +403,4 @@ class FakeEmulator extends Emulator {
     throw UnimplementedError('Not implemented in Mock');
   }
 }
-
-class MockProcessManager extends Mock implements ProcessManager {
-
-  @override
-  ProcessResult runSync(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
-    bool includeParentEnvironment = true,
-    bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
-  }) {
-    final String program = command[0] as String;
-    final List<String> args = command.sublist(1) as List<String>;
-    switch (program) {
-      case '/usr/bin/xcode-select':
-        throw ProcessException(program, args);
-        break;
-    }
-    throw StateError('Unexpected process call: $command');
-  }
-}
-
 class MockXcode extends Mock implements Xcode {}

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -326,6 +326,7 @@ void main() {
       final IOSSimulator simulator = IOSSimulator(
         '1234',
         name: 'iPhone 12',
+        simulatorCategory: 'com.apple.CoreSimulator.SimRuntime.iOS-14-3',
         simControl: simControl,
         xcode: mockXcode,
       );
@@ -333,6 +334,8 @@ void main() {
 
       expect(emulator.id, '1234');
       expect(emulator.name, 'iPhone 12');
+      expect(emulator.category, Category.mobile);
+      expect(emulator.platformDisplay, 'iOS-14-3');
       await emulator.launch();
       expect(fakeProcessManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
@@ -367,7 +370,7 @@ class FakeEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  PlatformType get platformType => PlatformType.android;
+  String get platformDisplay => PlatformType.android.toString();
 
   @override
   Future<void> launch() {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -286,7 +286,7 @@ class FakeDoctor extends Doctor {
 
 class MockSimControl extends Mock implements SimControl {
   MockSimControl() {
-    when(getConnectedDevices()).thenAnswer((Invocation _) async => <SimDevice>[]);
+    when(getAvailableDevices()).thenAnswer((Invocation _) async => <SimDevice>[]);
   }
 }
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -114,6 +114,7 @@ void testUsingContext(
           IOSSimulatorUtils: () {
             final MockIOSSimulatorUtils mock = MockIOSSimulatorUtils();
             when(mock.getAttachedDevices()).thenAnswer((Invocation _) async => <IOSSimulator>[]);
+            when(mock.getAvailableDevices()).thenAnswer((Invocation _) async => <IOSSimulator>[]);
             return mock;
           },
           OutputPreferences: () => OutputPreferences.test(),


### PR DESCRIPTION
## Description

Only `$ flutter emulator --launch apple_ios_simulator` "worked" but it just launched the Simulator app, not a particular simulator.

Leverage the existing iOS simulator discovery code to populate the available simulators so `$ flutter emulator --launch "iPhone 12"` launches the app AND boots the simulator, if it's not already booted.

```
$ flutter emulator
60 available emulators:

51EE3952-BA4C-4269-A86D-82950530D2BF • Old Phone                             • Apple  • iOS-10-3
5D64FA8B-A670-4574-A3FB-28D6084C6700 • iPhone 5s                             • Apple  • iOS-10-3
848FCC5C-5848-4FA7-A075-9F312010292A • iPhone 6 Plus                         • Apple  • iOS-10-3
A0CBF21B-24F0-4C75-AE1B-0FD63C2D81FE • iPhone 6                              • Apple  • iOS-10-3
224A25A2-EC05-474F-8A1B-66DB05E5DCB2 • iPhone 6s                             • Apple  • iOS-10-3
D7AD8D26-81DE-44AD-B06D-9B9D4296BA63 • iPhone 6s Plus                        • Apple  • iOS-10-3
6D7FA026-42FF-401F-8710-F8AEF09C97AE • iPhone SE (1st generation)            • Apple  • iOS-10-3
BD4F3423-0FE0-42E9-BE35-429DFA04A6A1 • iPhone 7                              • Apple  • iOS-10-3
20CFC304-9E7C-4AB4-A75D-AE22487863A4 • iPhone 7 Plus                         • Apple  • iOS-10-3
D18A6F32-1392-401B-B552-B6D70C39A79B • iPad Air                              • Apple  • iOS-10-3
47FC3063-1C4F-4FCA-96E8-ED168B27F096 • iPad Air 2                            • Apple  • iOS-10-3
F61A6B4C-CB69-4814-B5B4-C3E3AADB0479 • iPad Pro (9.7-inch)                   • Apple  • iOS-10-3
D7A97316-E27A-4F76-AACF-DE6B130A94A7 • iPad Pro (12.9-inch) (1st generation) • Apple  • iOS-10-3
D057B208-72EB-4EC0-865F-DC6EFBD0827D • iPad (5th generation)                 • Apple  • iOS-10-3
68C09F24-C11D-4106-9DE0-5AE9F14EDF8F • iPad Pro (12.9-inch) (2nd generation) • Apple  • iOS-10-3
DC327A42-503F-4AE7-98E7-4699A2F481F3 • iPad Pro (10.5-inch)                  • Apple  • iOS-10-3
C9DE2F54-C0B6-4FF2-A34C-E2B0E29F2EB7 • iPhone 5s                             • Apple  • iOS-12-4
EBB74968-47AD-456B-BA8B-3A58BE85F302 • iPhone 6 Plus                         • Apple  • iOS-12-4
F34B0CAD-75A7-41A7-BF2A-26C625535FC6 • iPhone 6                              • Apple  • iOS-12-4
084ECAE7-FE00-42D9-A68E-90F3BDCC68B0 • iPhone 6s                             • Apple  • iOS-12-4
36DED3AA-D9B0-4BBA-9448-B3E199121CE0 • iPhone 6s Plus                        • Apple  • iOS-12-4
FFFC335F-EAAC-416A-81EF-596496383CCE • iPhone SE                             • Apple  • iOS-12-4
61727199-6726-4FFB-A573-9731BBA33D97 • iPhone 7                              • Apple  • iOS-12-4
EEFCCF18-66FB-426A-A24B-F93FBE280701 • iPhone 7 Plus                         • Apple  • iOS-12-4
1FB04F3A-9F57-4640-B2F3-873286905C6B • iPhone 8                              • Apple  • iOS-12-4
E536FBE2-3229-4CD7-843C-C60C8F2B42B2 • iPhone 8 Plus                         • Apple  • iOS-12-4
C9A36DF7-7034-48B5-AE15-2AA8E3F84B79 • iPhone X                              • Apple  • iOS-12-4
BEE28698-093D-4489-A503-B5F8CDC33B8B • iPhone Xs                             • Apple  • iOS-12-4
FD60F847-4E6E-4320-8212-9B90606FA573 • iPhone Xs Max                         • Apple  • iOS-12-4
97114501-3851-4C01-8814-159668DBBBA9 • iPhone Xʀ                             • Apple  • iOS-12-4
14E6D86E-0730-4D82-A79E-E41A9AAEC866 • iPad Air                              • Apple  • iOS-12-4
28BECDD1-91F9-4DBE-B61C-41F6B3155703 • iPad Air 2                            • Apple  • iOS-12-4
EB4E42C8-3AF2-444C-8AC2-5AE64B98EF35 • iPad Pro (9.7-inch)                   • Apple  • iOS-12-4
957B76DB-3BF1-4EDC-8A49-979E9C29C5CA • iPad Pro (12.9-inch)                  • Apple  • iOS-12-4
DA66733D-8726-4AAC-94CC-64DFA151D56C • iPad (5th generation)                 • Apple  • iOS-12-4
DD9469D8-2641-43C1-9C90-E66FB901C9A7 • iPad Pro (12.9-inch) (2nd generation) • Apple  • iOS-12-4
6FA6755E-602A-42D1-A580-9C9F348160AD • iPad Pro (10.5-inch)                  • Apple  • iOS-12-4
D7ECE9D0-6950-4AD4-84E9-7D9591DF6CD8 • iPad (6th generation)                 • Apple  • iOS-12-4
A5D3F45B-440F-4F7A-A7C1-B167236DB8D8 • iPad Pro (11-inch)                    • Apple  • iOS-12-4
04859A3A-62AA-4865-9173-669E06A2D5B0 • iPad Pro (12.9-inch) (3rd generation) • Apple  • iOS-12-4
3C4B0A26-A714-45C1-91AB-0F59DCDD9E36 • iPad Air (3rd generation)             • Apple  • iOS-12-4
55C655D3-171A-4915-AE26-BE2294297DC5 • iPhone 8                              • Apple  • iOS-14-3
4E473E9E-2B3C-4792-B8A3-749B7661466A • iPhone 8 Plus                         • Apple  • iOS-14-3
D7C49E84-166A-44B3-90F7-7C661638065C • iPhone 11                             • Apple  • iOS-14-3
304E4EF3-D787-4ECA-B543-356145CDC709 • TestAdd2AppSim                        • Apple  • iOS-14-3
086F5A9B-AC47-4B28-BDD9-32C1E5ACC7D1 • iPhone 11 Pro                         • Apple  • iOS-14-3
303D3A69-A51C-4295-9ECB-24F09B5C8C77 • iPhone 11 Pro Max                     • Apple  • iOS-14-3
D5DF141D-622C-456B-908C-81D9F64E57D1 • iPhone SE (2nd generation)            • Apple  • iOS-14-3
D0688106-4E2D-43F7-8600-A235AE61092B • iPhone 12 mini                        • Apple  • iOS-14-3
06841A41-188A-4F33-B7A6-CDEBFC8D6DE8 • iPhone 12                             • Apple  • iOS-14-3
CF084244-2392-4051-ABF4-E60D1DB1EC75 • iPhone 12 Pro                         • Apple  • iOS-14-3
4A89F39B-1E22-46D5-9982-955D5FE0BB50 • iPhone 12 Pro Max                     • Apple  • iOS-14-3
B3201500-C7F6-4054-802A-9970B98E3AEC • iPod touch (7th generation)           • Apple  • iOS-14-3
C00C69F0-0D79-4D2C-8E64-2E5BA17AB6D2 • iPad Pro (9.7-inch)                   • Apple  • iOS-14-3
42F05AF6-ED6E-445C-B0DE-EA1AFEB088C0 • iPad Pro (11-inch) (2nd generation)   • Apple  • iOS-14-3
8D5CEC57-6FCF-476D-8B64-142099630090 • iPad Pro (12.9-inch) (4th generation) • Apple  • iOS-14-3
48E8D4B4-7670-47F4-9E18-323CA44D06D7 • iPad (8th generation)                 • Apple  • iOS-14-3
C2FAE9F3-0973-4EFB-BE4E-77513BE5E91B • iPad Air (4th generation)             • Apple  • iOS-14-3
My_Pixel_XL_123                      • My Pixel XL 123                       • Google • android
Pixel_3_XL_API_29                    • Pixel 3 XL API 29                     • Google • android

To run an emulator, run 'flutter emulators --launch <emulator id>'.
To create a new emulator, run 'flutter emulators --create [--name xyz]'.
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/72293
Unblocks https://github.com/flutter/flutter/issues/72294