### PR TITLE
Deprecated obsolete Material classes: FlatButton, RaisedButton, OutlineButton

### DIFF
--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -14,13 +14,13 @@ import 'theme_data.dart';
 
 /// A material design "flat button".
 ///
-/// ### This class is obsolete, please use [TextButton] instead.
+/// ### This class is deprecated, please use [TextButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
 /// TextButton, ElevatedButton, and OutlinedButton respectively.
 /// ButtonTheme has been replaced by TextButtonTheme,
 /// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
-/// will be deprecated soon, please migrate code that uses them.
+/// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
@@ -108,6 +108,10 @@ import 'theme_data.dart';
 ///  * [RawMaterialButton], the widget this widget is based on.
 ///  * <https://material.io/design/components/buttons.html>
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
+@Deprecated(
+  'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+  'This feature was deprecated after v1.25.0.'
+)
 class FlatButton extends MaterialButton {
   /// Create a simple text button.
   ///

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -12,102 +12,18 @@ import 'material_button.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-/// A material design "flat button".
+/// A Material Design "flat button".
 ///
 /// ### This class is deprecated, please use [TextButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
-/// TextButton, ElevatedButton, and OutlinedButton respectively.
-/// ButtonTheme has been replaced by TextButtonTheme,
-/// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
+/// [TextButton], [ElevatedButton], and [OutlinedButton] respectively.
+/// ButtonTheme has been replaced by [TextButtonTheme],
+/// [ElevatedButtonTheme], and [OutlinedButtonTheme]. The original classes
 /// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
-///
-/// A flat button is a text label displayed on a (zero elevation) [Material]
-/// widget that reacts to touches by filling with color.
-///
-/// Use flat buttons on toolbars, in dialogs, or inline with other content but
-/// offset from that content with padding so that the button's presence is
-/// obvious. Flat buttons intentionally do not have visible borders and must
-/// therefore rely on their position relative to other content for context. In
-/// dialogs and cards, they should be grouped together in one of the bottom
-/// corners. Avoid using flat buttons where they would blend in with other
-/// content, for example in the middle of lists.
-///
-/// Material design flat buttons have an all-caps label, some internal padding,
-/// and some defined dimensions. To have a part of your application be
-/// interactive, with ink splashes, without also committing to these stylistic
-/// choices, consider using [InkWell] instead.
-///
-/// If the [onPressed] and [onLongPress] callbacks are null, then this button will be disabled,
-/// will not react to touch, and will be colored as specified by
-/// the [disabledColor] property instead of the [color] property. If you are
-/// trying to change the button's [color] and it is not having any effect, check
-/// that you are passing a non-null [onPressed] handler.
-///
-/// Flat buttons have a minimum size of 88.0 by 36.0 which can be overridden
-/// with [ButtonTheme].
-///
-/// The [clipBehavior] argument must not be null.
-///
-/// {@tool snippet}
-///
-/// This example shows a simple [FlatButton].
-///
-/// ![A simple FlatButton](https://flutter.github.io/assets-for-api-docs/assets/material/flat_button.png)
-///
-/// ```dart
-/// FlatButton(
-///   onPressed: () {
-///     /*...*/
-///   },
-///   child: Text(
-///     "Flat Button",
-///   ),
-/// )
-/// ```
-/// {@end-tool}
-///
-/// {@tool snippet}
-///
-/// This example shows a [FlatButton] that is normally white-on-blue,
-/// with splashes rendered in a different shade of blue.
-/// It turns black-on-grey when disabled.
-/// The button has 8px of padding on each side, and the text is 20px high.
-///
-/// ![A FlatButton with white text on a blue background](https://flutter.github.io/assets-for-api-docs/assets/material/flat_button_properties.png)
-///
-/// ```dart
-/// FlatButton(
-///   color: Colors.blue,
-///   textColor: Colors.white,
-///   disabledColor: Colors.grey,
-///   disabledTextColor: Colors.black,
-///   padding: EdgeInsets.all(8.0),
-///   splashColor: Colors.blueAccent,
-///   onPressed: () {
-///     /*...*/
-///   },
-///   child: Text(
-///     "Flat Button",
-///     style: TextStyle(fontSize: 20.0),
-///   ),
-/// )
-/// ```
-/// {@end-tool}
-///
-/// See also:
-///
-///  * [RaisedButton], a filled button whose material elevates when pressed.
-///  * [DropdownButton], which offers the user a choice of a number of options.
-///  * [SimpleDialogOption], which is used in [SimpleDialog]s.
-///  * [IconButton], to create buttons that just contain icons.
-///  * [InkWell], which implements the ink splash part of a flat button.
-///  * [RawMaterialButton], the widget this widget is based on.
-///  * <https://material.io/design/components/buttons.html>
-///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
   'This feature was deprecated after v1.25.0-8.1.pre.'

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -110,7 +110,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre'
+  'This feature was deprecated after 1.25.0-8.1.pre.'
 )
 class FlatButton extends MaterialButton {
   /// Create a simple text button.

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -110,7 +110,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0.'
+  'This feature was deprecated after 1.25.0-8.1.pre'
 )
 class FlatButton extends MaterialButton {
   /// Create a simple text button.

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -110,7 +110,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.25.0-8.1.pre.'
 )
 class FlatButton extends MaterialButton {
   /// Create a simple text button.

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -84,7 +84,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 ///  * <https://material.io/design/components/buttons.html>
 @Deprecated(
   'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.25.0-8.1.pre.'
 )
 class OutlineButton extends MaterialButton {
   /// Create an outline button.

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -24,13 +24,13 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 
 /// Similar to a [FlatButton] with a thin grey rounded rectangle border.
 ///
-/// ### This class is obsolete, please use [OutlinedButton] instead.
+/// ### This class is deprecated, please use [OutlinedButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
 /// TextButton, ElevatedButton, and OutlinedButton respectively.
 /// ButtonTheme has been replaced by TextButtonTheme,
 /// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
-/// will be deprecated soon, please migrate code that uses them.
+/// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
@@ -82,6 +82,10 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 ///  * [IconButton], to create buttons that just contain icons.
 ///  * [InkWell], which implements the ink splash part of a flat button.
 ///  * <https://material.io/design/components/buttons.html>
+@Deprecated(
+  'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+  'This feature was deprecated after v1.25.0.'
+)
 class OutlineButton extends MaterialButton {
   /// Create an outline button.
   ///

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -27,61 +27,13 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 /// ### This class is deprecated, please use [OutlinedButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
-/// TextButton, ElevatedButton, and OutlinedButton respectively.
+/// [TextButton], [ElevatedButton], and [OutlinedButton] respectively.
 /// ButtonTheme has been replaced by TextButtonTheme,
 /// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
 /// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
-///
-/// The outline button's border shape is defined by [shape]
-/// and its appearance is defined by [borderSide], [disabledBorderColor],
-/// and [highlightedBorderColor]. By default the border is a one pixel
-/// wide grey rounded rectangle that does not change when the button is
-/// pressed or disabled. By default the button's background is transparent.
-///
-/// If the [onPressed] or [onLongPress] callbacks are null, then the button will be disabled and by
-/// default will resemble a flat button in the [disabledColor].
-///
-/// The button's [highlightElevation], which defines the size of the
-/// drop shadow when the button is pressed, is 0.0 (no shadow) by default.
-/// If [highlightElevation] is given a value greater than 0.0 then the button
-/// becomes a cross between [RaisedButton] and [FlatButton]: a bordered
-/// button whose elevation increases and whose background becomes opaque
-/// when the button is pressed.
-///
-/// If you want an ink-splash effect for taps, but don't want to use a button,
-/// consider using [InkWell] directly.
-///
-/// Outline buttons have a minimum size of 88.0 by 36.0 which can be overridden
-/// with [ButtonTheme].
-///
-/// {@tool dartpad --template=stateless_widget_scaffold_center}
-///
-/// Here is an example of a basic [OutlineButton].
-///
-/// ```dart
-///   Widget build(BuildContext context) {
-///     return OutlineButton(
-///       onPressed: () {
-///         print('Received click');
-///       },
-///       child: Text('Click Me'),
-///     );
-///   }
-/// ```
-/// {@end-tool}
-///
-/// See also:
-///
-///  * [RaisedButton], a filled material design button with a shadow.
-///  * [FlatButton], a material design button without a shadow.
-///  * [DropdownButton], a button that shows options to select from.
-///  * [FloatingActionButton], the round button in material applications.
-///  * [IconButton], to create buttons that just contain icons.
-///  * [InkWell], which implements the ink splash part of a flat button.
-///  * <https://material.io/design/components/buttons.html>
 @Deprecated(
   'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
   'This feature was deprecated after v1.25.0-8.1.pre.'

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -84,7 +84,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 ///  * <https://material.io/design/components/buttons.html>
 @Deprecated(
   'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0.'
+  'This feature was deprecated after 1.25.0-8.1.pre'
 )
 class OutlineButton extends MaterialButton {
   /// Create an outline button.

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -84,7 +84,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 ///  * <https://material.io/design/components/buttons.html>
 @Deprecated(
   'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre'
+  'This feature was deprecated after 1.25.0-8.1.pre.'
 )
 class OutlineButton extends MaterialButton {
   /// Create an outline button.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -14,13 +14,13 @@ import 'theme_data.dart';
 
 /// A material design "raised button".
 ///
-/// ### This class is obsolete, please use [ElevatedButton] instead.
+/// ### This class is deprecated, please use [ElevatedButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
 /// TextButton, ElevatedButton, and OutlinedButton respectively.
 /// ButtonTheme has been replaced by TextButtonTheme,
 /// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
-/// will be deprecated soon, please migrate code that uses them.
+/// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
@@ -111,6 +111,10 @@ import 'theme_data.dart';
 ///  * [RawMaterialButton], the widget this widget is based on.
 ///  * <https://material.io/design/components/buttons.html>
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
+@Deprecated(
+  'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+  'This feature was deprecated after v1.25.0.'
+)
 class RaisedButton extends MaterialButton {
   /// Create a filled button.
   ///

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -113,7 +113,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0.'
+  'This feature was deprecated after 1.25.0-8.1.pre'
 )
 class RaisedButton extends MaterialButton {
   /// Create a filled button.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -113,7 +113,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.25.0-8.1.pre.'
 )
 class RaisedButton extends MaterialButton {
   /// Create a filled button.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -113,7 +113,7 @@ import 'theme_data.dart';
 ///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after 1.25.0-8.1.pre'
+  'This feature was deprecated after 1.25.0-8.1.pre.'
 )
 class RaisedButton extends MaterialButton {
   /// Create a filled button.

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -12,105 +12,18 @@ import 'material_button.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
-/// A material design "raised button".
+/// A Material Design "raised button".
 ///
 /// ### This class is deprecated, please use [ElevatedButton] instead.
 ///
 /// FlatButton, RaisedButton, and OutlineButton have been replaced by
-/// TextButton, ElevatedButton, and OutlinedButton respectively.
-/// ButtonTheme has been replaced by TextButtonTheme,
-/// ElevatedButtonTheme, and OutlinedButtonTheme. The original classes
+/// [TextButton], [ElevatedButton], and [OutlinedButton] respectively.
+/// ButtonTheme has been replaced by [TextButtonTheme],
+/// [ElevatedButtonTheme], and [OutlinedButtonTheme]. The original classes
 /// will eventually be removed, please migrate code that uses them.
 /// There's a detailed migration guide for the new button and button
 /// theme classes in
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
-///
-/// A raised button is based on a [Material] widget whose [Material.elevation]
-/// increases when the button is pressed.
-///
-/// Use raised buttons to add dimension to otherwise mostly flat layouts, e.g.
-/// in long busy lists of content, or in wide spaces. Avoid using raised buttons
-/// on already-raised content such as dialogs or cards.
-///
-/// If [onPressed] and [onLongPress] callbacks are null, then the button will be disabled and by
-/// default will resemble a flat button in the [disabledColor]. If you are
-/// trying to change the button's [color] and it is not having any effect, check
-/// that you are passing a non-null [onPressed] or [onLongPress] callbacks.
-///
-/// If you want an ink-splash effect for taps, but don't want to use a button,
-/// consider using [InkWell] directly.
-///
-/// Raised buttons have a minimum size of 88.0 by 36.0 which can be overridden
-/// with [ButtonTheme].
-///
-/// {@tool dartpad --template=stateless_widget_scaffold}
-///
-/// This sample shows how to render a disabled RaisedButton, an enabled RaisedButton
-/// and lastly a RaisedButton with gradient background.
-///
-/// ![Three raised buttons, one enabled, another disabled, and the last one
-/// styled with a blue gradient background](https://flutter.github.io/assets-for-api-docs/assets/material/raised_button.png)
-///
-/// ```dart
-/// Widget build(BuildContext context) {
-///   return Center(
-///     child: Column(
-///       mainAxisSize: MainAxisSize.min,
-///       children: <Widget>[
-///         const RaisedButton(
-///           onPressed: null,
-///           child: Text(
-///             'Disabled Button',
-///             style: TextStyle(fontSize: 20)
-///           ),
-///         ),
-///         const SizedBox(height: 30),
-///         RaisedButton(
-///           onPressed: () {},
-///           child: const Text(
-///             'Enabled Button',
-///             style: TextStyle(fontSize: 20)
-///           ),
-///         ),
-///         const SizedBox(height: 30),
-///         RaisedButton(
-///           onPressed: () {},
-///           textColor: Colors.white,
-///           padding: const EdgeInsets.all(0.0),
-///           child: Container(
-///             decoration: const BoxDecoration(
-///               gradient: LinearGradient(
-///                 colors: <Color>[
-///                   Color(0xFF0D47A1),
-///                   Color(0xFF1976D2),
-///                   Color(0xFF42A5F5),
-///                 ],
-///               ),
-///             ),
-///             padding: const EdgeInsets.all(10.0),
-///             child: const Text(
-///               'Gradient Button',
-///               style: TextStyle(fontSize: 20)
-///             ),
-///           ),
-///         ),
-///       ],
-///     ),
-///   );
-/// }
-/// ```
-/// {@end-tool}
-///
-/// See also:
-///
-///  * [FlatButton], a material design button without a shadow.
-///  * [DropdownButton], a button that shows options to select from.
-///  * [FloatingActionButton], the round button in material applications.
-///  * [IconButton], to create buttons that just contain icons.
-///  * [InkWell], which implements the ink splash part of a flat button.
-///  * [RawMaterialButton], the widget this widget is based on.
-///  * <https://material.io/design/components/buttons.html>
-///  * Cookbook: [Build a form with validation](https://flutter.dev/docs/cookbook/forms/validation)
 @Deprecated(
   'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
   'This feature was deprecated after v1.25.0-8.1.pre.'

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2787,7 +2787,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///         ),
 ///       ),
 ///       Text('Flutter logo is offstage: $_offstage'),
-///       RaisedButton(
+///       ElevatedButton(
 ///         child: Text('Toggle Offstage Value'),
 ///         onPressed: () {
 ///           setState(() {
@@ -2796,7 +2796,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///         },
 ///       ),
 ///       if (_offstage)
-///         RaisedButton(
+///         ElevatedButton(
 ///           child: Text('Get Flutter Logo size'),
 ///           onPressed: () {
 ///             ScaffoldMessenger.of(context).showSnackBar(

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1650,7 +1650,7 @@ void main() {
     await tester.pumpWidget(CupertinoApp(
       home: Center(
         child: Builder(builder: (BuildContext context) {
-          return RaisedButton(
+          return ElevatedButton(
             child: const Text('Home'),
             onPressed: () {
               navigator = Navigator.of(context);
@@ -1663,7 +1663,7 @@ void main() {
     ));
 
     final TestGesture gesture = await tester.createGesture();
-    await gesture.down(tester.getCenter(find.byType(RaisedButton)));
+    await gesture.down(tester.getCenter(find.byType(ElevatedButton)));
     await gesture.up();
 
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3119,12 +3119,12 @@ void main() {
             return Scaffold(
               appBar: AppBar(
                 actions: <Widget>[
-                  FlatButton(
+                  TextButton(
                     key: const Key('Add tab'),
                     child: const Text('Add tab'),
                     onPressed: () => _onTabAdd(setState),
                   ),
-                  FlatButton(
+                  TextButton(
                     key: const Key('Remove tab'),
                     child: const Text('Remove tab'),
                     onPressed: () => _onTabRemove(setState),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2651,7 +2651,7 @@ Future<void> main() async {
             ),
             Builder(
               builder: (BuildContext context) {
-                return FlatButton(
+                return TextButton(
                   child: const Text('push'),
                   onPressed: () {
                     Navigator.push(context, PageRouteBuilder<void>(
@@ -2723,7 +2723,7 @@ Future<void> main() async {
             ),
             Builder(
               builder: (BuildContext context) {
-                return FlatButton(
+                return TextButton(
                   child: const Text('push'),
                   onPressed: () {
                     Navigator.push(context, PageRouteBuilder<void>(

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -1738,7 +1738,7 @@ void main() {
         child: Draggable<int>(
           feedback: Container(width: 20, height: 20, color: Colors.blue),
           childWhenDragging: Container(width: 20, height: 20, color: Colors.yellow),
-          child: RaisedButton(child: const Text('Drag me'), onPressed: (){}),
+          child: ElevatedButton(child: const Text('Drag me'), onPressed: (){}),
         ),
       ),
     ));


### PR DESCRIPTION
This PR deprecates three obsolete Material button classes: FlatButton, RaisedButton, OutlineButton.  It does not (yet) deprecate the obsolete ButtonTheme and ButtonThemeData classes because there's one remaining reference in _DropDownButtonState. The ButtonTheme classes will be deprecated shortly.

FlatButton, RaisedButton, and OutlineButton have been replaced by TextButton, ElevatedButton, and OutlinedButton respectively. ButtonTheme has been replaced by TextButtonTheme, ElevatedButtonTheme, and OutlinedButtonTheme. The original classes will eventually be removed, please migrate code that uses them. There's a detailed migration guide for the new button and button theme classes in [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
