### PR TITLE
Fix/ValueListenableBuilder rebuilds

### DIFF
--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -179,7 +179,9 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   }
 
   void _valueChanged() {
-    setState(() { value = widget.valueListenable.value; });
+    if (value !=  widget.valueListenable.value) {
+      setState(() { value = widget.valueListenable.value; });
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -179,7 +179,7 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   }
 
   void _valueChanged() {
-    if (value !=  widget.valueListenable.value) {
+    if (value != widget.valueListenable.value) {
       setState(() { value = widget.valueListenable.value; });
     }
   }

--- a/packages/flutter/test/widgets/value_listenable_builder_test.dart
+++ b/packages/flutter/test/widgets/value_listenable_builder_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 void main() {
   late SpyStringValueNotifier valueListenable;
   late Widget textBuilderUnderTest;
+  late int rebuildCount;
 
   Widget builderForValueListenable(
     ValueListenable<String?> valueListenable,
@@ -18,6 +19,8 @@ void main() {
       child: ValueListenableBuilder<String?>(
         valueListenable: valueListenable,
         builder: (BuildContext context, String? value, Widget? child) {
+          ++rebuildCount;
+
           if (value == null)
             return const Placeholder();
           return Text(value);
@@ -29,6 +32,7 @@ void main() {
   setUp(() {
     valueListenable = SpyStringValueNotifier(null);
     textBuilderUnderTest = builderForValueListenable(valueListenable);
+    rebuildCount = 0;
   });
 
   testWidgets('Null value is ok', (WidgetTester tester) async {
@@ -56,6 +60,46 @@ void main() {
     await tester.pump();
     expect(find.text('Gilfoyle'), findsNothing);
     expect(find.text('Dinesh'), findsOneWidget);
+  });
+
+  testWidgets('Widget does not rebuilds if value is the same', (WidgetTester tester) async {
+    const Duration duration = Duration(milliseconds: 100);
+    final AnimationController controller = AnimationController(
+      vsync: const TestVSync(),
+      duration: duration,
+    )..value = 0;
+    final Animation<String> animation = TweenSequence<String>(<TweenSequenceItem<String>>[
+      TweenSequenceItem<String>(tween: ConstantTween<String>('Gilfoyle'), weight: 1.0),
+      TweenSequenceItem<String>(tween: ConstantTween<String>('Dinesh'), weight: 1.0),
+    ]).animate(controller);
+
+    final Finder finder1 = find.text('Gilfoyle');
+    final Finder finder2 = find.text('Dinesh');
+
+    await tester.pumpWidget(builderForValueListenable(animation));
+
+    await tester.pump();
+    expect(finder1, findsOneWidget);
+    expect(finder2, findsNothing);
+    expect(rebuildCount, equals(1));
+
+    controller.value = 0.3;
+    await tester.pump();
+    expect(finder1, findsOneWidget);
+    expect(finder2, findsNothing);
+    expect(rebuildCount, equals(1));
+
+    controller.animateTo(0.6);
+    await tester.pumpAndSettle(duration);
+    expect(finder1, findsNothing);
+    expect(finder2, findsOneWidget);
+    expect(rebuildCount, equals(2));
+
+    controller.forward();
+    await tester.pumpAndSettle(duration);
+    expect(finder1, findsNothing);
+    expect(finder2, findsOneWidget);
+    expect(rebuildCount, equals(2));
   });
 
   testWidgets('Can change listenable', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/value_listenable_builder_test.dart
+++ b/packages/flutter/test/widgets/value_listenable_builder_test.dart
@@ -19,7 +19,7 @@ void main() {
       child: ValueListenableBuilder<String?>(
         valueListenable: valueListenable,
         builder: (BuildContext context, String? value, Widget? child) {
-          ++rebuildCount;
+          rebuildCount += 1;
 
           if (value == null)
             return const Placeholder();


### PR DESCRIPTION
## Description
check if value really changed in ValueListenableBuilder

## Related Issues

fixes #72002

## Tests

I added the following tests:
- "Widget does not rebuilds if value is the same" in `packages/flutter/test/widgets/value_listenable_builder_test.dart`

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
