### PR TITLE
Revert "Launch named iOS simulators"

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -142,7 +142,7 @@ class AndroidEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  String get platformDisplay => PlatformType.android.toString();
+  PlatformType get platformType => PlatformType.android;
 
   String _prop(String name) => _properties != null ? _properties[name] : null;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -933,7 +933,7 @@ Map<String, dynamic> _emulatorToMap(Emulator emulator) {
     'id': emulator.id,
     'name': emulator.name,
     'category': emulator.category?.toString(),
-    'platformType': emulator.platformDisplay,
+    'platformType': emulator.platformType?.toString(),
   };
 }
 

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -27,7 +27,7 @@ class EmulatorsCommand extends FlutterCommand {
   final String description = 'List, launch and create emulators.';
 
   @override
-  final List<String> aliases = <String>['emulator', 'simulators', 'simulator'];
+  final List<String> aliases = <String>['emulator'];
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -614,6 +614,10 @@ abstract class Device {
   /// Check if the device is supported by Flutter.
   bool isSupported();
 
+  // String meant to be displayed to the user indicating if the device is
+  // supported by Flutter, and, if not, why.
+  String supportMessage() => isSupported() ? 'Supported' : 'Unsupported';
+
   /// The device's platform.
   Future<TargetPlatform> get targetPlatform;
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -252,7 +252,7 @@ abstract class Emulator {
   String get name;
   String get manufacturer;
   Category get category;
-  String get platformDisplay;
+  PlatformType get platformType;
 
   @override
   int get hashCode => id.hashCode;
@@ -283,7 +283,7 @@ abstract class Emulator {
           emulator.id ?? '',
           emulator.name ?? '',
           emulator.manufacturer ?? '',
-          emulator.platformDisplay ?? '',
+          emulator.platformType?.toString() ?? '',
         ],
     ];
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -16,26 +16,17 @@ class IOSEmulators extends EmulatorDiscovery {
   bool get canListAnything => globals.iosWorkflow.canListEmulators;
 
   @override
-  Future<List<Emulator>> get emulators async {
-    final List<IOSSimulator> simulators = await globals.iosSimulatorUtils.getAvailableDevices();
-    return simulators.map<Emulator>((IOSSimulator device) {
-      return IOSEmulator(device);
-    }).toList();
-  }
+  Future<List<Emulator>> get emulators async => getEmulators();
 
   @override
   bool get canLaunchAnything => canListAnything;
 }
 
 class IOSEmulator extends Emulator {
-  IOSEmulator(IOSSimulator simulator)
-      : _simulator = simulator,
-        super(simulator.id, true);
-
-  final IOSSimulator _simulator;
+  const IOSEmulator(String id) : super(id, true);
 
   @override
-  String get name => _simulator.name;
+  String get name => 'iOS Simulator';
 
   @override
   String get manufacturer => 'Apple';
@@ -44,20 +35,43 @@ class IOSEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  String get platformDisplay =>
-      // com.apple.CoreSimulator.SimRuntime.iOS-10-3 => iOS-10-3
-      _simulator.simulatorCategory?.split('.')?.last ?? 'ios';
+  PlatformType get platformType => PlatformType.ios;
 
   @override
   Future<void> launch() async {
-    final RunResult launchResult = await globals.processUtils.run(<String>[
-      'open',
-      '-a',
-      globals.xcode.getSimulatorPath(),
-    ]);
-    if (launchResult.exitCode != 0) {
-      globals.printError('$launchResult');
+    Future<bool> launchSimulator(List<String> additionalArgs) async {
+      final List<String> args = <String>[
+        'open',
+        ...additionalArgs,
+        '-a',
+        globals.xcode.getSimulatorPath(),
+      ];
+
+      final RunResult launchResult = await globals.processUtils.run(args);
+      if (launchResult.exitCode != 0) {
+        globals.printError('$launchResult');
+        return false;
+      }
+      return true;
     }
-    return _simulator.boot();
+
+    // First run with `-n` to force a device to boot if there isn't already one
+    if (!await launchSimulator(<String>['-n'])) {
+      return;
+    }
+
+    // Run again to force it to Foreground (using -n doesn't force existing
+    // devices to the foreground)
+    await launchSimulator(<String>[]);
   }
+}
+
+/// Return the list of iOS Simulators (there can only be zero or one).
+List<IOSEmulator> getEmulators() {
+  final String simulatorPath = globals.xcode.getSimulatorPath();
+  if (simulatorPath == null) {
+    return <IOSEmulator>[];
+  }
+
+  return <IOSEmulator>[const IOSEmulator(iosSimulatorId)];
 }

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(emulator.name, displayName);
       expect(emulator.manufacturer, manufacturer);
       expect(emulator.category, Category.mobile);
-      expect(emulator.platformDisplay, 'android');
+      expect(emulator.platformType, PlatformType.android);
     });
 
     testWithoutContext('prefers displayname for name', () {

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
-import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -43,10 +45,14 @@ const FakeCommand kListEmulatorsCommand = FakeCommand(
 );
 
 void main() {
+  MockProcessManager mockProcessManager;
   MockAndroidSdk mockSdk;
+  MockXcode mockXcode;
 
   setUp(() {
+    mockProcessManager = MockProcessManager();
     mockSdk = MockAndroidSdk();
+    mockXcode = MockXcode();
 
     when(mockSdk.avdManagerPath).thenReturn('avdmanager');
     when(mockSdk.getAvdManagerPath()).thenReturn('avdmanager');
@@ -293,53 +299,24 @@ void main() {
   });
 
   group('ios_emulators', () {
-    MockXcode mockXcode;
-    FakeProcessManager fakeProcessManager;
-
+    bool didAttemptToRunSimulator = false;
     setUp(() {
-      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
-      mockXcode = MockXcode();
-      when(mockXcode.xcrunCommand()).thenReturn(<String>['xcrun']);
-      when(mockXcode.getSimulatorPath())
-          .thenAnswer((_) => '/fake/simulator.app');
+      when(mockXcode.xcodeSelectPath).thenReturn('/fake/Xcode.app/Contents/Developer');
+      when(mockXcode.getSimulatorPath()).thenAnswer((_) => '/fake/simulator.app');
+      when(mockProcessManager.run(any)).thenAnswer((Invocation invocation) async {
+        final List<String> args = invocation.positionalArguments[0] as List<String>;
+        if (args.length >= 3 && args[0] == 'open' && args[1] == '-a' && args[2] == '/fake/simulator.app') {
+          didAttemptToRunSimulator = true;
+        }
+        return ProcessResult(101, 0, '', '');
+      });
     });
-
     testUsingContext('runs correct launch commands', () async {
-      fakeProcessManager.addCommands(<FakeCommand>[
-        const FakeCommand(command: <String>[
-          'open',
-          '-a',
-          '/fake/simulator.app',
-        ]),
-        const FakeCommand(command: <String>[
-          'xcrun',
-          'simctl',
-          'boot',
-          '1234',
-        ]),
-      ]);
-      final SimControl simControl = SimControl.test(
-        processManager: fakeProcessManager,
-        xcode: mockXcode,
-      );
-
-      final IOSSimulator simulator = IOSSimulator(
-        '1234',
-        name: 'iPhone 12',
-        simulatorCategory: 'com.apple.CoreSimulator.SimRuntime.iOS-14-3',
-        simControl: simControl,
-        xcode: mockXcode,
-      );
-      final IOSEmulator emulator = IOSEmulator(simulator);
-
-      expect(emulator.id, '1234');
-      expect(emulator.name, 'iPhone 12');
-      expect(emulator.category, Category.mobile);
-      expect(emulator.platformDisplay, 'iOS-14-3');
+      const Emulator emulator = IOSEmulator('ios');
       await emulator.launch();
-      expect(fakeProcessManager.hasRemainingExpectations, false);
+      expect(didAttemptToRunSimulator, equals(true));
     }, overrides: <Type, Generator>{
-      ProcessManager: () => fakeProcessManager,
+      ProcessManager: () => mockProcessManager,
       Xcode: () => mockXcode,
     });
   });
@@ -370,11 +347,35 @@ class FakeEmulator extends Emulator {
   Category get category => Category.mobile;
 
   @override
-  String get platformDisplay => PlatformType.android.toString();
+  PlatformType get platformType => PlatformType.android;
 
   @override
   Future<void> launch() {
     throw UnimplementedError('Not implemented in Mock');
   }
 }
+
+class MockProcessManager extends Mock implements ProcessManager {
+
+  @override
+  ProcessResult runSync(
+    List<dynamic> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
+  }) {
+    final String program = command[0] as String;
+    final List<String> args = command.sublist(1) as List<String>;
+    switch (program) {
+      case '/usr/bin/xcode-select':
+        throw ProcessException(program, args);
+        break;
+    }
+    throw StateError('Unexpected process call: $command');
+  }
+}
+
 class MockXcode extends Mock implements Xcode {}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -114,7 +114,6 @@ void testUsingContext(
           IOSSimulatorUtils: () {
             final MockIOSSimulatorUtils mock = MockIOSSimulatorUtils();
             when(mock.getAttachedDevices()).thenAnswer((Invocation _) async => <IOSSimulator>[]);
-            when(mock.getAvailableDevices()).thenAnswer((Invocation _) async => <IOSSimulator>[]);
             return mock;
           },
           OutputPreferences: () => OutputPreferences.test(),
@@ -287,7 +286,7 @@ class FakeDoctor extends Doctor {
 
 class MockSimControl extends Mock implements SimControl {
   MockSimControl() {
-    when(getAvailableDevices()).thenAnswer((Invocation _) async => <SimDevice>[]);
+    when(getConnectedDevices()).thenAnswer((Invocation _) async => <SimDevice>[]);
   }
 }
 


### PR DESCRIPTION
Reverts flutter/flutter#72323

@DanTup says this caused a regression https://github.com/flutter/flutter/pull/72323#discussion_r544170769:

> Looks like the `platformType` in the daemon response from `emulator.getEmulators` ([docs](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/doc/daemon.md#emulatorgetemulators)) isn't right. It should be "ios" but is coming through as "iOS-14-3".
> 
> We compare that string to the output of `daemon.getSupportedPlatforms` to know which devices/emulators are valid for the current project, so this means none of them are showing up right now. 