### PR TITLE
Add BuildContext parameter to TextEditingController.buildTextSpan

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -31,7 +31,7 @@ class _TextSpanEditingController extends TextEditingController {
   final TextSpan _textSpan;
 
   @override
-  TextSpan buildTextSpan({TextStyle? style ,bool? withComposing}) {
+  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
     // This does not care about composing.
     return TextSpan(
       style: style,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -186,7 +186,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   ///
   /// By default makes text in composing range appear as underlined. Descendants
   /// can override this method to customize appearance of text.
-  TextSpan buildTextSpan({TextStyle? style , required bool withComposing}) {
+  TextSpan buildTextSpan({TextStyle? style , required bool withComposing, required BuildContext context}) {
     assert(!value.composing.isValid || !withComposing || value.isComposingRangeValid);
     // If the composing range is out of range for the current text, ignore it to
     // preserve the tree integrity, otherwise in release mode a RangeError will
@@ -2675,6 +2675,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     return widget.controller.buildTextSpan(
       style: widget.style,
       withComposing: !widget.readOnly,
+      context: context,
     );
   }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5676,9 +5676,10 @@ void main() {
     });
 
     testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
-      final AccentColorTextEditingController controller = AccentColorTextEditingController('a');
+      final _AccentColorTextEditingController controller = _AccentColorTextEditingController('a');
+      const Color color = Color.fromARGB(255, 1, 2, 3);
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData.light().copyWith(accentColor: const Color.fromARGB(255, 1, 2, 3)),
+        theme: ThemeData.light().copyWith(accentColor: color),
         home: EditableText(
           controller: controller,
           focusNode: FocusNode(),
@@ -5690,7 +5691,7 @@ void main() {
 
       final RenderEditable renderEditable = findRenderEditable(tester);
       final TextSpan textSpan = renderEditable.text!;
-      expect(textSpan.style!.color, const Color.fromARGB(255, 1, 2, 3));
+      expect(textSpan.style!.color, color);
     });
   });
 
@@ -7128,8 +7129,8 @@ class SkipPaintingRenderObject extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) { }
 }
 
-class AccentColorTextEditingController extends TextEditingController {
-  AccentColorTextEditingController(String text) : super(text: text);
+class _AccentColorTextEditingController extends TextEditingController {
+  _AccentColorTextEditingController(String text) : super(text: text);
 
   @override
   TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5674,6 +5674,24 @@ void main() {
         }),
       );
     });
+
+    testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
+      final AccentColorTextEditingController controller = AccentColorTextEditingController('a');
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.light().copyWith(accentColor: const Color.fromARGB(255, 1, 2, 3)),
+        home: EditableText(
+          controller: controller,
+          focusNode: FocusNode(),
+          style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!,
+          cursorColor: Colors.blue,
+          backgroundCursorColor: Colors.grey,
+        ),
+      ));
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final TextSpan textSpan = renderEditable.text!;
+      expect(textSpan.style!.color, const Color.fromARGB(255, 1, 2, 3));
+    });
   });
 
   testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {
@@ -7108,4 +7126,14 @@ class SkipPainting extends SingleChildRenderObjectWidget {
 class SkipPaintingRenderObject extends RenderProxyBox {
   @override
   void paint(PaintingContext context, Offset offset) { }
+}
+
+class AccentColorTextEditingController extends TextEditingController {
+  AccentColorTextEditingController(String text) : super(text: text);
+
+  @override
+  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
+    final Color color = Theme.of(context).accentColor;
+    return super.buildTextSpan(style: TextStyle(color: color), withComposing: withComposing, context: context);
+  }
 }


### PR DESCRIPTION
## Description

This adds a `BuildContext` parameter to `TextEditingController.buildTextSpan` so inheritors can use the context, for example to access inherited themes. #72343 describes my use case in more detail.

## Related Issues

Resolves #72343

## Tests

~The added parameter is only useful for inheritors outside flutter and with NNBD guaranteeing the passed `BuildContext` is not null, there's really no useful tests to do here.~

EDIT: Added a test that styles the text span with a value from Theme of the build context.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] ~I updated/added relevant documentation (doc comments with `///`).~
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

This does not break any tests, but it is a breaking change to the API.
Inheritors will need to add the `BuildContext` parameter and users of this API need to pass a `BuildContext`.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
