### PR TITLE
Exclude ARM from macOS builds

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -86,6 +86,9 @@ def flutter_additional_macos_build_settings(target)
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir
     build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS'] = "\"#{configuration_engine_dir}\" $(inherited)"
+
+    # ARM not yet supported https://github.com/flutter/flutter/issues/69221
+    build_configuration.build_settings['EXCLUDED_ARCHS'] = 'arm64'
   end
 end
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -206,6 +206,10 @@ List<String> _xcodeBuildSettingsLines({
       xcodeBuildSettings.add('ARCHS=$arch');
     }
   }
+  if (useMacOSConfig) {
+    // ARM not yet supported https://github.com/flutter/flutter/issues/69221
+    xcodeBuildSettings.add('EXCLUDED_ARCHS=arm64');
+  }
 
   for (final MapEntry<String, String> config in buildInfo.toEnvironmentConfig().entries) {
     xcodeBuildSettings.add('${config.key}=${config.value}');

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -111,7 +111,6 @@ Future<void> buildMacOS({
       else
         '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
-      'EXCLUDED_ARCHS=arm64', // TODO(jmagman): Allow ARM https://github.com/flutter/flutter/issues/69221
     ],
     trace: true,
     stdoutErrorMatcher: verboseLogging ? null : _anyOutput,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -97,7 +97,6 @@ void main() {
         else
           '-quiet',
         'COMPILER_INDEX_STORE_ENABLE=NO',
-        'EXCLUDED_ARCHS=arm64',
       ],
       stdout: 'STDOUT STUFF',
       onRun: () {
@@ -265,6 +264,7 @@ void main() {
       'TREE_SHAKE_ICONS=true',
       'FLUTTER_TARGET=lib/other.dart',
       'BUNDLE_SKSL_PATH=foo/bar.sksl.json',
+      'EXCLUDED_ARCHS=arm64',
     ]));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -41,7 +41,10 @@ void main() {
 
     // Config is updated if command succeeded.
     expect(generatedConfig, exists);
-    expect(generatedConfig.readAsStringSync(), contains('DART_OBFUSCATION=true'));
+    expect(generatedConfig.readAsStringSync(), allOf(
+      contains('DART_OBFUSCATION=true'),
+      isNot(contains('EXCLUDED_ARCHS')),
+    ));
 
     // file that only exists if app was fully built.
     final File frameworkPlist = fileSystem.file(


### PR DESCRIPTION
## Description

Now that the [macOS Podfile logic is in the tool](https://github.com/flutter/flutter/pull/72020), we can exclude arm64 for plugins without a scary user project Podfile migration.

Exclude arm64 for plugins and the app.  Revert https://github.com/flutter/flutter/pull/70649 since it's handled in the Xcode build settings and so doesn't need to be passed in the command line. This will allow building/running/archiving in Release mode in Xcode instead of just working on via `flutter` on the command line.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/70566
Can be reverted when arm64 is natively supported https://github.com/flutter/flutter/issues/69221
Reverts https://github.com/flutter/flutter/pull/70649

## Tests

build_macos_test, build_ios_config_only_test