### PR TITLE
Remove deprecated [PointerEnterEvent, PointerExitEvent].fromHoverEvent

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -22,7 +22,7 @@ transforms:
       - kind: 'rename'
         newName: 'fromMouseEvent'
 
-  # Changes made it https://github.com/flutter/flutter/pull/28602
+  # Changes made in https://github.com/flutter/flutter/pull/28602
   - title: 'Rename to fromMouseEvent'
     date: 2020-12-15
     element:

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -11,6 +11,29 @@
 version: 1
 transforms:
 
+  # Changes made in https://github.com/flutter/flutter/pull/28602
+  - title: 'Rename to fromMouseEvent'
+    date: 2020-12-15
+    element:
+      uris: [ 'gestures.dart' ]
+      constructor: 'fromHoverEvent'
+      inClass: 'PointerEnterEvent'
+    changes:
+      - kind: 'rename'
+        newName: 'fromMouseEvent'
+
+  # Changes made it https://github.com/flutter/flutter/pull/28602
+  - title: 'Rename to fromMouseEvent'
+    date: 2020-12-15
+    element:
+      uris: [ 'gestures.dart' ]
+      constructor: 'fromHoverEvent'
+      inClass: 'PointerExitEvent'
+    changes:
+      - kind: 'rename'
+        newName: 'fromMouseEvent'
+
+
   # Changes made in https://github.com/flutter/flutter/pull/41859
   - title: 'Remove brightness'
     date: 2020-12-10

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1222,15 +1222,6 @@ class PointerEnterEvent extends PointerEvent with _PointerEventDescription, _Cop
          embedderId: embedderId,
        );
 
-  /// Creates an enter event from a [PointerHoverEvent].
-  ///
-  /// Deprecated. Please use [PointerEnterEvent.fromMouseEvent] instead.
-  @Deprecated(
-    'Use PointerEnterEvent.fromMouseEvent instead. '
-    'This feature was deprecated after v1.4.3.'
-  )
-  factory PointerEnterEvent.fromHoverEvent(PointerHoverEvent event) => PointerEnterEvent.fromMouseEvent(event);
-
   /// Creates an enter event from a [PointerEvent].
   ///
   /// This is used by the [MouseTracker] to synthesize enter events.
@@ -1396,15 +1387,6 @@ class PointerExitEvent extends PointerEvent with _PointerEventDescription, _Copy
          synthesized: synthesized,
          embedderId: embedderId,
        );
-
-  /// Creates an enter event from a [PointerHoverEvent].
-  ///
-  /// Deprecated. Please use [PointerExitEvent.fromMouseEvent] instead.
-  @Deprecated(
-    'Use PointerExitEvent.fromMouseEvent instead. '
-    'This feature was deprecated after v1.4.3.'
-  )
-  factory PointerExitEvent.fromHoverEvent(PointerHoverEvent event) => PointerExitEvent.fromMouseEvent(event);
 
   /// Creates an exit event from a [PointerEvent].
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2554,7 +2554,7 @@ abstract class BuildContext {
 class BuildOwner {
   /// Creates an object that manages widgets.
   BuildOwner({ this.onBuildScheduled, FocusManager? focusManager }) :
-        = focusManager ?? FocusManager();
+      focusManager = focusManager ?? FocusManager();
 
   /// Called on each build pass when the first buildable element is marked
   /// dirty.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2554,7 +2554,7 @@ abstract class BuildContext {
 class BuildOwner {
   /// Creates an object that manages widgets.
   BuildOwner({ this.onBuildScheduled, FocusManager? focusManager }) :
-      focusManager = focusManager ?? FocusManager();
+        = focusManager ?? FocusManager();
 
   /// Called on each build pass when the first buildable element is marked
   /// dirty.

--- a/packages/flutter/test_fixes/gestures.dart
+++ b/packages/flutter/test_fixes/gestures.dart
@@ -1,0 +1,13 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+
+void main() {
+  // Change made in https://github.com/flutter/flutter/pull/28602
+  final PointerEnterEvent enterEvent = PointerEnterEvent.fromHoverEvent(PointerHoverEvent());
+
+  // Change made in https://github.com/flutter/flutter/pull/28602
+  final PointerExitEvent exitEvent = PointerExitEvent.fromHoverEvent(PointerHoverEvent());
+}

--- a/packages/flutter/test_fixes/gestures.dart.expect
+++ b/packages/flutter/test_fixes/gestures.dart.expect
@@ -1,0 +1,13 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+
+void main() {
+  // Change made in https://github.com/flutter/flutter/pull/28602
+  final PointerEnterEvent enterEvent = PointerEnterEvent.fromMouseEvent(PointerHoverEvent());
+
+  // Change made in https://github.com/flutter/flutter/pull/28602
+  final PointerExitEvent exitEvent = PointerExitEvent.fromMouseEvent(PointerHoverEvent());
+}


### PR DESCRIPTION
## Description

This removes the deprecated `PointerEnterEvent.fromHoverEvent` and `PointerExitEvent.fromHoverEvent`.  Instances of these methods should be replaced by `fromMouseEvent`.

Part of deprecations that are slated for removal for next release in https://flutter.dev/go/deprecation-lifetime

More context: https://medium.com/flutter/deprecation-lifetime-in-flutter-e4d76ee738ad

## Related Issues

Deprecated in https://github.com/flutter/flutter/pull/28602

## Tests

Tests for quick fix tool.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
