### PR TITLE
Fixes: "FloatingActionButton.extended's isExtended property if false should show icon, not label"

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -210,7 +210,11 @@ class FloatingActionButton extends StatelessWidget {
                  label,
                  const SizedBox(width: 20.0),
                ]
-             : <Widget>[
+             : !isExtended ? <Widget>[
+               const SizedBox(width: 20.0),
+               icon,
+               const SizedBox(width: 20.0),
+           ] : <Widget>[
                  const SizedBox(width: 16.0),
                  icon,
                  const SizedBox(width: 8.0),

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -942,6 +942,38 @@ void main() {
       paints..circle(color: splashColor),
     );
   });
+
+  testWidgets('extended FAB does not show label when isExtended is false', (WidgetTester tester) async {
+    const Key iconKey = Key('icon');
+    const Key labelKey = Key('label');
+    const Icon icon = Icon(Icons.add, key: iconKey);
+    const Text label = Text('', key: labelKey);
+
+    bool didPressedTheIcon = false;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FloatingActionButton.extended(
+          isExtended: false,
+          label: label,
+          icon: icon,
+          onPressed: () {
+            didPressedTheIcon = true;
+          },
+        ),
+      ),
+    );
+
+    // Verify that Icon is present.
+    expect(didPressedTheIcon, false);
+    await tester.tap(find.byKey(iconKey));
+    await tester.pump();
+    expect(didPressedTheIcon, true);
+
+    // Verify that label is not present.
+    expect(find.byKey(labelKey), findsNothing);
+  });
 }
 
 Offset _rightEdgeOfFab(WidgetTester tester) {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -946,32 +946,21 @@ void main() {
   testWidgets('extended FAB does not show label when isExtended is false', (WidgetTester tester) async {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
-    const Icon icon = Icon(Icons.add, key: iconKey);
-    const Text label = Text('', key: labelKey);
-
-    bool didPressedTheIcon = false;
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: FloatingActionButton.extended(
           isExtended: false,
-          label: label,
-          icon: icon,
-          onPressed: () {
-            didPressedTheIcon = true;
-          },
+          label: const Text('', key: labelKey),
+          icon: const Icon(Icons.add, key: iconKey),
+          onPressed: () {},
         ),
       ),
     );
 
-    // Verify that Icon is present.
-    expect(didPressedTheIcon, false);
-    await tester.tap(find.byKey(iconKey));
-    await tester.pump();
-    expect(didPressedTheIcon, true);
-
-    // Verify that label is not present.
+    // Verify that Icon is present and label is not.
+    expect(find.byKey(iconKey), findsOneWidget);
     expect(find.byKey(labelKey), findsNothing);
   });
 }


### PR DESCRIPTION
## Description

Prevent FloatingActionButton to not show label when created with `FloatingActionButton.extended` factory constructor and `isExtended` argument is to `false`.

| Before this PR | After this PR |
|-|-|
|![Screen Shot 2020-12-16 at 15 50 49](https://user-images.githubusercontent.com/33294549/102364196-7be2f000-3fb6-11eb-861d-322fc2a7cbf5.png)|![Screen Shot 2020-12-16 at 15 42 45](https://user-images.githubusercontent.com/33294549/102364235-843b2b00-3fb6-11eb-83de-99bee03b5343.png)|

## Related Issues

Fixes https://github.com/flutter/flutter/issues/57406

## Tests

- [x] Verify that label is not present when extended FAB has `isExtended` set to false.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
