### PR TITLE
Improve the Scaffold.bottomSheet update behavior

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2062,7 +2062,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   final GlobalKey<DrawerControllerState> _drawerKey = GlobalKey<DrawerControllerState>();
   final GlobalKey<DrawerControllerState> _endDrawerKey = GlobalKey<DrawerControllerState>();
 
-
   /// Whether this scaffold has a non-null [Scaffold.appBar].
   bool get hasAppBar => widget.appBar != null;
   /// Whether this scaffold has a non-null [Scaffold.drawer].

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2366,7 +2366,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   // bottom sheet.
   final List<_StandardBottomSheet> _dismissedBottomSheets = <_StandardBottomSheet>[];
   PersistentBottomSheetController<dynamic>? _currentBottomSheet;
-  late StateSetter _currentBottomSheetStateSetter;
+  final GlobalKey _currentBottomSheetKey = GlobalKey();
 
   void _maybeBuildPersistentBottomSheet() {
     if (widget.bottomSheet != null && _currentBottomSheet == null) {
@@ -2399,10 +2399,10 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           return NotificationListener<DraggableScrollableNotification>(
             onNotification: _persistentBottomSheetExtentChanged,
             child: DraggableScrollableActuator(
-              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-                _currentBottomSheetStateSetter = setState;
-                return widget.bottomSheet!;
-              }),
+              child: StatefulBuilder(
+                key: _currentBottomSheetKey,
+                builder: (BuildContext context, StateSetter setState) => widget.bottomSheet!,
+              ),
             ),
           );
         },
@@ -2427,7 +2427,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
   }
 
   void _updatePersistentBottomSheet() {
-    _currentBottomSheetStateSetter((){});
+    _currentBottomSheetKey.currentState!.setState(() {});
   }
 
   PersistentBottomSheetController<T> _buildBottomSheet<T>(

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 void main() {
   // Pumps and ensures that the BottomSheet animates non-linearly.
@@ -473,6 +474,28 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('showModalBottomSheet'), findsNothing);
     expect(find.byKey(bottomSheetKey), findsNothing);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/71435
+  testWidgets('Scaffold.bottomSheet should be updated without creating a new RO'
+      ' when the new widget has the same key and type.', (WidgetTester tester) async {
+    Widget buildFrame(String text) {
+      return MaterialApp(
+        home: Scaffold(
+          body: const Placeholder(),
+          bottomSheet: Text(text),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame('I love Flutter!'));
+    final RenderParagraph renderBeforeUpdate = tester.renderObject(find.text('I love Flutter!'));
+
+    await tester.pumpWidget(buildFrame('Flutter is the best!'));
+    await tester.pumpAndSettle();
+    final RenderParagraph renderAfterUpdate = tester.renderObject(find.text('Flutter is the best!'));
+
+    expect(renderBeforeUpdate, renderAfterUpdate);
   });
 
   testWidgets('Verify that visual properties are passed through', (WidgetTester tester) async {


### PR DESCRIPTION
## Description
Currently, put `TextField` into `Scaffold.bottomSheet` may cause the IME show and hide infinite loop, see #71435 and https://github.com/flutter/flutter/issues/71435#issuecomment-736516358 for details.

This change let `Scaffold.bottomSheet` can be updated without creating a new RO when the new widget has the same key and type.

This patch tries to fix the related issues and waiting for your review and thoughts.


I noticed that #2115 has discussed this behavior, CC @Hixie 

## Related Issues

Fixes #71435
Fixes #73033

## Tests

I added the following tests:

See files.