### PR TITLE
Force plugins to inherit minimum macOS version from Flutter app

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -9,5 +9,6 @@ Future<void> main() async {
   await task(combine(<TaskFunction>[
     PluginTest('ios', <String>['-i', 'objc', '--platforms=ios']),
     PluginTest('ios', <String>['-i', 'swift', '--platforms=ios']),
+    PluginTest('macos', <String>['--platforms=macos']),
   ]));
 }

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -75,10 +75,14 @@ end
 def flutter_additional_macos_build_settings(target)
   return unless target.platform_name == :osx
 
-  # [target.deployment_target] is a [String] formatted as "10.8". Check if this is < 10.9
-  # See MACOSX_DEPLOYMENT_TARGET note below.
-  deployment_target_major, deployment_target_minor = target.deployment_target.match(/(\d*).?(\d*)/).captures
-  inherit_deployment_target = deployment_target_major.to_i < 10 || deployment_target_minor.to_i < 9
+  # [target.deployment_target] is a [String] formatted as "10.8".
+  deployment_target_major, deployment_target_minor = target.deployment_target.match(/(\d+).?(\d*)/).captures
+
+  # Suppress warning when pod supports a version lower than the minimum supported by the latest stable version of Xcode (currently 10.9).
+  # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
+  inherit_deployment_target = !target.deployment_target.blank? &&
+    (deployment_target_major.to_i < 10) ||
+    (deployment_target_major.to_i == 10 && deployment_target_minor.to_i < 9)
 
   # This podhelper script is at $FLUTTER_ROOT/packages/flutter_tools/bin.
   # Add search paths from $FLUTTER_ROOT/bin/cache/artifacts/engine.
@@ -94,8 +98,6 @@ def flutter_additional_macos_build_settings(target)
     # ARM not yet supported https://github.com/flutter/flutter/issues/69221
     build_configuration.build_settings['EXCLUDED_ARCHS'] = 'arm64'
 
-    # Suppress warning when pod supports a version lower than the minimum supported by Xcode (Xcode 12 - macOS 10.9).
-    # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
     # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
     # If the pod only supports a higher version, do not delete to correctly produce an error.
     build_configuration.build_settings.delete 'MACOSX_DEPLOYMENT_TARGET' if inherit_deployment_target

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -73,8 +73,12 @@ end
 
 # Same as flutter_ios_podfile_setup for macOS.
 def flutter_additional_macos_build_settings(target)
-  print target.platform_name
   return unless target.platform_name == :osx
+
+  # [target.deployment_target] is a [String] formatted as "10.8". Check if this is < 10.9
+  # See MACOSX_DEPLOYMENT_TARGET note below.
+  deployment_target_major, deployment_target_minor = target.deployment_target.match(/(\d*).?(\d*)/).captures
+  inherit_deployment_target = deployment_target_major.to_i < 10 || deployment_target_minor.to_i < 9
 
   # This podhelper script is at $FLUTTER_ROOT/packages/flutter_tools/bin.
   # Add search paths from $FLUTTER_ROOT/bin/cache/artifacts/engine.
@@ -89,6 +93,12 @@ def flutter_additional_macos_build_settings(target)
 
     # ARM not yet supported https://github.com/flutter/flutter/issues/69221
     build_configuration.build_settings['EXCLUDED_ARCHS'] = 'arm64'
+
+    # Suppress warning when pod supports a version lower than the minimum supported by Xcode (Xcode 12 - macOS 10.9).
+    # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
+    # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
+    # If the pod only supports a higher version, do not delete to correctly produce an error.
+    build_configuration.build_settings.delete 'MACOSX_DEPLOYMENT_TARGET' if inherit_deployment_target
   end
 end
 


### PR DESCRIPTION
## Background

macOS version of #66590

Xcode supports specific SDK ranges, and every release they drop the lowest.  For example, Xcode 12 dropped support for 10.8.
Xcode emits a warning when build targets support a minimum version lower than the range to indicate it can't validate compilation against the older SDK.
```
The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.6, but the range of supported deployment target versions is 10.9 to 10.16.99
```
This warning is benign: if the app supports a minimum of macOS 10.9, it doesn't cause any problems that a plugin framework embedded in the app supports macOS 10.8.  These warnings concern users who think there's something wrong with their app, and there's no way for users to fix it (the plugin author would have to up their minimum supported version).

This warning was seen in flutter_gallery because the `Reachability` pod supported 10.8.

## Description
If the plugin's minimum version is less than macOS 10.9, remove the version build setting.  This will cause it to inherit from the minimum version set in the Flutter app (currently 10.11).

If the plugin minimum is higher than macOS 10.9, leave the build setting so if there is a versioning range issue (the plugin supports a minimum macOS 11 but the app needs 10.11) the correct error (not warning) will be emitted.

## Related Issues

iOS issue at https://github.com/flutter/flutter/issues/40109, there's no macOS equivalent.

## Tests

Added macOS to the plugin integration test.  Confirm this test fails on master.