### PR TITLE
Map Linux AltGr to right alt. It was currently being ignored.

### DIFF
--- a/dev/tools/gen_keycodes/data/key_data.json
+++ b/dev/tools/gen_keycodes/data/key_data.json
@@ -6619,7 +6619,8 @@
         "RIGHT_ALT"
       ],
       "gtk": [
-        "Alt_R"
+        "Alt_R",
+        "ISO_Level3_Shift"
       ],
       "windows": [
         "RMENU"
@@ -6644,7 +6645,8 @@
         346
       ],
       "gtk": [
-        65514
+        65514,
+        65027
       ],
       "windows": [
         165

--- a/dev/tools/gen_keycodes/data/key_name_to_gtk_name.json
+++ b/dev/tools/gen_keycodes/data/key_name_to_gtk_name.json
@@ -1,6 +1,6 @@
 {
   "altLeft": ["Alt_L"],
-  "altRight": ["Alt_R"],
+  "altRight": ["Alt_R", "ISO_Level3_Shift"],
   "arrowDown": ["Down", "KP_Down"],
   "arrowLeft": ["Left", "KP_Left"],
   "arrowRight": ["Right", "KP_Right"],

--- a/packages/flutter/lib/src/services/keyboard_maps.dart
+++ b/packages/flutter/lib/src/services/keyboard_maps.dart
@@ -1664,6 +1664,7 @@ const Map<int, LogicalKeyboardKey> kGtkToLogicalKey = <int, LogicalKeyboardKey>{
   65508: LogicalKeyboardKey.controlRight,
   65506: LogicalKeyboardKey.shiftRight,
   65514: LogicalKeyboardKey.altRight,
+  65027: LogicalKeyboardKey.altRight,
   65512: LogicalKeyboardKey.metaRight,
   269025026: LogicalKeyboardKey.brightnessUp,
   269025027: LogicalKeyboardKey.brightnessDown,


### PR DESCRIPTION
## Description

Pressing the AltGr key in Linux generates an unknown keycode to Flutter. Since Flutter doesn't have the concept of an AltGr key, lets just map it to right Alt.

## Related Issues

https://github.com/flutter/flutter/issues/68713

## Tests

No tests added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
