### PR TITLE
[flutter_tools] catch fatal build output errors on Linux

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -17,10 +17,10 @@ import '../plugins.dart';
 import '../project.dart';
 
 // Matches the following error and warning patterns:
-// - <file path>:<line>:<column>: error: <error...>
+// - <file path>:<line>:<column>: (fatal) error: <error...>
 // - <file path>:<line>:<column>: warning: <warning...>
 // - clang: error: <link error...>
-final RegExp errorMatcher = RegExp(r'(?:.*:\d+:\d+|clang):\s?(?:error|warning):\s.*', caseSensitive: false);
+final RegExp errorMatcher = RegExp(r'(?:.*:\d+:\d+|clang):\s?(fatal\s)?(?:error|warning):\s.*', caseSensitive: false);
 
 /// Builds the Linux project through the Makefile.
 Future<void> buildLinux(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -224,6 +224,7 @@ lib/main.dart:4:3: Error: Method not found: 'foo'.
 /foo/linux/main.cc:9:7: warning: unused variable 'unused_variable' [-Wunused-variable]
 /foo/linux/main.cc:10:3: error: unknown type name 'UnknownType'
 /foo/linux/main.cc:12:7: error: 'bar' is a private member of 'Foo'
+/foo/linux/my_application.h:4:10: fatal error: 'gtk/gtk.h' file not found
 [3/6] Building CXX object CMakeFiles/foo_bar.dir/flutter/generated_plugin_registrant.cc.o
 [4/6] Building CXX object CMakeFiles/foo_bar.dir/my_application.cc.o
 [5/6] Linking CXX executable intermediates_do_not_run/foo_bar
@@ -249,6 +250,7 @@ lib/main.dart:4:3: Error: Method not found: 'foo'.
 /foo/linux/main.cc:9:7: warning: unused variable 'unused_variable' [-Wunused-variable]
 /foo/linux/main.cc:10:3: error: unknown type name 'UnknownType'
 /foo/linux/main.cc:12:7: error: 'bar' is a private member of 'Foo'
+/foo/linux/my_application.h:4:10: fatal error: 'gtk/gtk.h' file not found
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ''');
   }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

#71003 added a basic error matcher for Clang errors but missed fatal errors, such as when a header is not found:

```
/path/to/my_app/linux/my_application.cc:10:10: fatal error: 'non_existent.h' file not found
```

This PR was split off from #72196.

## Related Issues

#33584

## Tests

I updated the following tests:

- `test/commands.shard/hermetic/build_linux_test.dart`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
