### PR TITLE
Support flutter_test_config for `flutter test` on web platforms

### DIFF
--- a/packages/flutter/test/_goldens_io.dart
+++ b/packages/flutter/test/_goldens_io.dart
@@ -2,8 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
-import 'package:flutter_goldens/flutter_goldens.dart' as flutter_goldens;
-
-Future<void> testExecutable(FutureOr<void> testMain()) => flutter_goldens.testExecutable(testMain);
+export 'package:flutter_goldens/flutter_goldens.dart' show testExecutable;

--- a/packages/flutter/test/_goldens_io.dart
+++ b/packages/flutter/test/_goldens_io.dart
@@ -1,0 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_goldens/flutter_goldens.dart' as flutter_goldens;
+
+Future<void> testExecutable(FutureOr<void> testMain()) => flutter_goldens.testExecutable(testMain);

--- a/packages/flutter/test/_goldens_web.dart
+++ b/packages/flutter/test/_goldens_web.dart
@@ -1,0 +1,8 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+// package:flutter_goldens is not used as part of the test process for web.
+Future<void> testExecutable(FutureOr<void> testMain()) async => testMain();

--- a/packages/flutter/test/flutter_test_config.dart
+++ b/packages/flutter/test/flutter_test_config.dart
@@ -2,4 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'package:flutter_goldens/flutter_goldens.dart' show testExecutable;
+export '_goldens_io.dart'
+  if (dart.library.html) '_goldens_web.dart' show testExecutable;

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -18,6 +18,7 @@ import '../compile.dart';
 import '../dart/language_version.dart';
 import '../web/bootstrap.dart';
 import '../web/memory_fs.dart';
+import 'test_config.dart';
 
 /// A web compiler for the test runner.
 class WebTestCompiler {
@@ -79,6 +80,7 @@ class WebTestCompiler {
         ..writeAsStringSync(generateTestEntrypoint(
             relativeTestPath: relativeTestSegments.join('/'),
             absolutePath: testFilePath,
+            testConfigPath: findTestConfigFile(_fileSystem.file(testFilePath))?.path,
             languageVersion: languageVersion,
         ));
       generatedFiles.add(generatedFile);

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -102,6 +102,7 @@ define("$bootstrapModule", ["$entrypoint", "dart_sdk"], function(app, dart_sdk) 
 String generateTestEntrypoint({
   @required String relativeTestPath,
   @required String absolutePath,
+  @required String testConfigPath,
   @required LanguageVersion languageVersion,
 }) {
   return '''
@@ -110,6 +111,7 @@ String generateTestEntrypoint({
   import 'dart:ui' as ui;
   import 'dart:html';
   import 'dart:js';
+  ${testConfigPath != null ? "import '${Uri.file(testConfigPath)}' as test_config;" : ""}
   import 'package:stream_channel/stream_channel.dart';
   import 'package:flutter_test/flutter_test.dart';
   import 'package:test_api/src/backend/stack_trace_formatter.dart'; // ignore: implementation_imports
@@ -122,7 +124,10 @@ String generateTestEntrypoint({
     webGoldenComparator = DefaultWebGoldenComparator(Uri.parse('$absolutePath'));
     (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
     (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);
-    internalBootstrapBrowserTest(() => test.main);
+
+    internalBootstrapBrowserTest(() {
+      return ${testConfigPath != null ? "() => test_config.testExecutable(test.main)" : "test.main"};
+    });
   }
 
   void internalBootstrapBrowserTest(Function getMain()) {

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/web/bootstrap.dart';
+import 'package:package_config/package_config.dart';
 
 import '../../src/common.dart';
 
@@ -69,5 +70,27 @@ void main() {
     final String result = generateTestBootstrapFileContents('foo.dart.js', 'require.js', 'mapper.js');
 
     expect(result, contains('el.setAttribute("data-main", \'foo.dart.js\');'));
+  });
+
+  test('generateTestEntrypoint does not generate test config wrappers when testConfigPath is not passed', () {
+    final String result = generateTestEntrypoint(
+      relativeTestPath: 'relative_path.dart',
+      absolutePath: 'absolute_path.dart',
+      testConfigPath: null,
+      languageVersion: LanguageVersion(2, 8),
+    );
+
+    expect(result, isNot(contains('test_config.testExecutable')));
+  });
+
+  test('generateTestEntrypoint generates test config wrappers when testConfigPath is passed', () {
+    final String result = generateTestEntrypoint(
+      relativeTestPath: 'relative_path.dart',
+      absolutePath: 'absolute_path.dart',
+      testConfigPath: 'test_config_path.dart',
+      languageVersion: LanguageVersion(2, 8),
+    );
+
+    expect(result, contains('test_config.testExecutable'));
   });
 }


### PR DESCRIPTION
## Description

On the flutter_test library docs, we [mention](https://master-api.flutter.dev/flutter/flutter_test/flutter_test-library.html) that we support test configuration in the form of `flutter_test_config.dart`. However, this does not work when `--platform=chrome` is passed to `flutter test`.

This PR adds support for that.

## Related Issues

In #70730, we want to use `flutter_test_config.dart` to explicitly turn on certain debug checks for the framework tests.

## Tests

I added the following tests:

- Test that the codegen is correct

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
