### PR TITLE
Run pod repo update in iOS extension test

### DIFF
--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -30,6 +30,10 @@ Future<void> main() async {
         projectDir,
       );
 
+      // For some reason devicelab machines have really old spec snapshots.
+      // TODO(jmagman): Remove this if this test is moved to a machine that installs CocoaPods on every run.
+      await eval('pod', <String>['repo', 'update', '--verbose']);
+
       section('Create release build');
 
       await inDirectory(projectDir, () async {

--- a/dev/integration_tests/ios_app_with_extensions/ios/Podfile
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Podfile
@@ -39,7 +39,7 @@ target 'watch Extension' do
   use_frameworks!
   use_modular_headers!
 
-  pod 'EFQRCode/watchOS', '5.1.6'
+  pod 'EFQRCode', '6.0'
 end
 
 post_install do |installer|


### PR DESCRIPTION
In [a PR I updated an integration test pod](https://github.com/flutter/flutter/pull/72761) to version [EFQRCode=6.0 released 2020-11-04](https://cocoapods.org/pods/EFQRCode#600-2020-11-04), and the test succeeded on my machine but failed in the devicelab.
```
stdout:     Resolving dependencies of `Podfile`
stdout:       CDN: trunk Relative path: CocoaPods-version.yml exists! Returning local because checking is only perfomed in repo update
stdout:       CDN: trunk Relative path: all_pods_versions_9_f_5.txt exists! Returning local because checking is only perfomed in repo update
2021-01-06T14:45:02.365845: stdout:       CDN: trunk Relative path: Specs/9/f/5/EFQRCode/5.1.7/EFQRCode.podspec.json exists! Returning local because checking is only perfomed in repo update
stdout:     [!] CocoaPods could not find compatible versions for pod "EFQRCode":
stdout:       In Podfile:
stdout:         EFQRCode (= 6.0)
stdout: 
stdout:     None of your spec sources contain a spec satisfying the dependency: `EFQRCode (= 6.0)`.
stdout: 
stdout:     You have either:
stdout:      * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
stdout:      * mistyped the name or version.
stdout:      * not added the source repo that hosts the Podspec to your Podfile.
```
I'm not sure why the CocoaPods specs repo is so far out of date.  Run `pod repo update` before the integration test to update the snapshot.

Original PR:
https://github.com/flutter/flutter/pull/72761

Revert due to test failure:
https://github.com/flutter/flutter/pull/73437