### PR TITLE
Enable remaining LUCI devicelab linux builders to flutter dashboard

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -73,6 +73,42 @@
          "flaky": true
       },
       {
+         "name": "Linux complex_layout_android__scroll_smoothness",
+         "repo": "flutter",
+         "task_name": "linux_complex_layout_android__scroll_smoothness",
+         "flaky": true
+      },
+      {
+         "name": "Linux complex_layout_scroll_perf__devtools_memory",
+         "repo": "flutter",
+         "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
+         "flaky": true
+      },
+      {
+         "name": "Linux complex_layout_semantics_perf",
+         "repo": "flutter",
+         "task_name": "linux_complex_layout_semantics_perf",
+         "flaky": true
+      },
+      {
+         "name": "Linux cubic_bezier_perf__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_cubic_bezier_perf__e2e_summary",
+         "flaky": true
+      },
+      {
+         "name": "Linux cubic_bezier_perf_sksl_warmup__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_cubic_bezier_perf_sksl_warmup__e2e_summary",
+         "flaky": true
+      },
+      {
+         "name": "Linux cull_opacity_perf__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_cull_opacity_perf__e2e_summary",
+         "flaky": true
+      },
+      {
          "name": "Linux customer_testing",
          "repo": "flutter",
          "task_name": "linux_customer_testing",
@@ -103,6 +139,12 @@
          "flaky": false
       },
       {
+         "name": "Linux fast_scroll_heavy_gridview__memory",
+         "repo": "flutter",
+         "task_name": "linux_fast_scroll_heavy_gridview__memory",
+         "flaky": true
+      },
+      {
          "name": "Linux firebase_abstract_method_smoke_test",
          "repo": "flutter",
          "task_name": "linux_firebase_abstract_method_smoke_test",
@@ -119,6 +161,96 @@
          "repo": "flutter",
          "task_name": "linux_firebase_release_smoke_test",
          "flaky": false
+      },
+      {
+         "name": "Linux flutter_gallery__back_button_memory",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__back_button_memory",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__image_cache_memory",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__image_cache_memory",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__memory_nav",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__memory_nav",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__start_up",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__start_up",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__transition_perf_e2e",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__transition_perf_e2e",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__transition_perf_hybrid",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__transition_perf_hybrid",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__transition_perf_with_semantics",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__transition_perf_with_semantics",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery__transition_perf",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery__transition_perf",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery_android__compile",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery_android__compile",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery_sksl_warmup__transition_perf_e2e",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery_sksl_warmup__transition_perf_e2e",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery_sksl_warmup__transition_perf",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery_sksl_warmup__transition_perf",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery_v2_chrome_run_test",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery_v2_chrome_run_test",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_gallery_v2_web_compile_test",
+         "repo": "flutter",
+         "task_name": "linux_flutter_gallery_v2_web_compile_test",
+         "flaky": true
+      },
+      {
+         "name": "Linux flutter_test_performance",
+         "repo": "flutter",
+         "task_name": "linux_flutter_test_performance",
+         "flaky": true
+      },
+      {
+         "name": "Linux frame_policy_delay_test_android",
+         "repo": "flutter",
+         "task_name": "linux_frame_policy_delay_test_android",
+         "flaky": true
       },
       {
          "name": "Linux framework_tests",
@@ -151,6 +283,36 @@
          "flaky": false
       },
       {
+         "name": "Linux hot_mode_dev_cycle_linux__benchmark",
+         "repo": "flutter",
+         "task_name": "linux_hot_mode_dev_cycle_linux__benchmark",
+         "flaky": true
+      },
+      {
+         "name": "Linux image_list_jit_reported_duration",
+         "repo": "flutter",
+         "task_name": "linux_image_list_jit_reported_duration",
+         "flaky": true
+      },
+      {
+         "name": "Linux image_list_reported_duration",
+         "repo": "flutter",
+         "task_name": "linux_image_list_reported_duration",
+         "flaky": true
+      },
+      {
+         "name": "Linux large_image_changer_perf_android",
+         "repo": "flutter",
+         "task_name": "linux_large_image_changer_perf_android",
+         "flaky": true
+      },
+      {
+         "name": "Linux linux_chrome_dev_mode",
+         "repo": "flutter",
+         "task_name": "linux_linux_chrome_dev_mode",
+         "flaky": true
+      },
+      {
          "name": "Linux module_custom_host_app_name_test",
          "repo": "flutter",
          "task_name": "linux_module_custom_host_app_name_test",
@@ -169,16 +331,58 @@
          "flaky": false
       },
       {
+         "name": "Linux multi_widget_construction_perf__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_multi_widget_construction_perf__e2e_summary",
+         "flaky": true
+      },
+      {
+         "name": "Linux multi_widget_construction_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "linux_multi_widget_construction_perf__timeline_summary",
+         "flaky": true
+      },
+      {
+         "name": "Linux new_gallery__crane_perf",
+         "repo": "flutter",
+         "task_name": "linux_new_gallery__crane_perf",
+         "flaky": true
+      },
+      {
+         "name": "Linux picture_cache_perf__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_picture_cache_perf__e2e_summary",
+         "flaky": true
+      },
+      {
+         "name": "Linux platform_views_scroll_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "linux_platform_views_scroll_perf__timeline_summary",
+         "flaky": true
+      },
+      {
          "name": "Linux plugin_test",
          "repo": "flutter",
          "task_name": "linux_plugin_test",
          "flaky": false
       },
       {
+         "name": "Linux routing_test",
+         "repo": "flutter",
+         "task_name": "linux_routing_test",
+         "flaky": true
+      },
+      {
          "name": "Linux technical_debt__cost",
          "repo": "flutter",
          "task_name": "linux_technical_debt__cost",
          "flaky": false
+      },
+      {
+         "name": "Linux textfield_perf__e2e_summary",
+         "repo": "flutter",
+         "task_name": "linux_textfield_perf__e2e_summary",
+         "flaky": true
       },
       {
          "name": "Linux tool_tests",
@@ -203,6 +407,12 @@
          "repo": "flutter",
          "task_name": "linux_web_benchmarks_html",
          "flaky": false
+      },
+      {
+         "name": "Linux web_size__compile_test",
+         "repo": "flutter",
+         "task_name": "linux_web_size__compile_test",
+         "flaky": true
       },
       {
          "name": "Linux web_tests",


### PR DESCRIPTION
## Description

This is a follow up of https://github.com/flutter/flutter/pull/72401, enabling remaining devicelab linux tests in prod_builders.json. Same as the earlier PR, this PR marks these tests as flaky first.

These newly added tests correspond to `linux_tasks` from https://devops-console-oss.corp.google.com/flutter/infra/+/master:config/devicelab_config.star;l=240.

## Related Issues

*https://github.com/flutter/flutter/issues/71615