### PR TITLE
SliverAppBar with ShrinkWrap Patch

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -2010,10 +2010,10 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
 
   @override
   Iterable<RenderSliver> get childrenInPaintOrder sync* {
-    RenderSliver? child = firstChild;
+    RenderSliver? child = lastChild;
     while (child != null) {
       yield child;
-      child = childAfter(child);
+      child = childBefore(child);
     }
   }
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -2019,10 +2019,10 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
 
   @override
   Iterable<RenderSliver> get childrenInHitTestOrder sync* {
-    RenderSliver? child = lastChild;
+    RenderSliver? child = firstChild;
     while (child != null) {
       yield child;
-      child = childBefore(child);
+      child = childAfter(child);
     }
   }
 }

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1746,6 +1746,49 @@ void main() {
     );
   });
 
+  group('Viewport childrenInPaintOrder control test', () {
+    test('RenderViewport', () async {
+      final List<RenderSliver> children = <RenderSliver>[
+        RenderSliverToBoxAdapter(),
+        RenderSliverToBoxAdapter(),
+        RenderSliverToBoxAdapter(),
+      ];
+
+      final RenderViewport renderViewport = RenderViewport(
+        crossAxisDirection: AxisDirection.right,
+        offset: ViewportOffset.zero(),
+        children: children,
+      );
+
+      // Children should be painted in reverse order to the list given
+      expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
+      // childrenInPaintOrder should be reverse of childrenInHitTestOrder
+      expect(renderViewport.childrenInPaintOrder,
+          equals(renderViewport.childrenInHitTestOrder.toList().reversed));
+    });
+
+    test('RenderShrinkWrappingViewport', () async {
+      final List<RenderSliver> children = <RenderSliver>[
+        RenderSliverToBoxAdapter(),
+        RenderSliverToBoxAdapter(),
+        RenderSliverToBoxAdapter(),
+      ];
+
+      final RenderShrinkWrappingViewport renderViewport =
+          RenderShrinkWrappingViewport(
+        crossAxisDirection: AxisDirection.right,
+        offset: ViewportOffset.zero(),
+        children: children,
+      );
+
+      // Children should be painted in reverse order to the list given
+      expect(renderViewport.childrenInPaintOrder, equals(children.reversed));
+      // childrenInPaintOrder should be reverse of childrenInHitTestOrder
+      expect(renderViewport.childrenInPaintOrder,
+          equals(renderViewport.childrenInHitTestOrder.toList().reversed));
+    });
+  });
+
   testWidgets('Handles infinite constraints when TargetPlatform is iOS or macOS', (WidgetTester tester) async {
     // regression test for https://github.com/flutter/flutter/issues/45866
     await tester.pumpWidget(


### PR DESCRIPTION
This better emulates the behavior of the standard Viewport class, which, after painting all children before its center child, paints its center child and all subsequent children in reverse order. This fixes a bug causing children of a shrink-wrapping CustomScrollView to paint over a SliverAppBar.

## Description

This PR simply reverses childrenInPaintOrder for the RenderShrinkWrappingViewport class. This solves any issues where slivers in a CustomScrollView would paint over a SliverAppBar whenever the scroll view had shrink-wrapping enabled.

## Related Issues

#28197 Resolved by this PR.
#36002 Partly resolved by this PR. I did not modify scrolling behavior.
#52976 Partly resolved by this PR.

## Tests

I added the following tests:

- "Viewport childrenInPaintOrder control test" (rendering/viewport_test.dart)
  - Tests both RenderViewport and RenderShrinkWrappingViewport.
  - Checks if childrenInPaintOrder is in reverse order of a list of three children.
    - Does NOT test how specifying a center child modifies that order.
  - Checks if childrenInPaintOrder is in reverse order of childrenInHitTestOrder.
    - This rule is specified in the documentation of RenderViewportBase.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
