### PR TITLE
Reland "Add BuildContext parameter to TextEditingController.buildTextSpan"

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -31,7 +31,7 @@ class _TextSpanEditingController extends TextEditingController {
   final TextSpan _textSpan;
 
   @override
-  TextSpan buildTextSpan({TextStyle? style ,bool? withComposing}) {
+  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
     // This does not care about composing.
     return TextSpan(
       style: style,

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -31,7 +31,7 @@ class _TextSpanEditingController extends TextEditingController {
   final TextSpan _textSpan;
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
     // This does not care about composing.
     return TextSpan(
       style: style,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -186,7 +186,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   ///
   /// By default makes text in composing range appear as underlined. Descendants
   /// can override this method to customize appearance of text.
-  TextSpan buildTextSpan({TextStyle? style , required bool withComposing}) {
+  TextSpan buildTextSpan({TextStyle? style , required bool withComposing, required BuildContext context}) {
     assert(!value.composing.isValid || !withComposing || value.isComposingRangeValid);
     // If the composing range is out of range for the current text, ignore it to
     // preserve the tree integrity, otherwise in release mode a RangeError will
@@ -2675,6 +2675,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     return widget.controller.buildTextSpan(
       style: widget.style,
       withComposing: !widget.readOnly,
+      context: context,
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -186,7 +186,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   ///
   /// By default makes text in composing range appear as underlined. Descendants
   /// can override this method to customize appearance of text.
-  TextSpan buildTextSpan({TextStyle? style , required bool withComposing, required BuildContext context}) {
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style , required bool withComposing}) {
     assert(!value.composing.isValid || !withComposing || value.isComposingRangeValid);
     // If the composing range is out of range for the current text, ignore it to
     // preserve the tree integrity, otherwise in release mode a RangeError will
@@ -2673,9 +2673,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     // Read only mode should not paint text composing.
     return widget.controller.buildTextSpan(
+      context: context,
       style: widget.style,
       withComposing: !widget.readOnly,
-      context: context,
     );
   }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5676,9 +5676,10 @@ void main() {
     });
 
     testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
-      final AccentColorTextEditingController controller = AccentColorTextEditingController('a');
+      final _AccentColorTextEditingController controller = _AccentColorTextEditingController('a');
+      const Color color = Color.fromARGB(255, 1, 2, 3);
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData.light().copyWith(accentColor: const Color.fromARGB(255, 1, 2, 3)),
+        theme: ThemeData.light().copyWith(accentColor: color),
         home: EditableText(
           controller: controller,
           focusNode: FocusNode(),
@@ -5690,7 +5691,7 @@ void main() {
 
       final RenderEditable renderEditable = findRenderEditable(tester);
       final TextSpan textSpan = renderEditable.text!;
-      expect(textSpan.style!.color, const Color.fromARGB(255, 1, 2, 3));
+      expect(textSpan.style!.color, color);
     });
   });
 
@@ -7128,8 +7129,8 @@ class SkipPaintingRenderObject extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) { }
 }
 
-class AccentColorTextEditingController extends TextEditingController {
-  AccentColorTextEditingController(String text) : super(text: text);
+class _AccentColorTextEditingController extends TextEditingController {
+  _AccentColorTextEditingController(String text) : super(text: text);
 
   @override
   TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5674,6 +5674,24 @@ void main() {
         }),
       );
     });
+
+    testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
+      final AccentColorTextEditingController controller = AccentColorTextEditingController('a');
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.light().copyWith(accentColor: const Color.fromARGB(255, 1, 2, 3)),
+        home: EditableText(
+          controller: controller,
+          focusNode: FocusNode(),
+          style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!,
+          cursorColor: Colors.blue,
+          backgroundCursorColor: Colors.grey,
+        ),
+      ));
+
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final TextSpan textSpan = renderEditable.text!;
+      expect(textSpan.style!.color, const Color.fromARGB(255, 1, 2, 3));
+    });
   });
 
   testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {
@@ -7108,4 +7126,14 @@ class SkipPainting extends SingleChildRenderObjectWidget {
 class SkipPaintingRenderObject extends RenderProxyBox {
   @override
   void paint(PaintingContext context, Offset offset) { }
+}
+
+class AccentColorTextEditingController extends TextEditingController {
+  AccentColorTextEditingController(String text) : super(text: text);
+
+  @override
+  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
+    final Color color = Theme.of(context).accentColor;
+    return super.buildTextSpan(style: TextStyle(color: color), withComposing: withComposing, context: context);
+  }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7133,8 +7133,8 @@ class _AccentColorTextEditingController extends TextEditingController {
   _AccentColorTextEditingController(String text) : super(text: text);
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, required bool withComposing, required BuildContext context}) {
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
     final Color color = Theme.of(context).accentColor;
-    return super.buildTextSpan(style: TextStyle(color: color), withComposing: withComposing, context: context);
+    return super.buildTextSpan(context: context, style: TextStyle(color: color), withComposing: withComposing);
   }
 }


### PR DESCRIPTION
Redo of #72344 after revert in #73503.

The original PR did not follow the breaking changes policy.

Fixes #72343, which should be reopened.

Sorry about that @justinmc, and thanks for picking this up. Should I set up a design document? I'm new to this 😬

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

Design doc: https://docs.google.com/document/d/1nr-g45gXcWTYoW9UmChZV7Ije3lKP4pEvDQCdz6NFdI/edit?usp=sharing 