### PR TITLE
Add [pointerCount] property to Scale Gesture Details

### DIFF
--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -60,7 +60,10 @@ class ScaleStartDetails {
   ///    coordinates.
   final Offset localFocalPoint;
 
-  /// The number of the pointers in contact with the screen.
+  /// The number of pointers being tracked by the gesture recognizer.
+  ///
+  /// Typically this is the number of fingers being used to pan the widget using the gesture
+  /// recognizer.
  final int pointerCount;
 
   @override
@@ -149,7 +152,10 @@ class ScaleUpdateDetails {
   /// Expressed in radians.
   final double rotation;
 
-  /// The number of the pointers in contact with the screen.
+  /// The number of pointers being tracked by the gesture recognizer.
+  ///
+  /// Typically this is the number of fingers being used to pan the widget using the gesture
+  /// recognizer.
   final int pointerCount;
 
   @override
@@ -174,7 +180,10 @@ class ScaleEndDetails {
   /// The velocity of the last pointer to be lifted off of the screen.
   final Velocity velocity;
 
-  /// The number of the pointers in contact with the screen.
+  /// The number of pointers being tracked by the gesture recognizer.
+  ///
+  /// Typically this is the number of fingers being used to pan the widget using the gesture
+  /// recognizer.
   final int pointerCount;
 
   @override

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -64,7 +64,7 @@ class ScaleStartDetails {
  final int pointerCount;
 
   @override
-  String toString() => 'ScaleStartDetails(focalPoint: $focalPoint, localFocalPoint: $pointerCount, pointersCount: $pointerCount)';
+  String toString() => 'ScaleStartDetails(focalPoint: $focalPoint, localFocalPoint: $localFocalPoint, pointersCount: $pointerCount)';
 }
 
 /// Details for [GestureScaleUpdateCallback].

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -36,7 +36,7 @@ class ScaleStartDetails {
   /// Creates details for [GestureScaleStartCallback].
   ///
   /// The [focalPoint] argument must not be null.
-  ScaleStartDetails({ this.focalPoint = Offset.zero, Offset? localFocalPoint, this.pointerCount = 0, })
+  ScaleStartDetails({ this.focalPoint = Offset.zero, Offset? localFocalPoint, this.pointerCount = 0 })
     : assert(focalPoint != null), localFocalPoint = localFocalPoint ?? focalPoint;
 
   /// The initial focal point of the pointers in contact with the screen.
@@ -174,7 +174,7 @@ class ScaleEndDetails {
   /// Creates details for [GestureScaleEndCallback].
   ///
   /// The [velocity] argument must not be null.
-  ScaleEndDetails({ this.velocity = Velocity.zero, this.pointerCount = 0, })
+  ScaleEndDetails({ this.velocity = Velocity.zero, this.pointerCount = 0 })
     : assert(velocity != null);
 
   /// The velocity of the last pointer to be lifted off of the screen.

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -36,7 +36,7 @@ class ScaleStartDetails {
   /// Creates details for [GestureScaleStartCallback].
   ///
   /// The [focalPoint] argument must not be null.
-  ScaleStartDetails({ this.focalPoint = Offset.zero, Offset? localFocalPoint, })
+  ScaleStartDetails({ this.focalPoint = Offset.zero, Offset? localFocalPoint, this.pointerCount = 0, })
     : assert(focalPoint != null), localFocalPoint = localFocalPoint ?? focalPoint;
 
   /// The initial focal point of the pointers in contact with the screen.
@@ -60,8 +60,11 @@ class ScaleStartDetails {
   ///    coordinates.
   final Offset localFocalPoint;
 
+  /// The number of the pointers in contact with the screen.
+ final int pointerCount;
+
   @override
-  String toString() => 'ScaleStartDetails(focalPoint: $focalPoint, localFocalPoint: $localFocalPoint)';
+  String toString() => 'ScaleStartDetails(focalPoint: $focalPoint, localFocalPoint: $pointerCount, pointersCount: $pointerCount)';
 }
 
 /// Details for [GestureScaleUpdateCallback].
@@ -78,6 +81,7 @@ class ScaleUpdateDetails {
     this.horizontalScale = 1.0,
     this.verticalScale = 1.0,
     this.rotation = 0.0,
+    this.pointerCount = 0,
   }) : assert(focalPoint != null),
        assert(scale != null && scale >= 0.0),
        assert(horizontalScale != null && horizontalScale >= 0.0),
@@ -145,8 +149,18 @@ class ScaleUpdateDetails {
   /// Expressed in radians.
   final double rotation;
 
+  /// The number of the pointers in contact with the screen.
+  final int pointerCount;
+
   @override
-  String toString() => 'ScaleUpdateDetails(focalPoint: $focalPoint, localFocalPoint: $localFocalPoint, scale: $scale, horizontalScale: $horizontalScale, verticalScale: $verticalScale, rotation: $rotation)';
+  String toString() => 'ScaleUpdateDetails('
+    'focalPoint: $focalPoint,'
+    ' localFocalPoint: $localFocalPoint,'
+    ' scale: $scale,'
+    ' horizontalScale: $horizontalScale,'
+    ' verticalScale: $verticalScale,'
+    ' rotation: $rotation,'
+    ' pointerCount: $pointerCount)';
 }
 
 /// Details for [GestureScaleEndCallback].
@@ -154,14 +168,17 @@ class ScaleEndDetails {
   /// Creates details for [GestureScaleEndCallback].
   ///
   /// The [velocity] argument must not be null.
-  ScaleEndDetails({ this.velocity = Velocity.zero })
+  ScaleEndDetails({ this.velocity = Velocity.zero, this.pointerCount = 0, })
     : assert(velocity != null);
 
   /// The velocity of the last pointer to be lifted off of the screen.
   final Velocity velocity;
 
+  /// The number of the pointers in contact with the screen.
+  final int pointerCount;
+
   @override
-  String toString() => 'ScaleEndDetails(velocity: $velocity)';
+  String toString() => 'ScaleEndDetails(velocity: $velocity, pointerCount: $pointerCount)';
 }
 
 /// Signature for when the pointers in contact with the screen have established
@@ -434,9 +451,9 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
           final Offset pixelsPerSecond = velocity.pixelsPerSecond;
           if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity)
             velocity = Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
-          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: velocity)));
+          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: velocity, pointerCount: _pointerQueue.length)));
         } else {
-          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: Velocity.zero)));
+          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: Velocity.zero, pointerCount: _pointerQueue.length)));
         }
       }
       _state = _ScaleState.accepted;
@@ -472,6 +489,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
           focalPoint: _currentFocalPoint,
           localFocalPoint: PointerEvent.transformPosition(_lastTransform, _currentFocalPoint),
           rotation: _computeRotationFactor(),
+          pointerCount: _pointerQueue.length,
         ));
       });
   }
@@ -483,6 +501,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
         onStart!(ScaleStartDetails(
           focalPoint: _currentFocalPoint,
           localFocalPoint: PointerEvent.transformPosition(_lastTransform, _currentFocalPoint),
+          pointerCount: _pointerQueue.length,
         ));
       });
   }

--- a/packages/flutter/test/foundation/bit_field_test.dart
+++ b/packages/flutter/test/foundation/bit_field_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import '../flutter_test_alternative.dart';
 
 // ignore: unused_field
-enum _TestEnum { a, b, c, d, e, f, g, h, }
+enum _TestEnum { a, b, c, d, e, f, g, h }
 
 void main() {
   test('BitField control test', () {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8695,7 +8695,7 @@ void main() {
   // Regressing test for https://github.com/flutter/flutter/issues/70625
   testWidgets('TextFields can inherit [FloatingLabelBehaviour] from InputDecorationTheme.', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
-    Widget textFieldBuilder({FloatingLabelBehavior behavior = FloatingLabelBehavior.auto, }) {
+    Widget textFieldBuilder({ FloatingLabelBehavior behavior = FloatingLabelBehavior.auto }) {
       return MaterialApp(
         theme: ThemeData(
           inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
Context addresses https://github.com/flutter/flutter/issues/13101#issuecomment-345876853 and #13102

Adding `pointerCount` property to scale gesture details is useful for developers. Use it to distinguish the scale caused by pan(one finger) and zoom(more than one finger) gesture.

CC @Hixie 

Fixes #13102
Fixes #49025 