### PR TITLE
hourOfPeriod fails at noon

### DIFF
--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -93,7 +93,7 @@ class TimeOfDay {
   DayPeriod get period => hour < hoursPerPeriod ? DayPeriod.am : DayPeriod.pm;
 
   /// Which hour of the current period (e.g., am or pm) this time is.
-  int get hourOfPeriod => hour - periodOffset;
+  int get hourOfPeriod => hour > hoursPerPeriod ? hour - periodOffset : hour;
 
   /// The hour at which the current period starts.
   int get periodOffset => period == DayPeriod.am ? 0 : hoursPerPeriod;


### PR DESCRIPTION


## Description

When you need the time in 12 hours format this `hourOfPeriod` send back a failed value at noon.

if you looks like this at 10am - 11 am - 0pm - 1pm which is wrong it should be `12pm` it needs an extra validation to subtract `periodOffset` only if `hour` is bigger than `hoursPerPeriod`.

## Related Issues



![showTimePicker](https://user-images.githubusercontent.com/29683014/102425637-edc53480-3fca-11eb-8103-7f5516b48830.png)
![showTimePicker - using hourOfPeriod](https://user-images.githubusercontent.com/29683014/102425642-f0278e80-3fca-11eb-968f-369ef09b2417.png)

