### PR TITLE
Purpose tween looping fix

### DIFF
--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -273,10 +273,10 @@ class Tween<T extends dynamic> extends Animatable<T> {
   /// subclass.
   @override
   T transform(double t) {
-    if (t == 0.0)
-      return begin as T;
-    if (t == 1.0)
-      return end as T;
+    // if (t == 0.0)
+    //   return begin as T;
+    // if (t == 1.0)
+    //   return end as T;
     return lerp(t);
   }
 


### PR DESCRIPTION
Consider the following curve
```
class OffsetCurve extends Curve {
  OffsetCurve({this.offset = 0});
  final double offset;
  @override
  double transform(double t) {
    final offsetValue = (t + offset) % 1.0;
    return offsetValue;
  }
}
```
To perform looping animation, I am make this offset curve. But I found out tween have bolted to begin at t=0 and end at t=1. For advance looping animations this is very annoying...

Similar restrictions are thr other part of animation code. If you guys agree, we can amend that too.

Looking forward to your feedback.

Jas
