### PR TITLE
[flutter_tools] provide default value for allowExistingDdsInstance

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1217,7 +1217,7 @@ abstract class ResidentRunner {
     Restart restart,
     CompileExpression compileExpression,
     GetSkSLMethod getSkSLMethod,
-    bool allowExistingDdsInstance,
+    bool allowExistingDdsInstance = true,
   }) async {
     if (!debuggingOptions.debuggingEnabled) {
       throw 'The service protocol is not enabled.';


### PR DESCRIPTION
b/176931351

Ensure that allowExistingDdsInstance is always initialized by providing a default value.
