### PR TITLE
[devicelab] Remove plugin_test_win from manifest

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -698,12 +698,6 @@ tasks:
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
 
-  plugin_test_win:
-    description: >
-      Checks that the project template works and supports plugins on Windows.
-    stage: devicelab_win
-    required_agent_capabilities: ["windows/android"]
-
   hot_mode_dev_cycle_win__benchmark:
     description: >
       Measures the performance of Dart VM hot patching feature on Windows.


### PR DESCRIPTION
## Description

This task is already running on LUCI.

https://ci.chromium.org/p/flutter/builders/prod/Windows%20plugin_test

## Related Issues

https://github.com/flutter/flutter/issues/70635