### PR TITLE
Updated syntax on line 150, 365, 598 and 877

### DIFF
--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -146,7 +146,7 @@ abstract class Gradient {
   /// no other rotation or perspective transformations have been applied to the
   /// [Canvas]. If null, no transformation is applied.
   const Gradient({
-    required this.colors,
+    @required this.colors,
     this.stops,
     this.transform,
   }) : assert(colors != null);
@@ -366,7 +366,7 @@ class LinearGradient extends Gradient {
   const LinearGradient({
     this.begin = Alignment.centerLeft,
     this.end = Alignment.centerRight,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     GradientTransform? transform,
@@ -596,7 +596,7 @@ class RadialGradient extends Gradient {
   const RadialGradient({
     this.center = Alignment.center,
     this.radius = 0.5,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     this.focal,
@@ -872,7 +872,7 @@ class SweepGradient extends Gradient {
     this.center = Alignment.center,
     this.startAngle = 0.0,
     this.endAngle = math.pi * 2,
-    required List<Color> colors,
+    @required List<Color> colors,
     List<double>? stops,
     this.tileMode = TileMode.clamp,
     GradientTransform? transform,


### PR DESCRIPTION
"@" was missing in front of "required" keyword which was resulting bad auto-complete in editor and error `Context: Found this candidate, but the arguments don't match.`

## Description
In this PR I am simply correcting the "required" syntax by adding "@" in front of them.
Without "@", we can face bad auto-complete as well as error.

```dart
// Invalid
return LinearGradient(
      List: [
        Color(0xFF3772E9),
        Color(0xFF1A9BFD),
      ],
      begin: Alignment.center,
      end: Alignment.bottomCenter,
    );

// Valid
return LinearGradient(
      colors: [
        Color(0xFF3772E9),
        Color(0xFF1A9BFD),
      ],
      begin:  Alignment.center,
      end: Alignment.bottomCenter,
    );
```

## Related Issues

https://github.com/flutter/flutter/pull/72200

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
