### PR TITLE
Migrate usage value plugin count off .flutter-plugins

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -12,6 +12,7 @@ import '../cache.dart';
 import '../dart/generate_synthetic_packages.dart';
 import '../dart/pub.dart';
 import '../globals.dart' as globals;
+import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
@@ -79,10 +80,10 @@ class PackagesGetCommand extends FlutterCommand {
       return usageValues;
     }
     final FlutterProject rootProject = FlutterProject.fromPath(target);
-    final bool hasPlugins = rootProject.flutterPluginsFile.existsSync();
+    final bool hasPlugins = rootProject.flutterPluginsDependenciesFile.existsSync();
     if (hasPlugins) {
-      final int numberOfPlugins = (rootProject.flutterPluginsFile.readAsLinesSync()).length;
-      usageValues[CustomDimensions.commandPackagesNumberPlugins] = '$numberOfPlugins';
+      final List<Plugin> plugins = await findPlugins(rootProject);
+      usageValues[CustomDimensions.commandPackagesNumberPlugins] = plugins.length.toString();
     } else {
       usageValues[CustomDimensions.commandPackagesNumberPlugins] = '0';
     }

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -227,7 +227,7 @@ void main() {
       ),
     });
 
-    testUsingContext('set the number of plugins as usage value', () async {
+    testUsingContext('set no plugins as usage value', () async {
       final String projectPath = await createProject(tempDir,
         arguments: <String>['--no-pub', '--template=module']);
       removeGeneratedFiles(projectPath);
@@ -237,6 +237,31 @@ void main() {
 
       expect(await getCommand.usageValues,
              containsPair(CustomDimensions.commandPackagesNumberPlugins, '0'));
+    }, overrides: <Type, Generator>{
+      Pub: () => Pub(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        processManager: globals.processManager,
+        usage: globals.flutterUsage,
+        botDetector: globals.botDetector,
+        platform: globals.platform,
+      ),
+    });
+
+    testUsingContext('set the number of plugins as usage value', () async {
+      final String projectPath = await createProject(
+        tempDir,
+        arguments: <String>['--template=plugin', '--no-pub', '--platforms=ios,android,macos,windows'],
+      );
+      final String exampleProjectPath = globals.fs.path.join(projectPath, 'example');
+
+      final PackagesCommand command = await runCommandIn(exampleProjectPath, 'get');
+      final PackagesGetCommand getCommand = command.subcommands['get'] as PackagesGetCommand;
+
+      // Should be 1 instead of 2, but integration_test is always included.
+      // https://github.com/flutter/flutter/issues/56591
+      expect(await getCommand.usageValues,
+          containsPair(CustomDimensions.commandPackagesNumberPlugins, '2'));
     }, overrides: <Type, Generator>{
       Pub: () => Pub(
         fileSystem: globals.fs,


### PR DESCRIPTION
## Description

`.flutter-plugins` is a legacy non-platform aware representation of plugins.  Migrate usage calculation off parsing this file so it can eventually be removed.

## Related Issues

Part of https://github.com/flutter/flutter/issues/48918

## Tests

packages_test