### PR TITLE
Build/copy macOS frameworks to built products instead of ephemeral directory

### DIFF
--- a/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner.xcodeproj/project.pbxproj
@@ -416,10 +416,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -546,10 +542,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -570,10 +562,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -421,10 +421,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -551,10 +547,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -575,10 +567,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dev/integration_tests/ui/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ui/macos/Runner.xcodeproj/project.pbxproj
@@ -361,10 +361,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -491,10 +487,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -515,10 +507,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/dev/manual_tests/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/manual_tests/macos/Runner.xcodeproj/project.pbxproj
@@ -361,10 +361,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -491,10 +487,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -515,10 +507,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -98,26 +98,24 @@ BuildApp() {
       --ExtraFrontEndOptions="${EXTRA_FRONT_END_OPTIONS}"                     \
       --build-inputs="${build_inputs_path}"                                   \
       --build-outputs="${build_outputs_path}"                                 \
-      --output="${ephemeral_dir}"                                             \
+      --output="${BUILT_PRODUCTS_DIR}"                                        \
      "${build_mode}_macos_bundle_flutter_assets"
 }
 
 # Adds the App.framework as an embedded binary and the flutter_assets as
 # resources.
 EmbedFrameworks() {
-  local ephemeral_dir="${SOURCE_ROOT}/Flutter/ephemeral"
-
   # Embed App.framework from Flutter into the app (after creating the Frameworks directory
   # if it doesn't already exist).
   local xcode_frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
   RunCommand mkdir -p -- "${xcode_frameworks_dir}"
-  RunCommand rsync -av --delete --filter "- .DS_Store/" "${ephemeral_dir}/App.framework" "${xcode_frameworks_dir}"
+  RunCommand rsync -av --delete --filter "- .DS_Store/" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
 
   # Embed the actual FlutterMacOS.framework that the Flutter app expects to run against,
   # which could be a local build or an arch/type specific build.
 
   # Copy Xcode behavior and don't copy over headers or modules.
-  RunCommand rsync -av --delete --filter "- .DS_Store/" --filter "- Headers/" --filter "- Modules/" "${ephemeral_dir}/FlutterMacOS.framework" "${xcode_frameworks_dir}/"
+  RunCommand rsync -av --delete --filter "- .DS_Store/" --filter "- Headers/" --filter "- Modules/" "${BUILT_PRODUCTS_DIR}/FlutterMacOS.framework" "${xcode_frameworks_dir}/"
 
   # Sign the binaries we moved.
   if [[ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -38,13 +38,12 @@ abstract class UnpackMacOS extends Target {
   ];
 
   @override
-  List<Source> get outputs => const <Source>[];
+  List<Source> get outputs => const <Source>[
+    Source.pattern('{OUTPUT_DIR}/FlutterMacOS.framework/FlutterMacOS'),
+  ];
 
   @override
   List<Target> get dependencies => <Target>[];
-
-  @override
-  List<String> get depfiles => const <String>['unpack_macos.d'];
 
   @override
   Future<void> build(Environment environment) async {
@@ -53,38 +52,22 @@ abstract class UnpackMacOS extends Target {
     }
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final String basePath = environment.artifacts.getArtifactPath(Artifact.flutterMacOSFramework, mode: buildMode);
-    final Directory targetDirectory = environment
-      .outputDir
-      .childDirectory('FlutterMacOS.framework');
-    // Deleting this directory is required or else the FlutterMacOS module
-    // cannot be found.
-    if (targetDirectory.existsSync()) {
-      targetDirectory.deleteSync(recursive: true);
-    }
-    final List<File> inputs = environment.fileSystem.directory(basePath)
-      .listSync(recursive: true)
-      .whereType<File>()
-      .toList();
-    final List<File> outputs = inputs.map((File file) {
-      final String relativePath = environment.fileSystem.path.relative(file.path, from: basePath);
-      return environment.fileSystem.file(environment.fileSystem.path.join(targetDirectory.path, relativePath));
-    }).toList();
-    final ProcessResult result = await environment.processManager
-        .run(<String>['cp', '-R', basePath, targetDirectory.path]);
+
+    final ProcessResult result = environment.processManager.runSync(<String>[
+      'rsync',
+      '-av',
+      '--delete',
+      '--filter',
+      '- .DS_Store/',
+      basePath,
+      environment.outputDir.path,
+    ]);
     if (result.exitCode != 0) {
       throw Exception(
         'Failed to copy framework (exit ${result.exitCode}:\n'
-        '${result.stdout}\n---\n${result.stderr}',
+            '${result.stdout}\n---\n${result.stderr}',
       );
     }
-    final DepfileService depfileService = DepfileService(
-      logger: environment.logger,
-      fileSystem: environment.fileSystem,
-    );
-    depfileService.writeToFile(
-      Depfile(inputs, outputs),
-      environment.buildDir.childFile('unpack_macos.d'),
-    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -16,14 +16,11 @@ import 'assets.dart';
 import 'common.dart';
 import 'icon_tree_shaker.dart';
 
-/// Copy the macOS framework to the correct copy dir by invoking 'cp -R'.
+/// Copy the macOS framework to the correct copy dir by invoking 'rsync'.
 ///
 /// This class is abstract to share logic between the three concrete
 /// implementations. The shelling out is done to avoid complications with
 /// preserving special files (e.g., symbolic links) in the framework structure.
-///
-/// Removes any previous version of the framework that already exists in the
-/// target directory.
 ///
 /// The real implementations are:
 ///   * [DebugUnpackMacOS]

--- a/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
+++ b/packages/flutter_tools/templates/app/macos.tmpl/Runner.xcodeproj/project.pbxproj.tmpl
@@ -361,10 +361,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -491,10 +487,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -515,10 +507,6 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Flutter/ephemeral",
-				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -44,13 +44,17 @@ void main() {
   });
 
   testUsingContext('Copies files to correct cache directory', () async {
+    final Directory outputDir = fileSystem.directory('output');
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      const FakeCommand(
+      FakeCommand(
         command: <String>[
-          'cp',
-          '-R',
+          'rsync',
+          '-av',
+          '--delete',
+          '--filter',
+          '- .DS_Store/',
           'Artifact.flutterMacOSFramework.debug',
-          '/FlutterMacOS.framework',
+          outputDir.path,
         ],
       ),
     ]);
@@ -65,18 +69,9 @@ void main() {
       processManager: processManager,
       logger: BufferLogger.test(),
       fileSystem: fileSystem,
-      engineVersion: '2'
+      engineVersion: '2',
+      outputDir: outputDir,
     );
-
-    final Directory cacheDirectory = fileSystem.directory(
-      artifacts.getArtifactPath(
-        Artifact.flutterMacOSFramework,
-        mode: BuildMode.debug,
-      ))
-      ..createSync();
-    cacheDirectory.childFile('dummy').createSync();
-    environment.buildDir.createSync(recursive: true);
-    environment.outputDir.createSync(recursive: true);
 
     await const DebugUnpackMacOS().build(environment);
 


### PR DESCRIPTION
## Description

macOS version of https://github.com/flutter/flutter/pull/69699 and part of https://github.com/flutter/flutter/pull/70224.

- Instead of building App.framework and copying FlutterMacOS.framework to `Flutter/ephemeral`, instead target `BUILT_PRODUCTS_DIR` (for example `build/macos/Build/Products/Debug/`).  
- Remove `FRAMEWORK_SEARCH_PATHS` build setting from template and all example projects to prefer the built products directory, which we always get for free.  I didn't write a migrator since leaving this around in existing apps is harmless--the `inherited` part means it will find our copied framework first.

This:
1. Prevents issues like https://github.com/flutter/flutter/issues/37850 where `flutter build macos --debug` is run right before running in Release/archiving in Xcode and some pieces build before the xcconfig can be updated.
2. Makes caching indirectly aware of `$CONFIGURATION`s so we don't have to keep track of whether to rebuild or recopy frameworks when switching from Debug to Release.  Either the frameworks are in `build/macos/Build/Products/{Debug,Release}/` or they aren't.

## Related Issues
https://github.com/flutter/flutter/pull/72372
Blocked by https://github.com/flutter/flutter/pull/72020, which changes plugins from linking on `Flutter/ephemeral/FlutterMacOS.framework` to instead linking directly on the framework in the engine artifacts.

## Tests

Updated macos_test 
Already validated by [macos_content_validation_test](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart)
