### PR TITLE
build ios-framework simulator slices for profile/release

### DIFF
--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -10,10 +10,6 @@ import 'utils.dart';
 
 typedef SimulatorFunction = Future<void> Function(String deviceId);
 
-Future<String> dylibSymbols(String pathToDylib) {
-  return eval('nm', <String>['-g', pathToDylib]);
-}
-
 Future<String> fileType(String pathToBinary) {
   return eval('file', <String>[pathToBinary]);
 }


### PR DESCRIPTION
## Description

Generate an x86 simulator slice for profile and release for add-to-app `flutter build ios-framework` for plugins, App.framework, and plugin registrant framework.  This matches profile and release `Flutter.xcframework`.

This lets users build in profile/release against the simulator in their host app, (even though it uses a Debug version of Flutter).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66474

Blocked by https://github.com/flutter/flutter/pull/73383 to avoid https://github.com/flutter/flutter/issues/47930

## Tests

Updated build_ios_framework_module_test