### PR TITLE
Update ink feature splashFactory test coverage to not rely on the Theme's default value

### DIFF
--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1579,10 +1579,10 @@ void main() {
 
   group('BottomNavigationBar shifting backgroundColor with transition', () {
     // Regression test for: https://github.com/flutter/flutter/issues/22226
-    Widget runTest() {
+    Widget runTest({required InteractiveInkFeatureFactory splashFactory}) {
       int _currentIndex = 0;
       return MaterialApp(
-        theme: ThemeData(splashFactory: InkSplash.splashFactory),
+        theme: ThemeData(splashFactory: splashFactory),
         home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
@@ -1614,20 +1614,40 @@ void main() {
         ),
       );
     }
-    for (int pump = 1; pump < 9; pump++) {
-      testWidgets('pump $pump', (WidgetTester tester) async {
-        await tester.pumpWidget(runTest());
-        await tester.tap(find.text('Green'));
 
-        for (int i = 0; i < pump; i++) {
-          await tester.pump(const Duration(milliseconds: 30));
-        }
-        await expectLater(
-          find.byType(BottomNavigationBar),
-          matchesGoldenFile('bottom_navigation_bar.shifting_transition.${pump - 1}.png'),
-        );
-      });
-    }
+    group('with InkSplash.splashFactory', () {
+      for (int pump = 1; pump < 9; pump++) {
+        testWidgets('pump $pump', (WidgetTester tester) async {
+          await tester.pumpWidget(runTest(splashFactory: InkSplash.splashFactory));
+          await tester.tap(find.text('Green'));
+
+          for (int i = 0; i < pump; i++) {
+            await tester.pump(const Duration(milliseconds: 30));
+          }
+          await expectLater(
+            find.byType(BottomNavigationBar),
+            matchesGoldenFile('bottom_navigation_bar.shifting_transition.ink_splash.${pump - 1}.png'),
+          );
+        });
+      }
+    });
+
+    group('with InkRipple.splashFactory', () {
+      for (int pump = 1; pump < 9; pump++) {
+        testWidgets('pump $pump', (WidgetTester tester) async {
+          await tester.pumpWidget(runTest(splashFactory: InkRipple.splashFactory));
+          await tester.tap(find.text('Green'));
+
+          for (int i = 0; i < pump; i++) {
+            await tester.pump(const Duration(milliseconds: 30));
+          }
+          await expectLater(
+            find.byType(BottomNavigationBar),
+            matchesGoldenFile('bottom_navigation_bar.shifting_transition.ink_ripple.${pump - 1}.png'),
+          );
+        });
+      }
+    });
   });
 
   testWidgets('BottomNavigationBar item title should not be nullable', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1582,6 +1582,7 @@ void main() {
     Widget runTest() {
       int _currentIndex = 0;
       return MaterialApp(
+        theme: ThemeData(splashFactory: InkSplash.splashFactory),
         home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1019,15 +1019,15 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(163, 6), radius: 21)); // Splash is centered and growing
-        expect(box, paints..ripple(center: const Offset(163, 6), radius: 21, unique: true));
+        expect(box, paintsRipple(center: const Offset(163, 6), radius: 21)); // Splash is centered and growing
+        expect(box, paintsRipple(center: const Offset(163, 6), radius: 21, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(163, 6), radius: 42));
-        expect(box, paints..ripple(center: const Offset(163, 6), radius: 42, unique: true));
+        expect(box, paintsRipple(center: const Offset(163, 6), radius: 42));
+        expect(box, paintsRipple(center: const Offset(163, 6), radius: 42, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
@@ -1065,16 +1065,16 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(3, 3), radius: 3.5));
-        expect(box, paints..ripple(center: const Offset(3, 3), radius: 3.5, unique: true));
+        expect(box, paintsRipple(center: const Offset(3, 3), radius: 3.5));
+        expect(box, paintsRipple(center: const Offset(3, 3), radius: 3.5, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(5, 5), radius: 10.5)); // Moves toward center of delete icon
-        expect(box, paints..ripple(center: const Offset(5, 5), radius: 10.5, unique: true));
+        expect(box, paintsRipple(center: const Offset(5, 5), radius: 10.5)); // Moves toward center of delete icon
+        expect(box, paintsRipple(center: const Offset(5, 5), radius: 10.5, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
@@ -1109,15 +1109,15 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(378, 22), radius: 38));
-        expect(box, paints..ripple(center: const Offset(378, 22), radius: 38, unique: true));
+        expect(box, paintsRipple(center: const Offset(378, 22), radius: 38));
+        expect(box, paintsRipple(center: const Offset(378, 22), radius: 38, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(378, 22), radius: 76));
-        expect(box, paints..ripple(center: const Offset(378, 22), radius: 76, unique: true));
+        expect(box, paintsRipple(center: const Offset(378, 22), radius: 76));
+        expect(box, paintsRipple(center: const Offset(378, 22), radius: 76, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
@@ -1376,15 +1376,15 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(165, 7), radius: 69));
-        expect(box, paints..ripple(center: const Offset(165, 7), radius: 69, unique: true));
+        expect(box, paintsRipple(center: const Offset(165, 7), radius: 69));
+        expect(box, paintsRipple(center: const Offset(165, 7), radius: 69, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(170, 9), radius: 96));
-        expect(box, paints..ripple(center: const Offset(170, 9), radius: 96, unique: true));
+        expect(box, paintsRipple(center: const Offset(170, 9), radius: 96));
+        expect(box, paintsRipple(center: const Offset(170, 9), radius: 96, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
@@ -1422,16 +1422,16 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(3, 3), radius: 6.7));
-        expect(box, paints..ripple(center: const Offset(3, 3), radius: 6.7, unique: true));
+        expect(box, paintsRipple(center: const Offset(3, 3), radius: 6.7));
+        expect(box, paintsRipple(center: const Offset(3, 3), radius: 6.7, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(7.2, 7.2), radius: 13.7)); // Moves toward center of delete icon
-        expect(box, paints..ripple(center: const Offset(7.2, 7.2), radius: 13.7, unique: true));
+        expect(box, paintsRipple(center: const Offset(7.2, 7.2), radius: 13.7)); // Moves toward center of delete icon
+        expect(box, paintsRipple(center: const Offset(7.2, 7.2), radius: 13.7, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
@@ -1466,15 +1466,15 @@ void main() {
         expect(find.byType(InkWell), findsOneWidget);
         expect(find.byType(InkResponse), findsNothing);
 
-        expect(box, paints..ripple(center: const Offset(360.4, 21.4), radius: 71.8));
-        expect(box, paints..ripple(center: const Offset(360.4, 21.4), radius: 71.8, unique: true));
+        expect(box, paintsRipple(center: const Offset(360.4, 21.4), radius: 71.8));
+        expect(box, paintsRipple(center: const Offset(360.4, 21.4), radius: 71.8, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(box, paints..ripple(center: const Offset(323.4, 20.2), radius: 100.3));
-        expect(box, paints..ripple(center: const Offset(323.4, 20.2), radius: 100.3, unique: true));
+        expect(box, paintsRipple(center: const Offset(323.4, 20.2), radius: 100.3));
+        expect(box, paintsRipple(center: const Offset(323.4, 20.2), radius: 100.3, unique: true));
 
         expect(findTooltipContainer('Delete'), findsNothing);
 

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1164,13 +1164,13 @@ void main() {
         // With avatar, but not selectable.
         final UniqueKey avatarKey = UniqueKey();
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
         );
         expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
 
         // Turn on selection.
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
           selectable: true,
         );
         await tester.pumpAndSettle();
@@ -1324,7 +1324,7 @@ void main() {
 
         final UniqueKey avatarKey = UniqueKey();
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
           selectable: true,
         );
         await tester.pumpAndSettle();
@@ -1521,13 +1521,13 @@ void main() {
         // With avatar, but not selectable.
         final UniqueKey avatarKey = UniqueKey();
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
         );
         expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
 
         // Turn on selection.
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
           selectable: true,
         );
         await tester.pumpAndSettle();
@@ -1681,7 +1681,7 @@ void main() {
 
         final UniqueKey avatarKey = UniqueKey();
         await pushChip(
-          avatar: Container(width: 40.0, height: 40.0, key: avatarKey),
+          avatar: SizedBox(width: 40.0, height: 40.0, key: avatarKey),
           selectable: true,
         );
         await tester.pumpAndSettle();

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1400,7 +1400,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200)); // splash is well underway
 
       expect(
-        getMaterial<InkWell>(tester),
+        getMaterialInkController<InkWell>(tester),
         paintsRipple(center: const Offset(68, 24), color: stateColor),
       );
       await gesture.up();
@@ -1418,13 +1418,13 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200)); // ripple is well underway
 
       expect(
-        getMaterial<InkWell>(tester),
+        getMaterialInkController<InkWell>(tester),
         paintsRipple(center: const Offset(68, 24), color: stateColor, alpha: 0),
       );
 
       await tester.pump(const Duration(milliseconds: 200));
       expect(
-        getMaterial<InkWell>(tester),
+        getMaterialInkController<InkWell>(tester),
         paintsRipple(center: const Offset(159, 24), color: stateColor),
       );
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -992,8 +992,7 @@ void main() {
 
     // CUSTOM VALUES
     await tester.pumpWidget(MaterialApp(
-      home: Material(
-          child: buildCustomTable(
+      home: Material(child: buildCustomTable(
         horizontalMargin: _customHorizontalMargin,
         columnSpacing: _customColumnSpacing,
       )),

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -992,7 +992,8 @@ void main() {
 
     // CUSTOM VALUES
     await tester.pumpWidget(MaterialApp(
-      home: Material(child: buildCustomTable(
+      home: Material(
+          child: buildCustomTable(
         horizontalMargin: _customHorizontalMargin,
         columnSpacing: _customColumnSpacing,
       )),
@@ -1399,7 +1400,10 @@ void main() {
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Content2')));
       await tester.pump(const Duration(milliseconds: 200)); // splash is well underway
 
-      expect(tester.material<InkWell>(), paints..ripple(center: const Offset(68, 24), color: stateColor));
+      expect(
+        getMaterial<InkWell>(tester),
+        paintsRipple(center: const Offset(68, 24), color: stateColor),
+      );
       await gesture.up();
     });
 
@@ -1414,10 +1418,16 @@ void main() {
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Content2')));
       await tester.pump(const Duration(milliseconds: 200)); // ripple is well underway
 
-      expect(tester.material<InkWell>(), paints..ripple(center: const Offset(68, 24), color: stateColor, alpha: 0));
+      expect(
+        getMaterial<InkWell>(tester),
+        paintsRipple(center: const Offset(68, 24), color: stateColor, alpha: 0),
+      );
 
       await tester.pump(const Duration(milliseconds: 200));
-      expect(tester.material<InkWell>(), paints..ripple(center: const Offset(159, 24), color: stateColor));
+      expect(
+        getMaterial<InkWell>(tester),
+        paintsRipple(center: const Offset(159, 24), color: stateColor),
+      );
 
       await gesture.up();
     });

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1350,7 +1350,7 @@ void main() {
             columns: const <DataColumn>[DataColumn(label: Text('Column1'))],
             rows: <DataRow>[
               DataRow(
-                onSelectChanged: (bool? _) {},
+                onSelectChanged: (bool? checked) {},
                 cells: const <DataCell>[DataCell(Text('Content1'))],
               ),
               DataRow(
@@ -1360,7 +1360,7 @@ void main() {
                   return defaultColor;
                 }),
                 selected: selected,
-                onSelectChanged: disabled ? null : (bool? _) {},
+                onSelectChanged: disabled ? null : (bool? checked) {},
                 cells: const <DataCell>[DataCell(Text('Content2'))],
               ),
             ],

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -283,8 +283,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
       expect(
-        tester.material<IconButton>(),
-        paints..ripple(color: directSplashColor)..ripple(color: directHighlightColor),
+        getMaterial<IconButton>(tester),
+        paintsRipple(color: directSplashColor)..circle(color: directHighlightColor),
       );
 
       const Color themeSplashColor1 = Color(0xFF000F00);
@@ -308,8 +308,8 @@ void main() {
       );
 
       expect(
-        tester.material<IconButton>(),
-        paints..ripple(color: themeSplashColor1)..ripple(color: themeHighlightColor1),
+        getMaterial<IconButton>(tester),
+        paintsRipple(color: themeSplashColor1)..circle(color: themeHighlightColor1),
       );
 
       const Color themeSplashColor2 = Color(0xFF002200);
@@ -326,7 +326,7 @@ void main() {
       );
 
       expect(
-        tester.material<IconButton>(),
+        getMaterial<IconButton>(tester),
         paints..circle(color: themeSplashColor2)..circle(color: themeHighlightColor2),
       );
 
@@ -358,7 +358,7 @@ void main() {
         await tester.pump(); // Start gesture.
         await tester.pump(const Duration(milliseconds: 1000)); // Wait for splash to be well under way.
 
-        expect(tester.material<IconButton>(), paints..ripple(radius: splashRadius));
+        expect(getMaterial<IconButton>(tester), paintsRipple(radius: splashRadius));
 
         await gesture.up();
       });
@@ -389,7 +389,7 @@ void main() {
         await tester.pump(); // Start gesture.
         await tester.pump(const Duration(milliseconds: 1000)); // Wait for ripple to be well under way.
 
-        expect(tester.material<IconButton>(), paints..ripple(radius: splashRadius + 5));
+        expect(getMaterial<IconButton>(tester), paintsRipple(radius: splashRadius + 5));
 
         await gesture.up();
       });
@@ -408,23 +408,28 @@ void main() {
       ),
     );
 
-    expect(semantics, hasSemantics(TestSemantics.root(
-      children: <TestSemantics>[
-        TestSemantics.rootChild(
-          rect: const Rect.fromLTRB(0.0, 0.0, 48.0, 48.0),
-          actions: <SemanticsAction>[
-            SemanticsAction.tap,
-          ],
-          flags: <SemanticsFlag>[
-            SemanticsFlag.hasEnabledState,
-            SemanticsFlag.isButton,
-            SemanticsFlag.isEnabled,
-            SemanticsFlag.isFocusable,
-          ],
-          label: 'link',
-        ),
-      ],
-    ), ignoreId: true, ignoreTransform: true));
+    expect(
+        semantics,
+        hasSemantics(
+            TestSemantics.root(
+              children: <TestSemantics>[
+                TestSemantics.rootChild(
+                  rect: const Rect.fromLTRB(0.0, 0.0, 48.0, 48.0),
+                  actions: <SemanticsAction>[
+                    SemanticsAction.tap,
+                  ],
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.hasEnabledState,
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isEnabled,
+                    SemanticsFlag.isFocusable,
+                  ],
+                  label: 'link',
+                ),
+              ],
+            ),
+            ignoreId: true,
+            ignoreTransform: true));
 
     semantics.dispose();
   });

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -283,7 +283,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
       expect(
-        getMaterial<IconButton>(tester),
+        getMaterialInkController<IconButton>(tester),
         paintsRipple(color: directSplashColor)..circle(color: directHighlightColor),
       );
 
@@ -308,7 +308,7 @@ void main() {
       );
 
       expect(
-        getMaterial<IconButton>(tester),
+        getMaterialInkController<IconButton>(tester),
         paintsRipple(color: themeSplashColor1)..circle(color: themeHighlightColor1),
       );
 
@@ -326,7 +326,7 @@ void main() {
       );
 
       expect(
-        getMaterial<IconButton>(tester),
+        getMaterialInkController<IconButton>(tester),
         paints..circle(color: themeSplashColor2)..circle(color: themeHighlightColor2),
       );
 
@@ -358,7 +358,7 @@ void main() {
         await tester.pump(); // Start gesture.
         await tester.pump(const Duration(milliseconds: 1000)); // Wait for splash to be well under way.
 
-        expect(getMaterial<IconButton>(tester), paintsRipple(radius: splashRadius));
+        expect(getMaterialInkController<IconButton>(tester), paintsRipple(radius: splashRadius));
 
         await gesture.up();
       });
@@ -389,7 +389,7 @@ void main() {
         await tester.pump(); // Start gesture.
         await tester.pump(const Duration(milliseconds: 1000)); // Wait for ripple to be well under way.
 
-        expect(getMaterial<IconButton>(tester), paintsRipple(radius: splashRadius + 5));
+        expect(getMaterialInkController<IconButton>(tester), paintsRipple(radius: splashRadius + 5));
 
         await gesture.up();
       });

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
     expect(
-      tester.material<InkWell>(),
+      getMaterial<InkWell>(tester),
       paints
         ..translate(x: 0.0, y: 0.0)
         ..save()
@@ -118,33 +118,46 @@ void main() {
     await tester.tapAt(tapDownOffset);
     await tester.pump(); // start gesture
 
-    final RenderBox box = tester.material<InkWell>() as RenderBox;
-
     // Initially the ripple's center is where the tap occurred;
-    // ripplePattern always add a translation of tapDownOffset.
-    expect(box, paints..ripple(tapDown: tapDownOffset, center: Offset.zero, radius: 30.0, alpha: 0));
+    // paintsRipple always adds a translation of tapDownOffset.
+    expect(
+      getMaterial<InkWell>(tester),
+      paintsRipple(tapDown: tapDownOffset, center: Offset.zero, radius: 30.0, alpha: 0),
+    );
 
     // The ripple fades in for 75ms. During that time its alpha is eased from
     // 0 to the splashColor's alpha value and its center moves towards the
     // center of the ink well.
     await tester.pump(const Duration(milliseconds: 50));
-    expect(box, paints..ripple(tapDown: tapDownOffset, center: const Offset(17, 17), radius: 56, alpha: 120));
+    expect(
+      getMaterial<InkWell>(tester),
+      paintsRipple(tapDown: tapDownOffset, center: const Offset(17, 17), radius: 56, alpha: 120),
+    );
 
     // At 75ms the ripple has fade in: it's alpha matches the splashColor's
     // alpha and its center has moved closer to the ink well's center.
     await tester.pump(const Duration(milliseconds: 25));
-    expect(box, paints..ripple(tapDown: tapDownOffset, center: const Offset(29, 29), radius: 73, alpha: 180));
+    expect(
+      getMaterial<InkWell>(tester),
+      paintsRipple(tapDown: tapDownOffset, center: const Offset(29, 29), radius: 73, alpha: 180),
+    );
 
     // At this point the splash radius has expanded to its limit: 5 past the
     // ink well's radius parameter. The splash center has moved to its final
     // location at the inkwell's center and the fade-out is about to start.
     // The fade-out begins at 225ms = 50ms + 25ms + 150ms.
     await tester.pump(const Duration(milliseconds: 150));
-    expect(box, paints..ripple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 180));
+    expect(
+      getMaterial<InkWell>(tester),
+      paintsRipple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 180),
+    );
 
     // After another 150ms the fade-out is complete.
     await tester.pump(const Duration(milliseconds: 150));
-    expect(box, paints..ripple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 0));
+    expect(
+      getMaterial<InkWell>(tester),
+      paintsRipple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 0),
+    );
   });
 
   testWidgets('Does the Ink widget render anything', (WidgetTester tester) async {
@@ -172,9 +185,8 @@ void main() {
     await tester.pump(); // start gesture
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
     expect(
-      box,
+      getMaterial<InkWell>(tester),
       paints
         ..rect(rect: const Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), color: Color(Colors.blue.value))
         ..circle(color: Color(Colors.green.value)),
@@ -199,10 +211,8 @@ void main() {
       ),
     );
 
-    expect(Material.of(tester.element(find.byType(InkWell))), same(box));
-
     expect(
-      box,
+      getMaterial<InkWell>(tester),
       paints
         ..rect(rect: const Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), color: Color(Colors.red.value))
         ..circle(color: Color(Colors.green.value)),
@@ -222,10 +232,8 @@ void main() {
       ),
     );
 
-    expect(Material.of(tester.element(find.byType(InkWell))), same(box));
-
-    expect(box, isNot(paints..rect()));
-    expect(box, isNot(paints..circle()));
+    expect(getMaterial<InkWell>(tester), isNot(paints..rect()));
+    expect(getMaterial<InkWell>(tester), isNot(paints..circle()));
 
     await gesture.up();
   });
@@ -281,27 +289,27 @@ void main() {
     final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
 
     // ripplePattern always add a translation of topLeft.
-    expect(box, paints..ripple(tapDown: topLeft, center: inkWellCenter, radius: 30, alpha: 0));
+    expect(box, paintsRipple(tapDown: topLeft, center: inkWellCenter, radius: 30, alpha: 0));
 
     // The ripple fades in for 75ms. During that time its alpha is eased from
     // 0 to the splashColor's alpha value.
     await tester.pump(const Duration(milliseconds: 50));
-    expect(box, paints..ripple(tapDown: topLeft, center: inkWellCenter, radius: 56, alpha: 120));
+    expect(box, paintsRipple(tapDown: topLeft, center: inkWellCenter, radius: 56, alpha: 120));
 
     // At 75ms the ripple has faded in: it's alpha matches the splashColor's
     // alpha.
     await tester.pump(const Duration(milliseconds: 25));
-    expect(box, paints..ripple(tapDown: topLeft, center: inkWellCenter, radius: 73, alpha: 180));
+    expect(box, paintsRipple(tapDown: topLeft, center: inkWellCenter, radius: 73, alpha: 180));
 
     // At this point the splash radius has expanded to its limit: 5 past the
     // ink well's radius parameter. The fade-out is about to start.
     // The fade-out begins at 225ms = 50ms + 25ms + 150ms.
     await tester.pump(const Duration(milliseconds: 150));
-    expect(box, paints..ripple(tapDown: topLeft, center: inkWellCenter, radius: 105, alpha: 180));
+    expect(box, paintsRipple(tapDown: topLeft, center: inkWellCenter, radius: 105, alpha: 180));
 
     // After another 150ms the fade-out is complete.
     await tester.pump(const Duration(milliseconds: 150));
-    expect(box, paints..ripple(tapDown: topLeft, center: inkWellCenter, radius: 105, alpha: 0));
+    expect(box, paintsRipple(tapDown: topLeft, center: inkWellCenter, radius: 105, alpha: 0));
   });
 
   testWidgets('Cancel an InkRipple that was disposed when its animation ended', (WidgetTester tester) async {
@@ -374,7 +382,6 @@ void main() {
     await gesture.moveTo(Offset.zero);
     await gesture.up(); // generates a tap cancel
 
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))! as RenderBox;
-    expect(box, paints..ripple(tapDown: tapDownOffset, alpha: 0, unique: true));
+    expect(getMaterial<InkWell>(tester), paintsRipple(tapDown: tapDownOffset, alpha: 0, unique: true));
   });
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paints
         ..translate(x: 0.0, y: 0.0)
         ..save()
@@ -121,7 +121,7 @@ void main() {
     // Initially the ripple's center is where the tap occurred;
     // paintsRipple always adds a translation of tapDownOffset.
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paintsRipple(tapDown: tapDownOffset, center: Offset.zero, radius: 30.0, alpha: 0),
     );
 
@@ -130,7 +130,7 @@ void main() {
     // center of the ink well.
     await tester.pump(const Duration(milliseconds: 50));
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paintsRipple(tapDown: tapDownOffset, center: const Offset(17, 17), radius: 56, alpha: 120),
     );
 
@@ -138,7 +138,7 @@ void main() {
     // alpha and its center has moved closer to the ink well's center.
     await tester.pump(const Duration(milliseconds: 25));
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paintsRipple(tapDown: tapDownOffset, center: const Offset(29, 29), radius: 73, alpha: 180),
     );
 
@@ -148,14 +148,14 @@ void main() {
     // The fade-out begins at 225ms = 50ms + 25ms + 150ms.
     await tester.pump(const Duration(milliseconds: 150));
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paintsRipple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 180),
     );
 
     // After another 150ms the fade-out is complete.
     await tester.pump(const Duration(milliseconds: 150));
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paintsRipple(tapDown: tapDownOffset, center: inkWellCenter - tapDownOffset, radius: 105, alpha: 0),
     );
   });
@@ -186,7 +186,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paints
         ..rect(rect: const Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), color: Color(Colors.blue.value))
         ..circle(color: Color(Colors.green.value)),
@@ -212,7 +212,7 @@ void main() {
     );
 
     expect(
-      getMaterial<InkWell>(tester),
+      getMaterialInkController<InkWell>(tester),
       paints
         ..rect(rect: const Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), color: Color(Colors.red.value))
         ..circle(color: Color(Colors.green.value)),
@@ -232,8 +232,8 @@ void main() {
       ),
     );
 
-    expect(getMaterial<InkWell>(tester), isNot(paints..rect()));
-    expect(getMaterial<InkWell>(tester), isNot(paints..circle()));
+    expect(getMaterialInkController<InkWell>(tester), isNot(paints..rect()));
+    expect(getMaterialInkController<InkWell>(tester), isNot(paints..circle()));
 
     await gesture.up();
   });
@@ -382,6 +382,6 @@ void main() {
     await gesture.moveTo(Offset.zero);
     await gesture.up(); // generates a tap cancel
 
-    expect(getMaterial<InkWell>(tester), paintsRipple(tapDown: tapDownOffset, alpha: 0, unique: true));
+    expect(getMaterialInkController<InkWell>(tester), paintsRipple(tapDown: tapDownOffset, alpha: 0, unique: true));
   });
 }

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -1,0 +1,59 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/mock_canvas.dart';
+
+PaintPatternPredicate _ripplePatternPredicate(Offset? expectedCenter, double? expectedRadius, Color? expectedColor, int? expectedAlpha, bool unique) {
+  String formattedValues(Offset? center, double? radius, Color? color, int? alpha) => <String>[
+        if (expectedCenter != null) 'center: $center',
+        if (expectedRadius != null) 'radius: ${(radius! * 10).truncateToDouble() / 10}',
+        if (expectedColor != null) 'color: $color',
+        if (expectedAlpha != null) 'alpha: $alpha',
+      ].join(', ');
+
+  return (Symbol method, List<dynamic> arguments) {
+    if (method != #drawCircle) {
+      return unique; //
+    }
+    final Offset center = arguments[0] as Offset;
+    final double radius = arguments[1] as double;
+    final Color color = (arguments[2] as Paint).color;
+    final int alpha = color.alpha;
+
+    // Any alpha passed to this predicate overrides the alpha baked into the expected color.
+    // This should make it easier to test that the color of ripples don't change, but the alphas do.
+    final Color? expectedColorWithAlpha = expectedColor?.withAlpha(expectedAlpha ?? expectedColor.alpha);
+
+    if ((expectedCenter == null || (center - expectedCenter).distanceSquared < 1.0) &&
+        (expectedRadius == null || (radius - expectedRadius).abs() < 1.0) &&
+        (expectedColorWithAlpha == null || color == expectedColorWithAlpha) &&
+        (expectedAlpha == null || alpha == expectedAlpha)) {
+      return true;
+    }
+    throw '''
+    
+Expected - ${formattedValues(expectedCenter, expectedRadius, expectedColorWithAlpha, expectedAlpha)}
+   Found - ${formattedValues(center, radius, color, alpha)}''';
+  };
+}
+
+extension RipplePaintPatternX on PaintPattern {
+  void ripple({Offset? tapDown, Offset? center, double? radius, Color? color, int? alpha, bool unique = false}) {
+    if (tapDown != null) {
+      translate(x: 0, y: 0);
+      translate(x: tapDown.dx, y: tapDown.dy);
+    }
+    final PaintPatternPredicate predicate = _ripplePatternPredicate(center, radius, color, alpha, unique);
+    return unique ? everything(predicate) : something(predicate);
+  }
+}
+
+extension MaterialFinderX on WidgetTester {
+  MaterialInkController material<T>() => Material.of(element(find.byType(T)))!;
+
+  RenderObject get inkFeatures => allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+}

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -83,7 +83,3 @@ PaintPattern paintsRipple({Offset? tapDown, Offset? center, double? radius, Colo
 MaterialInkController getMaterialInkController<T>(WidgetTester tester) {
   return Material.of(tester.element(find.byType(T)))!;
 }
-
-RenderObject getInkFeatures(WidgetTester tester) {
-  return tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-}

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -41,6 +41,32 @@ Expected - ${formattedValues(expectedCenter, expectedRadius, expectedColorWithAl
   };
 }
 
+/// Indicates that a circular ink feature is expected next.
+///
+/// This is a convenience method, that checks the paint against a
+/// [PaintPatternPredicate] representing an ink-feature-like painting. That
+/// predicate internally checks calls matching the [Canvas.drawCircle] method,
+/// with additional optional details specific to how an ink ripple or splash
+/// ink feature would be drawn. Any arguments that are passed to this method
+/// are compared to the actual [Canvas.drawCircle] call's arguments and any
+/// mismatches result in failure.
+///
+/// If no call to [Canvas.drawCircle] was made, then this results in failure.
+///
+/// Provide an offset for the `tapDown` and `center` parameters to test the
+/// position of the center of a ripple, relative to the position of the tap
+/// that initiated the ripple.
+///
+/// Provide a value for the `color` parameter to test that the ripple is drawn
+/// with a specific color. Without providing a specific `alpha` value, the
+/// predicate will check the ripple's color against it's `color`'s alpha.
+///
+/// Provide a value for the `alpha` parameter to override the alpha for the
+/// given color, or to only test the value of the ripple's alpha.
+///
+/// By default, calls made between the last matched call (if any) and the
+/// [Canvas.drawCircle] call are ignored. To test that only a ripple pattern
+/// was drawn, and no other canvas methods were called, set `unique` to `true`.
 PaintPattern paintsRipple({Offset? tapDown, Offset? center, double? radius, Color? color, int? alpha, bool unique = false}) {
   final PaintPattern pattern = paints;
   if (tapDown != null) {
@@ -52,6 +78,8 @@ PaintPattern paintsRipple({Offset? tapDown, Offset? center, double? radius, Colo
   return pattern;
 }
 
+// Returns the `MaterialInkController` used by a widget of type `T` to draw
+// ink features.
 MaterialInkController getMaterialInkController<T>(WidgetTester tester) {
   return Material.of(tester.element(find.byType(T)))!;
 }

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -41,19 +41,21 @@ Expected - ${formattedValues(expectedCenter, expectedRadius, expectedColorWithAl
   };
 }
 
-extension RipplePaintPatternX on PaintPattern {
-  void ripple({Offset? tapDown, Offset? center, double? radius, Color? color, int? alpha, bool unique = false}) {
-    if (tapDown != null) {
-      translate(x: 0, y: 0);
-      translate(x: tapDown.dx, y: tapDown.dy);
-    }
-    final PaintPatternPredicate predicate = _ripplePatternPredicate(center, radius, color, alpha, unique);
-    return unique ? everything(predicate) : something(predicate);
+PaintPattern paintsRipple({Offset? tapDown, Offset? center, double? radius, Color? color, int? alpha, bool unique = false}) {
+  final PaintPattern pattern = paints;
+  if (tapDown != null) {
+    pattern.translate(x: 0, y: 0);
+    pattern.translate(x: tapDown.dx, y: tapDown.dy);
   }
+  final PaintPatternPredicate predicate = _ripplePatternPredicate(center, radius, color, alpha, unique);
+  unique ? pattern.everything(predicate) : pattern.something(predicate);
+  return pattern;
 }
 
-extension MaterialFinderX on WidgetTester {
-  MaterialInkController material<T>() => Material.of(element(find.byType(T)))!;
+MaterialInkController getMaterial<T>(WidgetTester tester) {
+  return Material.of(tester.element(find.byType(T)))!;
+}
 
-  RenderObject get inkFeatures => allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+RenderObject getInkFeatures(WidgetTester tester) {
+  return tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
 }

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -35,7 +35,7 @@ PaintPatternPredicate _ripplePatternPredicate(Offset? expectedCenter, double? ex
       return true;
     }
     throw '''
-    
+
 Expected - ${formattedValues(expectedCenter, expectedRadius, expectedColorWithAlpha, expectedAlpha)}
    Found - ${formattedValues(center, radius, color, alpha)}''';
   };

--- a/packages/flutter/test/material/ink_paint_test_utils.dart
+++ b/packages/flutter/test/material/ink_paint_test_utils.dart
@@ -52,7 +52,7 @@ PaintPattern paintsRipple({Offset? tapDown, Offset? center, double? radius, Colo
   return pattern;
 }
 
-MaterialInkController getMaterial<T>(WidgetTester tester) {
+MaterialInkController getMaterialInkController<T>(WidgetTester tester) {
   return Material.of(tester.element(find.byType(T)))!;
 }
 

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -165,7 +165,7 @@ void main() {
         final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
         await gesture.addPointer();
         addTearDown(gesture.removePointer);
-        await gesture.moveTo(tester.getCenter(find.byType(Container)));
+        await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
         await tester.pumpAndSettle();
         expect(
           getInkFeatures(tester),
@@ -186,7 +186,7 @@ void main() {
         final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
         await gesture.addPointer();
         addTearDown(gesture.removePointer);
-        await gesture.moveTo(tester.getCenter(find.byType(Container)));
+        await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
         await tester.pumpAndSettle();
 
         expect(

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -140,7 +140,7 @@ void main() {
           child: Directionality(
             textDirection: TextDirection.ltr,
             child: Center(
-              child: Container(
+              child: SizedBox(
                 width: 100,
                 height: 100,
                 child: child,

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -168,7 +168,7 @@ void main() {
         await gesture.moveTo(tester.getCenter(find.byType(SizedBox)));
         await tester.pumpAndSettle();
         expect(
-          getInkFeatures(tester),
+          getMaterialInkController<InkWell>(tester),
           paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)),
         );
       });
@@ -190,7 +190,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          getInkFeatures(tester),
+          getMaterialInkController<InkWell>(tester),
           paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)),
         );
       });
@@ -215,11 +215,11 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
         expect(
-          getInkFeatures(tester),
+          getMaterialInkController<InkWell>(tester),
           paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)),
         );
       });
@@ -239,10 +239,13 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)));
+        expect(
+          getMaterialInkController<InkWell>(tester),
+          paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)),
+        );
       });
 
       testWidgets('ink response uses radius for focus highlight', (WidgetTester tester) async {
@@ -259,10 +262,13 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawCircle, 0));
+        expect(getMaterialInkController<InkResponse>(tester), paintsExactlyCountTimes(#drawCircle, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paints..circle(radius: 20, color: const Color(0xff0000ff)));
+        expect(
+          getMaterialInkController<InkResponse>(tester),
+          paints..circle(radius: 20, color: const Color(0xff0000ff)),
+        );
       });
 
       testWidgets("ink response doesn't change color on focus when on touch device", (WidgetTester tester) async {
@@ -283,10 +289,10 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsExactlyCountTimes(#drawRect, 0));
       });
     });
 
@@ -308,7 +314,7 @@ void main() {
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor),
           );
           await gesture.up();
@@ -329,13 +335,13 @@ void main() {
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor),
           );
 
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor),
           );
           await gesture.up();
@@ -358,13 +364,13 @@ void main() {
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200));
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor, alpha: 0),
           );
 
           await tester.pump(const Duration(milliseconds: 200));
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor),
           );
           await gesture.up();
@@ -385,13 +391,13 @@ void main() {
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200));
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor, alpha: 0),
           );
 
           await tester.pump(const Duration(milliseconds: 200));
           expect(
-            getInkFeatures(tester),
+            getMaterialInkController<InkWell>(tester),
             paintsRipple(center: const Offset(50, 50), color: splashColor),
           );
           await gesture.up();

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -125,6 +125,14 @@ void main() {
   });
 
   group('Ink feature color states', () {
+    MaterialStateProperty<Color> resolveColor({required MaterialState state, required Color color}) {
+      return MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+        if (states.contains(state))
+          return color;
+        return const Color(0xffbadbad); // Shouldn't happen.
+      });
+    }
+
     Widget boilerplate({InteractiveInkFeatureFactory? splashFactory, required Widget child}) {
       return Theme(
         data: ThemeData(splashFactory: splashFactory),
@@ -166,10 +174,7 @@ void main() {
         await tester.pumpWidget(
           boilerplate(
             child: InkWell(
-              overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                if (states.contains(MaterialState.hovered)) return const Color(0xff00ff00);
-                return const Color(0xffbadbad); // Shouldn't happen.
-              }),
+              overlayColor: resolveColor(state: MaterialState.hovered, color: const Color(0xff00ff00)),
               onTap: () {},
               onHover: (bool hover) {},
             ),
@@ -217,10 +222,7 @@ void main() {
           boilerplate(
             child: InkWell(
               focusNode: focusNode,
-              overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                if (states.contains(MaterialState.focused)) return const Color(0xff0000ff);
-                return const Color(0xffbadbad); // Shouldn't happen.
-              }),
+              overlayColor: resolveColor(state: MaterialState.focused, color: const Color(0xff0000ff)),
               highlightColor: const Color(0xf00fffff),
               onTap: () {},
               onHover: (bool hover) {},
@@ -306,10 +308,7 @@ void main() {
             boilerplate(
               splashFactory: InkSplash.splashFactory,
               child: InkWell(
-                overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                  if (states.contains(MaterialState.pressed)) return splashColor;
-                  return const Color(0xffbadbad); // Shouldn't happen.
-                }),
+                overlayColor: resolveColor(state: MaterialState.pressed, color: splashColor),
                 onTap: () {},
               ),
             ),
@@ -353,10 +352,7 @@ void main() {
             boilerplate(
               splashFactory: InkRipple.splashFactory,
               child: InkWell(
-                overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                  if (states.contains(MaterialState.pressed)) return splashColor;
-                  return const Color(0xffbadbad); // Shouldn't happen.
-                }),
+                overlayColor: resolveColor(state: MaterialState.pressed, color: splashColor),
                 onTap: () {},
               ),
             ),

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -167,7 +167,10 @@ void main() {
         addTearDown(gesture.removePointer);
         await gesture.moveTo(tester.getCenter(find.byType(Container)));
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)));
+        expect(
+          getInkFeatures(tester),
+          paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)),
+        );
       });
 
       testWidgets('InkWell uses resolved overlayColor MaterialState.hovered', (WidgetTester tester) async {
@@ -186,7 +189,10 @@ void main() {
         await gesture.moveTo(tester.getCenter(find.byType(Container)));
         await tester.pumpAndSettle();
 
-        expect(tester.inkFeatures, paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)));
+        expect(
+          getInkFeatures(tester),
+          paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff00ff00)),
+        );
       });
     });
 
@@ -209,10 +215,13 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)));
+        expect(
+          getInkFeatures(tester),
+          paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)),
+        );
       });
 
       testWidgets('ink response changes color on focus with overlayColor', (WidgetTester tester) async {
@@ -230,10 +239,10 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)));
+        expect(getInkFeatures(tester), paints..rect(rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), color: const Color(0xff0000ff)));
       });
 
       testWidgets('ink response uses radius for focus highlight', (WidgetTester tester) async {
@@ -250,10 +259,10 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawCircle, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paints..circle(radius: 20, color: const Color(0xff0000ff)));
+        expect(getInkFeatures(tester), paints..circle(radius: 20, color: const Color(0xff0000ff)));
       });
 
       testWidgets("ink response doesn't change color on focus when on touch device", (WidgetTester tester) async {
@@ -274,10 +283,10 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
         focusNode.requestFocus();
         await tester.pumpAndSettle();
-        expect(tester.inkFeatures, paintsExactlyCountTimes(#drawRect, 0));
+        expect(getInkFeatures(tester), paintsExactlyCountTimes(#drawRect, 0));
       });
     });
 
@@ -298,7 +307,10 @@ void main() {
           await tester.pumpAndSettle();
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor),
+          );
           await gesture.up();
         });
 
@@ -316,10 +328,16 @@ void main() {
           await tester.pumpAndSettle();
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor),
+          );
 
           await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor),
+          );
           await gesture.up();
         });
       });
@@ -339,10 +357,16 @@ void main() {
           await tester.pumpAndSettle();
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200));
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor, alpha: 0));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor, alpha: 0),
+          );
 
           await tester.pump(const Duration(milliseconds: 200));
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor),
+          );
           await gesture.up();
         });
 
@@ -360,10 +384,16 @@ void main() {
           await tester.pumpAndSettle();
           final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
           await tester.pump(const Duration(milliseconds: 200));
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor, alpha: 0));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor, alpha: 0),
+          );
 
           await tester.pump(const Duration(milliseconds: 200));
-          expect(tester.inkFeatures, paints..ripple(center: const Offset(50, 50), color: splashColor));
+          expect(
+            getInkFeatures(tester),
+            paintsRipple(center: const Offset(50, 50), color: splashColor),
+          );
           await gesture.up();
         });
       });

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -356,7 +356,7 @@ void main() {
         // paints above above material
         expect(
           getMaterialInkController<InkWell>(tester),
-          paintsRipple(center: const Offset(44, 0), color: splashColor),
+          paintsRipple(center: const Offset(44, 5), color: splashColor),
         );
         await gesture.up();
       });

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -38,7 +38,7 @@ void main() {
         await tester.tap(find.text('BUTTON'));
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -80,7 +80,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 10));
 
         if (!kIsWeb) {
-          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+          expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
         }
 
         await tester.pumpAndSettle();
@@ -97,7 +97,7 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -141,7 +141,7 @@ void main() {
 
         // centered in material button.
         expect(
-          getMaterial<InkWell>(tester),
+          getMaterialInkController<InkWell>(tester),
           paintsRipple(center: const Offset(44, 18), color: splashColor),
         );
         await gesture.up();
@@ -177,7 +177,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
         // paints above above material
         expect(
-          getMaterial<InkWell>(tester),
+          getMaterialInkController<InkWell>(tester),
           paintsRipple(center: const Offset(44, 0), color: splashColor),
         );
         await gesture.up();
@@ -207,10 +207,10 @@ void main() {
         await tester.tap(find.text('BUTTON'));
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
         await tester.pump(const Duration(milliseconds: 100));
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -252,10 +252,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 10));
 
         if (!kIsWeb) {
-          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
+          expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
           await tester.pump(const Duration(milliseconds: 100));
-          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+          expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
         }
 
         await tester.pumpAndSettle();
@@ -272,10 +272,10 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
         await tester.pump(const Duration(milliseconds: 100));
-        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
+        expect(getMaterialInkController<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -319,7 +319,7 @@ void main() {
 
         // centered in material button.
         expect(
-          getMaterial<InkWell>(tester),
+          getMaterialInkController<InkWell>(tester),
           paintsRipple(center: const Offset(44, 18), color: splashColor),
         );
         await gesture.up();
@@ -355,7 +355,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
         // paints above above material
         expect(
-          getMaterial<InkWell>(tester),
+          getMaterialInkController<InkWell>(tester),
           paintsRipple(center: const Offset(44, 0), color: splashColor),
         );
         await gesture.up();
@@ -523,12 +523,12 @@ void main() {
         ),
       ),
     );
-    expect(getMaterial<InkWell>(tester), isNot(paints..rect(color: focusColor)));
+    expect(getMaterialInkController<InkWell>(tester), isNot(paints..rect(color: focusColor)));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(getMaterial<InkWell>(tester), paints..rect(color: focusColor));
+    expect(getMaterialInkController<InkWell>(tester), paints..rect(color: focusColor));
   });
 
   testWidgets('RawMaterialButton loses focus when disabled.', (WidgetTester tester) async {
@@ -624,12 +624,12 @@ void main() {
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
-    expect(getMaterial<InkWell>(tester), isNot(paints..rect(color: hoverColor)));
+    expect(getMaterialInkController<InkWell>(tester), isNot(paints..rect(color: hoverColor)));
 
     await gesture.moveTo(tester.getCenter(find.byType(RawMaterialButton)));
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(getMaterial<InkWell>(tester), paints..rect(color: hoverColor));
+    expect(getMaterialInkController<InkWell>(tester), paints..rect(color: hoverColor));
   });
 
   testWidgets('RawMaterialButton onPressed and onLongPress callbacks are correctly called when non-null', (WidgetTester tester) async {

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -38,7 +38,7 @@ void main() {
         await tester.tap(find.text('BUTTON'));
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(tester.material<InkWell>(), paints..ripple(color: splashColor));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -80,7 +80,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 10));
 
         if (!kIsWeb) {
-          expect(tester.material<InkWell>(), paints..ripple(color: splashColor));
+          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
         }
 
         await tester.pumpAndSettle();
@@ -97,7 +97,7 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(tester.material<InkWell>(), paints..ripple(color: splashColor));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -140,7 +140,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
         // centered in material button.
-        expect(tester.material<InkWell>(), paints..ripple(center: const Offset(44, 18), color: splashColor));
+        expect(
+          getMaterial<InkWell>(tester),
+          paintsRipple(center: const Offset(44, 18), color: splashColor),
+        );
         await gesture.up();
       });
 
@@ -173,7 +176,10 @@ void main() {
         await tester.pump(); // start gesture
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
         // paints above above material
-        expect(tester.material<InkWell>(), paints..ripple(center: const Offset(44, 0), color: splashColor));
+        expect(
+          getMaterial<InkWell>(tester),
+          paintsRipple(center: const Offset(44, 0), color: splashColor),
+        );
         await gesture.up();
       });
     });
@@ -201,11 +207,10 @@ void main() {
         await tester.tap(find.text('BUTTON'));
         await tester.pump(const Duration(milliseconds: 10));
 
-        final RenderBox box = tester.material<InkWell>() as RenderBox;
-        expect(box, paints..ripple(color: splashColor, alpha: 0));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
         await tester.pump(const Duration(milliseconds: 100));
-        expect(box, paints..ripple(color: splashColor));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -247,11 +252,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 10));
 
         if (!kIsWeb) {
-          final RenderBox box = tester.material<InkWell>() as RenderBox;
-          expect(box, paints..ripple(color: splashColor, alpha: 0));
+          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
           await tester.pump(const Duration(milliseconds: 100));
-          expect(box, paints..ripple(color: splashColor));
+          expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
         }
 
         await tester.pumpAndSettle();
@@ -268,11 +272,10 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
         await tester.pump(const Duration(milliseconds: 10));
 
-        final RenderBox box = tester.material<InkWell>() as RenderBox;
-        expect(box, paints..ripple(color: splashColor, alpha: 0));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor, alpha: 0));
 
         await tester.pump(const Duration(milliseconds: 100));
-        expect(box, paints..ripple(color: splashColor));
+        expect(getMaterial<InkWell>(tester), paintsRipple(color: splashColor));
 
         await tester.pumpAndSettle();
 
@@ -315,7 +318,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
         // centered in material button.
-        expect(tester.material<InkWell>(), paints..ripple(center: const Offset(44, 18), color: splashColor));
+        expect(
+          getMaterial<InkWell>(tester),
+          paintsRipple(center: const Offset(44, 18), color: splashColor),
+        );
         await gesture.up();
       });
 
@@ -348,7 +354,10 @@ void main() {
         await tester.pump(); // start gesture
         await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
         // paints above above material
-        expect(tester.material<InkWell>(), paints..ripple(center: const Offset(44, 0), color: splashColor));
+        expect(
+          getMaterial<InkWell>(tester),
+          paintsRipple(center: const Offset(44, 0), color: splashColor),
+        );
         await gesture.up();
       });
     });
@@ -514,13 +523,12 @@ void main() {
         ),
       ),
     );
-    final RenderBox box = tester.material<InkWell>() as RenderBox;
-    expect(box, isNot(paints..rect(color: focusColor)));
+    expect(getMaterial<InkWell>(tester), isNot(paints..rect(color: focusColor)));
 
     focusNode.requestFocus();
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(box, paints..rect(color: focusColor));
+    expect(getMaterial<InkWell>(tester), paints..rect(color: focusColor));
   });
 
   testWidgets('RawMaterialButton loses focus when disabled.', (WidgetTester tester) async {
@@ -613,16 +621,15 @@ void main() {
         ),
       ),
     );
-    final RenderBox box = tester.material<InkWell>() as RenderBox;
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
-    expect(box, isNot(paints..rect(color: hoverColor)));
+    expect(getMaterial<InkWell>(tester), isNot(paints..rect(color: hoverColor)));
 
     await gesture.moveTo(tester.getCenter(find.byType(RawMaterialButton)));
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    expect(box, paints..rect(color: hoverColor));
+    expect(getMaterial<InkWell>(tester), paints..rect(color: hoverColor));
   });
 
   testWidgets('RawMaterialButton onPressed and onLongPress callbacks are correctly called when non-null', (WidgetTester tester) async {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -844,7 +844,7 @@ void main() {
       boilerplate(
         child: TabBarView(
           controller: controller,
-          children: const <Widget>[ Text('First'), Text('Second') ],
+          children: const <Widget>[Text('First'), Text('Second')],
         ),
       ),
     );
@@ -2783,17 +2783,16 @@ void main() {
       await tester.pumpWidget(
         boilerplate(
           child: DefaultTabController(
-            length: 1,
-            child: TabBar(
-              tabs: const <Tab>[
-                Tab(text: 'A'),
-              ],
-              overlayColor: MaterialStateProperty.resolveWith<Color>(
-                (Set<MaterialState> states) {
-                 if (states.contains(MaterialState.hovered))
-                    return const Color(0xff00ff00);
-                  if (states.contains(MaterialState.pressed))
-                    return const Color(0xf00fffff);
+              length: 1,
+              child: TabBar(
+                tabs: const <Tab>[
+                  Tab(
+                    text: 'A',
+                  )
+                ],
+                overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                  if (states.contains(MaterialState.hovered)) return const Color(0xff00ff00);
+                  if (states.contains(MaterialState.pressed)) return const Color(0xf00fffff);
                   return const Color(0xffbadbad); // Shouldn't happen.
                 },
               ),
@@ -2806,7 +2805,10 @@ void main() {
       addTearDown(gesture.removePointer);
       await gesture.moveTo(tester.getCenter(find.byType(Tab)));
       await tester.pumpAndSettle();
-      expect(tester.inkFeatures, paints..rect(rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0), color: const Color(0xff00ff00)));
+      expect(
+        getInkFeatures(tester),
+        paints..rect(rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0), color: const Color(0xff00ff00)),
+      );
     });
 
     testWidgets(
@@ -2837,10 +2839,12 @@ void main() {
         final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
         await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
 
-        expect(tester.inkFeatures, paints..ripple(center: const Offset(400, 24), color: splashColor));
-        await gesture.up();
-      },
-    );
+      expect(
+        getInkFeatures(tester),
+        paintsRipple(center: const Offset(400, 24), color: splashColor),
+      );
+      await gesture.up();
+    });
 
     testWidgets('Tab\'s InkRipple color matches resolved Tab overlayColor for MaterialState.pressed', (WidgetTester tester) async {
       const Color splashColor = Color(0xf00fffff);
@@ -2868,10 +2872,16 @@ void main() {
       final TestGesture gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
       await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
 
-      expect(tester.inkFeatures, paints..ripple(center: const Offset(400, 24), color: splashColor, alpha: 0));
+      expect(
+        getInkFeatures(tester),
+        paintsRipple(center: const Offset(400, 24), color: splashColor, alpha: 0),
+      );
       await tester.pump(const Duration(milliseconds: 200));
 
-      expect(tester.inkFeatures, paints..ripple(center: const Offset(400, 24), color: splashColor));
+      expect(
+        getInkFeatures(tester),
+        paintsRipple(center: const Offset(400, 24), color: splashColor),
+      );
       await gesture.up();
     });
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2848,7 +2848,7 @@ void main() {
       await gesture.up();
     });
 
-    testWidgets('Tab\'s InkRipple color matches resolved Tab overlayColor for MaterialState.pressed', (WidgetTester tester) async {
+    testWidgets("Tab's InkRipple color matches resolved Tab overlayColor for MaterialState.pressed", (WidgetTester tester) async {
       const Color splashColor = Color(0xf00fffff);
       await tester.pumpWidget(
         boilerplate(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2808,7 +2808,7 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byType(Tab)));
       await tester.pumpAndSettle();
       expect(
-        getInkFeatures(tester),
+        getMaterialInkController<TabBar>(tester),
         paints..rect(rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0), color: const Color(0xff00ff00)),
       );
     });
@@ -2842,7 +2842,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
 
       expect(
-        getInkFeatures(tester),
+        getMaterialInkController<TabBar>(tester),
         paintsRipple(center: const Offset(400, 24), color: splashColor),
       );
       await gesture.up();
@@ -2875,13 +2875,13 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200)); // unconfirmed splash is well underway
 
       expect(
-        getInkFeatures(tester),
+        getMaterialInkController<TabBar>(tester),
         paintsRipple(center: const Offset(400, 24), color: splashColor, alpha: 0),
       );
       await tester.pump(const Duration(milliseconds: 200));
 
       expect(
-        getInkFeatures(tester),
+        getMaterialInkController<TabBar>(tester),
         paintsRipple(center: const Offset(400, 24), color: splashColor),
       );
       await gesture.up();

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2791,8 +2791,10 @@ void main() {
                   )
                 ],
                 overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                  if (states.contains(MaterialState.hovered)) return const Color(0xff00ff00);
-                  if (states.contains(MaterialState.pressed)) return const Color(0xf00fffff);
+                  if (states.contains(MaterialState.hovered))
+                    return const Color(0xff00ff00);
+                  if (states.contains(MaterialState.pressed))
+                    return const Color(0xf00fffff);
                   return const Color(0xffbadbad); // Shouldn't happen.
                 },
               ),


### PR DESCRIPTION
## Description

This is the first in a series of PRs planned for several small improvements to the `InkWell` and its ripple animations. See https://github.com/flutter/flutter/issues/73163 for additional context:

> SplashFactory Test Coverage: Currently, many tests fail after changing the default splash factory on the material Theme. To make the PR changing the default splash factory easier, test coverage should be improved for widgets using ink features, to be able to pass regardless of what the theme’s default splash factory is. We can take the opportunity here to consolidate some duplicated code for utils related to testing how ripples are drawn.

This PR is just updating tests for widgets using `InkWell`s, to include test coverage for when the `InkWell`s in question will use both the `InkRipple.splashFactory` and the `InkSplash.splashFactory`. Specifically, this PR is meant to improve test coverage, so that when we update the default `splashFactory` on the material `Theme` from the `InkSplash.splashFactory` to the `InkRipple.splashFactory`, it isn't necessary to update a bunch of failing tests, but just add a small test for the default value on the `Theme`.

Also, you'll find that I added some small utils in `ink_paint_test_utils.dart`, to help consolidate a bunch of boilerplate code. This contributed to some extra diffs. Similarly, in places where it made sense, I organized tests into groups, which similarly led to a bunch of extra diffs.

## Related Issues

- [#73163: [proposal] InkRipple and InkSplash implementations warrant improvements](https://github.com/flutter/flutter/issues/73163)

## Tests

I added/modified the following tests:
`bottom_navigation_bar_test`:
- **BottomNavigationBar shifting backgroundColor with transition**

`chip_test`
- _Ink features
  - with InkSplashFactory_
    - **Chip creates centered, unique splash when label is tapped**
    - **Delete button creates non-centered, unique splash when tapped**
    - **Chip without delete button creates correct ripple**
    - **Selection with avatar works as expected on RawChip**
    - **Selection without avatar works as expected on RawChip**
    - **Activation works as expected on RawChip**
  - _with InkRippleFactory_
    - **Chip creates centered, unique splash when label is tapped**
    - **Delete button creates non-centered, unique splash when tapped**
    - **Chip without delete button creates correct ripple**
    - **Selection with avatar works as expected on RawChip**
    - **Selection without avatar works as expected on RawChip**
    - **Activation works as expected on RawChip**

`data_table_test`
- _DataRow custom colors_
  - **DataRow renders custom colors when selected**
  - **DataRow renders custom colors when disabled**
  - **DataRow with InkSplash splash factory renders custom colors when pressed**
  - **DataRow with InkRipple splash factory renders custom colors when pressed**

`icon_button_test`
- _Ink features_
  - **IconButton with explicit splashColor and highlightColor**
  - _with InkSplash splash factory_
    - **IconButton draws splash with explicit splashRadius**
  - _with InkRipple splash factory_
    - **IconButton ripple radius is 5 greater than splashRadius**

`ink_paint_test`
- **The InkWell widget renders an ink splash**
- **Does the Ink widget render anything**
- **The InkWell widget renders an SelectAction or ActivateAction-induced ink ripple**
- **Canceling InkRipple that was disposed when its animation ended draws one transparent circle**

`ink_well_test` (a bunch of organizing)
- _Ink feature color states_
  - _on hover_
    - **InkWell uses hoverColor**
    - **InkWell uses resolved overlayColor MaterialState.hovered**
  - _on focus_
    - **ink response changes color on focus**
    - **ink response changes color on focus with overlayColor**
    - **ink response uses radius for focus highlight**
    - **ink response doesn't change color on focus when on touch device**
  - _on pressed_
    - _with InkSplash splash factory_
      - **splash color matches splashColor**
      - **splash color matches resolved overlayColor for MaterialState.pressed**
    - _with InkSplash splash factory_
      - **ripple color matches splashColor**
      - **ripple color matches resolved overlayColor for MaterialState.pressed**

`raw_material_button_test`
- _Ink Features_
  - _with InkSplash.splashFactory_
    - **RawMaterialButton responds with splash when tapped**
    - **RawMaterialButton responds to shortcut with splash when activated**
    - **Ink splash from center tap originates in correct location**
    - **Ink splash from tap above material originates in correct location**
  - _with InkRipple.splashFactory_
    - **RawMaterialButton responds with ripple when tapped**
    - **RawMaterialButton responds to shortcut with ripple when activated**
    - **Ink ripple from center tap originates in correct location**
    - **Ink ripple from tap above material originates in correct location**

`tabs_test`
- **Tab's InkSplash color matches resolved Tab overlayColor for MaterialState.pressed**
- **Tab's InkRipple color matches resolved Tab overlayColor for MaterialState.pressed**

*Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
