### PR TITLE
Avoid broken symlinks in embedded Flutter frameworks

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -80,6 +80,9 @@ Future<void> main() async {
           'Frameworks',
           'Flutter.framework',
         ));
+
+        checkDirectoryNotExists(path.join(outputFlutterFramework.path, 'Headers'));
+        checkDirectoryNotExists(path.join(outputFlutterFramework.path, 'Modules'));
         final File outputFlutterFrameworkBinary = File(path.join(
           outputFlutterFramework.path,
           'Flutter',

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -109,13 +109,13 @@ EmbedFrameworks() {
   # if it doesn't already exist).
   local xcode_frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
   RunCommand mkdir -p -- "${xcode_frameworks_dir}"
-  RunCommand rsync -av --delete --filter "- .DS_Store/" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
+  RunCommand rsync -av --delete --filter "- .DS_Store" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
 
   # Embed the actual FlutterMacOS.framework that the Flutter app expects to run against,
   # which could be a local build or an arch/type specific build.
 
   # Copy Xcode behavior and don't copy over headers or modules.
-  RunCommand rsync -av --delete --filter "- .DS_Store/" --filter "- Headers/" --filter "- Modules/" "${BUILT_PRODUCTS_DIR}/FlutterMacOS.framework" "${xcode_frameworks_dir}/"
+  RunCommand rsync -av --delete --filter "- .DS_Store" --filter "- Headers" --filter "- Modules" "${BUILT_PRODUCTS_DIR}/FlutterMacOS.framework" "${xcode_frameworks_dir}/"
 
   # Sign the binaries we moved.
   if [[ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -279,13 +279,13 @@ EmbedFlutterFrameworks() {
   # if it doesn't already exist).
   local xcode_frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
   RunCommand mkdir -p -- "${xcode_frameworks_dir}"
-  RunCommand rsync -av --delete --filter "- .DS_Store/" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
+  RunCommand rsync -av --delete --filter "- .DS_Store" "${BUILT_PRODUCTS_DIR}/App.framework" "${xcode_frameworks_dir}"
 
   # Embed the actual Flutter.framework that the Flutter app expects to run against,
   # which could be a local build or an arch/type specific build.
 
   # Copy Xcode behavior and don't copy over headers or modules.
-  RunCommand rsync -av --delete --filter "- .DS_Store/" --filter "- Headers/" --filter "- Modules/" "${BUILT_PRODUCTS_DIR}/Flutter.framework" "${xcode_frameworks_dir}/"
+  RunCommand rsync -av --delete --filter "- .DS_Store" --filter "- Headers" --filter "- Modules" "${BUILT_PRODUCTS_DIR}/Flutter.framework" "${xcode_frameworks_dir}/"
   if [[ "$ACTION" != "install" || "$ENABLE_BITCODE" == "NO" ]]; then
     # Strip bitcode from the destination unless archiving, or if bitcode is disabled entirely.
     RunCommand "${DT_TOOLCHAIN_DIR}"/usr/bin/bitcode_strip "${BUILT_PRODUCTS_DIR}/Flutter.framework/Flutter" -r -o "${xcode_frameworks_dir}/Flutter.framework/Flutter"


### PR DESCRIPTION
## Description
Xcode strips embedded framework module and header directories since they aren't needed after linking (presumably to reduce size).  Flutter also did this:
https://github.com/flutter/flutter/blob/9a9339fbcb01b47ab28c2ebcc7dba31a3691ad77/packages/flutter_tools/bin/macos_assemble.sh#L117-L118
and
https://github.com/flutter/flutter/blob/b372c52b2f428c477cb0cdcff9a299ac633b279d/packages/flutter_tools/bin/xcode_backend.sh#L287-L288

This logic leaves behind and empty `Headers` and `Modules` directory, which for macOS frameworks is a broken symlink.

Remove the trailing `/` to avoid copying the entire directory/symlink instead.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/73028
Introduced in https://github.com/flutter/flutter/pull/71764

## Tests

Added more checks to macos_content_validation_test, confirm this fails on master:
```
02:09 +0 -2: flutter build macos --release builds a valid app [E]                                                                                                                                                                                                                                                                                                        
  Expected: not a file system entity that exists
    Actual: LocalLink:<LocalLink: 'flutter/dev/integration_tests/flutter_gallery/build/macos/Build/Products/Release/flutter_gallery.app/Contents/Frameworks/FlutterMacOS.framework/Headers'>
  
  package:test_api                                                 expect
  test/integration.shard/macos_content_validation_test.dart 102:7  main.<fn>
```
Simpler check added to ios_content_validation_test since there's less symlinking in iOS framework bundles.