### PR TITLE
Revert "Add BuildContext parameter to TextEditingController.buildTextSpan"

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -31,7 +31,7 @@ class _TextSpanEditingController extends TextEditingController {
   final TextSpan _textSpan;
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
+  TextSpan buildTextSpan({TextStyle? style ,bool? withComposing}) {
     // This does not care about composing.
     return TextSpan(
       style: style,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -185,7 +185,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   ///
   /// By default makes text in composing range appear as underlined. Descendants
   /// can override this method to customize appearance of text.
-  TextSpan buildTextSpan({TextStyle? style , required bool withComposing, required BuildContext context}) {
+  TextSpan buildTextSpan({TextStyle? style , required bool withComposing}) {
     assert(!value.composing.isValid || !withComposing || value.isComposingRangeValid);
     // If the composing range is out of range for the current text, ignore it to
     // preserve the tree integrity, otherwise in release mode a RangeError will
@@ -2669,7 +2669,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     return widget.controller.buildTextSpan(
       style: widget.style,
       withComposing: !widget.readOnly,
-      context: context,
     );
   }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5674,25 +5674,6 @@ void main() {
         }),
       );
     });
-
-    testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
-      final _AccentColorTextEditingController controller = _AccentColorTextEditingController('a');
-      const Color color = Color.fromARGB(255, 1, 2, 3);
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData.light().copyWith(accentColor: color),
-        home: EditableText(
-          controller: controller,
-          focusNode: FocusNode(),
-          style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!,
-          cursorColor: Colors.blue,
-          backgroundCursorColor: Colors.grey,
-        ),
-      ));
-
-      final RenderEditable renderEditable = findRenderEditable(tester);
-      final TextSpan textSpan = renderEditable.text!;
-      expect(textSpan.style!.color, color);
-    });
   });
 
   testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {
@@ -7168,14 +7149,4 @@ class SkipPainting extends SingleChildRenderObjectWidget {
 class SkipPaintingRenderObject extends RenderProxyBox {
   @override
   void paint(PaintingContext context, Offset offset) { }
-}
-
-class _AccentColorTextEditingController extends TextEditingController {
-  _AccentColorTextEditingController(String text) : super(text: text);
-
-  @override
-  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
-    final Color color = Theme.of(context).accentColor;
-    return super.buildTextSpan(style: TextStyle(color: color), withComposing: withComposing, context: context);
-  }
 }


### PR DESCRIPTION
Reverts flutter/flutter#72344

That PR caused a failure in users that had overridden buildTextSpan.  It's a breaking change and should have followed the breaking change policy, but I missed that.

@Jjagg Would you be able to reopen your PR after this revert is merged?  Then we can do the steps in the [breaking changes guide](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes) to make people aware of how to migrate.  Then when we re-merge, I can update the customers that need to add the BuildContext to their overridden buildTextSpan methods.