### PR TITLE
[integration_test] Fix incorrect logging for the legacy reporter

### DIFF
--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -126,12 +126,13 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// execute their tests instead.
   IntegrationTestWidgetsFlutterBinding() {
     if (!_isUsingLegacyReporting) {
-      // TODO(jiahaog): Point users to use the CLI https://github.com/flutter/flutter/issues/66264.
-      print('Using the legacy test result reporter, which will not catch all '
-          'errors thrown in declared tests. Consider wrapping tests with '
-          'https://api.flutter.dev/flutter/integration_test/run.html instead.');
       return;
     }
+
+    // TODO(jiahaog): Point users to use the CLI https://github.com/flutter/flutter/issues/66264.
+    print('Using the legacy test result reporter, which will not catch all '
+        'errors thrown in declared tests. Consider wrapping tests with '
+        'https://api.flutter.dev/flutter/integration_test/run.html instead.');
 
     tearDownAll(() async {
       _updateTestResultState(results);


### PR DESCRIPTION
The print statement telling users that they are using the old legacy reporter is incorrect.