### PR TITLE
Make it easier to catch multiple errors during a test

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -901,6 +903,15 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// See [TestWidgetsFlutterBinding.takeException] for details.
   dynamic takeException() {
     return binding.takeException();
+  }
+
+  /// Intercepts errors reported by the framework until [callback] finishes.
+  ///
+  /// See [TestWidgetsFlutterBinding.wrapExceptions] for details.
+  Future<T> wrapExceptions<T>(FutureOr<T> Function() callback, {
+    required FlutterExceptionHandler onError,
+  }) {
+    return binding.wrapExceptions(callback, onError: onError);
   }
 
   /// Acts as if the application went idle.

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -905,13 +905,14 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     return binding.takeException();
   }
 
-  /// Intercepts errors reported by the framework until [callback] finishes.
+  /// Returns a list of errors reported by the framework after [callback]
+  //  completes.
   ///
   /// See [TestWidgetsFlutterBinding.wrapExceptions] for details.
-  Future<T> wrapExceptions<T>(FutureOr<T> Function() callback, {
-    required FlutterExceptionHandler onError,
-  }) {
-    return binding.wrapExceptions(callback, onError: onError);
+  Future<List<FlutterErrorDetails>> wrapExceptions<T>(
+    FutureOr<T> Function() callback,
+  ) {
+    return binding.wrapExceptions(callback);
   }
 
   /// Acts as if the application went idle.

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -587,21 +587,15 @@ void main() {
     });
 
     testWidgets('can catch multiple framework errors', (WidgetTester tester) async {
-      int exceptions = 0;
-      final String result = await tester.wrapExceptions(() async {
+      final List<FlutterErrorDetails> errors = await tester.wrapExceptions(() async {
         for (int j = 0; j < 3; j += 1) {
           await tester.runAsync<String>(() async {
             throw ArgumentError('foo');
           });
         }
-        return '123';
-      }, onError: (FlutterErrorDetails details) {
-        expect(details.exception, isArgumentError);
-        expect((details.exception as ArgumentError).message, 'foo');
-        exceptions++;
       });
-      expect(result, '123');
-      expect(exceptions, 3);
+
+      expect(errors.length, 3);
 
       await tester.runAsync<String>(() async {
         throw StateError('bar');
@@ -611,7 +605,7 @@ void main() {
       final dynamic exception = tester.takeException();
       expect(exception, isStateError);
       expect((exception as StateError).message, 'bar');
-      expect(exceptions, 3);
+      expect(errors.length, 3);
     });
 
     testWidgets('disallows re-entry', (WidgetTester tester) async {


### PR DESCRIPTION
## Background

Tests that expect multiple exceptions to occur (such as during layout) are difficult to implement, the current approach is to override `FlutterError.onError`, for example: https://github.com/flutter/flutter/blob/fe55dc2b135b5b71ae3c19062b34dc6e8d02e9d5/packages/flutter/test/rendering/viewport_test.dart#L1615-L1631

However, this is much less elegant than the `takeException` method provided by the test binding, and prone to error as some tests forget to restore `FlutterError.onError` to its original state.

This PR fixes this small issue by adding a new `wrapExceptions` method to the test binding, allowing tests to catch multiple exceptions easily without manually touching `FlutterError.onError`.

## Related Issues

Fixes #8338

## Tests

I added the following tests:

* A test to make sure `wrapExceptions` catches framework errors and restores default behavior when finished

## Breaking Change

No breaking changes