### PR TITLE
Correct typos in RenderParagraph

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -266,11 +266,10 @@ class RenderParagraph extends RenderBox
   /// Used by this paragraph's internal [TextPainter] to select a
   /// locale-specific font.
   ///
-  /// In some cases the same Unicode character may be rendered differently
-  /// depending
-  /// on the locale. For example the '骨' character is rendered differently in
-  /// the Chinese and Japanese locales. In these cases the [locale] may be used
-  /// to select a locale-specific font.
+  /// In some cases, the same Unicode character may be rendered differently
+  /// depending on the locale. For example, the '骨' character is rendered
+  /// differently in the Chinese and Japanese locales. In these cases, the
+  /// [locale] may be used to select a locale-specific font.
   Locale? get locale => _textPainter.locale;
   /// The value may be null.
   set locale(Locale? value) {
@@ -378,7 +377,7 @@ class RenderParagraph extends RenderBox
         case ui.PlaceholderAlignment.belowBaseline: {
           assert(RenderObject.debugCheckingIntrinsics,
             'Intrinsics are not available for PlaceholderAlignment.baseline, '
-            'PlaceholderAlignment.aboveBaseline, or PlaceholderAlignment.belowBaseline,');
+            'PlaceholderAlignment.aboveBaseline, or PlaceholderAlignment.belowBaseline.');
           return false;
         }
         case ui.PlaceholderAlignment.top:
@@ -432,7 +431,7 @@ class RenderParagraph extends RenderBox
     final List<PlaceholderDimensions> placeholderDimensions = List<PlaceholderDimensions>.filled(childCount, PlaceholderDimensions.empty, growable: false);
     int childIndex = 0;
     // Takes textScaleFactor into account because the content of the placeholder
-    // span will be scale up when it paints.
+    // span will be scaled up when it paints.
     width = width / textScaleFactor;
     while (child != null) {
       final Size size = child.getDryLayout(BoxConstraints(maxWidth: width));
@@ -556,7 +555,7 @@ class RenderParagraph extends RenderBox
     // Leave height unconstrained, which will overflow if expanded past.
     BoxConstraints boxConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
     // The content will be enlarged by textScaleFactor during painting phase.
-    // We reduce constraint by textScaleFactor so that the content will fit
+    // We reduce constraints by textScaleFactor, so that the content will fit
     // into the box once it is enlarged.
     boxConstraints = boxConstraints / textScaleFactor;
     while (child != null) {


### PR DESCRIPTION
## Description

Corrects some typos I found while reading through `RenderParagraph`. It turned out to be less useful because some of the typos were removed with the recent rework (#70656).

I am not sure if this PR is even useful now, however, I figured I would open it anyway :)

## Tests

I only changed docs and comments (+ one assert) and all existing tests are passing.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
