### PR TITLE
[State Restoration] Adds remaining Restorable{Property}N

### DIFF
--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -209,6 +209,10 @@ class _RestorablePrimitiveValue<T extends Object> extends _RestorablePrimitiveVa
 /// Instead of using the more generic [RestorableNum] directly, consider using
 /// one of the more specific subclasses (e.g. [RestorableDouble] to store a
 /// [double] and [RestorableInt] to store an [int]).
+///
+/// See also:
+///
+///  * [RestorableNumN] for the nullable version of this class.
 class RestorableNum<T extends num> extends _RestorablePrimitiveValue<T> {
   /// Creates a [RestorableNum].
   ///
@@ -216,68 +220,62 @@ class RestorableNum<T extends num> extends _RestorablePrimitiveValue<T> {
   /// If no restoration data is available to restore the value in this property
   /// from, the property will be initialized with the provided `defaultValue`.
   /// {@endtemplate}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableNumN] for the nullable version of this class.
-
   RestorableNum(T defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore a [double].
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableDoubleN] for the nullable version of this class.
 class RestorableDouble extends RestorableNum<double> {
   /// Creates a [RestorableDouble].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableDoubleN] for the nullable version of this class.
   RestorableDouble(double defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore an [int].
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableIntN] for the nullable version of this class.
 class RestorableInt extends RestorableNum<int> {
   /// Creates a [RestorableInt].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableIntN] for the nullable version of this class.
   RestorableInt(int defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore a [String].
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableStringN] for the nullable version of this class.
 class RestorableString extends _RestorablePrimitiveValue<String> {
   /// Creates a [RestorableString].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableStringN] for the nullable version of this class.
-
   RestorableString(String defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
 /// A [RestorableProperty] that knows how to store and restore a [bool].
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableBoolN] for the nullable version of this class.
 class RestorableBool extends _RestorablePrimitiveValue<bool> {
   /// Creates a [RestorableBool].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableBoolN] for the nullable version of this class.
   RestorableBool(bool defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
@@ -285,14 +283,14 @@ class RestorableBool extends _RestorablePrimitiveValue<bool> {
 /// nullable.
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableBool] for the non-nullable version of this class.
 class RestorableBoolN extends _RestorablePrimitiveValueN<bool?> {
   /// Creates a [RestorableBoolN].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableBool] for the non-nullable version of this class.
   RestorableBoolN(bool? defaultValue) : super(defaultValue);
 }
 
@@ -304,14 +302,14 @@ class RestorableBoolN extends _RestorablePrimitiveValueN<bool?> {
 /// Instead of using the more generic [RestorableNumN] directly, consider using
 /// one of the more specific subclasses (e.g. [RestorableDoubleN] to store a
 /// [double] and [RestorableIntN] to store an [int]).
+///
+/// See also:
+///
+///  * [RestorableNum] for the non-nullable version of this class.
 class RestorableNumN<T extends num?> extends _RestorablePrimitiveValueN<num?> {
   /// Creates a [RestorableNumN].
   ///
   /// {@macro flutter.widgets.RestorableNumN.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableNum] for the non-nullable version of this class.
   RestorableNumN(num? defaultValue) : super(defaultValue);
 }
 
@@ -319,14 +317,14 @@ class RestorableNumN<T extends num?> extends _RestorablePrimitiveValueN<num?> {
 /// that is nullable.
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableDouble] for the non-nullable version of this class.
 class RestorableDoubleN extends RestorableNumN<double> {
   /// Creates a [RestorableDoubleN].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableDouble] for the non-nullable version of this class.
   RestorableDoubleN(double? defaultValue) : super(defaultValue);
 }
 
@@ -334,14 +332,14 @@ class RestorableDoubleN extends RestorableNumN<double> {
 /// that is nullable.
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableInt] for the non-nullable version of this class.
 class RestorableIntN extends RestorableNumN<int> {
   /// Creates a [RestorableIntN].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  /// See also:
-  ///
-  ///  * [RestorableInt] for the non-nullable version of this class.
   RestorableIntN(int? defaultValue) : super(defaultValue);
 }
 
@@ -349,12 +347,14 @@ class RestorableIntN extends RestorableNumN<int> {
 /// that is nullable.
 ///
 /// {@macro flutter.widgets.RestorableNum}
+///
+/// See also:
+///
+///  * [RestorableString] for the non-nullable version of this class.
 class RestorableStringN extends _RestorablePrimitiveValueN<String?> {
   /// Creates a [RestorableString].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
-  ///
-  ///  * [RestorableString] for the non-nullable version of this class.
   RestorableStringN(String? defaultValue) : super(defaultValue);
 }
 

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -216,6 +216,11 @@ class RestorableNum<T extends num> extends _RestorablePrimitiveValue<T> {
   /// If no restoration data is available to restore the value in this property
   /// from, the property will be initialized with the provided `defaultValue`.
   /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableNumN] for the nullable version of this class.
+
   RestorableNum(T defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
@@ -226,6 +231,10 @@ class RestorableDouble extends RestorableNum<double> {
   /// Creates a [RestorableDouble].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableDoubleN] for the nullable version of this class.
   RestorableDouble(double defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
@@ -236,6 +245,10 @@ class RestorableInt extends RestorableNum<int> {
   /// Creates a [RestorableInt].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableIntN] for the nullable version of this class.
   RestorableInt(int defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 
@@ -246,6 +259,11 @@ class RestorableString extends _RestorablePrimitiveValue<String> {
   /// Creates a [RestorableString].
   ///
   /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableStringN] for the nullable version of this class.
+
   RestorableString(String defaultValue) : assert(defaultValue != null), super(defaultValue);
 }
 

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -278,6 +278,68 @@ class RestorableBoolN extends _RestorablePrimitiveValueN<bool?> {
   RestorableBoolN(bool? defaultValue) : super(defaultValue);
 }
 
+/// A [RestorableProperty] that knows how to store and restore a [num]
+/// that is nullable.
+///
+/// {@macro flutter.widgets.RestorableNumN}
+///
+/// Instead of using the more generic [RestorableNumN] directly, consider using
+/// one of the more specific subclasses (e.g. [RestorableDoubleN] to store a
+/// [double] and [RestorableIntN] to store an [int]).
+class RestorableNumN<T extends num?> extends _RestorablePrimitiveValueN<num?> {
+  /// Creates a [RestorableNumN].
+  ///
+  /// {@macro flutter.widgets.RestorableNumN.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableNum] for the non-nullable version of this class.
+  RestorableNumN(num? defaultValue) : super(defaultValue);
+}
+
+/// A [RestorableProperty] that knows how to store and restore a [double]
+/// that is nullable.
+///
+/// {@macro flutter.widgets.RestorableNum}
+class RestorableDoubleN extends RestorableNumN<double> {
+  /// Creates a [RestorableDoubleN].
+  ///
+  /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableDouble] for the non-nullable version of this class.
+  RestorableDoubleN(double? defaultValue) : super(defaultValue);
+}
+
+/// A [RestorableProperty] that knows how to store and restore an [int]
+/// that is nullable.
+///
+/// {@macro flutter.widgets.RestorableNum}
+class RestorableIntN extends RestorableNumN<int> {
+  /// Creates a [RestorableIntN].
+  ///
+  /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  /// See also:
+  ///
+  ///  * [RestorableInt] for the non-nullable version of this class.
+  RestorableIntN(int? defaultValue) : super(defaultValue);
+}
+
+/// A [RestorableProperty] that knows how to store and restore a [String]
+/// that is nullable.
+///
+/// {@macro flutter.widgets.RestorableNum}
+class RestorableStringN extends _RestorablePrimitiveValueN<String?> {
+  /// Creates a [RestorableString].
+  ///
+  /// {@macro flutter.widgets.RestorableNum.constructor}
+  ///
+  ///  * [RestorableString] for the non-nullable version of this class.
+  RestorableStringN(String? defaultValue) : super(defaultValue);
+}
+
 /// A base class for creating a [RestorableProperty] that stores and restores a
 /// [Listenable].
 ///

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -297,7 +297,7 @@ class RestorableBoolN extends _RestorablePrimitiveValueN<bool?> {
 /// A [RestorableProperty] that knows how to store and restore a [num]
 /// that is nullable.
 ///
-/// {@macro flutter.widgets.RestorableNumN}
+/// {@macro flutter.widgets.RestorableNum}
 ///
 /// Instead of using the more generic [RestorableNumN] directly, consider using
 /// one of the more specific subclasses (e.g. [RestorableDoubleN] to store a
@@ -309,7 +309,7 @@ class RestorableBoolN extends _RestorablePrimitiveValueN<bool?> {
 class RestorableNumN<T extends num?> extends _RestorablePrimitiveValueN<num?> {
   /// Creates a [RestorableNumN].
   ///
-  /// {@macro flutter.widgets.RestorableNumN.constructor}
+  /// {@macro flutter.widgets.RestorableNum.constructor}
   RestorableNumN(num? defaultValue) : super(defaultValue);
 }
 

--- a/packages/flutter/test/widgets/restorable_property_test.dart
+++ b/packages/flutter/test/widgets/restorable_property_test.dart
@@ -13,6 +13,10 @@ void main() {
     expect(() => RestorableInt(1).value, throwsAssertionError);
     expect(() => RestorableString('hello').value, throwsAssertionError);
     expect(() => RestorableBool(true).value, throwsAssertionError);
+    expect(() => RestorableNumN<num>(0).value, throwsAssertionError);
+    expect(() => RestorableDoubleN(1.0).value, throwsAssertionError);
+    expect(() => RestorableIntN(1).value, throwsAssertionError);
+    expect(() => RestorableStringN('hello').value, throwsAssertionError);
     expect(() => RestorableBoolN(true).value, throwsAssertionError);
     expect(() => RestorableTextEditingController().value, throwsAssertionError);
     expect(() => _TestRestorableValue().value, throwsAssertionError);
@@ -126,6 +130,10 @@ void main() {
       state.intValue.value = 10;
       state.stringValue.value = 'guten tag';
       state.boolValue.value = true;
+      state.nullableNumValue.value = 5.0;
+      state.nullableDoubleValue.value = 2.0;
+      state.nullableIntValue.value = 1;
+      state.nullableStringValue.value = 'hullo';
       state.nullableBoolValue.value = false;
       state.controllerValue.value.text = 'blabla';
       state.objectValue.value = 53;
@@ -142,6 +150,10 @@ void main() {
       state.intValue.value = 20;
       state.stringValue.value = 'ciao';
       state.boolValue.value = false;
+      state.nullableNumValue.value = 20.0;
+      state.nullableDoubleValue.value = 20.0;
+      state.nullableIntValue.value = 20;
+      state.nullableStringValue.value = 'ni hao';
       state.nullableBoolValue.value = null;
       state.controllerValue.value.text = 'blub';
       state.objectValue.value = 20;
@@ -157,6 +169,10 @@ void main() {
     expect(state.intValue.value, 10);
     expect(state.stringValue.value, 'guten tag');
     expect(state.boolValue.value, true);
+    expect(state.nullableNumValue.value, 5.0);
+    expect(state.nullableDoubleValue.value, 2.0);
+    expect(state.nullableIntValue.value, 1);
+    expect(state.nullableStringValue.value, 'hullo');
     expect(state.nullableBoolValue.value, false);
     expect(state.controllerValue.value.text, 'blabla');
     expect(state.objectValue.value, 53);
@@ -170,6 +186,10 @@ void main() {
     expect(state.intValue.value, 42);
     expect(state.stringValue.value, 'hello world');
     expect(state.boolValue.value, false);
+    expect(state.nullableNumValue.value, null);
+    expect(state.nullableDoubleValue.value, null);
+    expect(state.nullableIntValue.value, null);
+    expect(state.nullableStringValue.value, null);
     expect(state.nullableBoolValue.value, null);
     expect(state.controllerValue.value.text, 'FooBar');
     expect(state.objectValue.value, 55);
@@ -328,6 +348,10 @@ class _RestorableWidgetState extends State<_RestorableWidget> with RestorationMi
   final RestorableInt intValue = RestorableInt(42);
   final RestorableString stringValue = RestorableString('hello world');
   final RestorableBool boolValue = RestorableBool(false);
+  final RestorableNumN<num> nullableNumValue = RestorableNumN<num>(null);
+  final RestorableDoubleN nullableDoubleValue = RestorableDoubleN(null);
+  final RestorableIntN nullableIntValue = RestorableIntN(null);
+  final RestorableStringN nullableStringValue = RestorableStringN(null);
   final RestorableBoolN nullableBoolValue = RestorableBoolN(null);
   final RestorableTextEditingController controllerValue = RestorableTextEditingController(text: 'FooBar');
   final _TestRestorableValue objectValue = _TestRestorableValue();
@@ -339,6 +363,10 @@ class _RestorableWidgetState extends State<_RestorableWidget> with RestorationMi
     registerForRestoration(intValue, 'int');
     registerForRestoration(stringValue, 'string');
     registerForRestoration(boolValue, 'bool');
+    registerForRestoration(nullableNumValue, 'nullableNum');
+    registerForRestoration(nullableDoubleValue, 'nullableDouble');
+    registerForRestoration(nullableIntValue, 'nullableInt');
+    registerForRestoration(nullableStringValue, 'nullableString');
     registerForRestoration(nullableBoolValue, 'nullableBool');
     registerForRestoration(controllerValue, 'controller');
     registerForRestoration(objectValue, 'object');
@@ -350,7 +378,7 @@ class _RestorableWidgetState extends State<_RestorableWidget> with RestorationMi
 
   @override
   Widget build(BuildContext context) {
-    return Text(stringValue.value, textDirection: TextDirection.ltr,);
+    return Text(stringValue.value, textDirection: TextDirection.ltr);
   }
 
   @override


### PR DESCRIPTION
## Description

Introduces RestorableNumN, RestorableDoubleN, RestorableIntN, and RestorableStringN. 

RestorableBoolN was already added and figured we might as well add the remaining properties so that we're consistent throughout in the framework.

## Related Issues

https://github.com/flutter/flutter/issues/62916, Gallery app uses workaround for `RestorableInt` for the choice chip and data table demoes when it makes more sense to use a `RestorableIntN`. 

## Tests

I added the following tests:

- Modified existing tests to test for the added properties.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
