### PR TITLE
Fix devicelab Linux builder names

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -7,49 +7,49 @@
          "flaky": false
       },
       {
-         "name": "Linux analyzer benchmark",
+         "name": "Linux analyzer_benchmark",
          "repo": "flutter",
          "task_name": "linux_analyzer_benchmark",
          "flaky": true
       },
       {
-         "name": "Linux android defines test",
+         "name": "Linux android_defines_test",
          "repo": "flutter",
          "task_name": "linux_android_defines_test",
          "flaky": true
       },
       {
-         "name": "Linux android obfuscate test",
+         "name": "Linux android_obfuscate_test",
          "repo": "flutter",
          "task_name": "linux_android_obfuscate_test",
          "flaky": true
       },
       {
-         "name": "Linux android view scroll perf timeline summary",
+         "name": "Linux android_view_scroll_perf_timeline_summary",
          "repo": "flutter",
          "task_name": "linux_android_view_scroll_perf__timeline_summary",
          "flaky": true
       },
       {
-         "name": "Linux animated placeholder perf e2e summary",
+         "name": "Linux animated_placeholder_perf_e2e_summary",
          "repo": "flutter",
          "task_name": "linux_animated_placeholder_perf__e2e_summary",
          "flaky": true
       },
       {
-         "name": "Linux animated placeholder perf",
+         "name": "Linux animated_placeholder_perf",
          "repo": "flutter",
          "task_name": "linux_animated_placeholder_perf",
          "flaky": true
       },
       {
-         "name": "Linux backdrop filter perf e2e summary",
+         "name": "Linux backdrop_filter_perf_e2e_summary",
          "repo": "flutter",
          "task_name": "linux_backdrop_filter_perf__e2e_summary",
          "flaky": true
       },
       {
-         "name": "Linux basic material app android compile",
+         "name": "Linux basic_material_app_android_compile",
          "repo": "flutter",
          "task_name": "linux_basic_material_app_android__compile",
          "flaky": true
@@ -61,13 +61,13 @@
          "flaky": false
       },
       {
-         "name": "Linux colorfilter and fade perf e2e summary",
+         "name": "Linux colorfilter_and_fade_perf_e2e_summary",
          "repo": "flutter",
          "task_name": "linux_color_filter_and_fade_perf__e2e_summary",
          "flaky": true
       },
       {
-         "name": "Linux complex layout android compile",
+         "name": "Linux complex_layout_android_compile",
          "repo": "flutter",
          "task_name": "linux_complex_layout_android__compile",
          "flaky": true


### PR DESCRIPTION
## Description

This is a follow up of https://github.com/flutter/flutter/pull/72401 to fix builder names.

## Related Issues

https://github.com/flutter/flutter/issues/71615