### PR TITLE
Check for iOS simulator SDK during AOT validation instead of assuming x86

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -66,10 +66,14 @@ abstract class AotAssemblyBase extends Target {
     if (targetPlatform != TargetPlatform.ios) {
       throw Exception('aot_assembly is only supported for iOS applications.');
     }
-    if (darwinArchs.contains(DarwinArch.x86_64)) {
+
+    final String sdkRoot = environment.defines[kSdkRoot];
+    final EnvironmentType environmentType =
+        environmentTypeFromSdkroot(environment.fileSystem.directory(sdkRoot));
+    if (environmentType == EnvironmentType.simulator) {
       throw Exception(
         'release/profile builds are only supported for physical devices. '
-        'attempted to build for $darwinArchs.'
+        'attempted to build for simulator.'
       );
     }
     final String codeSizeDirectory = environment.defines[kCodeSizeDirectory];
@@ -95,7 +99,7 @@ abstract class AotAssemblyBase extends Target {
         mainPath: environment.buildDir.childFile('app.dill').path,
         outputPath: environment.fileSystem.path.join(buildOutputPath, getNameForDarwinArch(darwinArch)),
         darwinArch: darwinArch,
-        sdkRoot: environment.defines[kSdkRoot],
+        sdkRoot: sdkRoot,
         bitcode: bitcode,
         quiet: true,
         splitDebugInfo: splitDebugInfo,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -469,7 +469,7 @@ void main() {
         '-arch',
         'armv7',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-c',
         '$build/armv7/snapshot_assembly.S',
         '-o',
@@ -481,7 +481,7 @@ void main() {
         '-arch',
         'arm64',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-c',
         '$build/arm64/snapshot_assembly.S',
         '-o',
@@ -505,7 +505,7 @@ void main() {
         '-install_name',
         '@rpath/App.framework/App',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-o',
         '$build/armv7/App.framework/App',
         '$build/armv7/snapshot_assembly.o',
@@ -528,7 +528,7 @@ void main() {
         '-install_name',
         '@rpath/App.framework/App',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',
@@ -543,7 +543,7 @@ void main() {
       ]),
     ]);
     iosEnvironment.defines[kIosArchs] ='armv7 arm64';
-    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
 
     await const AotAssemblyProfile().build(iosEnvironment);
 
@@ -557,7 +557,7 @@ void main() {
   testUsingContext('AotAssemblyProfile with bitcode sends correct argument to snapshotter (one arch)', () async {
     iosEnvironment.defines[kIosArchs] = 'arm64';
     iosEnvironment.defines[kBitcodeFlag] = 'true';
-    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
     final String build = iosEnvironment.buildDir.path;
     processManager.addCommands(<FakeCommand>[
       FakeCommand(command: <String>[
@@ -575,7 +575,7 @@ void main() {
         '-arch',
         'arm64',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-c',
@@ -603,7 +603,7 @@ void main() {
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',
@@ -629,7 +629,7 @@ void main() {
   testUsingContext('AotAssemblyRelease configures gen_snapshot with code size directory', () async {
     iosEnvironment.defines[kCodeSizeDirectory] = 'code_size_1';
     iosEnvironment.defines[kIosArchs] = 'arm64';
-    iosEnvironment.defines[kSdkRoot] = 'path/to/sdk';
+    iosEnvironment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
     iosEnvironment.defines[kBitcodeFlag] = 'true';
     final String build = iosEnvironment.buildDir.path;
     processManager.addCommands(<FakeCommand>[
@@ -650,7 +650,7 @@ void main() {
         '-arch',
         'arm64',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-c',
@@ -678,7 +678,7 @@ void main() {
         // Contains bitcode flag.
         '-fembed-bitcode',
         '-isysroot',
-        'path/to/sdk',
+        'path/to/iPhoneOS.sdk',
         '-o',
         '$build/arm64/App.framework/App',
         '$build/arm64/snapshot_assembly.o',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -181,21 +181,21 @@ void main() {
     Platform: () => macPlatform,
   });
 
-  testUsingContext('AotAssemblyRelease throws exception if asked to build for x86 target', () async {
+  testUsingContext('AotAssemblyRelease throws exception if asked to build for simulator', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Environment environment = Environment.test(
       fileSystem.currentDirectory,
       defines: <String, String>{
         kTargetPlatform: 'ios',
-        kSdkRoot: 'path/to/sdk',
+        kSdkRoot: 'path/to/iPhoneSimulator.sdk',
+        kBuildMode: 'release',
+        kIosArchs: 'arm64'
       },
       processManager: processManager,
       artifacts: artifacts,
       logger: logger,
       fileSystem: fileSystem,
     );
-    environment.defines[kBuildMode] = 'release';
-    environment.defines[kIosArchs] = 'x86_64';
 
     expect(const AotAssemblyRelease().build(environment), throwsA(isA<Exception>()
       .having(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -189,7 +189,7 @@ void main() {
         kTargetPlatform: 'ios',
         kSdkRoot: 'path/to/iPhoneSimulator.sdk',
         kBuildMode: 'release',
-        kIosArchs: 'arm64'
+        kIosArchs: 'x86_64',
       },
       processManager: processManager,
       artifacts: artifacts,


### PR DESCRIPTION
## Description

Check explicitly for a simulator SDK instead of assuming x86 == iOS simulator.

## Related Issues

https://github.com/flutter/flutter/issues/69334
https://github.com/flutter/flutter/pull/69840

## Tests

Updated `AotAssemblyRelease` test.