### PR TITLE
fix a DragTarget type cast bug

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -653,16 +653,14 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
   final List<_DragAvatar<Object>> _candidateAvatars = <_DragAvatar<Object>>[];
   final List<_DragAvatar<Object>> _rejectedAvatars = <_DragAvatar<Object>>[];
 
-  bool checkDataType(Object? data, Type type) {
-    if (!kIsWeb) {
-      return data is T?;
-    } else {
-      if ((type == int && T == double) || (type == double && T == int)) {
-        return false;
-      } else {
-        return data is T?;
-      }
-    }
+  // On non-web platforms, checks if data Object is equal to type[T] or subtype of [T].
+  // On web, it does the same, but requires a check for ints and doubles
+  // because dart doubles and ints are backed by the same kind of object on web.
+  // JavaScript does not support integers.
+  bool isExpectedDataType(Object? data, Type type) {
+    if (kIsWeb && ((type == int && T == double) || (type == double && T == int)))
+      return false;
+    return data is T?;
   }
 
   bool didEnter(_DragAvatar<Object> avatar) {
@@ -848,7 +846,7 @@ class _DragAvatar<T extends Object> extends Drag {
       final HitTestTarget target = entry.target;
       if (target is RenderMetaData) {
         final dynamic metaData = target.metaData;
-        if (metaData is _DragTargetState && metaData.checkDataType(data, T))
+        if (metaData is _DragTargetState && metaData.isExpectedDataType(data, T))
           yield metaData;
       }
     }

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -653,7 +653,7 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
   final List<_DragAvatar<Object>> _candidateAvatars = <_DragAvatar<Object>>[];
   final List<_DragAvatar<Object>> _rejectedAvatars = <_DragAvatar<Object>>[];
 
-  bool _checkDataType(Object? data, Type type) {
+  bool checkDataType(Object? data, Type type) {
     if (!kIsWeb) {
       return data is T?;
     } else {
@@ -848,7 +848,7 @@ class _DragAvatar<T extends Object> extends Drag {
       final HitTestTarget target = entry.target;
       if (target is RenderMetaData) {
         final dynamic metaData = target.metaData;
-        if (metaData is _DragTargetState && metaData._checkDataType(data, T))
+        if (metaData is _DragTargetState && metaData.checkDataType(data, T))
           yield metaData;
       }
     }

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -652,11 +653,22 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
   final List<_DragAvatar<Object>> _candidateAvatars = <_DragAvatar<Object>>[];
   final List<_DragAvatar<Object>> _rejectedAvatars = <_DragAvatar<Object>>[];
 
+  bool _checkDataType(Object? data, Type type) {
+    if (!kIsWeb) {
+      return data is T?;
+    } else {
+      if ((type == int && T == double) || (type == double && T == int)) {
+        return false;
+      } else {
+        return data is T?;
+      }
+    }
+  }
+
   bool didEnter(_DragAvatar<Object> avatar) {
     assert(!_candidateAvatars.contains(avatar));
     assert(!_rejectedAvatars.contains(avatar));
-    if ((avatar.data == null || avatar.data is T)
-        && (widget.onWillAccept == null || widget.onWillAccept!(avatar.data as T?))) {
+    if (widget.onWillAccept == null || widget.onWillAccept!(avatar.data as T?)) {
       setState(() {
         _candidateAvatars.add(avatar);
       });
@@ -836,7 +848,7 @@ class _DragAvatar<T extends Object> extends Drag {
       final HitTestTarget target = entry.target;
       if (target is RenderMetaData) {
         final dynamic metaData = target.metaData;
-        if (metaData is _DragTargetState)
+        if (metaData is _DragTargetState && metaData._checkDataType(data, T))
           yield metaData;
       }
     }


### PR DESCRIPTION
## Description

This patch fixes the following cases:
1, `DragTarget<Object>` should accept `Draggable<int>` data
2, `DragTarget<int>` should accept `Draggable<Object>` data when the data runtime type is `int`

## Related Issues

Fixes #72483

## Tests

I added the following tests:

See files.