### PR TITLE
Make RenderColoredBox.paint() skip painting color if it's transparent

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7683,7 +7683,11 @@ class _RenderColoredBox extends RenderProxyBoxWithHitTestBehavior {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (size > Size.zero && color.alpha > 0) {
+    // It's tempting to want to optimize out this `drawRect()` call if the
+    // color is transparent (alpha==0), but doing so would be incorrect. See
+    // https://github.com/flutter/flutter/pull/72526#issuecomment-749185938 for
+    // a good description of why.
+    if (size > Size.zero) {
       context.canvas.drawRect(offset & size, Paint()..color = color);
     }
     if (child != null) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7683,7 +7683,7 @@ class _RenderColoredBox extends RenderProxyBoxWithHitTestBehavior {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (size > Size.zero) {
+    if (size > Size.zero && color.alpha > 0) {
       context.canvas.drawRect(offset & size, Paint()..color = color);
     }
     if (child != null) {

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -412,6 +412,19 @@ void main() {
       expect(mockContext.offets, isEmpty);
     });
 
+    testWidgets('ColoredBox - size, no child, transparent color', (WidgetTester tester) async {
+      await tester.pumpWidget(const ColoredBox(color: Color(0x00000000)));
+      expect(find.byType(ColoredBox), findsOneWidget);
+      final RenderObject renderColoredBox = tester.renderObject(find.byType(ColoredBox));
+
+      renderColoredBox.paint(mockContext, Offset.zero);
+
+      expect(mockCanvas.rects, isEmpty);
+      expect(mockCanvas.paints, isEmpty);
+      expect(mockContext.children, isEmpty);
+      expect(mockContext.offets, isEmpty);
+    });
+
     testWidgets('ColoredBox - size, child', (WidgetTester tester) async {
       const ValueKey<int> key = ValueKey<int>(0);
       const Widget child = SizedBox.expand(key: key);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -412,19 +412,6 @@ void main() {
       expect(mockContext.offets, isEmpty);
     });
 
-    testWidgets('ColoredBox - size, no child, transparent color', (WidgetTester tester) async {
-      await tester.pumpWidget(const ColoredBox(color: Color(0x00000000)));
-      expect(find.byType(ColoredBox), findsOneWidget);
-      final RenderObject renderColoredBox = tester.renderObject(find.byType(ColoredBox));
-
-      renderColoredBox.paint(mockContext, Offset.zero);
-
-      expect(mockCanvas.rects, isEmpty);
-      expect(mockCanvas.paints, isEmpty);
-      expect(mockContext.children, isEmpty);
-      expect(mockContext.offets, isEmpty);
-    });
-
     testWidgets('ColoredBox - size, child', (WidgetTester tester) async {
       const ValueKey<int> key = ValueKey<int>(0);
       const Widget child = SizedBox.expand(key: key);


### PR DESCRIPTION
## Description

This avoids an unnecessary paint operation if you create a `ColoredBox` with a fully transparent color.

### Use case

If apps want to toggle a color on and off, they might want to conditionally include a `ColoredBox` in their widget tree.  But doing so will cause a `rebuild()` and a `layout()` every time they toggle the color.  By including the `ColoredBox` unconditionally in their widget tree and only changing the color, they will only trigger a `repaint()` every time they toggle the color.  However, in this case, they'll be frequently using a fully transparent color and would like to avoid the associated dart:ui operation.

## Tests

I added the following tests:

* A test that verifies that we do not issue a dart:ui paint operation in this case.
 
## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
