### PR TITLE
Optionally include CocoaPods xcconfig

### DIFF
--- a/dev/benchmarks/macrobenchmarks/ios/Flutter/Debug.xcconfig
+++ b/dev/benchmarks/macrobenchmarks/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/benchmarks/macrobenchmarks/ios/Flutter/Release.xcconfig
+++ b/dev/benchmarks/macrobenchmarks/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/benchmarks/macrobenchmarks/macos/Flutter/Flutter-Debug.xcconfig
+++ b/dev/benchmarks/macrobenchmarks/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/dev/benchmarks/macrobenchmarks/macos/Flutter/Flutter-Release.xcconfig
+++ b/dev/benchmarks/macrobenchmarks/macos/Flutter/Flutter-Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Flutter/Debug.xcconfig
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Flutter/Release.xcconfig
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/integration_tests/flutter_gallery/ios/Flutter/Debug.xcconfig
+++ b/dev/integration_tests/flutter_gallery/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
 #include "Generated.xcconfig"
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"

--- a/dev/integration_tests/flutter_gallery/ios/Flutter/Release.xcconfig
+++ b/dev/integration_tests/flutter_gallery/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
 #include "Generated.xcconfig"
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"

--- a/dev/integration_tests/flutter_gallery/macos/Flutter/Flutter-Debug.xcconfig
+++ b/dev/integration_tests/flutter_gallery/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/dev/integration_tests/flutter_gallery/macos/Flutter/Flutter-Release.xcconfig
+++ b/dev/integration_tests/flutter_gallery/macos/Flutter/Flutter-Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/dev/integration_tests/ios_app_with_extensions/ios/Flutter/Debug.xcconfig
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/integration_tests/ios_app_with_extensions/ios/Flutter/Release.xcconfig
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/integration_tests/release_smoke_test/ios/Flutter/Debug.xcconfig
+++ b/dev/integration_tests/release_smoke_test/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/dev/integration_tests/release_smoke_test/ios/Flutter/Release.xcconfig
+++ b/dev/integration_tests/release_smoke_test/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -272,7 +272,7 @@ class CocoaPods {
     final File file = xcodeProject.xcodeConfigFor(mode);
     if (file.existsSync()) {
       final String content = file.readAsStringSync();
-      final String include = '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
+      final String include = '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
           .toLowerCase()}.xcconfig"';
       if (!content.contains(include)) {
         file.writeAsStringSync('$include\n$content', flush: true);

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Config.tmpl/Debug.xcconfig
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Config.tmpl/Debug.xcconfig
@@ -1,2 +1,2 @@
 #include "Flutter.xcconfig"
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Config.tmpl/Release.xcconfig
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Config.tmpl/Release.xcconfig
@@ -1,2 +1,2 @@
 #include "Flutter.xcconfig"
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -124,13 +124,13 @@ void main() {
     ];
 
     const Map<String, String> pluginContentWitnesses = <String, String>{
-      'ios/Flutter/Debug.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
-      'ios/Flutter/Release.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
+      'ios/Flutter/Debug.xcconfig': '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
+      'ios/Flutter/Release.xcconfig': '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
     };
 
     const Map<String, String> modulePluginContentWitnesses = <String, String>{
-      '.ios/Config/Debug.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
-      '.ios/Config/Release.xcconfig': '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
+      '.ios/Config/Debug.xcconfig': '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"',
+      '.ios/Config/Release.xcconfig': '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"',
     };
 
     void expectDependenciesResolved(String projectPath) {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -273,11 +273,11 @@ void main() {
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
       expect(debugContents, contains(
-          '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"\n'));
+          '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"\n'));
       expect(debugContents, contains('Existing debug config'));
       final String releaseContents = projectUnderTest.ios.xcodeConfigFor('Release').readAsStringSync();
       expect(releaseContents, contains(
-          '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"\n'));
+          '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"\n'));
       expect(releaseContents, contains('Existing release config'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -305,11 +305,11 @@ void main() {
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
       expect(debugContents, contains(
-          '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"\n'));
+          '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"\n'));
       expect(debugContents, contains('Existing debug config'));
       final String releaseContents = projectUnderTest.ios.xcodeConfigFor('Release').readAsStringSync();
       expect(releaseContents, contains(
-          '#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"\n'));
+          '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"\n'));
       expect(releaseContents, contains('Existing release config'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,

--- a/packages/integration_test/example/ios/Flutter/Debug.xcconfig
+++ b/packages/integration_test/example/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/integration_test/example/ios/Flutter/Release.xcconfig
+++ b/packages/integration_test/example/ios/Flutter/Release.xcconfig
@@ -1,2 +1,2 @@
-#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"


### PR DESCRIPTION
## Description

When the first iOS/macOS Flutter plugin is added to a project, the Flutter xcconfigs are updated to include the CocoaPods build settings.
```c
#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
```

If the user removes all Flutter plugins from their pubspec and runs `pod deintegrate` (the only way to get rid of the last plugin since the [tooling doesn't handle it](https://github.com/flutter/flutter/issues/11819)) the project will not build:
```
could not find included file 'Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig' in search paths
```

Change this `#include` to an optional `#include?` so the project will build if the file is removed.

This seems safer than trying to migrate the user's project to remove this line.  I also didn't bother with an existing project migration since this scenario should hopefully be rare?  I couldn't even find an open issue describing this problem, just a [Stack Overflow question](https://stackoverflow.com/questions/57901358/error-could-not-find-included-file-pods-target-support-files-pods-runner-pods), though I've personally hit this before.

## Related Issues

https://github.com/flutter/flutter/issues/11819

## Tests

cocoapods_test
Updated integration test projects.