### PR TITLE
[Refactoring] Replacing Size(x, x) with default constructors

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -361,10 +361,10 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
     Size size;
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
-        size = const Size(kMinInteractiveDimension, kMinInteractiveDimension);
+        size = const Size.square(kMinInteractiveDimension);
         break;
       case MaterialTapTargetSize.shrinkWrap:
-        size = const Size(kMinInteractiveDimension - 8.0, kMinInteractiveDimension - 8.0);
+        size = const Size.square(kMinInteractiveDimension - 8.0);
         break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1284,7 +1284,7 @@ class _RenderDecoration extends RenderBox {
     assert(debugCannotComputeDryLayout(
       reason: 'Layout requires baseline metrics, which are only available after a full layout.',
     ));
-    return const Size(0, 0);
+    return Size.zero;
   }
 
   @override

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1674,7 +1674,7 @@ class _RenderListTile extends RenderBox {
     assert(debugCannotComputeDryLayout(
       reason: 'Layout requires baseline metrics, which are only available after a full layout.'
     ));
-    return const Size(0, 0);
+    return Size.zero;
   }
 
   // All of the dimensions below were taken from the Material Design spec:

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -452,10 +452,10 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
     Size size;
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
-        size = const Size(kMinInteractiveDimension, kMinInteractiveDimension);
+        size = const Size.square(kMinInteractiveDimension);
         break;
       case MaterialTapTargetSize.shrinkWrap:
-        size = const Size(kMinInteractiveDimension - 8.0, kMinInteractiveDimension - 8.0);
+        size = const Size.square(kMinInteractiveDimension - 8.0);
         break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -26,7 +26,7 @@ const double _kToolbarContentDistance = 8.0;
 class MaterialTextSelectionControls extends TextSelectionControls {
   /// Returns the size of the Material handle.
   @override
-  Size getHandleSize(double textLineHeight) => const Size(_kHandleSize, _kHandleSize);
+  Size getHandleSize(double textLineHeight) => const Size.square(_kHandleSize);
 
   /// Builder for material-style copy/paste text selection toolbar.
   @override

--- a/packages/flutter/lib/src/material/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar.dart
@@ -560,7 +560,7 @@ class _RenderTextSelectionToolbarItemsLayout extends RenderBox with ContainerRen
   // offset that painted children will be placed at.
   void _placeChildren() {
     int i = -1;
-    Size nextSize = const Size(0.0, 0.0);
+    Size nextSize = Size.zero;
     double fitWidth = 0.0;
     final RenderBox navButton = firstChild!;
     double overflowHeight = overflowOpen && !isAbove ? navButton.size.height : 0.0;

--- a/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
@@ -111,7 +111,7 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
       style: TextButton.styleFrom(
         primary: primary,
         shape: const RoundedRectangleBorder(),
-        minimumSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),
+        minimumSize: const Size.square(kMinInteractiveDimension),
         padding: padding,
       ),
       onPressed: onPressed,

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -233,7 +233,7 @@ class _AccountDetailsLayout extends MultiChildLayoutDelegate {
 
     if (bottomLine != null) {
       final Size constraintSize = iconSize == null ? size : Size(size.width - iconSize.width, size.height);
-      iconSize ??= const Size(_kAccountDetailsHeight, _kAccountDetailsHeight);
+      iconSize ??= const Size.square(_kAccountDetailsHeight);
 
       // place bottom line center at same height as icon center
       final Size bottomLineSize = layoutChild(bottomLine, BoxConstraints.loose(constraintSize));

--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -339,7 +339,7 @@ class _FlutterLogoPainter extends BoxPainter {
       logoSize = const Size(252.0, 306.0);
     } else {
       // only the mark
-      logoSize = const Size(202.0, 202.0);
+      logoSize = const Size.square(202.0);
     }
     final FittedSizes fittedSize = applyBoxFit(BoxFit.contain, logoSize, canvasSize);
     assert(fittedSize.source == logoSize);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1852,7 +1852,7 @@ abstract class RenderBox extends RenderObject {
   /// In such cases, it may be impossible (or at least impractical) to actually
   /// return a valid answer. In such cases, the function should call
   /// [debugCannotComputeDryLayout] from within an assert and and return a dummy
-  /// value of `const Size(0, 0)`.
+  /// value of `Size.zero`.
   @protected
   Size computeDryLayout(BoxConstraints constraints) {
     assert(debugCannotComputeDryLayout(
@@ -1864,7 +1864,7 @@ abstract class RenderBox extends RenderObject {
         ),
       ]),
     ));
-    return const Size(0, 0);
+    return Size.zero;
   }
 
   static bool _dryLayoutCalculationValid = true;

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -677,7 +677,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       assert(debugCannotComputeDryLayout(
         reason: 'Dry layout cannot be computed for CrossAxisAlignment.baseline, which requires a full layout.'
       ));
-      return const Size(0, 0);
+      return Size.zero;
     }
     FlutterError? constraintsError;
     assert(() {
@@ -689,7 +689,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     }());
     if (constraintsError != null) {
       assert(debugCannotComputeDryLayout(error: constraintsError));
-      return const Size(0, 0);
+      return Size.zero;
     }
 
     final _LayoutSizes sizes = _computeSizes(

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -637,7 +637,7 @@ class RenderParagraph extends RenderBox
       assert(debugCannotComputeDryLayout(
         reason: 'Dry layout not available for alignments that require baseline.',
       ));
-      return const Size(0, 0);
+      return Size.zero;
     }
     _textPainter.setPlaceholderDimensions(_layoutChildren(constraints, dry: true));
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2502,7 +2502,7 @@ class RenderFittedBox extends RenderProxyBox {
         assert(debugCannotComputeDryLayout(
           reason: 'Child provided invalid size of $childSize.',
         ));
-        return const Size(0, 0);
+        return Size.zero;
       }
 
       switch (fit) {

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -1287,7 +1287,7 @@ class RenderBaseline extends RenderShiftedBox {
       assert(debugCannotComputeDryLayout(
         reason: 'Baseline metrics are only available after a full layout.',
       ));
-      return const Size(0, 0);
+      return Size.zero;
     }
     return constraints.smallest;
   }

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1002,7 +1002,7 @@ class RenderTable extends RenderBox {
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     if (rows * columns == 0) {
-      return constraints.constrain(const Size(0.0, 0.0));
+      return constraints.constrain(Size.zero);
     }
     final List<double> widths = _computeColumnWidths(constraints);
     final double tableWidth = widths.fold(0.0, (double a, double b) => a + b);
@@ -1046,7 +1046,7 @@ class RenderTable extends RenderBox {
     if (rows * columns == 0) {
       // TODO(ianh): if columns is zero, this should be zero width
       // TODO(ianh): if columns is not zero, this should be based on the column width specifications
-      size = constraints.constrain(const Size(0.0, 0.0));
+      size = constraints.constrain(Size.zero);
       return;
     }
     final List<double> widths = _computeColumnWidths(constraints);

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -964,7 +964,7 @@ class TextInputConnection {
     if (rect == _cachedRect)
       return;
     _cachedRect = rect;
-    final Rect validRect = rect.isFinite ? rect : Offset.zero & const Size(-1, -1);
+    final Rect validRect = rect.isFinite ? rect : Offset.zero & const Size.square(-1);
     TextInput._instance._setComposingTextRect(
       <String, dynamic>{
         'width': validRect.width,

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -351,7 +351,7 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
       'Calculating the dry layout would require running the layout callback '
       'speculatively, which might mutate the live render object tree.',
     ));
-    return const Size(0, 0);
+    return Size.zero;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2452,7 +2452,7 @@ class _RenderInspectorOverlay extends RenderBox {
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    return constraints.constrain(const Size(double.infinity, double.infinity));
+    return constraints.constrain(const Size.square(double.infinity));
   }
 
   @override

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -215,7 +215,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(strutStyle: StrutStyle.disabled),
             ),
           ),
@@ -236,7 +236,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(),
             ),
           ),
@@ -257,7 +257,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(
                 maxLines: 3,
                 strutStyle: StrutStyle.disabled,
@@ -281,7 +281,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(maxLines: 3),
             ),
           ),
@@ -302,7 +302,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(
                 maxLines: 3,
                 strutStyle: StrutStyle(
@@ -329,7 +329,7 @@ void main() {
         CupertinoApp(
           home: Center(
             child: ConstrainedBox(
-              constraints: BoxConstraints.loose(const Size(200, 200)),
+              constraints: BoxConstraints.loose(const Size.square(200)),
               child: const CupertinoTextField(
                 maxLines: 3,
                 style: TextStyle(fontSize: 10),
@@ -512,7 +512,7 @@ void main() {
         child: RepaintBoundary(
           key: const ValueKey<int>(1),
           child: ConstrainedBox(
-            constraints: BoxConstraints.loose(const Size(400, 400)),
+            constraints: BoxConstraints.loose(const Size.square(400)),
             child: const CupertinoTextField(),
           ),
         ),
@@ -539,7 +539,7 @@ void main() {
         child: RepaintBoundary(
           key: const ValueKey<int>(1),
           child: ConstrainedBox(
-            constraints: BoxConstraints.loose(const Size(400, 400)),
+            constraints: BoxConstraints.loose(const Size.square(400)),
             child: const CupertinoTextField(),
           ),
         ),
@@ -3219,7 +3219,7 @@ void main() {
   group('Text selection toolbar', () {
     testWidgets('Collapsed selection works', (WidgetTester tester) async {
       EditableText.debugDeterministicCursor = true;
-      tester.binding.window.physicalSizeTestValue = const Size(400, 400);
+      tester.binding.window.physicalSizeTestValue = const Size.square(400);
       tester.binding.window.devicePixelRatioTestValue = 1;
       TextEditingController controller;
       EditableTextState state;
@@ -3408,7 +3408,7 @@ void main() {
 
     testWidgets('selecting multiple words works', (WidgetTester tester) async {
       EditableText.debugDeterministicCursor = true;
-      tester.binding.window.physicalSizeTestValue = const Size(400, 400);
+      tester.binding.window.physicalSizeTestValue = const Size.square(400);
       tester.binding.window.devicePixelRatioTestValue = 1;
       final TextEditingController controller;
       final EditableTextState state;
@@ -3479,7 +3479,7 @@ void main() {
 
     testWidgets('selecting multiline works', (WidgetTester tester) async {
       EditableText.debugDeterministicCursor = true;
-      tester.binding.window.physicalSizeTestValue = const Size(400, 400);
+      tester.binding.window.physicalSizeTestValue = const Size.square(400);
       tester.binding.window.devicePixelRatioTestValue = 1;
       final TextEditingController controller;
       final EditableTextState state;
@@ -4018,7 +4018,7 @@ void main() {
           CupertinoApp(
             home: Center(
               child: ConstrainedBox(
-                constraints: BoxConstraints.loose(const Size(200, 200)),
+                constraints: BoxConstraints.loose(const Size.square(200)),
                 child: const CupertinoTextField(
                   autofocus: true,
                 ),
@@ -4129,7 +4129,7 @@ void main() {
       CupertinoApp(
         home: Center(
           child: ConstrainedBox(
-            constraints: BoxConstraints.loose(const Size(200, 200)),
+            constraints: BoxConstraints.loose(const Size.square(200)),
             child: const CupertinoTextField(),
           ),
         ),
@@ -4157,7 +4157,7 @@ void main() {
       CupertinoApp(
         home: Center(
           child: ConstrainedBox(
-            constraints: BoxConstraints.loose(const Size(200, 200)),
+            constraints: BoxConstraints.loose(const Size.square(200)),
             child: const CupertinoTextField(
               enabled: false,
             ),

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -282,7 +282,7 @@ void main() {
 
     testWidgets('When a menu item doesn\'t fit, a second page is used.', (WidgetTester tester) async {
       // Set the screen size to more narrow, so that Paste can't fit.
-      tester.binding.window.physicalSizeTestValue = const Size(800, 800);
+      tester.binding.window.physicalSizeTestValue = const Size.square(800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');

--- a/packages/flutter/test/material/animated_icons_test.dart
+++ b/packages/flutter/test/material/animated_icons_test.dart
@@ -94,7 +94,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.capturedPaint, hasColor(0xFF666666));
   });
 
@@ -116,7 +116,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.capturedPaint, hasColor(0x80666666));
   });
 
@@ -138,7 +138,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.capturedPaint, hasColor(0xFF0000FF));
   });
 
@@ -160,7 +160,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(12.0, 12.0));
+    customPaint.painter!.paint(canvas, const Size.square(12.0));
     // arrow_menu default size is 48x48 so we expect it to be scaled by 0.25.
     expect(canvas.capturedSx, 0.25);
     expect(canvas.capturedSy, 0.25);
@@ -185,7 +185,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(12.0, 12.0));
+    customPaint.painter!.paint(canvas, const Size.square(12.0));
     // arrow_menu default size is 48x48 so we expect it to be scaled by 2.
     expect(canvas.capturedSx, 2);
     expect(canvas.capturedSy, 2);
@@ -228,7 +228,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.invocations, const <RecordedCanvasCall>[
       RecordedRotate(math.pi),
       RecordedTranslate(-48, -48),
@@ -252,7 +252,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.invocations, isEmpty);
   });
 
@@ -274,7 +274,7 @@ void main() {
     );
     final CustomPaint customPaint = tester.widget(find.byType(CustomPaint));
     final MockCanvas canvas = MockCanvas();
-    customPaint.painter!.paint(canvas, const Size(48.0, 48.0));
+    customPaint.painter!.paint(canvas, const Size.square(48.0));
     expect(canvas.invocations, const <RecordedCanvasCall>[
       RecordedRotate(math.pi),
       RecordedTranslate(-48, -48),

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -313,7 +313,7 @@ void main() {
             centerTitle: false,
             title: Container(
               key: titleKey,
-              constraints: BoxConstraints.loose(const Size(1000.0, 1000.0)),
+              constraints: BoxConstraints.loose(const Size.square(1000.0)),
             ),
             actions: actions,
           ),
@@ -554,7 +554,7 @@ void main() {
 
     final Finder hamburger = find.byTooltip('Open navigation menu');
     expect(tester.getTopLeft(hamburger), const Offset(0.0, 0.0));
-    expect(tester.getSize(hamburger), const Size(56.0, 56.0));
+    expect(tester.getSize(hamburger), const Size.square(56.0));
   });
 
   testWidgets('test action is 4dp from edge and 48dp min', (WidgetTester tester) async {
@@ -1275,7 +1275,7 @@ void main() {
       ),
     );
     expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size.square(56.0));
   });
 
   testWidgets('AppBar handles loose children 1', (WidgetTester tester) async {
@@ -1306,7 +1306,7 @@ void main() {
       ),
     );
     expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size.square(56.0));
   });
 
   testWidgets('AppBar handles loose children 2', (WidgetTester tester) async {
@@ -1348,7 +1348,7 @@ void main() {
       ),
     );
     expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size.square(56.0));
   });
 
   testWidgets('AppBar handles loose children 3', (WidgetTester tester) async {
@@ -1381,7 +1381,7 @@ void main() {
       ),
     );
     expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size.square(56.0));
   });
 
   testWidgets('AppBar positioning of leading and trailing widgets with top padding', (WidgetTester tester) async {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -424,7 +424,7 @@ void main() {
     expect(dependentBuildCount, equals(1));
 
     // didChangeMetrics
-    tester.binding.window.physicalSizeTestValue = const Size(42, 42);
+    tester.binding.window.physicalSizeTestValue = const Size.square(42);
     addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
     await tester.pump();

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -138,10 +138,10 @@ void main() {
 
     // Default margin is 4
     expect(tester.getTopLeft(find.byType(Card)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byType(Card)), const Size(108.0, 108.0));
+    expect(tester.getSize(find.byType(Card)), const Size.square(108.0));
 
     expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(4.0, 4.0));
-    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
+    expect(tester.getSize(find.byKey(contentsKey)), const Size.square(100.0));
 
     await tester.pumpWidget(
       Container(
@@ -160,10 +160,10 @@ void main() {
 
     // Specified margin is zero
     expect(tester.getTopLeft(find.byType(Card)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byType(Card)), const Size(100.0, 100.0));
+    expect(tester.getSize(find.byType(Card)), const Size.square(100.0));
 
     expect(tester.getTopLeft(find.byKey(contentsKey)), const Offset(0.0, 0.0));
-    expect(tester.getSize(find.byKey(contentsKey)), const Size(100.0, 100.0));
+    expect(tester.getSize(find.byKey(contentsKey)), const Size.square(100.0));
   });
 
   testWidgets('Card clipBehavior property passes through to the Material', (WidgetTester tester) async {

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -36,7 +36,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(Checkbox)), const Size(48.0, 48.0));
+    expect(tester.getSize(find.byType(Checkbox)), const Size.square(48.0));
 
     await tester.pumpWidget(
       Theme(
@@ -55,7 +55,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(Checkbox)), const Size(40.0, 40.0));
+    expect(tester.getSize(find.byType(Checkbox)), const Size.square(40.0));
   });
 
   testWidgets('CheckBox semantics', (WidgetTester tester) async {
@@ -625,15 +625,15 @@ void main() {
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(48, 48)));
+    expect(box.size, equals(const Size.square(48)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(60, 60)));
+    expect(box.size, equals(const Size.square(60)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(36, 36)));
+    expect(box.size, equals(const Size.square(36)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: -3.0));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/checkbox_theme_test.dart
+++ b/packages/flutter/test/material/checkbox_theme_test.dart
@@ -133,7 +133,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(_getCheckboxMaterial(tester), paints..drrect(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
-    expect(tester.getSize(find.byType(Checkbox)), const Size(40.0, 40.0) + visualDensity.baseSizeAdjustment);
+    expect(tester.getSize(find.byType(Checkbox)), const Size.square(40.0) + visualDensity.baseSizeAdjustment);
 
     // Selected checkbox.
     await tester.pumpWidget(buildCheckbox(selected: true));
@@ -232,7 +232,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(_getCheckboxMaterial(tester), paints..drrect(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
-    expect(tester.getSize(find.byType(Checkbox)), const Size(40.0, 40.0) + visualDensity.baseSizeAdjustment);
+    expect(tester.getSize(find.byType(Checkbox)), const Size.square(40.0) + visualDensity.baseSizeAdjustment);
 
     // Selected checkbox.
     await tester.pumpWidget(buildCheckbox(selected: true));

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -648,7 +648,7 @@ void main() {
       tester.getSize(find.byKey(keyA)),
       anyOf(const Size(84.0, 14.0), const Size(83.0, 14.0)),
     );
-    expect(tester.getSize(find.byKey(keyB)), const Size(10.0, 10.0));
+    expect(tester.getSize(find.byKey(keyB)), const Size.square(10.0));
     expect(
       tester.getSize(find.byType(Chip).first),
       anyOf(const Size(132.0, 48.0), const Size(131.0, 48.0)),
@@ -671,7 +671,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(keyA)), equals(const Size(20.0, 20.0)));
+    expect(tester.getSize(find.byKey(keyA)), equals(const Size.square(20.0)));
   });
 
   testWidgets('Delete icons can be non-icon widgets', (WidgetTester tester) async {
@@ -690,7 +690,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(keyA)), equals(const Size(20.0, 20.0)));
+    expect(tester.getSize(find.byKey(keyA)), equals(const Size.square(20.0)));
   });
 
   testWidgets('Chip padding - LTR', (WidgetTester tester) async {
@@ -802,32 +802,32 @@ void main() {
     );
     // Avatar drawer should start out closed.
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(80.0, 48.0)));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)), equals(const Offset(-20.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     // Avatar drawer should start expanding.
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(81.2, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-18.8, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(13.2, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(86.7, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-13.3, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(18.6, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(94.7, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-5.3, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(26.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(99.5, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-0.5, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(31.5, epsilon: 0.1));
 
@@ -835,7 +835,7 @@ void main() {
     // height.
     await tester.pumpAndSettle(const Duration(milliseconds: 200));
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)), equals(const Offset(4.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(36.0, 17.0)));
 
@@ -843,32 +843,32 @@ void main() {
     await pushChip();
     // Avatar drawer should start out open.
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)), equals(const Offset(4.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(36.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     // Avatar drawer should start contracting.
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(102.9, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(2.9, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(34.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(98.0, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-2.0, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(30.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(84.1, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-15.9, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(16.1, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(80.0, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(avatarKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(avatarKey)).dx, moreOrLessEquals(-20.0, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)).dx, moreOrLessEquals(12.0, epsilon: 0.1));
 
@@ -917,37 +917,37 @@ void main() {
     await pushChip(deletable: true);
     // Delete button drawer should start out closed.
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(80.0, 48.0)));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)), equals(const Offset(52.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     // Delete button drawer should start expanding.
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(81.2, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(53.2, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(86.7, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(58.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(94.7, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(66.7, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(99.5, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(71.5, epsilon: 0.1));
 
     // Wait for being done with animation, and make sure it didn't change
     // height.
     await tester.pumpAndSettle(const Duration(milliseconds: 200));
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)), equals(const Offset(76.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
@@ -962,30 +962,30 @@ void main() {
     await pushChip();
     // Delete button drawer should start out open.
     expect(tester.getSize(find.byType(RawChip)), equals(const Size(104.0, 48.0)));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)), equals(const Offset(76.0, 12.0)));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     // Delete button drawer should start contracting.
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(103.8, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(75.8, epsilon: 0.1));
     expect(tester.getTopLeft(find.byKey(labelKey)), equals(const Offset(12.0, 17.0)));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(102.9, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(74.9, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(101.0, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(73.0, epsilon: 0.1));
 
     await tester.pump(const Duration(milliseconds: 20));
     expect(tester.getSize(find.byType(RawChip)).width, moreOrLessEquals(97.5, epsilon: 0.1));
-    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size(24.0, 24.0)));
+    expect(tester.getSize(find.byKey(deleteButtonKey)), equals(const Size.square(24.0)));
     expect(tester.getTopLeft(find.byKey(deleteButtonKey)).dx, moreOrLessEquals(69.5, epsilon: 0.1));
 
     // Wait for being done with animation, make sure it didn't change
@@ -2723,8 +2723,8 @@ void main() {
     Rect avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 32.0 + 16.0)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
-    expect(avatarBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size.square(24)));
+    expect(avatarBox.size, equals(const Size.square(24)));
     expect(textBox.top, equals(17));
     expect(box.bottom - textBox.bottom, equals(17));
     expect(textBox.left, equals(372));
@@ -2738,8 +2738,8 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 60)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
-    expect(avatarBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size.square(24)));
+    expect(avatarBox.size, equals(const Size.square(24)));
     expect(textBox.top, equals(23));
     expect(box.bottom - textBox.bottom, equals(23));
     expect(textBox.left, equals(372));
@@ -2753,8 +2753,8 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 36)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
-    expect(avatarBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size.square(24)));
+    expect(avatarBox.size, equals(const Size.square(24)));
     expect(textBox.top, equals(11));
     expect(box.bottom - textBox.bottom, equals(11));
     expect(textBox.left, equals(372));
@@ -2770,8 +2770,8 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 36)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
-    expect(avatarBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size.square(24)));
+    expect(avatarBox.size, equals(const Size.square(24)));
     expect(textBox.top, equals(11));
     expect(box.bottom - textBox.bottom, equals(11));
     expect(textBox.left, equals(372));

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(backgroundColor));
@@ -47,7 +47,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(backgroundColor));
@@ -67,7 +67,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.image!.fit, equals(BoxFit.cover));
@@ -84,7 +84,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.image!.fit, equals(BoxFit.cover));
@@ -108,7 +108,7 @@ void main() {
 
     expect(caughtForegroundImageError, true);
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.image!.fit, equals(BoxFit.cover));
@@ -132,7 +132,7 @@ void main() {
     final ThemeData fallback = ThemeData.fallback();
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(40.0, 40.0)));
+    expect(box.size, equals(const Size.square(40.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(fallback.primaryColorDark));
@@ -202,7 +202,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.text('Z')), equals(const Size(16.0, 16.0)));
+    expect(tester.getSize(find.text('Z')), equals(const Size.square(16.0)));
 
     await tester.pumpWidget(
       wrap(
@@ -218,7 +218,7 @@ void main() {
                 final MediaQueryData data = MediaQuery.of(context);
 
                 // These should not change.
-                expect(data.size, equals(const Size(111.0, 111.0)));
+                expect(data.size, equals(const Size.square(111.0)));
                 expect(data.devicePixelRatio, equals(1.1));
                 expect(data.padding, equals(const EdgeInsets.all(11.0)));
 
@@ -231,7 +231,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getSize(find.text('Z')), equals(const Size(16.0, 16.0)));
+    expect(tester.getSize(find.text('Z')), equals(const Size.square(16.0)));
   });
 
   testWidgets('CircleAvatar respects minRadius', (WidgetTester tester) async {
@@ -249,7 +249,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(backgroundColor));
@@ -271,7 +271,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(backgroundColor));
@@ -294,7 +294,7 @@ void main() {
     );
 
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
     expect(decoration.color, equals(backgroundColor));

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -487,7 +487,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(30.0, 30.0));
+    expect(icon.size, const Size.square(30.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -787,7 +787,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(24.0, 24.0));
+    expect(icon.size, const Size.square(24.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
@@ -817,7 +817,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(30.0, 30.0));
+    expect(icon.size, const Size.square(30.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
@@ -856,7 +856,7 @@ void main() {
 
     // test for size
     final RenderBox icon = tester.renderObject(find.byKey(iconKey));
-    expect(icon.size, const Size(40.0, 40.0));
+    expect(icon.size, const Size.square(40.0));
 
     // test for enabled color
     final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));

--- a/packages/flutter/test/material/elevated_button_theme_test.dart
+++ b/packages/flutter/test/material/elevated_button_theme_test.dart
@@ -136,7 +136,7 @@ void main() {
       expect(material.borderRadius, null);
       expect(material.shape, shape);
       expect(material.animationDuration, animationDuration);
-      expect(tester.getSize(find.byType(ElevatedButton)), const Size(200, 200));
+      expect(tester.getSize(find.byType(ElevatedButton)), const Size.square(200));
     }
 
     testWidgets('Button style overrides defaults', (WidgetTester tester) async {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -374,7 +374,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key1)), const Size(48.0, 48.0));
+    expect(tester.getSize(find.byKey(key1)), const Size.square(48.0));
 
     final Key key2 = UniqueKey();
     await tester.pumpWidget(
@@ -392,7 +392,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key2)), const Size(40.0, 40.0));
+    expect(tester.getSize(find.byKey(key2)), const Size.square(40.0));
   });
 
   testWidgets('FloatingActionButton.isExtended', (WidgetTester tester) async {

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -38,7 +38,7 @@ void main() {
     );
 
     final RenderBox iconButton = tester.renderObject(find.byType(IconButton));
-    expect(iconButton.size, const Size(48.0, 48.0));
+    expect(iconButton.size, const Size.square(48.0));
 
     await tester.tap(find.byType(IconButton));
     expect(mockOnPressedFunction.called, 1);
@@ -56,7 +56,7 @@ void main() {
     );
 
     final RenderBox iconButton = tester.renderObject(find.byType(IconButton));
-    expect(iconButton.size, const Size(48.0, 48.0));
+    expect(iconButton.size, const Size.square(48.0));
   });
 
   testWidgets('test icons can be small when total size is >48dp', (WidgetTester tester) async {
@@ -72,7 +72,7 @@ void main() {
     );
 
     final RenderBox iconButton = tester.renderObject(find.byType(IconButton));
-    expect(iconButton.size, const Size(70.0, 70.0));
+    expect(iconButton.size, const Size.square(70.0));
   });
 
   testWidgets('Small icons with non-null constraints can be <48dp', (WidgetTester tester) async {
@@ -91,7 +91,7 @@ void main() {
 
     // By default IconButton has a padding of 8.0 on all sides, so both
     // width and height are 10.0 + 2 * 8.0 = 26.0
-    expect(iconButton.size, const Size(26.0, 26.0));
+    expect(iconButton.size, const Size.square(26.0));
   });
 
   testWidgets('Small icons with non-null constraints and custom padding can be <48dp', (WidgetTester tester) async {
@@ -111,7 +111,7 @@ void main() {
 
     // This IconButton has a padding of 3.0 on all sides, so both
     // width and height are 10.0 + 2 * 3.0 = 16.0
-    expect(iconButton.size, const Size(16.0, 16.0));
+    expect(iconButton.size, const Size.square(16.0));
   });
 
   testWidgets('Small icons comply with VisualDensity requirements', (WidgetTester tester) async {
@@ -151,7 +151,7 @@ void main() {
     );
 
     final RenderBox box = tester.renderObject(find.byType(IconButton));
-    expect(box.size, const Size(80.0, 80.0));
+    expect(box.size, const Size.square(80.0));
   });
 
   testWidgets('test default icon buttons can be stretched if specified', (WidgetTester tester) async {
@@ -188,7 +188,7 @@ void main() {
     );
 
     final RenderBox box = tester.renderObject(find.byType(IconButton));
-    expect(box.size, const Size(96.0, 96.0));
+    expect(box.size, const Size.square(96.0));
   });
 
   testWidgets('test tooltip', (WidgetTester tester) async {
@@ -624,15 +624,15 @@ void main() {
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(48, 48)));
+    expect(box.size, equals(const Size.square(48)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(60, 60)));
+    expect(box.size, equals(const Size.square(60)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(40, 40)));
+    expect(box.size, equals(const Size.square(40)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: -3.0));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -693,7 +693,7 @@ void main() {
         padding: const EdgeInsets.all(4.0),
       ),
     );
-    expect(tester.getSize(find.byType(MaterialButton)), const Size(8.0, 8.0));
+    expect(tester.getSize(find.byType(MaterialButton)), const Size.square(8.0));
 
     // Size is defined by the padded child.
     await tester.pumpWidget(
@@ -704,7 +704,7 @@ void main() {
         child: const SizedBox(width: 8.0, height: 8.0),
       ),
     );
-    expect(tester.getSize(find.byType(MaterialButton)), const Size(16.0, 16.0));
+    expect(tester.getSize(find.byType(MaterialButton)), const Size.square(16.0));
 
     // Size is defined by the minWidth, height constraints.
     await tester.pumpWidget(
@@ -715,7 +715,7 @@ void main() {
         child: const SizedBox(width: 8.0, height: 8.0),
       ),
     );
-    expect(tester.getSize(find.byType(MaterialButton)), const Size(18.0, 18.0));
+    expect(tester.getSize(find.byType(MaterialButton)), const Size.square(18.0));
   });
 
   testWidgets('MaterialButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -158,8 +158,8 @@ void main() {
     // We paint twice because we have two CustomPaint widgets in the tree above
     // to test repainting both inside and outside the Material widget.
     expect(log, equals(<Size>[
-      const Size(150.0, 150.0),
-      const Size(100.0, 100.0),
+      const Size.square(150.0),
+      const Size.square(100.0),
     ]));
     log.clear();
 

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -139,7 +139,7 @@ void main() {
       expect(material.borderRadius, null);
       expect(material.shape, shape);
       expect(material.animationDuration, animationDuration);
-      expect(tester.getSize(find.byType(OutlinedButton)), const Size(200, 200));
+      expect(tester.getSize(find.byType(OutlinedButton)), const Size.square(200));
     }
 
     testWidgets('Button style overrides defaults', (WidgetTester tester) async {

--- a/packages/flutter/test/material/page_selector_test.dart
+++ b/packages/flutter/test/material/page_selector_test.dart
@@ -213,7 +213,7 @@ void main() {
 
     // Indicators get an 8 pixel margin, 16 + 8 = 24.
     for (final Element indicatorElement in indicatorElements)
-      expect(indicatorElement.size, const Size(24.0, 24.0));
+      expect(indicatorElement.size, const Size.square(24.0));
 
     expect(tester.getSize(find.byType(TabPageSelector)).height, 24.0);
   });

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -230,7 +230,7 @@ void main() {
   });
 
   testWidgets('PaginatedDataTable with and without header and actions', (WidgetTester tester) async {
-    await binding.setSurfaceSize(const Size(800, 800));
+    await binding.setSurfaceSize(const Size.square(800));
     const String headerText = 'HEADER';
     final List<Widget> actions = <Widget>[
       IconButton(onPressed: () {}, icon: const Icon(Icons.add)),
@@ -765,7 +765,7 @@ void main() {
   });
 
   testWidgets('PaginatedDataTable with optional column checkbox', (WidgetTester tester) async {
-    await binding.setSurfaceSize(const Size(800, 800));
+    await binding.setSurfaceSize(const Size.square(800));
 
     Widget buildTable(bool checkbox) => MaterialApp(
       home: PaginatedDataTable(
@@ -789,7 +789,7 @@ void main() {
 
   testWidgets('Table should not use decoration from DataTableTheme', (WidgetTester tester) async {
     final Size originalSize = binding.renderView.size;
-    await binding.setSurfaceSize(const Size(800, 800));
+    await binding.setSurfaceSize(const Size.square(800));
 
     Widget buildTable() {
       return MaterialApp(

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -533,7 +533,7 @@ void main() {
   });
 
   testWidgets('Indeterminate CircularProgressIndicator uses expected animation', (WidgetTester tester) async {
-    final AnimationSheetBuilder animationSheet = AnimationSheetBuilder(frameSize: const Size(40, 40));
+    final AnimationSheetBuilder animationSheet = AnimationSheetBuilder(frameSize: const Size.square(40));
 
     await tester.pumpFrames(animationSheet.record(
       const Directionality(

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -142,7 +142,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key1)), const Size(48.0, 48.0));
+    expect(tester.getSize(find.byKey(key1)), const Size.square(48.0));
 
     final Key key2 = UniqueKey();
     await tester.pumpWidget(
@@ -164,7 +164,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key2)), const Size(40.0, 40.0));
+    expect(tester.getSize(find.byKey(key2)), const Size.square(40.0));
   });
 
 
@@ -652,15 +652,15 @@ void main() {
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(48, 48)));
+    expect(box.size, equals(const Size.square(48)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(60, 60)));
+    expect(box.size, equals(const Size.square(60)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(36, 36)));
+    expect(box.size, equals(const Size.square(36)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: -3.0));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/radio_theme_test.dart
+++ b/packages/flutter/test/material/radio_theme_test.dart
@@ -122,7 +122,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(_getRadioMaterial(tester), paints..circle(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
-    expect(tester.getSize(_findRadio()), const Size(40.0, 40.0) + visualDensity.baseSizeAdjustment);
+    expect(tester.getSize(_findRadio()), const Size.square(40.0) + visualDensity.baseSizeAdjustment);
 
     // Selected radio.
     await tester.pumpWidget(buildRadio(selected: true));
@@ -216,7 +216,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(_getRadioMaterial(tester), paints..circle(color: defaultFillColor));
     // Size from MaterialTapTargetSize.shrinkWrap with added VisualDensity.
-    expect(tester.getSize(_findRadio()), const Size(40.0, 40.0) + visualDensity.baseSizeAdjustment);
+    expect(tester.getSize(_findRadio()), const Size.square(40.0) + visualDensity.baseSizeAdjustment);
 
     // Selected radio.
     await tester.pumpWidget(buildRadio(selected: true));

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -114,7 +114,7 @@ void main() {
           onPressed: () {
             pressed++;
           },
-          constraints: BoxConstraints.tight(const Size(10.0, 10.0)),
+          constraints: BoxConstraints.tight(const Size.square(10.0)),
           materialTapTargetSize: MaterialTapTargetSize.padded,
           child: const Text('+'),
         ),
@@ -134,7 +134,7 @@ void main() {
         child: Center(
           child: RawMaterialButton(
             onPressed: () { },
-            constraints: BoxConstraints.tight(const Size(10.0, 10.0)),
+            constraints: BoxConstraints.tight(const Size.square(10.0)),
             materialTapTargetSize: MaterialTapTargetSize.padded,
             child: const Text('+'),
           ),
@@ -537,19 +537,19 @@ void main() {
     final RenderBox box = tester.renderObject(find.byKey(key));
     Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(100, 100)));
+    expect(box.size, equals(const Size.square(100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(124, 124)));
+    expect(box.size, equals(const Size.square(124)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(100, 100)));
+    expect(box.size, equals(const Size.square(100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -24,7 +24,7 @@ class LoggingThumbShape extends SliderComponentShape {
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
-    return const Size(10.0, 10.0);
+    return const Size.square(10.0);
   }
 
   @override

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -724,19 +724,19 @@ void main() {
     final RenderBox box = tester.renderObject(find.byKey(key));
     Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
-    expect(box.size, equals(const Size(116, 116)));
+    expect(box.size, equals(const Size.square(116)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(140, 140)));
+    expect(box.size, equals(const Size.square(140)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(100, 100)));
+    expect(box.size, equals(const Size.square(100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -134,7 +134,7 @@ void main() {
       expect(material.borderRadius, null);
       expect(material.shape, shape);
       expect(material.animationDuration, animationDuration);
-      expect(tester.getSize(find.byType(TextButton)), const Size(200, 200));
+      expect(tester.getSize(find.byType(TextButton)), const Size.square(200));
     }
 
     testWidgets('Button style overrides defaults', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -229,7 +229,7 @@ void main() {
 
     testWidgets('A smaller menu bumps more items to the overflow menu.', (WidgetTester tester) async {
       // Set the screen size so narrow that only Cut and Copy can fit.
-      tester.binding.window.physicalSizeTestValue = const Size(800, 800);
+      tester.binding.window.physicalSizeTestValue = const Size.square(800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -528,17 +528,17 @@ void main() {
 
     expect(tester.getSemantics(find.text('B')), matchesSemantics(
       label: 'B',
-      size: const Size(48.0, 48.0),
+      size: const Size.square(48.0),
     ));
 
     expect(tester.getSemantics(find.text('C')), matchesSemantics(
       label: 'C',
-      size: const Size(48.0, 48.0),
+      size: const Size.square(48.0),
     ));
 
     expect(tester.getSemantics(find.text('D')), matchesSemantics(
       label: 'D',
-      size: const Size(48.0, 48.0),
+      size: const Size.square(48.0),
     ));
     handle.dispose();
   });

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -673,7 +673,7 @@ void main() {
     final Invocation call = canvas.invocations.firstWhere((Invocation call) => call.memberName == #drawImageRect);
     // The image should scale down to Size(25.0, 25.0) from Size(100.0, 100.0)
     // considering DecorationImage scale to be 4.0 and Image scale to be 1.0.
-    expect(call.positionalArguments[2].size, const Size(25.0, 25.0));
+    expect(call.positionalArguments[2].size, const Size.square(25.0));
     expect(call.positionalArguments[2], const Rect.fromLTRB(0.0, 0.0, 25.0, 25.0));
   });
 

--- a/packages/flutter/test/painting/geometry_test.dart
+++ b/packages/flutter/test/painting/geometry_test.dart
@@ -11,7 +11,7 @@ void main() {
     // exist in: ../material/tooltip_test.dart
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(20.0, 10.0),
         target: const Offset(50.0, 50.0),
         preferBelow: false,
@@ -22,7 +22,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(200.0, 10.0),
         target: const Offset(50.0, 50.0),
         preferBelow: false,
@@ -33,7 +33,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(200.0, 10.0),
         target: const Offset(0.0, 50.0),
         preferBelow: false,
@@ -44,7 +44,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(200.0, 10.0),
         target: const Offset(100.0, 50.0),
         preferBelow: false,
@@ -55,7 +55,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(50.0, 50.0),
         preferBelow: false,
@@ -66,7 +66,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(50.0, 50.0),
         preferBelow: false,
@@ -77,7 +77,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(0.0, 50.0),
         preferBelow: false,
@@ -88,7 +88,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(0.0, 50.0),
         preferBelow: false,
@@ -99,7 +99,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(100.0, 50.0),
         preferBelow: false,
@@ -110,7 +110,7 @@ void main() {
     );
     expect(
       positionDependentBox(
-        size: const Size(100.0, 100.0),
+        size: const Size.square(100.0),
         childSize: const Size(50.0, 10.0),
         target: const Offset(100.0, 50.0),
         preferBelow: false,

--- a/packages/flutter/test/painting/image_provider_resize_image_test.dart
+++ b/packages/flutter/test/painting/image_provider_resize_image_test.dart
@@ -23,7 +23,7 @@ void main() {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
     final MemoryImage imageProvider = MemoryImage(bytes);
     final Size rawImageSize = await _resolveAndGetSize(imageProvider);
-    expect(rawImageSize, const Size(1, 1));
+    expect(rawImageSize, const Size.square(1));
 
     const Size resizeDims = Size(14, 7);
     final ResizeImage resizedImage = ResizeImage(MemoryImage(bytes), width: resizeDims.width.round(), height: resizeDims.height.round(), allowUpscaling: true);
@@ -37,7 +37,7 @@ void main() {
     final Uint8List bytes = Uint8List.fromList(kBlueSquarePng);
     final MemoryImage imageProvider = MemoryImage(bytes);
     final Size rawImageSize = await _resolveAndGetSize(imageProvider);
-    expect(rawImageSize, const Size(50, 50));
+    expect(rawImageSize, const Size.square(50));
 
     const Size resizeDims = Size(25, 25);
     final ResizeImage resizedImage = ResizeImage(MemoryImage(bytes), width: resizeDims.width.round(), height: resizeDims.height.round(), allowUpscaling: true);
@@ -50,7 +50,7 @@ void main() {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
     final MemoryImage imageProvider = MemoryImage(bytes);
     final Size rawImageSize = await _resolveAndGetSize(imageProvider);
-    expect(rawImageSize, const Size(1, 1));
+    expect(rawImageSize, const Size.square(1));
 
     const Size resizeDims = Size(1, 1);
     final ResizeImage resizedImage = ResizeImage(MemoryImage(bytes), width: resizeDims.width.round(), height: resizeDims.height.round());
@@ -63,13 +63,13 @@ void main() {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
     final MemoryImage imageProvider = MemoryImage(bytes);
     final Size rawImageSize = await _resolveAndGetSize(imageProvider);
-    expect(rawImageSize, const Size(1, 1));
+    expect(rawImageSize, const Size.square(1));
 
     // Cannot pass in two null arguments for cache dimensions, so will use the regular
     // MemoryImage
     final MemoryImage resizedImage = MemoryImage(bytes);
     final Size resizedImageSize = await _resolveAndGetSize(resizedImage);
-    expect(resizedImageSize, const Size(1, 1));
+    expect(resizedImageSize, const Size.square(1));
   });
 
   test('ResizeImage stores values', () async {

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -147,7 +147,7 @@ void main() {
     expect(count, 1);
     expect(imageSizeInfo, isNotNull);
     expect(imageSizeInfo.source, 'test.png');
-    expect(imageSizeInfo.imageSize, const Size(300, 300));
+    expect(imageSizeInfo.imageSize, const Size.square(300));
     expect(imageSizeInfo.displaySize, const Size(200, 100));
 
     // Make sure that we don't report an identical image size info if we
@@ -186,7 +186,7 @@ void main() {
     expect(count, 1);
     expect(imageSizeInfo, isNotNull);
     expect(imageSizeInfo.source, 'test.png');
-    expect(imageSizeInfo.imageSize, const Size(300, 300));
+    expect(imageSizeInfo.imageSize, const Size.square(300));
     expect(imageSizeInfo.displaySize, const Size(200, 100));
 
     // Make sure that we don't report an identical image size info if we
@@ -204,7 +204,7 @@ void main() {
     expect(count, 2);
     expect(imageSizeInfo, isNotNull);
     expect(imageSizeInfo.source, 'test.png');
-    expect(imageSizeInfo.imageSize, const Size(300, 300));
+    expect(imageSizeInfo.imageSize, const Size.square(300));
     expect(imageSizeInfo.displaySize, const Size(200, 150));
 
     debugOnPaintImage = null;

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -174,7 +174,7 @@ void main() {
       textDirection: TextDirection.ltr,
     );
     painter.layout();
-    expect(painter.size, const Size(123.0, 123.0));
+    expect(painter.size, const Size.square(123.0));
   });
 
   test('TextPainter textScaleFactor test', () {
@@ -191,7 +191,7 @@ void main() {
       textScaleFactor: 2.0,
     );
     painter.layout();
-    expect(painter.size, const Size(20.0, 20.0));
+    expect(painter.size, const Size.square(20.0));
   });
 
   test('TextPainter textScaleFactor null style test', () {
@@ -203,7 +203,7 @@ void main() {
       textScaleFactor: 2.0,
     );
     painter.layout();
-    expect(painter.size, const Size(28.0, 28.0));
+    expect(painter.size, const Size.square(28.0));
   });
 
   test('TextPainter default text height is 14 pixels', () {
@@ -213,7 +213,7 @@ void main() {
     );
     painter.layout();
     expect(painter.preferredLineHeight, 14.0);
-    expect(painter.size, const Size(14.0, 14.0));
+    expect(painter.size, const Size.square(14.0));
   });
 
   test('TextPainter sets paragraph size from root', () {
@@ -223,7 +223,7 @@ void main() {
     );
     painter.layout();
     expect(painter.preferredLineHeight, 100.0);
-    expect(painter.size, const Size(100.0, 100.0));
+    expect(painter.size, const Size.square(100.0));
   });
 
   test('TextPainter intrinsic dimensions', () {

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -81,7 +81,7 @@ void main() {
       ];
       int i = 0;
       for (final OffsetLayer layer in layers) {
-        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(i, size: const Size(100.0, 100.0));
+        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(i, size: const Size.square(100.0));
         layer.append(annotatedRegionLayer);
         transformLayer.append(layer);
         i += 1;
@@ -116,7 +116,7 @@ void main() {
 
     test('does not clip Layer.find on an AnnotatedRegion with an unrelated type', () {
       final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
-      final AnnotatedRegionLayer<String> parent = AnnotatedRegionLayer<String>('hello', size: const Size(10.0, 10.0));
+      final AnnotatedRegionLayer<String> parent = AnnotatedRegionLayer<String>('hello', size: const Size.square(10.0));
       final ContainerLayer layer = ContainerLayer();
       parent.append(child);
       layer.append(parent);
@@ -210,7 +210,7 @@ void main() {
       ];
       int i = 0;
       for (final OffsetLayer layer in layers) {
-        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(i, size: const Size(100.0, 100.0));
+        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(i, size: const Size.square(100.0));
         layer.append(annotatedRegionLayer);
         transformLayer.append(layer);
         i += 1;
@@ -228,11 +228,11 @@ void main() {
 
       int index = 0;
       final List<AnnotatedRegionLayer<int>> layers = <AnnotatedRegionLayer<int>>[
-        AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0)),
-        AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0)),
+        AnnotatedRegionLayer<int>(index++, size: const Size.square(100.0)),
+        AnnotatedRegionLayer<int>(index++, size: const Size.square(100.0)),
       ];
       for (final ContainerLayer layer in layers) {
-        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(index++, size: const Size(100.0, 100.0));
+        final AnnotatedRegionLayer<int> annotatedRegionLayer = AnnotatedRegionLayer<int>(index++, size: const Size.square(100.0));
         layer.append(annotatedRegionLayer);
         parent.append(layer);
       }
@@ -266,7 +266,7 @@ void main() {
 
     test('does not clip Layer.find on an AnnotatedRegion with an unrelated type', () {
       final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
-      final AnnotatedRegionLayer<String> parent = AnnotatedRegionLayer<String>('hello', size: const Size(10.0, 10.0));
+      final AnnotatedRegionLayer<String> parent = AnnotatedRegionLayer<String>('hello', size: const Size.square(10.0));
       final ContainerLayer layer = ContainerLayer();
       parent.append(child);
       layer.append(parent);

--- a/packages/flutter/test/rendering/aspect_ratio_test.dart
+++ b/packages/flutter/test/rendering/aspect_ratio_test.dart
@@ -140,22 +140,22 @@ void main() {
     outside.maxWidth = 100.0;
     outside.maxHeight = 90.0;
     pumpFrame();
-    expect(inside.size, const Size(90.0, 90.0));
+    expect(inside.size, const Size.square(90.0));
 
     outside.maxWidth = 90.0;
     outside.maxHeight = 100.0;
     pumpFrame();
-    expect(inside.size, const Size(90.0, 90.0));
+    expect(inside.size, const Size.square(90.0));
 
     outside.maxWidth = double.infinity;
     outside.maxHeight = 90.0;
     pumpFrame();
-    expect(inside.size, const Size(90.0, 90.0));
+    expect(inside.size, const Size.square(90.0));
 
     outside.maxWidth = 90.0;
     outside.maxHeight = double.infinity;
     pumpFrame();
-    expect(inside.size, const Size(90.0, 90.0));
+    expect(inside.size, const Size.square(90.0));
 
     inside.aspectRatio = 2.0;
 

--- a/packages/flutter/test/rendering/baseline_test.dart
+++ b/packages/flutter/test/rendering/baseline_test.dart
@@ -17,7 +17,7 @@ void main() {
       child: parent = RenderBaseline(
         baseline: 0.0,
         baselineType: TextBaseline.alphabetic,
-        child: child = RenderSizedBox(const Size(100.0, 100.0)),
+        child: child = RenderSizedBox(const Size.square(100.0)),
       ),
     );
     final BoxParentData childParentData = child.parentData! as BoxParentData;
@@ -43,7 +43,7 @@ void main() {
     pumpFrame(phase: EnginePhase.layout);
     expect(childParentData.offset.dx, equals(0.0));
     expect(childParentData.offset.dy, equals(0.0));
-    expect(parent.size, equals(const Size(100.0, 100.0)));
+    expect(parent.size, equals(const Size.square(100.0)));
 
     parent.baseline = 110.0;
     pumpFrame(phase: EnginePhase.layout);

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -12,7 +12,7 @@ import 'rendering_tester.dart';
 
 class MissingPerformLayoutRenderBox extends RenderBox {
   void triggerExceptionSettingSizeOutsideOfLayout() {
-    size = const Size(200, 200);
+    size = const Size.square(200);
   }
 
   // performLayout is left unimplemented to test the error reported if it is

--- a/packages/flutter/test/rendering/constraints_test.dart
+++ b/packages/flutter/test/rendering/constraints_test.dart
@@ -12,7 +12,7 @@ void main() {
     RenderBox root, leaf, test;
     root = RenderPositionedBox(
       child: RenderConstrainedBox(
-        additionalConstraints: BoxConstraints.tight(const Size(200.0, 200.0)),
+        additionalConstraints: BoxConstraints.tight(const Size.square(200.0)),
         child: test = RenderFractionallySizedOverflowBox(
           widthFactor: 2.0,
           heightFactor: 0.5,

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -37,7 +37,7 @@ void main() {
       ),
       onSelectionChanged: (_, __, ___) { },
     );
-    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size.square(1000.0)));
 
     final PipelineOwner owner = PipelineOwner(onNeedVisualUpdate: () { });
     final _PointerRouterSpy spy = GestureBinding.instance!.pointerRouter as _PointerRouterSpy;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -134,7 +134,7 @@ void main() {
         offset: 0,
       ),
     );
-    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size.square(1000.0)));
     expect(
       (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
       paints..clipRect(rect: const Rect.fromLTRB(0.0, 0.0, 1000.0, 10.0)),
@@ -168,7 +168,7 @@ void main() {
 
     layout(editable);
 
-    editable.layout(BoxConstraints.loose(const Size(100, 100)));
+    editable.layout(BoxConstraints.loose(const Size.square(100)));
     expect(
       editable,
       // Draw no cursor by default.
@@ -231,7 +231,7 @@ void main() {
 
     layout(editable);
 
-    editable.layout(BoxConstraints.loose(const Size(100, 100)));
+    editable.layout(BoxConstraints.loose(const Size.square(100)));
     expect(editable.textAlign, TextAlign.start);
     expect(editable.debugNeedsLayout, isFalse);
 
@@ -267,7 +267,7 @@ void main() {
 
     layout(editable);
 
-    editable.layout(BoxConstraints.loose(const Size(100, 100)));
+    editable.layout(BoxConstraints.loose(const Size.square(100)));
     expect(
       editable,
       // Draw no cursor by default.
@@ -654,7 +654,7 @@ void main() {
       promptRectColor: promptRectColor,
       promptRectRange: const TextRange(start: 0, end: 1),
     );
-    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size.square(1000.0)));
 
     expect(
       (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
@@ -663,7 +663,7 @@ void main() {
 
     editable.promptRectColor = null;
 
-    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size.square(1000.0)));
     pumpFrame();
 
     expect(editable.promptRectColor, promptRectColor);
@@ -735,7 +735,7 @@ void main() {
     editable.layout(BoxConstraints.loose(const Size(500.0, 1000.0)));
     expect(editable.maxScrollExtent, equals(10));
 
-    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    editable.layout(BoxConstraints.loose(const Size.square(1000.0)));
     expect(editable.maxScrollExtent, equals(10));
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/42772
 
@@ -1506,7 +1506,7 @@ void main() {
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
     );
-    editable.layout(BoxConstraints.loose(const Size(100, 100)));
+    editable.layout(BoxConstraints.loose(const Size.square(100)));
     final List<TextSelectionPoint> endpoints = editable.getEndpointsForSelection(
       const TextSelection(baseOffset: 0, extentOffset: 1));
     expect(endpoints[0].point.dx, 0);

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -452,9 +452,9 @@ void main() {
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 250.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 250.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 250.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
   });
 
   test('Flex RTL', () {
@@ -467,90 +467,90 @@ void main() {
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 250.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(100.0, 250.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(200.0, 250.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.mainAxisAlignment = MainAxisAlignment.end;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 250.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 250.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 250.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.textDirection = TextDirection.rtl;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(200.0, 250.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(100.0, 250.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 250.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.mainAxisAlignment = MainAxisAlignment.start;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 250.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 250.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 250.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.start; // vertical direction is down
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 0.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 0.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 0.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.end;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 500.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 500.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.verticalDirection = VerticalDirection.up;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 0.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 0.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 0.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.start;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(600.0, 500.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(500.0, 500.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.direction = Axis.vertical; // and main=start, cross=start, up, rtl
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 400.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 300.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.end;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 400.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 300.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.stretch;
     pumpFrame();
@@ -575,36 +575,36 @@ void main() {
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 400.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(0.0, 300.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.crossAxisAlignment = CrossAxisAlignment.end;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 500.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 400.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 300.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.verticalDirection = VerticalDirection.down;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 0.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 100.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 200.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
 
     flex.mainAxisAlignment = MainAxisAlignment.end;
     pumpFrame();
     expect(box1.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 300.0));
     expect(box2.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 400.0));
     expect(box3.localToGlobal(const Offset(0.0, 0.0)), const Offset(700.0, 500.0));
-    expect(box1.size, const Size(100.0, 100.0));
-    expect(box2.size, const Size(100.0, 100.0));
-    expect(box3.size, const Size(100.0, 100.0));
+    expect(box1.size, const Size.square(100.0));
+    expect(box2.size, const Size.square(100.0));
+    expect(box3.size, const Size.square(100.0));
   });
 
   test('Intrinsics throw if alignment is baseline', () {

--- a/packages/flutter/test/rendering/intrinsic_width_test.dart
+++ b/packages/flutter/test/rendering/intrinsic_width_test.dart
@@ -396,7 +396,7 @@ void main() {
   test('Padding and boring intrinsics', () {
     final RenderBox box = RenderPadding(
       padding: const EdgeInsets.all(15.0),
-      child: RenderSizedBox(const Size(20.0, 20.0)),
+      child: RenderSizedBox(const Size.square(20.0)),
     );
 
     expect(box.getMinIntrinsicWidth(0.0), 50.0);
@@ -472,7 +472,7 @@ void main() {
   test('Padding and boring intrinsics', () {
     final RenderBox box = RenderPadding(
       padding: const EdgeInsets.all(15.0),
-      child: RenderSizedBox(const Size(20.0, 20.0)),
+      child: RenderSizedBox(const Size.square(20.0)),
     );
 
     expect(box.getMinIntrinsicWidth(0.0), 50.0);

--- a/packages/flutter/test/rendering/layer_annotations_test.dart
+++ b/packages/flutter/test/rendering/layer_annotations_test.dart
@@ -151,7 +151,7 @@ void main() {
       _Layers(
         OffsetLayer(offset: const Offset(-10, 0)),
         children: <Object>[
-          _TestAnnotatedLayer(1, opaque: true, size: const Size(10, 10)),
+          _TestAnnotatedLayer(1, opaque: true, size: const Size.square(10)),
         ]
       ).build(),
     );
@@ -176,12 +176,12 @@ void main() {
 
     final Layer root = _withBackgroundAnnotation(1000,
       _Layers(
-        ClipRectLayer(clipRect: const Offset(10, 10) & const Size(5, 5)),
+        ClipRectLayer(clipRect: const Offset(10, 10) & const Size.square(5)),
         children: <Object>[
           _TestAnnotatedLayer(
             1,
             opaque: true,
-            size: const Size(10, 10),
+            size: const Size.square(10),
             offset: const Offset(10, 10),
           ),
         ]
@@ -207,7 +207,7 @@ void main() {
     // location (1, 1) is outside, while (2, 2) is inside.
     // Here we shift this RRect by (10, 10).
     final RRect rrect = RRect.fromRectAndRadius(
-      const Offset(10, 10) & const Size(10, 10),
+      const Offset(10, 10) & const Size.square(10),
       const Radius.circular(4),
     );
     const Offset insidePosition = Offset(12, 12);
@@ -220,7 +220,7 @@ void main() {
           _TestAnnotatedLayer(
             1,
             opaque: true,
-            size: const Size(10, 10),
+            size: const Size.square(10),
             offset: const Offset(10, 10),
           ),
         ]
@@ -264,7 +264,7 @@ void main() {
           _TestAnnotatedLayer(
             1,
             opaque: true,
-            size: const Size(10, 10),
+            size: const Size.square(10),
             offset: const Offset(10, 10),
           ),
         ]
@@ -302,7 +302,7 @@ void main() {
           _TestAnnotatedLayer(
             1,
             opaque: true,
-            size: const Size(10, 10),
+            size: const Size.square(10),
             offset: const Offset(10, 10),
           ),
         ]
@@ -453,7 +453,7 @@ void main() {
           _TestAnnotatedLayer(
             1,
             opaque: true,
-            size: const Size(10, 10),
+            size: const Size.square(10),
             offset: const Offset(10, 10),
           ),
         ]
@@ -486,7 +486,7 @@ void main() {
           offset: const Offset(-10, 0),
         ),
         children: <Object>[
-          _TestAnnotatedLayer(1, opaque: true, size: const Size(10, 10)),
+          _TestAnnotatedLayer(1, opaque: true, size: const Size.square(10)),
         ]
       ).build(),
     );
@@ -669,7 +669,7 @@ void main() {
       _Layers(
         AnnotatedRegionLayer<int>(
           1,
-          size: const Size(20, 20),
+          size: const Size.square(20),
           offset: const Offset(90, 90),
         ),
         children: <Object>[
@@ -679,7 +679,7 @@ void main() {
             // Use this offset to make sure AnnotatedRegionLayer's offset
             // does not affect its children.
             offset: const Offset(20, 20),
-            size: const Size(110, 110),
+            size: const Size.square(110),
           ),
         ]
       ).build()
@@ -704,11 +704,11 @@ void main() {
       _Layers(
         AnnotatedRegionLayer<int>(
           1,
-          size: const Size(20, 20),
+          size: const Size.square(20),
           offset: const Offset(90, 90),
         ),
         children: <Object>[
-          _TestAnnotatedLayer(2, opaque: false, size: const Size(110, 110)),
+          _TestAnnotatedLayer(2, opaque: false, size: const Size.square(110)),
         ]
       ).build()
     );

--- a/packages/flutter/test/rendering/non_render_object_root_test.dart
+++ b/packages/flutter/test/rendering/non_render_object_root_test.dart
@@ -37,7 +37,7 @@ class RealRoot extends AbstractNode {
   PipelineOwner? get owner => super.owner as PipelineOwner?;
 
   void layout() {
-    child.layout(BoxConstraints.tight(const Size(500.0, 500.0)));
+    child.layout(BoxConstraints.tight(const Size.square(500.0)));
   }
 }
 
@@ -47,7 +47,7 @@ void main() {
     final RealRoot root = RealRoot(
       child = RenderPositionedBox(
         alignment: Alignment.center,
-        child: RenderSizedBox(const Size(100.0, 100.0)),
+        child: RenderSizedBox(const Size.square(100.0)),
       ),
     );
     root.attach(PipelineOwner());

--- a/packages/flutter/test/rendering/paint_error_test.dart
+++ b/packages/flutter/test/rendering/paint_error_test.dart
@@ -63,7 +63,7 @@ void main() {
 
   test('needsCompositingBitsUpdate paint error', () {
     late FlutterError flutterError;
-    final RenderBox root = RenderRepaintBoundary(child: RenderSizedBox(const Size(100, 100)));
+    final RenderBox root = RenderRepaintBoundary(child: RenderSizedBox(const Size.square(100)));
     try {
       layout(root);
       PaintingContext.repaintCompositedChild(root, debugAlsoPaintedParent: true);
@@ -113,6 +113,6 @@ class TestReentrantPaintingErrorRenderBox extends RenderBox {
 
   @override
   void performLayout() {
-    size = const Size(100, 100);
+    size = const Size.square(100);
   }
 }

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -36,7 +36,7 @@ void main() {
     test('layout should size to max constraint', () {
       layout(platformViewRenderBox);
       platformViewRenderBox.layout(const BoxConstraints(minWidth: 50, minHeight: 50, maxWidth: 100, maxHeight: 100));
-      expect(platformViewRenderBox.size, const Size(100, 100));
+      expect(platformViewRenderBox.size, const Size.square(100));
     });
 
     test('send semantics update if id is changed', (){

--- a/packages/flutter/test/rendering/positioned_box_test.dart
+++ b/packages/flutter/test/rendering/positioned_box_test.dart
@@ -10,11 +10,11 @@ import 'rendering_tester.dart';
 void main() {
   test('RenderPositionedBox expands', () {
     final RenderConstrainedBox sizer = RenderConstrainedBox(
-      additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      additionalConstraints: BoxConstraints.tight(const Size.square(100.0)),
       child: RenderDecoratedBox(decoration: const BoxDecoration()),
     );
     final RenderPositionedBox positioner = RenderPositionedBox(child: sizer);
-    layout(positioner, constraints: BoxConstraints.loose(const Size(200.0, 200.0)));
+    layout(positioner, constraints: BoxConstraints.loose(const Size.square(200.0)));
 
     expect(positioner.size.width, equals(200.0), reason: 'positioner width');
     expect(positioner.size.height, equals(200.0), reason: 'positioner height');
@@ -22,11 +22,11 @@ void main() {
 
   test('RenderPositionedBox shrink wraps', () {
     final RenderConstrainedBox sizer = RenderConstrainedBox(
-      additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      additionalConstraints: BoxConstraints.tight(const Size.square(100.0)),
       child: RenderDecoratedBox(decoration: const BoxDecoration()),
     );
     final RenderPositionedBox positioner = RenderPositionedBox(child: sizer, widthFactor: 1.0);
-    layout(positioner, constraints: BoxConstraints.loose(const Size(200.0, 200.0)));
+    layout(positioner, constraints: BoxConstraints.loose(const Size.square(200.0)));
 
     expect(positioner.size.width, equals(100.0), reason: 'positioner width');
     expect(positioner.size.height, equals(200.0), reason: 'positioner height');
@@ -47,11 +47,11 @@ void main() {
 
   test('RenderPositionedBox width and height factors', () {
     final RenderConstrainedBox sizer = RenderConstrainedBox(
-      additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      additionalConstraints: BoxConstraints.tight(const Size.square(100.0)),
       child: RenderDecoratedBox(decoration: const BoxDecoration()),
     );
     final RenderPositionedBox positioner = RenderPositionedBox(child: sizer, widthFactor: 1.0, heightFactor: 0.0);
-    layout(positioner, constraints: BoxConstraints.loose(const Size(200.0, 200.0)));
+    layout(positioner, constraints: BoxConstraints.loose(const Size.square(200.0)));
 
     expect(positioner.size.width, equals(100.0));
     expect(positioner.size.height, equals(0.0));

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     // The RenderFittedBox paints if both its size and its child's size are nonempty.
     painted = false;
-    layout(makeFittedBox(const Size(1, 1)), phase: EnginePhase.paint);
+    layout(makeFittedBox(const Size.square(1)), phase: EnginePhase.paint);
     expect(painted, equals(true));
 
     // The RenderFittedBox should not paint if its child is empty-sized.
@@ -56,7 +56,7 @@ void main() {
 
     // The RenderFittedBox should not paint if it is empty.
     painted = false;
-    layout(makeFittedBox(const Size(1, 1)), constraints: BoxConstraints.tight(Size.zero), phase: EnginePhase.paint);
+    layout(makeFittedBox(const Size.square(1)), constraints: BoxConstraints.tight(Size.zero), phase: EnginePhase.paint);
     expect(painted, equals(false));
   });
 
@@ -216,7 +216,7 @@ void main() {
     );
     stack.add(positioned);
     boundary.child = stack;
-    layout(boundary, constraints: BoxConstraints.tight(const Size(20.0, 20.0)));
+    layout(boundary, constraints: BoxConstraints.tight(const Size.square(20.0)));
     pumpFrame(phase: EnginePhase.composite);
     image = await boundary.toImage();
     expect(image.width, equals(20));
@@ -232,7 +232,7 @@ void main() {
 
     final OffsetLayer layer = boundary.debugLayer! as OffsetLayer;
 
-    image = await layer.toImage(Offset.zero & const Size(20.0, 20.0));
+    image = await layer.toImage(Offset.zero & const Size.square(20.0));
     expect(image.width, equals(20));
     expect(image.height, equals(20));
     data = (await image.toByteData())!;
@@ -240,7 +240,7 @@ void main() {
     expect(getPixel(image.width - 1, 0 ), equals(0xffffffff));
 
     // non-zero offsets.
-    image = await layer.toImage(const Offset(-10.0, -10.0) & const Size(30.0, 30.0));
+    image = await layer.toImage(const Offset(-10.0, -10.0) & const Size.square(30.0));
     expect(image.width, equals(30));
     expect(image.height, equals(30));
     data = (await image.toByteData())!;
@@ -250,7 +250,7 @@ void main() {
     expect(getPixel(image.width - 1, 10), equals(0xffffffff));
 
     // offset combined with a custom pixel ratio.
-    image = await layer.toImage(const Offset(-10.0, -10.0) & const Size(30.0, 30.0), pixelRatio: 2.0);
+    image = await layer.toImage(const Offset(-10.0, -10.0) & const Size.square(30.0), pixelRatio: 2.0);
     expect(image.width, equals(60));
     expect(image.height, equals(60));
     data = (await image.toByteData())!;
@@ -263,7 +263,7 @@ void main() {
   test('RenderOpacity does not composite if it is transparent', () {
     final RenderOpacity renderOpacity = RenderOpacity(
       opacity: 0.0,
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     );
 
     layout(renderOpacity, phase: EnginePhase.composite);
@@ -273,7 +273,7 @@ void main() {
   test('RenderOpacity does not composite if it is opaque', () {
     final RenderOpacity renderOpacity = RenderOpacity(
       opacity: 1.0,
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     );
 
     layout(renderOpacity, phase: EnginePhase.composite);
@@ -283,7 +283,7 @@ void main() {
   test('RenderOpacity reuses its layer', () {
     _testLayerReuse<OpacityLayer>(RenderOpacity(
       opacity: 0.5,  // must not be 0 or 1.0. Otherwise, it won't create a layer
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     ));
   });
 
@@ -295,7 +295,7 @@ void main() {
     final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
       alwaysIncludeSemantics: false,
       opacity: opacityAnimation,
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     );
 
     layout(renderAnimatedOpacity, phase: EnginePhase.composite);
@@ -310,7 +310,7 @@ void main() {
     final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
       alwaysIncludeSemantics: false,
       opacity: opacityAnimation,
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     );
 
     layout(renderAnimatedOpacity, phase: EnginePhase.composite);
@@ -324,7 +324,7 @@ void main() {
 
     _testLayerReuse<OpacityLayer>(RenderAnimatedOpacity(
       opacity: opacityAnimation,
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     ));
   });
 
@@ -337,14 +337,14 @@ void main() {
           const <Color>[Color.fromRGBO(0, 0, 0, 1.0), Color.fromRGBO(255, 255, 255, 1.0)],
         );
       },
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     ));
   });
 
   test('RenderBackdropFilter reuses its layer', () {
     _testLayerReuse<BackdropFilterLayer>(RenderBackdropFilter(
       filter: ui.ImageFilter.blur(),
-      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
     ));
   });
 
@@ -354,7 +354,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -365,7 +365,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -376,7 +376,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -387,7 +387,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -398,7 +398,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -410,7 +410,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -422,7 +422,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1.0, 1.0)),
+        child: RenderSizedBox(const Size.square(1.0)),
       ), // size doesn't matter
     ));
   });
@@ -447,7 +447,7 @@ void main() {
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,
-        child: RenderSizedBox(const Size(1, 1)),
+        child: RenderSizedBox(const Size.square(1)),
       ), // size doesn't matter
     ));
   }
@@ -501,7 +501,7 @@ void main() {
     final _TestSemanticsUpdateRenderFractionalTranslation box = _TestSemanticsUpdateRenderFractionalTranslation(
       translation: const Offset(0.5, 0.5),
     );
-    layout(box, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    layout(box, constraints: BoxConstraints.tight(const Size.square(200.0)));
     expect(box.markNeedsSemanticsUpdateCallCount, 1);
     box.translation = const Offset(0.4, 0.4);
     expect(box.markNeedsSemanticsUpdateCallCount, 2);
@@ -513,9 +513,9 @@ void main() {
     final RenderFollowerLayer follower = RenderFollowerLayer(
       link: LayerLink(),
       showWhenUnlinked: true,
-      child: RenderSizedBox(const Size(1.0, 1.0)),
+      child: RenderSizedBox(const Size.square(1.0)),
     );
-    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    layout(follower, constraints: BoxConstraints.tight(const Size.square(200.0)));
     final BoxHitTestResult hitTestResult = BoxHitTestResult();
     expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
   });
@@ -524,9 +524,9 @@ void main() {
     final RenderFollowerLayer follower = RenderFollowerLayer(
       link: LayerLink(),
       showWhenUnlinked: false,
-      child: RenderSizedBox(const Size(1.0, 1.0)),
+      child: RenderSizedBox(const Size.square(1.0)),
     );
-    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    layout(follower, constraints: BoxConstraints.tight(const Size.square(200.0)));
     final BoxHitTestResult hitTestResult = BoxHitTestResult();
     expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isFalse);
   });
@@ -540,9 +540,9 @@ void main() {
     final RenderFollowerLayer follower = RenderFollowerLayer(
       link: link,
       showWhenUnlinked: true,
-      child: RenderSizedBox(const Size(1.0, 1.0)),
+      child: RenderSizedBox(const Size.square(1.0)),
     );
-    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    layout(follower, constraints: BoxConstraints.tight(const Size.square(200.0)));
     final BoxHitTestResult hitTestResult = BoxHitTestResult();
     expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
   });
@@ -556,9 +556,9 @@ void main() {
     final RenderFollowerLayer follower = RenderFollowerLayer(
       link: link,
       showWhenUnlinked: false,
-      child: RenderSizedBox(const Size(1.0, 1.0)),
+      child: RenderSizedBox(const Size.square(1.0)),
     );
-    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    layout(follower, constraints: BoxConstraints.tight(const Size.square(200.0)));
     final BoxHitTestResult hitTestResult = BoxHitTestResult();
     // The follower is still hit testable because there is a leader layer.
     expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
@@ -597,7 +597,7 @@ class _TestRRectClipper extends CustomClipper<RRect> {
 void _testLayerReuse<L extends Layer>(RenderBox renderObject) {
   expect(L, isNot(Layer));
   expect(renderObject.debugLayer, null);
-  layout(renderObject, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
+  layout(renderObject, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size.square(10)));
   final Layer layer = renderObject.debugLayer!;
   expect(layer, isA<L>());
   expect(layer, isNotNull);

--- a/packages/flutter/test/rendering/proxy_sliver_test.dart
+++ b/packages/flutter/test/rendering/proxy_sliver_test.dart
@@ -14,7 +14,7 @@ void main() {
     final RenderSliverOpacity renderSliverOpacity = RenderSliverOpacity(
       opacity: 0.0,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -34,7 +34,7 @@ void main() {
     final RenderSliverOpacity renderSliverOpacity = RenderSliverOpacity(
       opacity: 1.0,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -53,7 +53,7 @@ void main() {
     final RenderSliverOpacity renderSliverOpacity = RenderSliverOpacity(
       opacity: 0.5,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -66,7 +66,7 @@ void main() {
     );
 
     expect(renderSliverOpacity.debugLayer, null);
-    layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
+    layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size.square(10)));
     final ContainerLayer layer = renderSliverOpacity.debugLayer!;
     expect(layer, isNotNull);
 
@@ -87,7 +87,7 @@ void main() {
       alwaysIncludeSemantics: false,
       opacity: opacityAnimation,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -112,7 +112,7 @@ void main() {
       alwaysIncludeSemantics: false,
       opacity: opacityAnimation,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -136,7 +136,7 @@ void main() {
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
       opacity: opacityAnimation,
       sliver: RenderSliverToBoxAdapter(
-        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+        child: RenderSizedBox(const Size.square(1.0)), // size doesn't matter
       )
     );
 
@@ -149,7 +149,7 @@ void main() {
     );
 
     expect(renderSliverAnimatedOpacity.debugLayer, null);
-    layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size(10, 10)));
+    layout(root, phase: EnginePhase.paint, constraints: BoxConstraints.tight(const Size.square(10)));
     final ContainerLayer layer = renderSliverAnimatedOpacity.debugLayer!;
     expect(layer, isNotNull);
 

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -86,7 +86,7 @@ void main() {
     final TestTree testTree = TestTree();
     // Lay out
     layout(testTree.root, phase: EnginePhase.layout);
-    expect(testTree.child.size, equals(const Size(20.0, 20.0)));
+    expect(testTree.child.size, equals(const Size.square(20.0)));
     // Remove testTree from the custom render view
     renderer.renderView.child = null;
     expect(testTree.child.owner, isNull);
@@ -95,7 +95,7 @@ void main() {
       const BoxConstraints.tightFor(height: 5.0, width: 5.0);
     // Lay out again
     layout(testTree.root, phase: EnginePhase.layout);
-    expect(testTree.child.size, equals(const Size(5.0, 5.0)));
+    expect(testTree.child.size, equals(const Size.square(5.0)));
   });
   test('objects can be detached and re-attached: compositingBits', () {
     final TestCompositingBitsTree testTree = TestCompositingBitsTree();

--- a/packages/flutter/test/rendering/size_test.dart
+++ b/packages/flutter/test/rendering/size_test.dart
@@ -10,13 +10,13 @@ import 'rendering_tester.dart';
 void main() {
   test('Stack can layout with top, right, bottom, left 0.0', () {
     final RenderBox box = RenderConstrainedBox(
-      additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)));
+      additionalConstraints: BoxConstraints.tight(const Size.square(100.0)));
 
     layout(box, constraints: const BoxConstraints());
 
     expect(box.size.width, equals(100.0));
     expect(box.size.height, equals(100.0));
-    expect(box.size, equals(const Size(100.0, 100.0)));
+    expect(box.size, equals(const Size.square(100.0)));
     expect(box.size.runtimeType.toString(), equals('_DebugSize'));
   });
 }

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -10,7 +10,7 @@ import 'rendering_tester.dart';
 void main() {
   test('Stack can layout with top, right, bottom, left 0.0', () {
     final RenderBox size = RenderConstrainedBox(
-      additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0))
+      additionalConstraints: BoxConstraints.tight(const Size.square(100.0))
     );
 
     final RenderBox red = RenderDecoratedBox(
@@ -55,7 +55,7 @@ void main() {
       children: <RenderBox>[],
     );
 
-    layout(stack, constraints: BoxConstraints.tight(const Size(100.0, 100.0)));
+    layout(stack, constraints: BoxConstraints.tight(const Size.square(100.0)));
 
     expect(stack.size.width, equals(100.0));
     expect(stack.size.height, equals(100.0));
@@ -91,13 +91,13 @@ void main() {
   group('RenderIndexedStack', () {
     test('visitChildrenForSemantics only visits displayed child', () {
       final RenderBox child1 = RenderConstrainedBox(
-          additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0))
+          additionalConstraints: BoxConstraints.tight(const Size.square(100.0))
       );
       final RenderBox child2 = RenderConstrainedBox(
-          additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0))
+          additionalConstraints: BoxConstraints.tight(const Size.square(100.0))
       );
       final RenderBox child3 = RenderConstrainedBox(
-          additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0))
+          additionalConstraints: BoxConstraints.tight(const Size.square(100.0))
       );
       final RenderBox stack = RenderIndexedStack(
           index: 1,

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -44,7 +44,7 @@ void main() {
     RenderTable table;
     layout(RenderPositionedBox(child: table = RenderTable(textDirection: TextDirection.ltr)));
 
-    expect(table.size, equals(const Size(0.0, 0.0)));
+    expect(table.size, equals(Size.zero));
   });
 
   test('Table control test: constrained flex columns', () {
@@ -71,7 +71,7 @@ void main() {
       textBaseline: TextBaseline.alphabetic,
     )));
 
-    expect(table.size, equals(const Size(0.0, 0.0)));
+    expect(table.size, equals(Size.zero));
 
     table.setChild(2, 4, sizedBox(100.0, 200.0));
 

--- a/packages/flutter/test/rendering/transform_test.dart
+++ b/packages/flutter/test/rendering/transform_test.dart
@@ -19,9 +19,9 @@ void main() {
     final RenderBox sizer = RenderTransform(
       transform: Matrix4.identity(),
       alignment: Alignment.center,
-      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+      child: inner = RenderSizedBox(const Size.square(100.0)),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(inner.globalToLocal(const Offset(0.0, 0.0)), equals(const Offset(0.0, 0.0)));
     expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(100.0, 100.0)));
     expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(25.0, 75.0)));
@@ -42,7 +42,7 @@ void main() {
         child: inner = RenderSizedBox(const Size(80.0, 100.0)),
       ),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(inner.globalToLocal(const Offset(0.0, 0.0)), equals(const Offset(-20.0, 0.0)));
     expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(80.0, 100.0)));
     expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(5.0, 75.0)));
@@ -58,9 +58,9 @@ void main() {
     final RenderBox sizer = RenderTransform(
       transform: Matrix4.translationValues(50.0, 200.0, 0.0),
       alignment: Alignment.center,
-      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+      child: inner = RenderSizedBox(const Size.square(100.0)),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(inner.globalToLocal(const Offset(0.0, 0.0)), equals(const Offset(-50.0, -200.0)));
     expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(50.0, -100.0)));
     expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(-25.0, -125.0)));
@@ -81,7 +81,7 @@ void main() {
         child: inner = RenderSizedBox(const Size(80.0, 100.0)),
       ),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(inner.globalToLocal(const Offset(0.0, 0.0)), equals(const Offset(-70.0, -200.0)));
     expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(30.0, -100.0)));
     expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(-45.0, -125.0)));
@@ -97,9 +97,9 @@ void main() {
     final RenderBox sizer = RenderTransform(
       transform: Matrix4.rotationZ(math.pi),
       alignment: Alignment.center,
-      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+      child: inner = RenderSizedBox(const Size.square(100.0)),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(round(inner.globalToLocal(const Offset(0.0, 0.0))), equals(const Offset(100.0, 100.0)));
     expect(round(inner.globalToLocal(const Offset(100.0, 100.0))), equals(const Offset(0.0, 0.0)));
     expect(round(inner.globalToLocal(const Offset(25.0, 75.0))), equals(const Offset(75.0, 25.0)));
@@ -120,7 +120,7 @@ void main() {
         child: inner = RenderSizedBox(const Size(80.0, 100.0)),
       ),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
     expect(round(inner.globalToLocal(const Offset(0.0, 0.0))), equals(const Offset(80.0, 100.0)));
     expect(round(inner.globalToLocal(const Offset(100.0, 100.0))), equals(const Offset(-20.0, 0.0)));
     expect(round(inner.globalToLocal(const Offset(25.0, 75.0))), equals(const Offset(55.0, 25.0)));
@@ -136,9 +136,9 @@ void main() {
     final RenderBox sizer = RenderTransform(
       transform: rotateAroundXAxis(math.pi * 0.25), // at pi/4, we are about 70 pixels high
       alignment: Alignment.center,
-      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+      child: inner = RenderSizedBox(const Size.square(100.0)),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
 
     expect(round(inner.globalToLocal(const Offset(25.0, 50.0))), equals(const Offset(25.0, 50.0)));
     expect(inner.globalToLocal(const Offset(25.0, 17.0)).dy, greaterThan(0.0));
@@ -154,9 +154,9 @@ void main() {
     final RenderBox sizer = RenderTransform(
       transform: rotateAroundXAxis(math.pi * 0.4999), // at pi/2, we're seeing the box on its edge,
       alignment: Alignment.center,
-      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+      child: inner = RenderSizedBox(const Size.square(100.0)),
     );
-    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    layout(sizer, constraints: BoxConstraints.tight(const Size.square(100.0)), alignment: Alignment.topLeft);
 
     // the inner widget has a height of about half a pixel at this rotation, so
     // everything should end up around the middle of the outer box.

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1200,7 +1200,7 @@ void main() {
           // the viewport should not scroll.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: Offset.zero & const Size(300, 300),
+            rect: Offset.zero & const Size.square(300),
           );
           await tester.pumpAndSettle();
           // The header expands but doesn't move.
@@ -1214,7 +1214,7 @@ void main() {
           // See: https://github.com/flutter/flutter/issues/25507.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: const Offset(-1, -1) & const Size(300, 300),
+            rect: const Offset(-1, -1) & const Size.square(300),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 15);
@@ -1244,7 +1244,7 @@ void main() {
           // The persistent header is pinned to the leading edge thus still visible,
           // the viewport should not scroll.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
-            rect: Offset.zero & const Size(300, 300),
+            rect: Offset.zero & const Size.square(300),
           );
           await tester.pumpAndSettle();
           // The header expands but doesn't move.
@@ -1257,7 +1257,7 @@ void main() {
           //
           // See: https://github.com/flutter/flutter/issues/25507.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
-            rect: const Offset(-1, -1) & const Size(300, 300),
+            rect: const Offset(-1, -1) & const Size.square(300),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 15);
@@ -1292,7 +1292,7 @@ void main() {
 
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: Offset.zero & const Size(300, 300),
+            rect: Offset.zero & const Size.square(300),
           );
           await tester.pumpAndSettle();
           // The header doesn't move. It would have expanded to 300 but
@@ -1303,7 +1303,7 @@ void main() {
           // ignoreLeading still works.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: const Offset(-1, -1) & const Size(300, 300),
+            rect: const Offset(-1, -1) & const Size.square(300),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 15);
@@ -1317,7 +1317,7 @@ void main() {
           // Doesn't move, doesn't expand or shrink, leading still ignored.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: const Offset(-1, -1) & const Size(300, 300),
+            rect: const Offset(-1, -1) & const Size.square(300),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 10 + 50.0);
@@ -1352,7 +1352,7 @@ void main() {
 
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: Offset.zero & const Size(110, 110),
+            rect: Offset.zero & const Size.square(110),
           );
           await tester.pumpAndSettle();
           // The header doesn't move. It would have expanded to 110 but
@@ -1363,7 +1363,7 @@ void main() {
           // ignoreLeading still works.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: const Offset(-1, -1) & const Size(110, 110),
+            rect: const Offset(-1, -1) & const Size.square(110),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 15);
@@ -1377,7 +1377,7 @@ void main() {
           // Doesn't move, doesn't expand or shrink, leading still ignored.
           tester.renderObject(pinnedHeaderContent).showOnScreen(
             descendant: tester.renderObject(pinnedHeaderContent),
-            rect: const Offset(-1, -1) & const Size(110, 110),
+            rect: const Offset(-1, -1) & const Size.square(110),
           );
           await tester.pumpAndSettle();
           expect(controller.offset, 300.0 * 10 + 50.0);

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -25,7 +25,7 @@ void main() {
             id: 0,
             viewType: 'web',
             layoutDirection: TextDirection.ltr,
-          ).setSize(const Size(100.0, 100.0));
+          ).setSize(const Size.square(100.0));
         },
         throwsA(isA<PlatformException>()),
       );
@@ -45,7 +45,7 @@ void main() {
     test('create Android views', () async {
       viewsController.registerViewType('webview');
       await PlatformViewsService.initAndroidView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr)
-          .setSize(const Size(100.0, 100.0));
+          .setSize(const Size.square(100.0));
       await PlatformViewsService.initAndroidView( id: 1, viewType: 'webview', layoutDirection: TextDirection.rtl)
           .setSize(const Size(200.0, 300.0));
       await PlatformViewsService.initSurfaceAndroidView(id: 2, viewType: 'webview', layoutDirection: TextDirection.rtl).create();
@@ -64,10 +64,10 @@ void main() {
         id: 0,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      ).setSize(const Size(100.0, 100.0));
+      ).setSize(const Size.square(100.0));
       expect(
           () => PlatformViewsService.initAndroidView(
-              id: 0, viewType: 'web', layoutDirection: TextDirection.ltr).setSize(const Size(100.0, 100.0)),
+              id: 0, viewType: 'web', layoutDirection: TextDirection.ltr).setSize(const Size.square(100.0)),
           throwsA(isA<PlatformException>()));
 
       await PlatformViewsService.initSurfaceAndroidView(
@@ -84,7 +84,7 @@ void main() {
     test('dispose Android view', () async {
       viewsController.registerViewType('webview');
       await PlatformViewsService.initAndroidView(
-          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size(100.0, 100.0));
+          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size.square(100.0));
       final AndroidViewController viewController =
           PlatformViewsService.initAndroidView(id: 1, viewType: 'webview', layoutDirection: TextDirection.ltr);
       await viewController.setSize(const Size(200.0, 300.0));
@@ -104,7 +104,7 @@ void main() {
     test('dispose inexisting Android view', () async {
       viewsController.registerViewType('webview');
       await PlatformViewsService.initAndroidView(
-          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size(100.0, 100.0));
+          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size.square(100.0));
       final AndroidViewController viewController =
           PlatformViewsService.initAndroidView(id: 1, viewType: 'webview', layoutDirection: TextDirection.ltr);
       await viewController.setSize(const Size(200.0, 300.0));
@@ -121,7 +121,7 @@ void main() {
           layoutDirection: TextDirection.ltr,
           onFocus: () { didFocus = true; }
       );
-      await viewController.setSize(const Size(100.0, 100.0));
+      await viewController.setSize(const Size.square(100.0));
       await viewController.dispose();
       final ByteData message =
           SystemChannels.platform_views.codec.encodeMethodCall(const MethodCall('viewFocused', 0));
@@ -132,11 +132,11 @@ void main() {
     test('resize Android view', () async {
       viewsController.registerViewType('webview');
       await PlatformViewsService.initAndroidView(
-          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size(100.0, 100.0));
+          id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).setSize(const Size.square(100.0));
       final AndroidViewController viewController =
           PlatformViewsService.initAndroidView(id: 1, viewType: 'webview', layoutDirection: TextDirection.ltr);
       await viewController.setSize(const Size(200.0, 300.0));
-      await viewController.setSize(const Size(500.0, 500.0));
+      await viewController.setSize(const Size.square(500.0));
       expect(
           viewsController.views,
           unorderedEquals(<FakeAndroidPlatformView>[
@@ -157,7 +157,7 @@ void main() {
       )..addOnPlatformViewCreatedListener(callback);
       expect(createdViews, isEmpty);
 
-      await controller1.setSize(const Size(100.0, 100.0));
+      await controller1.setSize(const Size.square(100.0));
       expect(createdViews, orderedEquals(<int>[0]));
 
       final AndroidViewController controller2 = PlatformViewsService.initAndroidView(
@@ -177,7 +177,7 @@ void main() {
       final AndroidViewController viewController =
       PlatformViewsService.initAndroidView(id: 0, viewType: 'webview', layoutDirection: TextDirection.rtl);
       await viewController.setLayoutDirection(TextDirection.ltr);
-      await viewController.setSize(const Size(100.0, 100.0));
+      await viewController.setSize(const Size.square(100.0));
       expect(
           viewsController.views,
           unorderedEquals(<FakeAndroidPlatformView>[
@@ -189,7 +189,7 @@ void main() {
       viewsController.registerViewType('webview');
       final AndroidViewController viewController =
       PlatformViewsService.initAndroidView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr);
-      await viewController.setSize(const Size(100.0, 100.0));
+      await viewController.setSize(const Size.square(100.0));
       await viewController.setLayoutDirection(TextDirection.rtl);
       expect(
           viewsController.views,

--- a/packages/flutter/test/widgets/animated_size_test.dart
+++ b/packages/flutter/test/widgets/animated_size_test.dart
@@ -341,11 +341,11 @@ void main() {
         );
       }
 
-      await pumpWidget(const Size(100, 100));
-      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(100, 100));
+      await pumpWidget(const Size.square(100));
+      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size.square(100));
 
       await pumpWidget(const Size(150, 200));
-      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(100, 100));
+      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size.square(100));
 
       // Each pump triggers verification of dry layout.
       for (int total = 0; total < 200; total += 10) {
@@ -354,14 +354,14 @@ void main() {
       expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(150, 200));
 
       // Change every pump
-      await pumpWidget(const Size(100, 100));
+      await pumpWidget(const Size.square(100));
       expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(150, 200));
 
-      await pumpWidget(const Size(111, 111), const Duration(milliseconds: 10));
-      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(111, 111));
+      await pumpWidget(const Size.square(111), const Duration(milliseconds: 10));
+      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size.square(111));
 
-      await pumpWidget(const Size(222, 222), const Duration(milliseconds: 10));
-      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size(222, 222));
+      await pumpWidget(const Size.square(222), const Duration(milliseconds: 10));
+      expect(tester.renderObject<RenderBox>(find.byType(IntrinsicHeight)).size, const Size.square(222));
     });
   });
 }

--- a/packages/flutter/test/widgets/aspect_ratio_test.dart
+++ b/packages/flutter/test/widgets/aspect_ratio_test.dart
@@ -27,8 +27,8 @@ Future<Size> _getSize(WidgetTester tester, BoxConstraints constraints, double as
 
 void main() {
   testWidgets('Aspect ratio control test', (WidgetTester tester) async {
-    expect(await _getSize(tester, BoxConstraints.loose(const Size(500.0, 500.0)), 2.0), equals(const Size(500.0, 250.0)));
-    expect(await _getSize(tester, BoxConstraints.loose(const Size(500.0, 500.0)), 0.5), equals(const Size(250.0, 500.0)));
+    expect(await _getSize(tester, BoxConstraints.loose(const Size.square(500.0)), 2.0), equals(const Size(500.0, 250.0)));
+    expect(await _getSize(tester, BoxConstraints.loose(const Size.square(500.0)), 0.5), equals(const Size(250.0, 500.0)));
   });
 
   testWidgets('Aspect ratio infinite width', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -61,7 +61,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -89,7 +89,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -117,7 +117,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -145,7 +145,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -173,7 +173,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -201,7 +201,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;
@@ -229,7 +229,7 @@ void main() {
 
     final TestCanvas canvas = TestCanvas();
 
-    bannerPainter.paint(canvas, const Size(1000.0, 1000.0));
+    bannerPainter.paint(canvas, const Size.square(1000.0));
 
     final Invocation translateCommand = canvas.invocations.firstWhere((Invocation invocation) {
       return invocation.memberName == #translate;

--- a/packages/flutter/test/widgets/baseline_test.dart
+++ b/packages/flutter/test/widgets/baseline_test.dart
@@ -18,7 +18,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size(100.0, 100.0));
+    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size.square(100.0));
   });
 
   testWidgets('Baseline - position test', (WidgetTester tester) async {
@@ -37,7 +37,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size(100.0, 100.0));
+    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size.square(100.0));
     expect(tester.renderObject<RenderBox>(find.byType(Baseline)).size,
            within<Size>(from: const Size(100.0, 200.0), distance: 0.001));
   });

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -119,7 +119,7 @@ Future<void> main() async {
         ),
       ),
     );
-    expect(tester.getSize(find.byKey(key)), equals(const Size(45.0, 45.0)));
+    expect(tester.getSize(find.byKey(key)), equals(const Size.square(45.0)));
   });
 
   testWidgets('BoxDecoration paints its border correctly', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -293,7 +293,7 @@ void main() {
         testWidgets('$targetAlignment - $followerAlignment', (WidgetTester tester) async{
           await tester.pumpWidget(build(targetAlignment: targetAlignment, followerAlignment: followerAlignment));
           final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
-          expect(box2.size, const Size(2.0, 2.0));
+          expect(box2.size, const Size.square(2.0));
           expect(tapped, isFalse);
           await tester.tap(find.byKey(key3));
           expect(tapped, isTrue);

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -506,7 +506,7 @@ void main() {
 
     final Finder finder = find.byKey(key);
 
-    expect(tester.getSize(finder), equals(const Size(100, 100)));
+    expect(tester.getSize(finder), equals(const Size.square(100)));
 
     expect(tester.getTopLeft(finder), equals(const Offset(100, 100)));
     expect(tester.getTopRight(finder), equals(const Offset(200, 100)));

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -139,7 +139,7 @@ class InvalidConstraintsChildLayoutDelegate extends MultiChildLayoutDelegate {
   void performLayout(Size size) {
     final BoxConstraints constraints = BoxConstraints.loose(
       // Invalid because width and height must be greater than or equal to 0
-      const Size(-1, -1)
+      const Size.square(-1)
     );
     layoutChild(0, constraints);
   }
@@ -362,7 +362,7 @@ void main() {
         widget: Center(
           child: CustomMultiChildLayout(
             children: <Widget>[LayoutWithMissingId(child: Container(width: 100))],
-            delegate: PreferredSizeDelegate(preferredSize: const Size(10, 10)),
+            delegate: PreferredSizeDelegate(preferredSize: const Size.square(10)),
           ),
         ),
         tester: tester,

--- a/packages/flutter/test/widgets/custom_paint_test.dart
+++ b/packages/flutter/test/widgets/custom_paint_test.dart
@@ -150,9 +150,9 @@ void main() {
     expect(target.currentContext!.size, const Size(800.0, 600.0));
 
     await tester.pumpWidget(Center(
-      child: CustomPaint(key: target, size: const Size(20.0, 20.0)),
+      child: CustomPaint(key: target, size: const Size.square(20.0)),
     ));
-    expect(target.currentContext!.size, const Size(20.0, 20.0));
+    expect(target.currentContext!.size, const Size.square(20.0));
 
     await tester.pumpWidget(Center(
       child: CustomPaint(key: target, size: const Size(2000.0, 100.0)),

--- a/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
@@ -717,12 +717,12 @@ class _RenderTestLayoutPerformer extends RenderBox {
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    return const Size(1, 1);
+    return const Size.square(1);
   }
 
   @override
   void performLayout() {
-    size = const Size(1, 1);
+    size = const Size.square(1);
     if (_performLayout != null)
       _performLayout();
   }

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -50,7 +50,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.text('Arkansas')), equals(const Size(200.0, 200.0)));
+    expect(tester.getSize(find.text('Arkansas')), equals(const Size.square(200.0)));
 
     for (int i = 0; i < 8; ++i) {
       await tester.tap(find.text(kStates[i]));
@@ -123,7 +123,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.text('Arkansas')), equals(const Size(200.0, 200.0)));
+    expect(tester.getSize(find.text('Arkansas')), equals(const Size.square(200.0)));
 
     for (int i = 0; i < 8; ++i) {
       await tester.tap(find.text(kStates[i]));
@@ -264,7 +264,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.text('4')), equals(const Size(200.0, 200.0)));
+    expect(tester.getSize(find.text('4')), equals(const Size.square(200.0)));
 
     expect(log, equals(<int>[
       0, 1, 2, 3, // row 0
@@ -311,7 +311,7 @@ void main() {
     ]));
     log.clear();
 
-    expect(tester.getSize(find.text('3')), equals(const Size(400.0, 400.0)));
+    expect(tester.getSize(find.text('3')), equals(const Size.square(400.0)));
     expect(find.text('4'), findsNothing);
   });
 
@@ -339,7 +339,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.text('4')), equals(const Size(200.0, 200.0)));
+    expect(tester.getSize(find.text('4')), equals(const Size.square(200.0)));
 
     expect(log, equals(<int>[
       0, 1, 2, 3, // row 0
@@ -386,7 +386,7 @@ void main() {
     ]));
     log.clear();
 
-    expect(tester.getSize(find.text('3')), equals(const Size(400.0, 400.0)));
+    expect(tester.getSize(find.text('3')), equals(const Size.square(400.0)));
     expect(find.text('4'), findsNothing);
   });
 

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2446,7 +2446,7 @@ Future<void> main() async {
       );
 
       // Before push image1 should be laid out correctly.
-      expect(renderImage.size, const Size(100, 100));
+      expect(renderImage.size, const Size.square(100));
 
       navigatorKey.currentState!.push(route2);
       await tester.pump();
@@ -2462,7 +2462,7 @@ Future<void> main() async {
       // image1 should snap to the top left corner of the Row widget.
       expect(
         tester.getRect(find.byKey(imageKey1, skipOffstage: false)),
-        rectMoreOrLessEquals(tester.getTopLeft(find.widgetWithText(Row, '1')) & const Size(100, 100), epsilon: 0.01),
+        rectMoreOrLessEquals(tester.getTopLeft(find.widgetWithText(Row, '1')) & const Size.square(100), epsilon: 0.01),
       );
 
       // Text should respect the correct final size of image1.
@@ -2558,8 +2558,8 @@ Future<void> main() async {
     final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
 
     final Animatable<Size?> tween = SizeTween(
-      begin: const Size(200, 200),
-      end: const Size(100, 100),
+      begin: const Size.square(200),
+      end: const Size.square(100),
     ).chain(CurveTween(curve: Curves.fastOutSlowIn));
 
 
@@ -2584,7 +2584,7 @@ Future<void> main() async {
       ),
     );
     final Size originalSize = tester.getSize(find.byKey(container1));
-    expect(originalSize, const Size(100, 100));
+    expect(originalSize, const Size.square(100));
 
     navigator.currentState!.push(MaterialPageRoute<void>(builder: (BuildContext context) {
       return Scaffold(
@@ -2605,7 +2605,7 @@ Future<void> main() async {
     }));
     await tester.pumpAndSettle();
     final Size newSize = tester.getSize(find.byKey(container2));
-    expect(newSize, const Size(200, 200));
+    expect(newSize, const Size.square(200));
 
     navigator.currentState!.pop();
     await tester.pump();

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -108,7 +108,7 @@ Widget buildImageAtRatio(String imageName, Key key, double ratio, bool inferSize
 
   return MediaQuery(
     data: MediaQueryData(
-      size: const Size(windowSize, windowSize),
+      size: const Size.square(windowSize),
       devicePixelRatio: ratio,
       padding: const EdgeInsets.all(0.0),
     ),
@@ -183,11 +183,11 @@ void main() {
     const double ratio = 1.0;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 1.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 1.0);
   });
 
@@ -195,11 +195,11 @@ void main() {
     const double ratio = 0.5;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 1.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 1.0);
   });
 
@@ -207,11 +207,11 @@ void main() {
     const double ratio = 1.5;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 1.5);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 1.5);
   });
 
@@ -222,11 +222,11 @@ void main() {
     const double ratio = 1.75;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 2.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 2.0);
   });
 
@@ -234,11 +234,11 @@ void main() {
     const double ratio = 2.3;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 2.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 2.0);
   });
 
@@ -246,11 +246,11 @@ void main() {
     const double ratio = 3.7;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 4.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 4.0);
   });
 
@@ -258,11 +258,11 @@ void main() {
     const double ratio = 5.1;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 4.0);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 4.0);
   });
 
@@ -282,11 +282,11 @@ void main() {
     const double ratio = 1.0;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images, bundle));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     expect(getRenderImage(tester, key).scale, 1.5);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images, bundle));
-    expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+    expect(getRenderImage(tester, key).size, const Size.square(48.0));
     expect(getRenderImage(tester, key).scale, 1.5);
   });
 
@@ -311,12 +311,12 @@ void main() {
     const double ratio = 1.0;
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images, bundle));
-    expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+    expect(getRenderImage(tester, key).size, const Size.square(200.0));
     // Verify we got the 10x scaled image, since the TestByteData said it should be 10x.
     expect(getRenderImage(tester, key).image!.height, 480);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images, bundle));
-    expect(getRenderImage(tester, key).size, const Size(480.0, 480.0));
+    expect(getRenderImage(tester, key).size, const Size.square(480.0));
     // Verify we got the 10x scaled image, since the TestByteData said it should be 10x.
     expect(getRenderImage(tester, key).image!.height, 480);
   });
@@ -324,19 +324,19 @@ void main() {
   testWidgets('Image cache resize upscale display 5', (WidgetTester tester) async {
     final Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageCacheResized(image, key, 5, 5, 20, 20));
-    expect(getRenderImage(tester, key).size, const Size(5.0, 5.0));
+    expect(getRenderImage(tester, key).size, const Size.square(5.0));
   });
 
   testWidgets('Image cache resize upscale display 50', (WidgetTester tester) async {
     final Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageCacheResized(image, key, 50, 50, 20, 20));
-    expect(getRenderImage(tester, key).size, const Size(50.0, 50.0));
+    expect(getRenderImage(tester, key).size, const Size.square(50.0));
   });
 
   testWidgets('Image cache resize downscale display 5', (WidgetTester tester) async {
     final Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageCacheResized(image, key, 5, 5, 1, 1));
-    expect(getRenderImage(tester, key).size, const Size(5.0, 5.0));
+    expect(getRenderImage(tester, key).size, const Size.square(5.0));
   });
 
   // For low-resolution screens we prefer higher-resolution images due to
@@ -356,11 +356,11 @@ void main() {
     Future<void> testRatio({required double ratio, required double expectedScale}) async {
       Key key = GlobalKey();
       await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images, bundle));
-      expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
+      expect(getRenderImage(tester, key).size, const Size.square(200.0));
       expect(getRenderImage(tester, key).scale, expectedScale);
       key = GlobalKey();
       await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images, bundle));
-      expect(getRenderImage(tester, key).size, const Size(48.0, 48.0));
+      expect(getRenderImage(tester, key).size, const Size.square(48.0));
       expect(getRenderImage(tester, key).scale, expectedScale);
     }
 

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -794,7 +794,7 @@ void main() {
       expect(transformationController.value, equals(Matrix4.identity()));
 
       // Shrink the size of the screen.
-      tester.binding.window.physicalSizeTestValue = const Size(100.0, 100.0);
+      tester.binding.window.physicalSizeTestValue = const Size.square(100.0);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
       await tester.pump();
 

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -606,7 +606,7 @@ void main() {
       );
     }
 
-    await pumpTestWidget(const Size(10, 10));
+    await pumpTestWidget(const Size.square(10));
 
     final _RenderLayoutSpy spy = tester.renderObject(find.byType(_LayoutSpy));
 
@@ -631,7 +631,7 @@ void main() {
 
     // Cause the `update` to be called (but not `performRebuild`), triggering
     // builder invocation.
-    await pumpTestWidget(const Size(10, 10));
+    await pumpTestWidget(const Size.square(10));
     expect(builderInvocationCount, 2);
 
     // The spy does not invalidate its layout on widget update, so no
@@ -656,7 +656,7 @@ void main() {
     expect(spy.performResizeCount, 1);
 
     // Change the parent size, triggering constraint change.
-    await pumpTestWidget(const Size(20, 20));
+    await pumpTestWidget(const Size.square(20));
 
     // We should see everything invoked once.
     expect(builderInvocationCount, 3);

--- a/packages/flutter/test/widgets/overflow_box_test.dart
+++ b/packages/flutter/test/widgets/overflow_box_test.dart
@@ -56,14 +56,14 @@ void main() {
       textDirection: TextDirection.rtl,
       child: Center(
         child: SizedOverflowBox(
-          size: const Size(100.0, 100.0),
+          size: const Size.square(100.0),
           alignment: Alignment.topRight,
           child: Container(height: 50.0, width: 50.0, key: inner),
         ),
       ),
     ));
     final RenderBox box = inner.currentContext!.findRenderObject()! as RenderBox;
-    expect(box.size, equals(const Size(50.0, 50.0)));
+    expect(box.size, equals(const Size.square(50.0)));
     expect(
       box.localToGlobal(box.size.center(Offset.zero)),
       equals(const Offset(
@@ -79,14 +79,14 @@ void main() {
       textDirection: TextDirection.rtl,
       child: Center(
         child: SizedOverflowBox(
-          size: const Size(100.0, 100.0),
+          size: const Size.square(100.0),
           alignment: AlignmentDirectional.bottomStart,
           child: Container(height: 50.0, width: 50.0, key: inner),
         ),
       ),
     ));
     final RenderBox box = inner.currentContext!.findRenderObject()! as RenderBox;
-    expect(box.size, equals(const Size(50.0, 50.0)));
+    expect(box.size, equals(const Size.square(50.0)));
     expect(
       box.localToGlobal(box.size.center(Offset.zero)),
       equals(const Offset(

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -714,7 +714,7 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(build(const Size(300, 300)));
+    await tester.pumpWidget(build(const Size.square(300)));
     await tester.pumpAndSettle();
 
     verifyCentered();

--- a/packages/flutter/test/widgets/positioned_test.dart
+++ b/packages/flutter/test/widgets/positioned_test.dart
@@ -123,7 +123,7 @@ void main() {
     expect(completer.isCompleted, isFalse);
     recordMetrics();
 
-    expect(sizes, equals(<Size>[const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0), const Size(10.0, 10.0)]));
+    expect(sizes, equals(<Size>[const Size.square(10.0), const Size.square(10.0), const Size.square(10.0), const Size.square(10.0), const Size.square(10.0), const Size.square(10.0)]));
     expect(positions, equals(<Offset>[const Offset(10.0, 10.0), const Offset(10.0, 10.0), const Offset(17.0, 17.0), const Offset(24.0, 24.0), const Offset(45.0, 45.0), const Offset(80.0, 80.0)]));
 
     controller.stop(canceled: false);

--- a/packages/flutter/test/widgets/semantics_zero_surface_size_test.dart
+++ b/packages/flutter/test/widgets/semantics_zero_surface_size_test.dart
@@ -31,7 +31,7 @@ void main() {
       ), ignoreTransform: true,
     ));
 
-    await tester.binding.setSurfaceSize(const Size(0.0, 0.0));
+    await tester.binding.setSurfaceSize(Size.zero);
     await tester.pumpAndSettle();
 
     expect(semantics, hasSemantics(

--- a/packages/flutter/test/widgets/sized_box_test.dart
+++ b/packages/flutter/test/widgets/sized_box_test.dart
@@ -46,7 +46,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
 
     await tester.pumpWidget(
       Center(
@@ -56,7 +56,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
 
     await tester.pumpWidget(
       Center(
@@ -67,7 +67,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
 
     await tester.pumpWidget(
       Center(
@@ -78,7 +78,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(100.0, 100.0)));
+    expect(patient.currentContext!.size, equals(const Size.square(100.0)));
 
     await tester.pumpWidget(
       Center(
@@ -107,7 +107,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
   });
 
   testWidgets('SizedBox - container child', (WidgetTester tester) async {
@@ -144,7 +144,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
 
     await tester.pumpWidget(
       Center(
@@ -156,7 +156,7 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(100.0, 100.0)));
+    expect(patient.currentContext!.size, equals(const Size.square(100.0)));
 
     await tester.pumpWidget(
       Center(
@@ -188,6 +188,6 @@ void main() {
         ),
       ),
     );
-    expect(patient.currentContext!.size, equals(const Size(0.0, 0.0)));
+    expect(patient.currentContext!.size, equals(Size.zero));
   });
 }

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -318,7 +318,7 @@ void main() {
         final Finder logo = find.byType(FlutterLogo);
         expect(
           tester.renderObject<RenderBox>(logo).size,
-          const Size(100.0, 100.0),
+          const Size.square(100.0),
         );
         final VisualDensity density = VisualDensity.adaptivePlatformDensity;
         expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
@@ -341,7 +341,7 @@ void main() {
         );
         expect(
           tester.renderObject<RenderBox>(logo).size,
-          const Size(100.0, 100.0),
+          const Size.square(100.0),
         );
         expect(tester.getCenter(logo).dy, lessThan(351.0));
         expect(
@@ -588,7 +588,7 @@ void main() {
           final Finder logo = find.byType(FlutterLogo);
           expect(
             tester.renderObject<RenderBox>(logo).size,
-            const Size(100.0, 100.0),
+            const Size.square(100.0),
           );
           final VisualDensity density = VisualDensity.adaptivePlatformDensity;
           expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
@@ -613,7 +613,7 @@ void main() {
           );
           expect(
             tester.renderObject<RenderBox>(logo).size,
-            const Size(100.0, 100.0),
+            const Size.square(100.0),
           );
           expect(tester.getCenter(logo).dy, lessThan(351.0));
           expect(
@@ -632,7 +632,7 @@ void main() {
           );
           expect(
             tester.renderObject<RenderBox>(logo).size,
-            const Size(100.0, 100.0),
+            const Size.square(100.0),
           );
           expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
           expect(

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -411,7 +411,7 @@ void main() {
 
     await tester.tap(find.byType(IndexedStack));
     final RenderBox box = tester.renderObject(find.byType(IndexedStack));
-    expect(box.size, equals(const Size(200.0, 200.0)));
+    expect(box.size, equals(const Size.square(200.0)));
     expect(tapped, isNull);
   });
 

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -394,7 +394,7 @@ class TestRectPainter extends CustomPainter {
   @override
   void paint(ui.Canvas canvas, ui.Size size) {
     canvas.drawRect(
-      const Offset(200, 200) & const Size(10, 10),
+      const Offset(200, 200) & const Size.square(10),
       Paint()..color = const Color(0xFFFF0000),
     );
   }

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -826,7 +826,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size(100.0, 100.0));
+    expect(tester.renderObject<RenderBox>(find.text('X')).size, const Size.square(100.0));
     expect(tester.renderObject<RenderBox>(find.byType(Baseline)).size,
            within<Size>(from: const Size(100.0, 200.0), distance: 0.001));
   });


### PR DESCRIPTION
According to the official Flutter [Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#prefer-specialized-functions-methods-and-constructors), We should prefer specialized constructors whenever it is possible.

This PR is about replacing Size(x, x) with one specialized constructor (Size.square) and one constant value (Size.zero).

After creating a regex to replace every "const Size(x, x)" occurrences with "const Size.square(x)", I then created a second regex to replace every "const Size.square(0)" with Size.zero

I went through the troubles of reading every occurrence to make sure I was not breaking documentation (since this could actually never broke actual code).


No tests are required since no code was added (const Size(x, x) is strictly equivalent to const Size.square(x) (see source code of the Size class), the same goes for const Size.zero which equals const Size(0, 0))