### PR TITLE
[devicelab] Migrate remaining linux vm tests to LUCI

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -724,18 +724,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-  dartdocs:
-    description: >
-      Tracks how many members are still lacking documentation.
-    stage: devicelab
-    required_agent_capabilities: ["linux-vm"]
-
-  technical_debt__cost:
-    description: >
-      Estimates our technical debt (TODOs, analyzer ignores, etc).
-    stage: devicelab
-    required_agent_capabilities: ["linux-vm"]
-
   flutter_gallery__start_up:
     description: >
       Measures the startup time of the Flutter Gallery app on Android.
@@ -883,12 +871,6 @@ tasks:
       Measures the speed of Dart analyzer.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-
-  web_benchmarks_html:
-    description: >
-      Runs Web benchmarks on Chrome on a Linux machine using the HTML rendering backend.
-    stage: devicelab
-    required_agent_capabilities: ["linux-vm"]
 
   # android_splash_screen_integration_test:
   #   description: >

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -19,6 +19,12 @@
          "flaky": false
       },
       {
+         "name": "Linux dartdocs",
+         "repo": "flutter",
+         "task_name": "linux_dartdocs",
+         "flaky": false
+      },
+      {
          "name": "Linux docs",
          "repo": "flutter",
          "task_name": "linux_docs",
@@ -106,6 +112,12 @@
          "name": "Linux plugin_test",
          "repo": "flutter",
          "task_name": "linux_plugin_test",
+         "flaky": false
+      },
+      {
+         "name": "Linux technical_debt__cost",
+         "repo": "flutter",
+         "task_name": "linux_technical_debt__cost",
          "flaky": false
       },
       {


### PR DESCRIPTION
## Description

Adds the prod vm tasks to Cocoon and turns down the previous devicelab tests.

## Related Issues

Closes flutter/flutter#66225