### PR TITLE
Timer based pointer event resampling

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -456,6 +456,12 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     _hitTests.clear();
   }
 
+  /// Overrides the sampling clock for debugging and testing.
+  ///
+  /// This value is ignored in non-debug builds.
+  @protected
+  SamplingClock? get debugSamplingClock => null;
+
   void _handleSampleTimeChanged() {
     if (!locked) {
       if (resamplingEnabled) {
@@ -470,8 +476,9 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   SamplingClock get _samplingClock {
     SamplingClock value = SamplingClock();
     assert(() {
-      if (debugSamplingClock != null)
-        value = debugSamplingClock!;
+      final SamplingClock? debugValue = debugSamplingClock;
+      if (debugValue != null)
+        value = debugValue;
       return true;
     }());
     return value;
@@ -503,11 +510,6 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   /// Non-negative [samplingOffset] is allowed but will effectively
   /// disable resampling.
   Duration samplingOffset = _defaultSamplingOffset;
-
-  /// Overrides the sampling clock for debugging and testing.
-  ///
-  /// This value is ignored in non-debug builds.
-  SamplingClock? debugSamplingClock;
 }
 
 /// Variant of [FlutterErrorDetails] with extra fields for the gesture

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:ui' as ui show PointerDataPacket;
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -24,10 +25,12 @@ typedef _HandleSampleTimeChangedCallback = void Function();
 // Class that handles resampling of touch events for multiple pointer
 // devices.
 //
+// `samplingInterval` is used to determine the approximate next
+// time for resampling.
 // SchedulerBinding's `currentSystemFrameTimeStamp` is used to determine
 // sample time.
 class _Resampler {
-  _Resampler(this._handlePointerEvent, this._handleSampleTimeChanged);
+  _Resampler(this._handlePointerEvent, this._handleSampleTimeChanged, this._samplingInterval);
 
   // Resamplers used to filter incoming pointer events.
   final Map<int, PointerEventResampler> _resamplers = <int, PointerEventResampler>{};
@@ -35,8 +38,11 @@ class _Resampler {
   // Flag to track if a frame callback has been scheduled.
   bool _frameCallbackScheduled = false;
 
-  // Current frame time for resampling.
+  // Last frame time for resampling.
   Duration _frameTime = Duration.zero;
+
+  // Time since `_frameTime` was updated.
+  Stopwatch _frameTimeAge = clock.stopwatch()..start();
 
   // Last sample time and time stamp of last event.
   //
@@ -50,12 +56,18 @@ class _Resampler {
   // Callback used to handle sample time changes.
   final _HandleSampleTimeChangedCallback _handleSampleTimeChanged;
 
+  // Interval used for sampling.
+  final Duration _samplingInterval;
+
+  // Timer used to schedule sampling.
+  Timer? _sampleTimer;
+
   // Add `event` for resampling or dispatch it directly if
   // not a touch event.
   void addOrDispatch(PointerEvent event) {
     final SchedulerBinding? scheduler = SchedulerBinding.instance;
     assert(scheduler != null);
-      // Add touch event to resampler or dispatch pointer event directly.
+    // Add touch event to resampler or dispatch pointer event directly.
     if (event.kind == PointerDeviceKind.touch) {
       // Save last event time for debugPrint of resampling margin.
       _lastEventTime = event.timeStamp;
@@ -74,23 +86,35 @@ class _Resampler {
   //
   // `samplingOffset` is relative to the current frame time, which
   // can be in the past when we're not actively resampling.
-  // `samplingInterval` is used to determine the approximate next
-  // time for resampling.
-  // `currentSystemFrameTimeStamp` is used to determine the current
-  // frame time.
-  void sample(Duration samplingOffset, Duration samplingInterval) {
+  void sample(Duration samplingOffset) {
     final SchedulerBinding? scheduler = SchedulerBinding.instance;
     assert(scheduler != null);
+
+    // Initialize `_frameTime` if needed. This will be used for periodic
+    // sampling when frame callbacks are not received.
+    if (_frameTime == Duration.zero) {
+      _frameTime = Duration(milliseconds: clock.now().millisecondsSinceEpoch);
+      _frameTimeAge = clock.stopwatch()..start();
+    }
+
+    // Calculate the effective frame time by taking the number
+    // of sampling intervals since last time `_frameTime` was
+    // updated into account. This allows us to advance sample
+    // time without having to receive frame callbacks.
+    final int samplingIntervalUs = _samplingInterval.inMicroseconds;
+    final int elapsedIntervals = _frameTimeAge.elapsedMicroseconds ~/ samplingIntervalUs;
+    final int elapsedUs = elapsedIntervals * samplingIntervalUs;
+    final Duration frameTime = _frameTime + Duration(microseconds: elapsedUs);
 
     // Determine sample time by adding the offset to the current
     // frame time. This is expected to be in the past and not
     // result in any dispatched events unless we're actively
     // resampling events.
-    final Duration sampleTime = _frameTime + samplingOffset;
+    final Duration sampleTime = frameTime + samplingOffset;
 
     // Determine next sample time by adding the sampling interval
     // to the current sample time.
-    final Duration nextSampleTime = sampleTime + samplingInterval;
+    final Duration nextSampleTime = sampleTime + _samplingInterval;
 
     // Iterate over active resamplers and sample pointer events for
     // current sample time.
@@ -106,25 +130,34 @@ class _Resampler {
     // Save last sample time for debugPrint of resampling margin.
     _lastSampleTime = sampleTime;
 
+    // Early out if another call to `sample` isn't needed.
+    if (_resamplers.isEmpty) {
+      _sampleTimer?.cancel();
+      return;
+    }
+
     // Schedule a frame callback if another call to `sample` is needed.
-    if (!_frameCallbackScheduled && _resamplers.isNotEmpty) {
+    if (!_frameCallbackScheduled) {
       _frameCallbackScheduled = true;
-      scheduler?.scheduleFrameCallback((_) {
+      // Add a post frame callback as this avoids producing unnecessary
+      // frames but ensures that sampling phase is adjusted to frame
+      // time when frames are produced.
+      scheduler?.addPostFrameCallback((_) {
         _frameCallbackScheduled = false;
         // We use `currentSystemFrameTimeStamp` here as it's critical that
         // sample time is in the same clock as the event time stamps, and
         // never adjusted or scaled like `currentFrameTimeStamp`.
         _frameTime = scheduler.currentSystemFrameTimeStamp;
-        assert(() {
-          if (debugPrintResamplingMargin) {
-            final Duration resamplingMargin = _lastEventTime - _lastSampleTime;
-              debugPrint('$resamplingMargin');
-          }
-          return true;
-        }());
-        _handleSampleTimeChanged();
+        _frameTimeAge.reset();
+        // Trigger a sample time change.
+        _onSampleTimeChanged();
       });
     }
+
+    // Schedule a sample callback if another call to `sample` is needed.
+    // This provides periodic samples based on the last `_frameTime`
+    // until another frame callback is received.
+    _scheduleSampleCallback();
   }
 
   // Stop all resampling and dispatched any queued events.
@@ -133,6 +166,23 @@ class _Resampler {
       resampler.stop(_handlePointerEvent);
     }
     _resamplers.clear();
+    _frameTime = Duration.zero;
+  }
+
+  void _scheduleSampleCallback() {
+    _sampleTimer?.cancel();
+    _sampleTimer = Timer(_samplingInterval, _onSampleTimeChanged);
+  }
+
+  void _onSampleTimeChanged() {
+    assert(() {
+      if (debugPrintResamplingMargin) {
+        final Duration resamplingMargin = _lastEventTime - _lastSampleTime;
+          debugPrint('$resamplingMargin');
+      }
+      return true;
+    }());
+    _handleSampleTimeChanged();
   }
 }
 
@@ -147,7 +197,8 @@ const Duration _defaultSamplingOffset = Duration(milliseconds: -38);
 // The sampling interval.
 //
 // Sampling interval is used to determine the approximate time for subsequent
-// sampling. This is used to decide if early processing of up and removed events
+// sampling. This is used to sample events when frame callbacks are not
+// being received and decide if early processing of up and removed events
 // is appropriate. 16667 us for 60hz sampling interval.
 const Duration _samplingInterval = Duration(microseconds: 16667);
 
@@ -270,7 +321,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
 
     if (resamplingEnabled) {
       _resampler.addOrDispatch(event);
-      _resampler.sample(samplingOffset, _samplingInterval);
+      _resampler.sample(samplingOffset);
       return;
     }
 
@@ -401,7 +452,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void _handleSampleTimeChanged() {
     if (!locked) {
       if (resamplingEnabled) {
-        _resampler.sample(samplingOffset, _samplingInterval);
+        _resampler.sample(samplingOffset);
       }
       else {
         _resampler.stop();
@@ -414,6 +465,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   late final _Resampler _resampler = _Resampler(
     _handlePointerEventImmediately,
     _handleSampleTimeChanged,
+    _samplingInterval,
   );
 
   /// Enable pointer event resampling for touch devices by setting

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -33,7 +33,7 @@ class SamplingClock {
 // Class that handles resampling of touch events for multiple pointer
 // devices.
 //
-// `samplingInterval` is used to determine the approximate next
+// The `samplingInterval` is used to determine the approximate next
 // time for resampling.
 // SchedulerBinding's `currentSystemFrameTimeStamp` is used to determine
 // sample time.
@@ -92,9 +92,9 @@ class _Resampler {
 
   // Sample and dispatch events.
   //
-  // `samplingOffset` is relative to the current frame time, which
+  // The `samplingOffset` is relative to the current frame time, which
   // can be in the past when we're not actively resampling.
-  // `samplingClock` is the clock used to determine frame time age.
+  // The `samplingClock` is the clock used to determine frame time age.
   void sample(Duration samplingOffset, SamplingClock clock) {
     final SchedulerBinding? scheduler = SchedulerBinding.instance;
     assert(scheduler != null);

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
@@ -10,7 +10,9 @@
 
 import 'dart:ui' as ui;
 
+import 'package:clock/clock.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -19,6 +21,7 @@ void main() {
   testWidgets('PointerEvent resampling on a widget', (WidgetTester tester) async {
     assert(WidgetsBinding.instance == binding);
     Duration currentTestFrameTime() => Duration(milliseconds: binding.clock.now().millisecondsSinceEpoch);
+    void requestFrame() => SchedulerBinding.instance!.scheduleFrameCallback((_) {});
     final Duration epoch = currentTestFrameTime();
     final ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
@@ -30,37 +33,37 @@ void main() {
         ui.PointerData(
             change: ui.PointerChange.down,
             physicalX: 0.0,
+            timeStamp: epoch + const Duration(milliseconds: 0),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 15.0,
             timeStamp: epoch + const Duration(milliseconds: 10),
         ),
         ui.PointerData(
             change: ui.PointerChange.move,
-            physicalX: 10.0,
+            physicalX: 30.0,
             timeStamp: epoch + const Duration(milliseconds: 20),
         ),
         ui.PointerData(
             change: ui.PointerChange.move,
-            physicalX: 20.0,
+            physicalX: 45.0,
             timeStamp: epoch + const Duration(milliseconds: 30),
         ),
         ui.PointerData(
             change: ui.PointerChange.move,
-            physicalX: 30.0,
+            physicalX: 50.0,
             timeStamp: epoch + const Duration(milliseconds: 40),
         ),
         ui.PointerData(
-            change: ui.PointerChange.move,
-            physicalX: 40.0,
-            timeStamp: epoch + const Duration(milliseconds: 50),
-        ),
-        ui.PointerData(
             change: ui.PointerChange.up,
-            physicalX: 40.0,
-            timeStamp: epoch + const Duration(milliseconds: 60),
+            physicalX: 60.0,
+            timeStamp: epoch + const Duration(milliseconds: 40),
         ),
         ui.PointerData(
             change: ui.PointerChange.remove,
-            physicalX: 40.0,
-            timeStamp: epoch + const Duration(milliseconds: 70),
+            physicalX: 60.0,
+            timeStamp: epoch + const Duration(milliseconds: 40),
         ),
       ],
     );
@@ -78,35 +81,39 @@ void main() {
       ),
     );
 
-    GestureBinding.instance!.resamplingEnabled = true;
-    const Duration kSamplingOffset = Duration(milliseconds: -5);
-    GestureBinding.instance!.samplingOffset = kSamplingOffset;
-    ui.window.onPointerDataPacket!(packet);
-    expect(events.length, 0);
+    await withClock(binding.clock, () async {
+      GestureBinding.instance!.resamplingEnabled = true;
+      const Duration kSamplingOffset = Duration(milliseconds: -5);
+      GestureBinding.instance!.samplingOffset = kSamplingOffset;
+      ui.window.onPointerDataPacket!(packet);
+      expect(events.length, 0);
 
-    await tester.pump(const Duration(milliseconds: 20));
-    expect(events.length, 1);
-    expect(events[0], isA<PointerDownEvent>());
-    expect(events[0].timeStamp, currentTestFrameTime() + kSamplingOffset);
-    expect(events[0].position, Offset(5.0 / ui.window.devicePixelRatio, 0.0));
+      requestFrame();
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(events.length, 1);
+      expect(events[0], isA<PointerDownEvent>());
+      expect(events[0].timeStamp, currentTestFrameTime() + kSamplingOffset);
+      expect(events[0].position, Offset(7.5 / ui.window.devicePixelRatio, 0.0));
 
-    // Now the system time is epoch + 40ms
-    await tester.pump(const Duration(milliseconds: 20));
-    expect(events.length, 2);
-    expect(events[1].timeStamp, currentTestFrameTime() + kSamplingOffset);
-    expect(events[1], isA<PointerMoveEvent>());
-    expect(events[1].position, Offset(25.0 / ui.window.devicePixelRatio, 0.0));
-    expect(events[1].delta, Offset(20.0 / ui.window.devicePixelRatio, 0.0));
+      // Now the system time is epoch + 20ms
+      requestFrame();
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(events.length, 2);
+      expect(events[1].timeStamp, currentTestFrameTime() + kSamplingOffset);
+      expect(events[1], isA<PointerMoveEvent>());
+      expect(events[1].position, Offset(22.5 / ui.window.devicePixelRatio, 0.0));
+      expect(events[1].delta, Offset(15.0 / ui.window.devicePixelRatio, 0.0));
 
-    // Now the system time is epoch + 60ms
-    await tester.pump(const Duration(milliseconds: 20));
-    expect(events.length, 4);
-    expect(events[2].timeStamp, currentTestFrameTime() + kSamplingOffset);
-    expect(events[2], isA<PointerMoveEvent>());
-    expect(events[2].position, Offset(40.0 / ui.window.devicePixelRatio, 0.0));
-    expect(events[2].delta, Offset(15.0 / ui.window.devicePixelRatio, 0.0));
-    expect(events[3].timeStamp, currentTestFrameTime() + kSamplingOffset);
-    expect(events[3], isA<PointerUpEvent>());
-    expect(events[3].position, Offset(40.0 / ui.window.devicePixelRatio, 0.0));
+      // Now the system time is epoch + 30ms
+      requestFrame();
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(events.length, 4);
+      expect(events[2].timeStamp, currentTestFrameTime() + kSamplingOffset);
+      expect(events[2], isA<PointerMoveEvent>());
+      expect(events[2].position, Offset(37.5 / ui.window.devicePixelRatio, 0.0));
+      expect(events[2].delta, Offset(15.0 / ui.window.devicePixelRatio, 0.0));
+      expect(events[3].timeStamp, currentTestFrameTime() + kSamplingOffset);
+      expect(events[3], isA<PointerUpEvent>());
+    });
   });
 }

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
@@ -16,18 +16,25 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class TestResampleEventFlutterBinding extends AutomatedTestWidgetsFlutterBinding {
+  @override
+  SamplingClock? get debugSamplingClock => TestSamplingClock(this.clock);
+}
+
 class TestSamplingClock implements SamplingClock {
   TestSamplingClock(this._clock);
 
   @override
   DateTime now() => _clock.now();
-  @override Stopwatch stopwatch() => _clock.stopwatch();
+
+  @override
+  Stopwatch stopwatch() => _clock.stopwatch();
 
   final Clock _clock;
 }
 
 void main() {
-  final TestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+  final TestWidgetsFlutterBinding binding = TestResampleEventFlutterBinding();
   testWidgets('PointerEvent resampling on a widget', (WidgetTester tester) async {
     assert(WidgetsBinding.instance == binding);
     Duration currentTestFrameTime() => Duration(milliseconds: binding.clock.now().millisecondsSinceEpoch);
@@ -94,7 +101,6 @@ void main() {
     GestureBinding.instance!.resamplingEnabled = true;
     const Duration kSamplingOffset = Duration(milliseconds: -5);
     GestureBinding.instance!.samplingOffset = kSamplingOffset;
-    GestureBinding.instance!.debugSamplingClock = TestSamplingClock(binding.clock);
     ui.window.onPointerDataPacket!(packet);
     expect(events.length, 0);
 

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
@@ -19,7 +19,8 @@ import 'package:flutter_test/flutter_test.dart';
 class TestSamplingClock implements SamplingClock {
   TestSamplingClock(this._clock);
 
-  @override DateTime now() => _clock.now();
+  @override
+  DateTime now() => _clock.now();
   @override Stopwatch stopwatch() => _clock.stopwatch();
 
   final Clock _clock;

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
@@ -57,7 +57,7 @@ void testResampleEvent(String description, ResampleEventTest callback) {
     fakeAsync((FakeAsync async) {
       callback(async);
     }, initialTime: DateTime.utc(2015, 1, 1));
-  }, skip: isBrowser);
+  }, skip: isBrowser); // Fake clock is not working with the web platform.
 }
 
 void main() {

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
@@ -1,0 +1,186 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
+
+import '../flutter_test_alternative.dart';
+
+typedef HandleEventCallback = void Function(PointerEvent event);
+
+class TestResampleEventFlutterBinding extends BindingBase with GestureBinding, SchedulerBinding {
+  HandleEventCallback? callback;
+  FrameCallback? postFrameCallback;
+  Duration? frameTime;
+
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    super.handleEvent(event, entry);
+    if (callback != null)
+      callback?.call(event);
+  }
+
+  @override
+  Duration get currentSystemFrameTimeStamp {
+    assert(frameTime != null);
+    return frameTime!;
+  }
+
+  @override
+  int addPostFrameCallback(FrameCallback callback) {
+    postFrameCallback = callback;
+    return 0;
+  }
+
+  @override
+  SamplingClock? get debugSamplingClock => TestSamplingClock();
+}
+
+class TestSamplingClock implements SamplingClock {
+  @override
+  DateTime now() => clock.now();
+
+  @override
+  Stopwatch stopwatch() => clock.stopwatch();
+}
+
+typedef ResampleEventTest = void Function(FakeAsync async);
+
+void testResampleEvent(String description, ResampleEventTest callback) {
+  test(description, () {
+    fakeAsync((FakeAsync async) {
+      callback(async);
+    }, initialTime: DateTime.utc(2015, 1, 1));
+  });
+}
+
+void main() {
+  final TestResampleEventFlutterBinding binding = TestResampleEventFlutterBinding();
+  testResampleEvent('Pointer event resampling', (FakeAsync async) {
+    Duration currentTime() => Duration(milliseconds: clock.now().millisecondsSinceEpoch);
+    final Duration epoch = currentTime();
+    final ui.PointerDataPacket packet = ui.PointerDataPacket(
+      data: <ui.PointerData>[
+        ui.PointerData(
+            change: ui.PointerChange.add,
+            physicalX: 0.0,
+            timeStamp: epoch + const Duration(milliseconds: 0),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.down,
+            physicalX: 0.0,
+            timeStamp: epoch + const Duration(milliseconds: 10),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 10.0,
+            timeStamp: epoch + const Duration(milliseconds: 20),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 20.0,
+            timeStamp: epoch + const Duration(milliseconds: 30),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 30.0,
+            timeStamp: epoch + const Duration(milliseconds: 40),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 40.0,
+            timeStamp: epoch + const Duration(milliseconds: 50),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.move,
+            physicalX: 50.0,
+            timeStamp: epoch + const Duration(milliseconds: 60),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.up,
+            physicalX: 50.0,
+            timeStamp: epoch + const Duration(milliseconds: 70),
+        ),
+        ui.PointerData(
+            change: ui.PointerChange.remove,
+            physicalX: 50.0,
+            timeStamp: epoch + const Duration(milliseconds: 70),
+        ),
+      ],
+    );
+
+    const Duration samplingOffset = Duration(milliseconds: -5);
+    const Duration frameInterval = Duration(microseconds: 16667);
+
+    GestureBinding.instance!.resamplingEnabled = true;
+    GestureBinding.instance!.samplingOffset = samplingOffset;
+
+    final List<PointerEvent> events = <PointerEvent>[];
+    binding.callback = events.add;
+
+    ui.window.onPointerDataPacket?.call(packet);
+
+    // No pointer events should have been dispatched yet.
+    expect(events.length, 0);
+
+    // Frame callback should have been requested.
+    FrameCallback? callback = binding.postFrameCallback;
+    binding.postFrameCallback = null;
+    expect(callback, isNotNull);
+
+    binding.frameTime = epoch + const Duration(milliseconds: 15);
+    callback!(Duration.zero);
+
+    // One pointer event should have been dispatched.
+    expect(events.length, 1);
+    expect(events[0], isA<PointerDownEvent>());
+    expect(events[0].timeStamp, binding.frameTime! + samplingOffset);
+    expect(events[0].position, Offset(0.0 / ui.window.devicePixelRatio, 0.0));
+
+    // Second frame callback should have been requested.
+    callback = binding.postFrameCallback;
+    binding.postFrameCallback = null;
+    expect(callback, isNotNull);
+
+    final Duration frameTime = epoch + const Duration(milliseconds: 25);
+    binding.frameTime = frameTime;
+    callback!(Duration.zero);
+
+    // Second pointer event should have been dispatched.
+    expect(events.length, 2);
+    expect(events[1], isA<PointerMoveEvent>());
+    expect(events[1].timeStamp, binding.frameTime! + samplingOffset);
+    expect(events[1].position, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
+    expect(events[1].delta, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
+
+    // Verify that resampling continues without a frame callback.
+    async.elapse(frameInterval * 1.5);
+
+    // Third pointer event should have been dispatched.
+    expect(events.length, 3);
+    expect(events[2], isA<PointerMoveEvent>());
+    expect(events[2].timeStamp, frameTime + frameInterval + samplingOffset);
+
+    async.elapse(frameInterval);
+
+    // Remaining pointer events should have been dispatched.
+    expect(events.length, 5);
+    expect(events[3], isA<PointerMoveEvent>());
+    expect(events[3].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
+    expect(events[4], isA<PointerUpEvent>());
+    expect(events[4].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
+
+    async.elapse(frameInterval);
+
+    // No more pointer events should have been dispatched.
+    expect(events.length, 5);
+
+    GestureBinding.instance!.resamplingEnabled = false;
+  });
+}

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
@@ -57,7 +57,7 @@ void testResampleEvent(String description, ResampleEventTest callback) {
     fakeAsync((FakeAsync async) {
       callback(async);
     }, initialTime: DateTime.utc(2015, 1, 1));
-  });
+  }, skip: isBrowser);
 }
 
 void main() {

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -4,8 +4,6 @@
 
 import 'dart:ui' as ui;
 
-import 'package:clock/clock.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
@@ -16,8 +14,6 @@ typedef HandleEventCallback = void Function(PointerEvent event);
 
 class TestGestureFlutterBinding extends BindingBase with GestureBinding, SchedulerBinding {
   HandleEventCallback? callback;
-  FrameCallback? postFrameCallback;
-  Duration? frameTime;
 
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
@@ -25,27 +21,6 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding, Schedul
     if (callback != null)
       callback?.call(event);
   }
-
-  @override
-  Duration get currentSystemFrameTimeStamp {
-    assert(frameTime != null);
-    return frameTime!;
-  }
-
-  @override
-  int addPostFrameCallback(FrameCallback callback) {
-    postFrameCallback = callback;
-    return 0;
-  }
-}
-
-class TestSamplingClock implements SamplingClock {
-  TestSamplingClock(this._clock);
-
-  @override DateTime now() => _clock.now();
-  @override Stopwatch stopwatch() => _clock.stopwatch();
-
-  final Clock _clock;
 }
 
 TestGestureFlutterBinding? _binding;
@@ -326,130 +301,5 @@ void main() {
       expect(events[4], isA<PointerUpEvent>());
       expect(events[4].buttons, equals(0));
     }
-  });
-
-  test('Pointer event resampling', () {
-    fakeAsync((FakeAsync async) {
-      Duration currentTime() => Duration(milliseconds: clock.now().millisecondsSinceEpoch);
-      final Duration epoch = currentTime();
-      final ui.PointerDataPacket packet = ui.PointerDataPacket(
-        data: <ui.PointerData>[
-          ui.PointerData(
-              change: ui.PointerChange.add,
-              physicalX: 0.0,
-              timeStamp: epoch + const Duration(milliseconds: 0),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.down,
-              physicalX: 0.0,
-              timeStamp: epoch + const Duration(milliseconds: 10),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.move,
-              physicalX: 10.0,
-              timeStamp: epoch + const Duration(milliseconds: 20),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.move,
-              physicalX: 20.0,
-              timeStamp: epoch + const Duration(milliseconds: 30),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.move,
-              physicalX: 30.0,
-              timeStamp: epoch + const Duration(milliseconds: 40),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.move,
-              physicalX: 40.0,
-              timeStamp: epoch + const Duration(milliseconds: 50),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.move,
-              physicalX: 50.0,
-              timeStamp: epoch + const Duration(milliseconds: 60),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.up,
-              physicalX: 50.0,
-              timeStamp: epoch + const Duration(milliseconds: 70),
-          ),
-          ui.PointerData(
-              change: ui.PointerChange.remove,
-              physicalX: 50.0,
-              timeStamp: epoch + const Duration(milliseconds: 70),
-          ),
-        ],
-      );
-
-      const Duration samplingOffset = Duration(milliseconds: -5);
-      const Duration frameInterval = Duration(microseconds: 16667);
-
-      GestureBinding.instance!.resamplingEnabled = true;
-      GestureBinding.instance!.samplingOffset = samplingOffset;
-      GestureBinding.instance!.debugSamplingClock = TestSamplingClock(clock);
-
-      final List<PointerEvent> events = <PointerEvent>[];
-      _binding!.callback = events.add;
-
-      ui.window.onPointerDataPacket?.call(packet);
-
-      // No pointer events should have been dispatched yet.
-      expect(events.length, 0);
-
-      // Frame callback should have been requested.
-      FrameCallback? callback = _binding!.postFrameCallback;
-      _binding!.postFrameCallback = null;
-      expect(callback, isNotNull);
-
-      _binding!.frameTime = epoch + const Duration(milliseconds: 15);
-      callback!(Duration.zero);
-
-      // One pointer event should have been dispatched.
-      expect(events.length, 1);
-      expect(events[0], isA<PointerDownEvent>());
-      expect(events[0].timeStamp, _binding!.frameTime! + samplingOffset);
-      expect(events[0].position, Offset(0.0 / ui.window.devicePixelRatio, 0.0));
-
-      // Second frame callback should have been requested.
-      callback = _binding!.postFrameCallback;
-      _binding!.postFrameCallback = null;
-      expect(callback, isNotNull);
-
-      final frameTime = epoch + const Duration(milliseconds: 25);
-      _binding!.frameTime = frameTime;
-      callback!(Duration.zero);
-
-      // Second pointer event should have been dispatched.
-      expect(events.length, 2);
-      expect(events[1], isA<PointerMoveEvent>());
-      expect(events[1].timeStamp, _binding!.frameTime! + samplingOffset);
-      expect(events[1].position, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
-      expect(events[1].delta, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
-
-      // Verify that resampling continues without a frame callback.
-      async.elapse(frameInterval * 1.5);
-
-      // Third pointer event should have been dispatched.
-      expect(events.length, 3);
-      expect(events[2], isA<PointerMoveEvent>());
-      expect(events[2].timeStamp, frameTime + frameInterval + samplingOffset);
-
-      async.elapse(frameInterval);
-
-      // Remaining pointer events should have been dispatched.
-      expect(events.length, 5);
-      expect(events[3], isA<PointerMoveEvent>());
-      expect(events[3].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
-      expect(events[4], isA<PointerUpEvent>());
-      expect(events[4].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
-
-      async.elapse(frameInterval);
-
-      // No more pointer events should have been dispatched.
-      expect(events.length, 5);
-
-      GestureBinding.instance!.resamplingEnabled = false;
-    }, initialTime: DateTime.utc(2015, 1, 1));
   });
 }

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' as ui;
 
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
@@ -31,7 +33,7 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding, Schedul
   }
 
   @override
-  int scheduleFrameCallback(FrameCallback callback, {bool rescheduling = false}) {
+  int addPostFrameCallback(FrameCallback callback, {bool rescheduling = false}) {
     frameCallback = callback;
     return 0;
   }
@@ -315,5 +317,127 @@ void main() {
       expect(events[4], isA<PointerUpEvent>());
       expect(events[4].buttons, equals(0));
     }
+  });
+
+  test('Pointer event resampling', () {
+    fakeAsync((FakeAsync async) {
+      Duration currentTime() => Duration(milliseconds: clock.now().millisecondsSinceEpoch);
+      final Duration epoch = currentTime();
+      final ui.PointerDataPacket packet = ui.PointerDataPacket(
+        data: <ui.PointerData>[
+          ui.PointerData(
+              change: ui.PointerChange.add,
+              physicalX: 0.0,
+              timeStamp: epoch + const Duration(milliseconds: 0),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.down,
+              physicalX: 0.0,
+              timeStamp: epoch + const Duration(milliseconds: 10),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.move,
+              physicalX: 10.0,
+              timeStamp: epoch + const Duration(milliseconds: 20),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.move,
+              physicalX: 20.0,
+              timeStamp: epoch + const Duration(milliseconds: 30),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.move,
+              physicalX: 30.0,
+              timeStamp: epoch + const Duration(milliseconds: 40),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.move,
+              physicalX: 40.0,
+              timeStamp: epoch + const Duration(milliseconds: 50),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.move,
+              physicalX: 50.0,
+              timeStamp: epoch + const Duration(milliseconds: 60),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.up,
+              physicalX: 50.0,
+              timeStamp: epoch + const Duration(milliseconds: 70),
+          ),
+          ui.PointerData(
+              change: ui.PointerChange.remove,
+              physicalX: 50.0,
+              timeStamp: epoch + const Duration(milliseconds: 70),
+          ),
+        ],
+      );
+
+      const Duration samplingOffset = Duration(milliseconds: -5);
+
+      GestureBinding.instance!.resamplingEnabled = true;
+      GestureBinding.instance!.samplingOffset = samplingOffset;
+
+      final List<PointerEvent> events = <PointerEvent>[];
+      _binding!.callback = events.add;
+
+      ui.window.onPointerDataPacket?.call(packet);
+
+      // No pointer events should have been dispatched yet.
+      expect(events.length, 0);
+
+      // Frame callback should have been requested.
+      FrameCallback? callback = _binding!.frameCallback;
+      _binding!.frameCallback = null;
+      expect(callback, isNotNull);
+
+      _binding!.frameTime = epoch + const Duration(milliseconds: 15);
+      callback!(Duration.zero);
+
+      // One pointer event should have been dispatched.
+      expect(events.length, 1);
+      expect(events[0], isA<PointerDownEvent>());
+      expect(events[0].timeStamp, _binding!.frameTime! + samplingOffset);
+      expect(events[0].position, Offset(0.0 / ui.window.devicePixelRatio, 0.0));
+
+      // Second frame callback should have been requested.
+      callback = _binding!.frameCallback;
+      _binding!.frameCallback = null;
+      expect(callback, isNotNull);
+
+      _binding!.frameTime = epoch + const Duration(milliseconds: 25);
+      callback!(Duration.zero);
+
+      // Second pointer event should have been dispatched.
+      expect(events.length, 2);
+      expect(events[1], isA<PointerMoveEvent>());
+      expect(events[1].timeStamp, _binding!.frameTime! + samplingOffset);
+      expect(events[1].position, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
+      expect(events[1].delta, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
+
+      // Verify that resampling continues without a frame callback.
+      async.elapse(const Duration(milliseconds: 17));
+
+      // Third pointer event should have been dispatched.
+      expect(events.length, 3);
+      expect(events[2], isA<PointerMoveEvent>());
+      expect(events[2].timeStamp, greaterThan(currentTime() + samplingOffset));
+
+      async.elapse(const Duration(milliseconds: 34));
+
+      // Remaining pointer events should have been dispatched.
+      expect(events.length, 5);
+      expect(events[3], isA<PointerMoveEvent>());
+      expect(events[3].timeStamp, greaterThan(currentTime() + samplingOffset));
+      expect(events[4], isA<PointerUpEvent>());
+      expect(events[4].timeStamp, greaterThan(currentTime() + samplingOffset));
+
+      async.elapse(const Duration(milliseconds: 51));
+
+      // No more pointer events should have been dispatched.
+      expect(events.length, 5);
+
+      GestureBinding.instance!.resamplingEnabled = false;
+    }, initialTime: DateTime.utc(2015, 1, 1));
   });
 }

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -383,6 +383,7 @@ void main() {
       );
 
       const Duration samplingOffset = Duration(milliseconds: -5);
+      const Duration frameInterval = Duration(microseconds: 16667);
 
       GestureBinding.instance!.resamplingEnabled = true;
       GestureBinding.instance!.samplingOffset = samplingOffset;
@@ -415,7 +416,8 @@ void main() {
       _binding!.postFrameCallback = null;
       expect(callback, isNotNull);
 
-      _binding!.frameTime = epoch + const Duration(milliseconds: 25);
+      final frameTime = epoch + const Duration(milliseconds: 25);
+      _binding!.frameTime = frameTime;
       callback!(Duration.zero);
 
       // Second pointer event should have been dispatched.
@@ -426,23 +428,23 @@ void main() {
       expect(events[1].delta, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
 
       // Verify that resampling continues without a frame callback.
-      async.elapse(const Duration(milliseconds: 17));
+      async.elapse(frameInterval * 1.5);
 
       // Third pointer event should have been dispatched.
       expect(events.length, 3);
       expect(events[2], isA<PointerMoveEvent>());
-      expect(events[2].timeStamp, greaterThan(currentTime() + samplingOffset));
+      expect(events[2].timeStamp, frameTime + frameInterval + samplingOffset);
 
-      async.elapse(const Duration(milliseconds: 34));
+      async.elapse(frameInterval);
 
       // Remaining pointer events should have been dispatched.
       expect(events.length, 5);
       expect(events[3], isA<PointerMoveEvent>());
-      expect(events[3].timeStamp, greaterThan(currentTime() + samplingOffset));
+      expect(events[3].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
       expect(events[4], isA<PointerUpEvent>());
-      expect(events[4].timeStamp, greaterThan(currentTime() + samplingOffset));
+      expect(events[4].timeStamp, frameTime + frameInterval * 2 + samplingOffset);
 
-      async.elapse(const Duration(milliseconds: 51));
+      async.elapse(frameInterval);
 
       // No more pointer events should have been dispatched.
       expect(events.length, 5);


### PR DESCRIPTION
This provides two improvements to pointer event resampling:

1. PostFrameCallbacks are used instead of scheduling frames. This
avoids unnecessary rendering work when resampling is used.

2. Resampling continues when frames are not produced. I.e. input
events keep being delivered at a fixed frequency even if frame
production is taking a long time.

This fixes #72924 