### PR TITLE
Unflaky remaining linux tasks

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -64,13 +64,6 @@ tasks:
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
 
-  flutter_gallery_android__compile:
-    description: >
-      Collects various performance metrics of compiling the Flutter
-      Gallery for Android from Linux.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   flutter_gallery_ios__compile:
     description: >
       Collects various performance metrics of compiling the Flutter
@@ -93,13 +86,6 @@ tasks:
 
   # Android on-device tests
 
-  complex_layout_android__scroll_smoothness:
-    description: >
-      Measures the smoothness of scrolling of the Complex Layout sample app on
-      Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   complex_layout_scroll_perf__timeline_summary:
     description: >
       Measures the runtime performance of the Complex Layout sample app on
@@ -112,12 +98,6 @@ tasks:
       Measures the runtime performance of the tiles tab in the Complex Layout sample app on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  platform_views_scroll_perf__timeline_summary:
-    description: >
-      Measures the runtime performance of platform views in the Complex Layout sample app on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   home_scroll_perf__timeline_summary:
     description: >
@@ -138,42 +118,11 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
-  cull_opacity_perf__e2e_summary:
-    description: >
-      Measures the runtime performance of culling opacity widgets on Android on
-      E2E with self-driving test app.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  multi_widget_construction_perf__timeline_summary:
-    description: >
-      Measures the runtime performance of constructing and destructing widgets on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  multi_widget_construction_perf__e2e_summary:
-    description: >
-      Measures the runtime performance of constructing and destructing widgets on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  frame_policy_delay_test_android:
-    description: >
-      Tests the effect of LiveTestWidgetsFlutterBindingFramePolicy.benchmarkLive
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   picture_cache_perf__timeline_summary:
     description: >
       Measures the runtime performance of raster caching many pictures on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  picture_cache_perf__e2e_summary:
-    description: >
-      Measures the runtime performance of raster caching many pictures on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   cubic_bezier_perf__timeline_summary:
     description: >
@@ -181,26 +130,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
-  cubic_bezier_perf__e2e_summary:
-    description: >
-      Measures the runtime performance of cubic bezier animations on Android
-      using e2e.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   cubic_bezier_perf_sksl_warmup__timeline_summary:
     description: >
       Measures the runtime performance of cubic bezier animations on Android
       with SkSL shader warm-up.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  cubic_bezier_perf_sksl_warmup__e2e_summary:
-    description: >
-      Measures the runtime performance of cubic bezier animations on Android
-      with SkSL shader warm-up using e2e.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   flutter_gallery_sksl_warmup__transition_perf_e2e_ios32:
     description: >
@@ -221,12 +156,6 @@ tasks:
       Measures the runtime performance of textfield on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  textfield_perf__e2e_summary:
-    description: >
-      Measures the runtime performance of textfield on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   color_filter_and_fade_perf__timeline_summary:
     description: >
@@ -330,12 +259,6 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
-  complex_layout_scroll_perf__devtools_memory:
-    description: >
-      Measures memory usage of the scroll performance test using DevTools.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   hello_world_android__compile:
     description: >
       Measures the APK size of Hello World.
@@ -389,42 +312,6 @@ tasks:
       Validates our service protocol extensions.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  complex_layout_semantics_perf:
-    description: >
-      Measures duration of building the initial semantics tree.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  routing_test:
-    description: >
-      Verifies that `flutter drive --route` still works. No performance numbers.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  linux_chrome_dev_mode:
-    description: >
-      Run flutter web on the devicelab and hot restart.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  web_size__compile_test:
-    description: >
-      Measures the size of a dart2js bundle.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  image_list_reported_duration:
-    description: >
-      Measures image loading performance on release (aot) build.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  image_list_jit_reported_duration:
-    description: >
-      Measures image loading performance on debug (jit) build.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   # iOS on-device tests
 
@@ -661,38 +548,6 @@ tasks:
 
   # Tests running on Linux hosts
 
-  hot_mode_dev_cycle_linux__benchmark:
-    description: >
-      Measures the performance of Dart VM hot patching feature on a Linux host.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_test_performance:
-    description: >
-      Measures performance of running flutter test.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__start_up:
-    description: >
-      Measures the startup time of the Flutter Gallery app on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__transition_perf:
-    description: >
-      Measures the performance of screen transitions in Flutter Gallery on
-      Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__transition_perf_e2e:
-    description: >
-      Measures the performance of screen transitions in Flutter Gallery on
-      Android with e2e.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   flutter_gallery__transition_perf_e2e_ios32:
     description: >
       Measures the performance of screen transitions in Flutter Gallery on
@@ -708,54 +563,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  flutter_gallery__transition_perf_hybrid:
-    description: >
-      Measures the performance of screen transitions in Flutter Gallery on
-      Android where the page transitions are self-driven on device without host
-      interventions, but the timeline events are still sent to host to be
-      processed.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery_sksl_warmup__transition_perf:
-    description: >
-      Measures the runtime performance of Flutter gallery transitions on Android
-      with SkSL shader warm-up.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery_sksl_warmup__transition_perf_e2e:
-    description: >
-      Measures the runtime performance of Flutter gallery transitions on Android
-      with SkSL shader warm-up with e2e.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__transition_perf_with_semantics:
-    description: >
-      Measures the delta in performance of screen transitions without and
-      with semantics enabled.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__memory_nav:
-    description: >
-      Measures memory usage after repeated navigation in Gallery.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__back_button_memory:
-    description: >
-      Measures memory usage after Android app suspend and resume.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery__image_cache_memory:
-    description: >
-      Measures memory usage for a list of large red squares in smaller containers.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   new_gallery__transition_perf:
     description: >
       Measures the performance of screen transitions in the new Flutter Gallery on Android.
@@ -768,30 +575,11 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  new_gallery__crane_perf:
-    description: >
-      Measures the performance of the Crane page in the new Flutter Gallery on Android.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
   fast_scroll_large_images__memory:
     description: >
       Measures memory usage for scrolling through a list of large images.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-
-  fast_scroll_heavy_gridview__memory:
-    description: >
-      Measures memory usage for scrolling through a grid view of heavy memory
-      usage widgets.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  large_image_changer_perf_android:
-    description: >
-      Measures memory usage when rotating through a series of large images.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
 
   large_image_changer_perf_ios:
     description: >
@@ -805,16 +593,3 @@ tasks:
   #   stage: devicelab
   #   required_agent_capabilities: ["linux/android"]
   #   flaky: true
-
-  flutter_gallery_v2_chrome_run_test:
-    description: >
-      Checks that the New Flutter Gallery runs successfully on Chrome.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]
-
-  flutter_gallery_v2_web_compile_test:
-    description: >
-      Measures the time to compile the New Flutter Gallery to JavaScript
-      and the size of the compiled code.
-    stage: devicelab
-    required_agent_capabilities: ["linux/android"]

--- a/dev/devicelab/test/manifest_test.dart
+++ b/dev/devicelab/test/manifest_test.dart
@@ -14,10 +14,10 @@ void main() {
       final Manifest manifest = loadTaskManifest();
       expect(manifest.tasks, isNotEmpty);
 
-      final ManifestTask task = manifest.tasks.firstWhere((ManifestTask task) => task.name == 'flutter_gallery__start_up');
-      expect(task.description, 'Measures the startup time of the Flutter Gallery app on Android.\n');
-      expect(task.stage, 'devicelab');
-      expect(task.requiredAgentCapabilities, <String>['linux/android']);
+      final ManifestTask task = manifest.tasks.firstWhere((ManifestTask task) => task.name == 'simple_animation_perf_ios');
+      expect(task.description, 'Measure CPU/GPU usage percentages of a simple animation.\n');
+      expect(task.stage, 'devicelab_ios');
+      expect(task.requiredAgentCapabilities, <String>['mac/ios']);
 
       for (final ManifestTask task in manifest.tasks) {
         final File taskFile = File('bin/tasks/${task.name}.dart');

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -76,37 +76,37 @@
          "name": "Linux complex_layout_android__scroll_smoothness",
          "repo": "flutter",
          "task_name": "linux_complex_layout_android__scroll_smoothness",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux complex_layout_scroll_perf__devtools_memory",
          "repo": "flutter",
          "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux complex_layout_semantics_perf",
          "repo": "flutter",
          "task_name": "linux_complex_layout_semantics_perf",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux cubic_bezier_perf__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_cubic_bezier_perf__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux cubic_bezier_perf_sksl_warmup__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_cubic_bezier_perf_sksl_warmup__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux cull_opacity_perf__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_cull_opacity_perf__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux customer_testing",
@@ -142,7 +142,7 @@
          "name": "Linux fast_scroll_heavy_gridview__memory",
          "repo": "flutter",
          "task_name": "linux_fast_scroll_heavy_gridview__memory",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux firebase_abstract_method_smoke_test",
@@ -166,91 +166,91 @@
          "name": "Linux flutter_gallery__back_button_memory",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__back_button_memory",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__image_cache_memory",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__image_cache_memory",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__memory_nav",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__memory_nav",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__start_up",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__start_up",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__transition_perf_e2e",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__transition_perf_e2e",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__transition_perf_hybrid",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__transition_perf_hybrid",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__transition_perf_with_semantics",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__transition_perf_with_semantics",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__transition_perf",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery__transition_perf",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery_android__compile",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery_android__compile",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery_sksl_warmup__transition_perf_e2e",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery_sksl_warmup__transition_perf_e2e",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery_sksl_warmup__transition_perf",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery_sksl_warmup__transition_perf",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery_v2_chrome_run_test",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery_v2_chrome_run_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery_v2_web_compile_test",
          "repo": "flutter",
          "task_name": "linux_flutter_gallery_v2_web_compile_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_test_performance",
          "repo": "flutter",
          "task_name": "linux_flutter_test_performance",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux frame_policy_delay_test_android",
          "repo": "flutter",
          "task_name": "linux_frame_policy_delay_test_android",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux framework_tests",
@@ -286,31 +286,31 @@
          "name": "Linux hot_mode_dev_cycle_linux__benchmark",
          "repo": "flutter",
          "task_name": "linux_hot_mode_dev_cycle_linux__benchmark",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux image_list_jit_reported_duration",
          "repo": "flutter",
          "task_name": "linux_image_list_jit_reported_duration",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux image_list_reported_duration",
          "repo": "flutter",
          "task_name": "linux_image_list_reported_duration",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux large_image_changer_perf_android",
          "repo": "flutter",
          "task_name": "linux_large_image_changer_perf_android",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux linux_chrome_dev_mode",
          "repo": "flutter",
          "task_name": "linux_linux_chrome_dev_mode",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux module_custom_host_app_name_test",
@@ -334,31 +334,31 @@
          "name": "Linux multi_widget_construction_perf__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_multi_widget_construction_perf__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux multi_widget_construction_perf__timeline_summary",
          "repo": "flutter",
          "task_name": "linux_multi_widget_construction_perf__timeline_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux new_gallery__crane_perf",
          "repo": "flutter",
          "task_name": "linux_new_gallery__crane_perf",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux picture_cache_perf__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_picture_cache_perf__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux platform_views_scroll_perf__timeline_summary",
          "repo": "flutter",
          "task_name": "linux_platform_views_scroll_perf__timeline_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux plugin_test",
@@ -370,7 +370,7 @@
          "name": "Linux routing_test",
          "repo": "flutter",
          "task_name": "linux_routing_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux technical_debt__cost",
@@ -382,7 +382,7 @@
          "name": "Linux textfield_perf__e2e_summary",
          "repo": "flutter",
          "task_name": "linux_textfield_perf__e2e_summary",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux tool_tests",
@@ -412,7 +412,7 @@
          "name": "Linux web_size__compile_test",
          "repo": "flutter",
          "task_name": "linux_web_size__compile_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux web_tests",


### PR DESCRIPTION
## Description

This is to remove flaky flag for remaining devicelab linux tasks, following https://github.com/flutter/flutter/pull/72445.

In addition, since all device bots have been migrated to luci, this PR removes the tasks from manifest.

## Related Issues

https://github.com/flutter/flutter/issues/71615