### PR TITLE
[devicelab] Add results path flag to test runner

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -42,6 +42,12 @@ String luciBuilder;
 /// Whether to exit on first test failure.
 bool exitOnFirstTestFailure;
 
+/// Path for test results.
+///
+/// If passed along with a task name, the Cocoon test results will be stored in this file.
+/// If passed without a task name, the file contents will be uploaded to Cocoon.
+String resultsPath;
+
 /// File containing a service account token.
 ///
 /// If passed, the test run results will be uploaded to Flutter infrastructure.
@@ -65,6 +71,16 @@ Future<void> main(List<String> rawArgs) async {
     return;
   }
 
+  deviceId = args['device-id'] as String;
+  exitOnFirstTestFailure = args['exit'] as bool;
+  gitBranch = args['git-branch'] as String;
+  localEngine = args['local-engine'] as String;
+  localEngineSrcPath = args['local-engine-src-path'] as String;
+  luciBuilder = args['luci-builder'] as String;
+  resultsPath = args['results-path'] as String;
+  serviceAccountTokenFile = args['service-account-token-file'] as String;
+  silent = args['silent'] as bool;
+
   if (!args.wasParsed('task')) {
     if (args.wasParsed('stage') || args.wasParsed('all')) {
       addTasks(
@@ -83,20 +99,18 @@ Future<void> main(List<String> rawArgs) async {
     return;
   }
 
+  // Do not run any test. Instead, upload results from a test run.
+  if (resultsPath != null && serviceAccountTokenFile != null) {
+    final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
+    cocoon.sendResultsPath(resultsPath);
+    return;
+  }
+
   if (_taskNames.isEmpty) {
     stderr.writeln('Failed to find tasks to run based on supplied options.');
     exitCode = 1;
     return;
   }
-
-  deviceId = args['device-id'] as String;
-  exitOnFirstTestFailure = args['exit'] as bool;
-  gitBranch = args['git-branch'] as String;
-  localEngine = args['local-engine'] as String;
-  localEngineSrcPath = args['local-engine-src-path'] as String;
-  luciBuilder = args['luci-builder'] as String;
-  serviceAccountTokenFile = args['service-account-token-file'] as String;
-  silent = args['silent'] as bool;
 
   if (args.wasParsed('ab')) {
     await _runABTest();
@@ -120,7 +134,15 @@ Future<void> _runTasks() async {
     print(const JsonEncoder.withIndent('  ').convert(result));
     section('Finished task "$taskName"');
 
-    if (serviceAccountTokenFile != null) {
+    if (resultsPath != null) {
+      final Cocoon cocoon = Cocoon();
+      await cocoon.writeTaskResultToFile(
+        builderName: luciBuilder,
+        gitBranch: gitBranch,
+        result: result,
+        resultsPath: resultsPath,
+      );
+    } else if (serviceAccountTokenFile != null) {
       final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
       /// Cocoon references LUCI tasks by the [luciBuilder] instead of [taskName].
       await cocoon.sendTaskResult(builderName: luciBuilder, result: result, gitBranch: gitBranch);
@@ -366,6 +388,12 @@ final ArgParser _argParser = ArgParser()
           'test with a `required_agent_capabilities` value of "mac/android"\n'
           'on a windows host). Each test publishes its '
           '`required_agent_capabilities`\nin the `manifest.yaml` file.',
+  )
+  ..addOption(
+    'results-path',
+    help: '[Flutter infrastructure] File path for test results. If passed with\n'
+          'task, will write test results to the file. Otherwise, will upload\n'
+          'JSON in file to Cocoon as POST request.'
   )
   ..addOption(
     'service-account-token-file',

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -378,7 +378,7 @@ final ArgParser _argParser = ArgParser()
           '`required_agent_capabilities`\nin the `manifest.yaml` file.',
   )
   ..addOption(
-    'results-path',
+    'results-file',
     help: '[Flutter infrastructure] File path for test results. If passed with\n'
           'task, will write test results to the file.'
   )

--- a/dev/devicelab/bin/test_runner.dart
+++ b/dev/devicelab/bin/test_runner.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:flutter_devicelab/command/upload_metrics.dart';
+
+final CommandRunner<void> runner =
+    CommandRunner<void>('devicelab_runner', 'DeviceLab test runner for recording performance metrics on applications')
+      ..addCommand(UploadMetricsCommand());
+
+Future<void> main(List<String> rawArgs) async {
+  runner.run(rawArgs).catchError((dynamic error) {
+    stderr.writeln('$error\n');
+    stderr.writeln('Usage:\n');
+    stderr.writeln(runner.usage);
+    exit(64); // Exit code 64 indicates a usage error.
+  });
+}

--- a/dev/devicelab/lib/command/upload_metrics.dart
+++ b/dev/devicelab/lib/command/upload_metrics.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import '../framework/cocoon.dart';
+
+class UploadMetricsCommand extends Command<void> {
+  UploadMetricsCommand() {
+    argParser.addOption('results-file', help: 'Test results JSON to upload to Cocoon.');
+    argParser.addOption(
+      'service-account-token-file',
+      help: 'Authentication token for uploading results.',
+    );
+  }
+
+  @override
+  String get name => 'upload-metrics';
+
+  @override
+  String get description => '[Flutter infrastructure] Upload metrics data to Cocoon';
+
+  @override
+  Future<void> run() async {
+    final String resultsPath = argResults['results-file'] as String;
+    final String serviceAccountTokenFile = argResults['service-account-token-file'] as String;
+
+    final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
+    return cocoon.sendResultsPath(resultsPath);
+  }
+}

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -34,9 +34,9 @@ class Cocoon {
   Cocoon({
     String serviceAccountTokenPath,
     @visibleForTesting Client httpClient,
-    @visibleForTesting FileSystem filesystem,
+    @visibleForTesting this.fs = const LocalFileSystem(),
     @visibleForTesting this.processRunSync = Process.runSync,
-  }) : _httpClient = AuthenticatedCocoonClient(serviceAccountTokenPath, httpClient: httpClient, filesystem: filesystem);
+  }) : _httpClient = AuthenticatedCocoonClient(serviceAccountTokenPath, httpClient: httpClient, filesystem: fs);
 
   /// Client to make http requests to Cocoon.
   final AuthenticatedCocoonClient _httpClient;
@@ -45,6 +45,9 @@ class Cocoon {
 
   /// Url used to send results to.
   static const String baseCocoonApiUrl = 'https://flutter-dashboard.appspot.com/api';
+
+  /// Underlying [FileSystem] to use.
+  final FileSystem fs;
 
   static final Logger logger = Logger('CocoonClient');
 
@@ -61,8 +64,32 @@ class Cocoon {
     return _commitSha = result.stdout as String;
   }
 
+  /// Upload the JSON results in [resultsPath] to Cocoon.
+  ///
+  /// Flutter infrastructure's workflow is:
+  /// 1. Run DeviceLab test, writing results to a known path
+  /// 2. Request service account token from luci auth (valid for at least 3 minutes)
+  /// 3. Upload results from (1) to Cocooon
+  Future<void> sendResultsPath(String resultsPath) async {
+    final File resultFile = fs.file(resultsPath);
+    final Map<String, dynamic> resultsJson = json.decode(await resultFile.readAsString()) as Map<String, dynamic>;
+
+    final Map<String, dynamic> response = await _sendCocoonRequest('update-task-status', resultsJson);
+    if (response['Name'] != null) {
+      logger.info('Updated Cocoon with results from this task');
+    } else {
+      logger.info(response);
+      logger.severe('Failed to updated Cocoon with results from this task');
+    }
+  }
+
   /// Send [TaskResult] to Cocoon.
-  Future<void> sendTaskResult({@required String builderName, @required TaskResult result, @required String gitBranch}) async {
+  // TODO(chillers): Remove when sendResultsPath is used in prod. https://github.com/flutter/flutter/issues/72457
+  Future<void> sendTaskResult({
+    @required String builderName,
+    @required TaskResult result,
+    @required String gitBranch,
+  }) async {
     assert(builderName != null);
     assert(gitBranch != null);
     assert(result != null);
@@ -73,7 +100,51 @@ class Cocoon {
       print('${rec.level.name}: ${rec.time}: ${rec.message}');
     });
 
-    final Map<String, dynamic> status = <String, dynamic>{
+    final Map<String, dynamic> updateRequest = _constructUpdateRequest(
+      gitBranch: gitBranch,
+      builderName: builderName,
+      result: result,
+    );
+    final Map<String, dynamic> response = await _sendCocoonRequest('update-task-status', updateRequest);
+    if (response['Name'] != null) {
+      logger.info('Updated Cocoon with results from this task');
+    } else {
+      logger.info(response);
+      logger.severe('Failed to updated Cocoon with results from this task');
+    }
+  }
+
+  /// Write the given parameters into an update task request and store the JSON in [resultsPath].
+  Future<void> writeTaskResultToFile({
+    @required String builderName,
+    @required String gitBranch,
+    @required TaskResult result,
+    @required String resultsPath,
+  }) async {
+    assert(builderName != null);
+    assert(gitBranch != null);
+    assert(result != null);
+    assert(resultsPath != null);
+
+    final Map<String, dynamic> updateRequest = _constructUpdateRequest(
+      gitBranch: gitBranch,
+      builderName: builderName,
+      result: result,
+    );
+    final File resultFile = fs.file(resultsPath);
+    if (resultFile.existsSync()) {
+      throw CocoonException('Results file already exists');
+    }
+
+    resultFile.writeAsStringSync(json.encode(updateRequest));
+  }
+
+  Map<String, dynamic> _constructUpdateRequest({
+    @required String builderName,
+    @required TaskResult result,
+    @required String gitBranch,
+  }) {
+    final Map<String, dynamic> updateRequest = <String, dynamic>{
       'CommitBranch': gitBranch,
       'CommitSha': commitSha,
       'BuilderName': builderName,
@@ -81,7 +152,7 @@ class Cocoon {
     };
 
     // Make a copy of result data because we may alter it for validation below.
-    status['ResultData'] = result.data;
+    updateRequest['ResultData'] = result.data;
 
     final List<String> validScoreKeys = <String>[];
     if (result.benchmarkScoreKeys != null) {
@@ -95,15 +166,9 @@ class Cocoon {
         }
       }
     }
-    status['BenchmarkScoreKeys'] = validScoreKeys;
+    updateRequest['BenchmarkScoreKeys'] = validScoreKeys;
 
-    final Map<String, dynamic> response = await _sendCocoonRequest('update-task-status', status);
-    if (response['Name'] != null) {
-      logger.info('Updated Cocoon with results from this task');
-    } else {
-      logger.info(response);
-      logger.severe('Failed to updated Cocoon with results from this task');
-    }
+    return updateRequest;
   }
 
   /// Make an API request to Cocoon.

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -48,7 +48,7 @@ void main() {
       _processResult = ProcessResult(1, 0, commitSha, '');
       cocoon = Cocoon(
         serviceAccountTokenPath: serviceAccountTokenPath,
-        filesystem: fs,
+        fs: fs,
         httpClient: mockClient,
         processRunSync: runSyncStub,
       );
@@ -60,7 +60,7 @@ void main() {
       _processResult = ProcessResult(1, 1, '', '');
       cocoon = Cocoon(
         serviceAccountTokenPath: serviceAccountTokenPath,
-        filesystem: fs,
+        fs: fs,
         httpClient: mockClient,
         processRunSync: runSyncStub,
       );
@@ -68,12 +68,69 @@ void main() {
       expect(() => cocoon.commitSha, throwsA(isA<CocoonException>()));
     });
 
+    test('writes expected update task json', () async {
+      _processResult = ProcessResult(1, 0, commitSha, '');
+      final TaskResult result = TaskResult.fromJson(<String, dynamic>{
+        'success': true,
+        'data': <String, dynamic>{
+          'i': 0,
+          'j': 0,
+          'not_a_metric': 'something',
+        },
+        'benchmarkScoreKeys': <String>['i', 'j'],
+      });
+
+      cocoon = Cocoon(
+        fs: fs,
+        processRunSync: runSyncStub,
+      );
+
+      const String resultsPath = 'results.json';
+      await cocoon.writeTaskResultToFile(
+        builderName: 'builderAbc',
+        gitBranch: 'master',
+        result: result,
+        resultsPath: resultsPath,
+      );
+
+      final String resultJson = fs.file(resultsPath).readAsStringSync();
+      const String expectedJson = '{'
+          '"CommitBranch":"master",'
+          '"CommitSha":"$commitSha",'
+          '"BuilderName":"builderAbc",'
+          '"NewStatus":"Succeeded",'
+          '"ResultData":{"i":0.0,"j":0.0,"not_a_metric":"something"},'
+          '"BenchmarkScoreKeys":["i","j"]}';
+      expect(resultJson, expectedJson);
+    });
+
+    test('uploads expected update task payload from results file', () async {
+      _processResult = ProcessResult(1, 0, commitSha, '');
+      cocoon = Cocoon(
+        fs: fs,
+        httpClient: mockClient,
+        processRunSync: runSyncStub,
+        serviceAccountTokenPath: serviceAccountTokenPath,
+      );
+
+      const String resultsPath = 'results.json';
+      const String updateTaskJson = '{'
+          '"CommitBranch":"master",'
+          '"CommitSha":"$commitSha",'
+          '"BuilderName":"builderAbc",'
+          '"NewStatus":"Succeeded",'
+          '"ResultData":{"i":0.0,"j":0.0,"not_a_metric":"something"},'
+          '"BenchmarkScoreKeys":["i","j"]}';
+      fs.file(resultsPath).writeAsStringSync(updateTaskJson);
+      await cocoon.sendResultsPath(resultsPath);
+    });
+
     test('sends expected request from successful task', () async {
       mockClient = MockClient((Request request) async => Response('{}', 200));
 
       cocoon = Cocoon(
         serviceAccountTokenPath: serviceAccountTokenPath,
-        filesystem: fs,
+        fs: fs,
         httpClient: mockClient,
       );
 
@@ -87,12 +144,13 @@ void main() {
 
       cocoon = Cocoon(
         serviceAccountTokenPath: serviceAccountTokenPath,
-        filesystem: fs,
+        fs: fs,
         httpClient: mockClient,
       );
 
       final TaskResult result = TaskResult.success(<String, dynamic>{});
-      expect(() => cocoon.sendTaskResult(builderName: 'builderAbc', gitBranch: 'branchAbc', result: result), throwsA(isA<ClientException>()));
+      expect(() => cocoon.sendTaskResult(builderName: 'builderAbc', gitBranch: 'branchAbc', result: result),
+          throwsA(isA<ClientException>()));
     });
 
     test('null git branch throws error', () async {
@@ -100,12 +158,13 @@ void main() {
 
       cocoon = Cocoon(
         serviceAccountTokenPath: serviceAccountTokenPath,
-        filesystem: fs,
+        fs: fs,
         httpClient: mockClient,
       );
 
       final TaskResult result = TaskResult.success(<String, dynamic>{});
-      expect(() => cocoon.sendTaskResult(builderName: 'builderAbc', gitBranch: null, result: result), throwsA(isA<AssertionError>()));
+      expect(() => cocoon.sendTaskResult(builderName: 'builderAbc', gitBranch: null, result: result),
+          throwsA(isA<AssertionError>()));
     });
   });
 


### PR DESCRIPTION
## Description

`luci-auth` can only guarantee service account tokens are valid for 3 minutes after minted.  These tokens can last up to 45 minutes. There's a race condition where when a test has finished, it's token is no longer valid.

To fix this, we need to split the recipe to:
(1) Run devicelab test
(2) Write results to a file
(3) Request token from `luci-auth`
(4) Upload results from file to Cocoon

Since this is running in prod, this adds some complexity for the migration period. Once the recipe and branched recipes are using this method we can remove the extra branching logic. This is expected to be a no-op until enabled in the recipe.

## Related Issues

https://github.com/flutter/flutter/issues/72457

## Tests

Added tests to validate the json body being written to the file and that `Cocoon` can upload results from a file.
