### PR TITLE
[MergeSemantics] add a code snippet

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7241,7 +7241,7 @@ class Semantics extends SingleChildRenderObjectWidget {
 ///
 /// here is the sample code to use[MergeSemantics] to merge the semantics of  a [checkbox] and [Text] widget.
 ///
-/// ...dart
+///'''dart
 /// MergeSemantics{
 ///  child: ROW{
 ///    children:{
@@ -7252,12 +7252,9 @@ class Semantics extends SingleChildRenderObjectWidget {
 ///    ],
 ///  ),
 /// ),
-/// ...
+/// '''
 ///
 /// {@end-tool}
-///
-///
-///
 ///
 /// Be aware that if two nodes in the subtree have conflicting
 /// semantics, the result may be nonsensical. For example, a subtree

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7238,23 +7238,26 @@ class Semantics extends SingleChildRenderObjectWidget {
 /// the user would not be able to be sure that they were related.
 ///
 /// {@tool snippet}
-/// This snippet shows how to use [MergeSemantics] to merge the semantics of
-/// a [Checkbox] and [Text] widget.
 ///
-/// ```dart
-/// MergeSemantics(
-///   child: Row(
-///     children: <Widget>[
-///       Checkbox(
-///         value: true,
-///         onChanged: (bool value) => null,
-///       ),
-///       const Text("Settings"),
-///     ],
-///   ),
-/// )
-/// ```
+/// here is the sample code to use[MergeSemantics] to merge the semantics of  a [checkbox] and [Text] widget.
+///
+/// ...dart
+/// MergeSemantics{
+///  child: ROW{
+///    children:{
+///     value: true,
+///     onChanged:(value){},
+///    },
+///    Text("Settings"),
+///    ],
+///  ),
+/// ),
+/// ...
+///
 /// {@end-tool}
+///
+///
+///
 ///
 /// Be aware that if two nodes in the subtree have conflicting
 /// semantics, the result may be nonsensical. For example, a subtree


### PR DESCRIPTION
## Description

Added  a code for [MergeSemantics]

## Related Issues

Fixes #71970

## Tests

I added the following tests:N/A because only docs are changed.

## Screenshot
![2ww](https://user-images.githubusercontent.com/55308841/102955696-80e6f880-44fc-11eb-9a82-197d8b1416ba.png)

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I signed the [CLA].
- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] All existing and new tests are passing.
- [x ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
