### PR TITLE
Fix/animation notifications only on value change

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -362,8 +362,11 @@ class AnimationController extends Animation<double>
   set value(double newValue) {
     assert(newValue != null);
     stop();
+    final double oldValue = value;
     _internalSetValue(newValue);
-    notifyListeners();
+    if (oldValue != newValue) {
+      notifyListeners();
+    }
     _checkStatusChanged();
   }
 
@@ -817,6 +820,7 @@ class AnimationController extends Animation<double>
     _lastElapsedDuration = elapsed;
     final double elapsedInSeconds = elapsed.inMicroseconds.toDouble() / Duration.microsecondsPerSecond;
     assert(elapsedInSeconds >= 0.0);
+    final double oldValue = _value;
     _value = _simulation!.x(elapsedInSeconds).clamp(lowerBound, upperBound);
     if (_simulation!.isDone(elapsedInSeconds)) {
       _status = (_direction == _AnimationDirection.forward) ?
@@ -824,7 +828,9 @@ class AnimationController extends Animation<double>
         AnimationStatus.dismissed;
       stop(canceled: false);
     }
-    notifyListeners();
+    if (oldValue != _value) {
+      notifyListeners();
+    }
     _checkStatusChanged();
   }
 

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -442,7 +442,9 @@ class ReverseAnimation extends Animation<double>
 ///    [AnimationController].
 ///  * [Curve.flipped] and [FlippedCurve], which provide the reverse of a
 ///    [Curve].
-class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<double> {
+class CurvedAnimation extends Animation<double>
+    with AnimationLocalStatusListenersMixin, AnimationLocalListenersMixin,
+        AnimationLazyListenerMixin, AnimationLazyWithParentMixin<double, double> {
   /// Creates a curved animation.
   ///
   /// The parent and curve arguments must not be null.

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'animation.dart';
 import 'animations.dart';
 import 'curves.dart';
+import 'listener_helpers.dart';
 
 // Examples can assume:
 // late Animation<Offset> _animation;
@@ -75,7 +76,9 @@ abstract class Animatable<T> {
   }
 }
 
-class _AnimatedEvaluation<T> extends Animation<T> with AnimationWithParentMixin<double> {
+class _AnimatedEvaluation<T> extends Animation<T>
+    with AnimationLazyListenerMixin, AnimationLocalStatusListenersMixin, AnimationLocalListenersMixin,
+         AnimationLazyWithParentMixin<T, double> {
   _AnimatedEvaluation(this.parent, this._evaluatable);
 
   @override

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -330,6 +330,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
       _helper = _buildHelper();
     }
     _controller.addListener(_handleChange);
+    _controller.addStatusListener(_handleChange);
   }
 
   @override
@@ -338,7 +339,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
     super.dispose();
   }
 
-  void _handleChange() {
+  void _handleChange([AnimationStatus? _]) {
     setState(() {
       // The _controller's value has changed.
     });
@@ -1935,6 +1936,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       value: labelIsInitiallyFloating ? 1.0 : 0.0
     );
     _floatingLabelController.addListener(_handleChange);
+    _floatingLabelController.addStatusListener(_handleChange);
 
     _shakingLabelController = AnimationController(
       duration: _kTransitionDuration,
@@ -1955,7 +1957,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     super.dispose();
   }
 
-  void _handleChange() {
+  void _handleChange([AnimationStatus? _]) {
     setState(() {
       // The _floatingLabelController's value has changed.
     });

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1538,12 +1538,9 @@ class TabPageSelector extends StatelessWidget {
       }
       return true;
     }());
-    final Animation<double> animation = CurvedAnimation(
-      parent: tabController!.animation!,
-      curve: Curves.fastOutSlowIn,
-    );
+
     return AnimatedBuilder(
-      animation: animation,
+      animation: tabController!.animation!,
       builder: (BuildContext context, Widget? child) {
         return Semantics(
           label: 'Page ${tabController.index + 1} of ${tabController.length}',

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -521,7 +521,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       }
     } else {
       _resizeController = AnimationController(duration: widget.resizeDuration, vsync: this)
-        ..addListener(_handleResizeProgressChanged)
+        ..addStatusListener(_handleResizeProgressChanged)
         ..addStatusListener((AnimationStatus status) => updateKeepAlive());
       _resizeController!.forward();
       setState(() {
@@ -540,8 +540,8 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     }
   }
 
-  void _handleResizeProgressChanged() {
-    if (_resizeController!.isCompleted) {
+  void _handleResizeProgressChanged(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
       if (widget.onDismissed != null) {
         final DismissDirection direction = _dismissDirection;
         widget.onDismissed!(direction);

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -179,9 +179,7 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   }
 
   void _valueChanged() {
-    if (value !=  widget.valueListenable.value) {
-      setState(() { value = widget.valueListenable.value; });
-    }
+    setState(() { value = widget.valueListenable.value; });
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -179,7 +179,9 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   }
 
   void _valueChanged() {
-    setState(() { value = widget.valueListenable.value; });
+    if (value !=  widget.valueListenable.value) {
+      setState(() { value = widget.valueListenable.value; });
+    }
   }
 
   @override

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -110,7 +110,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     await tester.tapAt(const Offset(0.0, 0.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(cancels, equals(0));
 
     // Make sure callback is called when a non-selection tap occurs
@@ -118,7 +118,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     await tester.tapAt(const Offset(0.0, 0.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(cancels, equals(1));
 
     // Make sure callback is called when back navigation occurs

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1931,6 +1931,7 @@ void main() {
           '   showBottomSheet() to close the old bottom sheet before creating a\n'
           '   Scaffold with a (non null) bottomSheet.\n'
         );
+        await tester.pumpAndSettle();
     });
 
     testWidgets('Call to Scaffold.of() without context', (WidgetTester tester) async {

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -335,33 +335,32 @@ void main() {
 
     final List<Offset> expectedLog = <Offset>[
       const Offset(24.0, 300.0),
-      const Offset(24.0, 300.0),
       const Offset(400.0, 300.0),
     ];
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(sliderKey)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
     expect(value, equals(0.5));
-    expect(log.length, 3);
+    expect(log.length, 2);
     expect(log, orderedEquals(expectedLog));
     await gesture.moveBy(const Offset(-500.0, 0.0));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
-    expect(log.length, 5);
+    expect(log.length, 3);
     expect(log.last.dx, moreOrLessEquals(386.6, epsilon: 0.1));
     // With no more gesture or value changes, the thumb position should still
     // be redrawn in the animated position.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
-    expect(log.length, 7);
+    expect(log.length, 4);
     expect(log.last.dx, moreOrLessEquals(344.5, epsilon: 0.1));
     // Final position.
     await tester.pump(const Duration(milliseconds: 80));
     expectedLog.add(const Offset(24.0, 300.0));
     expect(value, equals(0.0));
-    expect(log.length, 8);
+    expect(log.length, 5);
     expect(log.last.dx, moreOrLessEquals(24.0, epsilon: 0.1));
     await gesture.up();
   });
@@ -450,33 +449,32 @@ void main() {
 
     final List<Offset> expectedLog = <Offset>[
       const Offset(24.0, 300.0),
-      const Offset(24.0, 300.0),
       const Offset(400.0, 300.0),
     ];
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(sliderKey)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
     expect(value, equals(0.5));
-    expect(log.length, 3);
+    expect(log.length, 2);
     expect(log, orderedEquals(expectedLog));
     await gesture.moveBy(const Offset(-500.0, 0.0));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
-    expect(log.length, 5);
+    expect(log.length, 3);
     expect(log.last.dx, moreOrLessEquals(386.6, epsilon: 0.1));
     // With no more gesture or value changes, the thumb position should still
     // be redrawn in the animated position.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     expect(value, equals(0.0));
-    expect(log.length, 7);
+    expect(log.length, 4);
     expect(log.last.dx, moreOrLessEquals(344.5, epsilon: 0.1));
     // Final position.
     await tester.pump(const Duration(milliseconds: 80));
     expectedLog.add(const Offset(24.0, 300.0));
     expect(value, equals(0.0));
-    expect(log.length, 8);
+    expect(log.length, 5);
     expect(log.last.dx, moreOrLessEquals(24.0, epsilon: 0.1));
     await gesture.up();
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -767,8 +767,8 @@ void main() {
       length: tabs.length,
     ));
 
-    tabController.animation!.addListener(() {
-      if (tabController.animation!.status == AnimationStatus.forward)
+    tabController.animation!.addStatusListener((AnimationStatus status) {
+      if (status == AnimationStatus.forward)
         tabController.index = 2;
       expect(tabController.indexIsChanging, true);
     });

--- a/packages/flutter/test/widgets/navigator_and_layers_test.dart
+++ b/packages/flutter/test/widgets/navigator_and_layers_test.dart
@@ -66,7 +66,7 @@ void main() {
     log.add('4');
     navigator.pop();
     log.add('5');
-    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 3);
     log.add('6');
     flipStatefulWidget(tester);
     expect(await tester.pumpAndSettle(), 1);

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -462,7 +462,7 @@ void main() {
     expect(find.text('AA'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 500));
     final Offset point1 = tester.getCenter(find.text('AA'));
-    await tester.dragFrom(point1, const Offset(0.0, 200.0));
+    await tester.dragFrom(point1, const Offset(0.0, -200.0));
     await tester.pump(const Duration(milliseconds: 20));
     final Offset point2 = tester.getCenter(find.text(
       'AA',

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -222,8 +222,7 @@ void main() {
   testWidgets('expanding page views', (WidgetTester tester) async {
     await tester.pumpWidget(Padding(padding: const EdgeInsets.only(right: 200.0), child: TabBarDemo()));
     await tester.tap(find.text('bike'));
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
     final Rect bike1 = tester.getRect(find.byIcon(Icons.directions_bike));
     await tester.pumpWidget(Padding(padding: EdgeInsets.zero, child: TabBarDemo()));
     final Rect bike2 = tester.getRect(find.byIcon(Icons.directions_bike));

--- a/packages/flutter/test/widgets/value_listenable_builder_test.dart
+++ b/packages/flutter/test/widgets/value_listenable_builder_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 void main() {
   late SpyStringValueNotifier valueListenable;
   late Widget textBuilderUnderTest;
+  late int rebuildCount;
 
   Widget builderForValueListenable(
     ValueListenable<String?> valueListenable,
@@ -18,6 +19,8 @@ void main() {
       child: ValueListenableBuilder<String?>(
         valueListenable: valueListenable,
         builder: (BuildContext context, String? value, Widget? child) {
+          ++rebuildCount;
+
           if (value == null)
             return const Placeholder();
           return Text(value);
@@ -29,6 +32,7 @@ void main() {
   setUp(() {
     valueListenable = SpyStringValueNotifier(null);
     textBuilderUnderTest = builderForValueListenable(valueListenable);
+    rebuildCount = 0;
   });
 
   testWidgets('Null value is ok', (WidgetTester tester) async {
@@ -56,6 +60,46 @@ void main() {
     await tester.pump();
     expect(find.text('Gilfoyle'), findsNothing);
     expect(find.text('Dinesh'), findsOneWidget);
+  });
+
+  testWidgets('Widget does not rebuilds if value is the same', (WidgetTester tester) async {
+    const Duration duration = Duration(milliseconds: 100);
+    final AnimationController controller = AnimationController(
+      vsync: const TestVSync(),
+      duration: duration,
+    )..value = 0;
+    final Animation<String> animation = TweenSequence<String>(<TweenSequenceItem<String>>[
+      TweenSequenceItem<String>(tween: ConstantTween<String>('Gilfoyle'), weight: 1.0),
+      TweenSequenceItem<String>(tween: ConstantTween<String>('Dinesh'), weight: 1.0),
+    ]).animate(controller);
+
+    final Finder finder1 = find.text('Gilfoyle');
+    final Finder finder2 = find.text('Dinesh');
+
+    await tester.pumpWidget(builderForValueListenable(animation));
+
+    await tester.pump();
+    expect(finder1, findsOneWidget);
+    expect(finder2, findsNothing);
+    expect(rebuildCount, equals(1));
+
+    controller.value = 0.3;
+    await tester.pump();
+    expect(finder1, findsOneWidget);
+    expect(finder2, findsNothing);
+    expect(rebuildCount, equals(1));
+
+    controller.animateTo(0.6);
+    await tester.pumpAndSettle(duration);
+    expect(finder1, findsNothing);
+    expect(finder2, findsOneWidget);
+    expect(rebuildCount, equals(2));
+
+    controller.forward();
+    await tester.pumpAndSettle(duration);
+    expect(finder1, findsNothing);
+    expect(finder2, findsOneWidget);
+    expect(rebuildCount, equals(2));
   });
 
   testWidgets('Can change listenable', (WidgetTester tester) async {


### PR DESCRIPTION
## Description
an improved version of this pull request:  #72707
reduce number of useless rebuilds 

instead of check in `ValueListenableBuilder`, call `notifyListeners` in animations only if value of animation really changed. (as it is written in the docs)

- add `AnimationLazyWithParentMixin`
- mix it in `_AnimatedEvaluation` and `CurvedAnimation`
- fix everything around:
  - remove wrong `CurvedAnimation` from `TabPageSelector`
  - use status listener instead of value listener in `_DismissibleState._startResizeAnimation`
  - fix `InputDecorator` animation listeners (listen both `value` and `status` changes)
  - fix tests, see commits:
    - `minor test fixes`: seems to be caused by changes in rebuilds number and density
    - `major test fixes (might be BREAKING)`:
      - had to replace `addListener` with `addStatusListener` in "TabController listener resets index" test
      - drag in the wrong direction worked in "NestedScrollViews with custom physics" test for some reason

seems to be **BREAKING**:
status changes won't cause notifyListeners call (although this is seems to be expected behavior according to docs)

## Related Issues
fixes #72002

## Tests

I added the following tests:
- `packages/flutter/test/widgets/value_listenable_builder_test.dart`
  - "Widget does not rebuilds if value is the same (using Animatable)" 
  - "Widget does not rebuilds if value is the same (using CurvedAnimation)"

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
