### PR TITLE
Revert "Exclude arm64 from supported iOS simulator architectures"

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -182,43 +182,6 @@ Future<void> main() async {
           await flutter('clean');
         });
 
-        section('Build app for simulator with all available architectures');
-
-        // Apple Silicon ARM simulators not yet supported.
-        // Prove (on Xcode 12) Flutter knows to exclude this architecture.
-        await inDirectory(flutterProject.rootPath, () async {
-          await flutter('build', options: <String>[
-            'ios',
-            '--simulator',
-            '--no-codesign',
-            '--verbose',
-          ], environment: <String, String>{
-            'FLUTTER_XCODE_ONLY_ACTIVE_ARCH': 'NO'
-          });
-        });
-
-        final String simulatorAppFrameworkBinary = path.join(
-          flutterProject.rootPath,
-          'build',
-          'ios',
-          'iphonesimulator',
-          'Runner.app',
-          'Frameworks',
-          'App.framework',
-          'App',
-        );
-
-        final String archs = await fileType(simulatorAppFrameworkBinary);
-        if (!archs.contains('Mach-O 64-bit dynamically linked shared library x86_64')) {
-          throw TaskResult.failure('Unexpected architecture');
-        }
-
-        section('Clean build');
-
-        await inDirectory(flutterProject.rootPath, () async {
-          await flutter('clean');
-        });
-
         section('Archive');
 
         await inDirectory(flutterProject.rootPath, () async {

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -68,9 +68,6 @@ def flutter_additional_ios_build_settings(target)
     # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
     # If the pod only supports a higher version, do not delete to correctly produce an error.
     build_configuration.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET' if inherit_deployment_target
-
-    # Apple Silicon ARM simulators not yet supported.
-    build_configuration.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64 i386'
   end
 end
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -250,7 +250,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     if (buildForDevice) {
       buildCommands.addAll(<String>['-sdk', 'iphoneos']);
     } else {
-      buildCommands.addAll(<String>['-sdk', 'iphonesimulator']);
+      buildCommands.addAll(<String>['-sdk', 'iphonesimulator', '-arch', 'x86_64']);
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -209,9 +209,6 @@ List<String> _xcodeBuildSettingsLines({
   if (useMacOSConfig) {
     // ARM not yet supported https://github.com/flutter/flutter/issues/69221
     xcodeBuildSettings.add('EXCLUDED_ARCHS=arm64');
-  } else {
-    // Apple Silicon ARM simulators not yet supported.
-    xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64 i386');
   }
 
   for (final MapEntry<String, String> config in buildInfo.toEnvironmentConfig().entries) {

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -683,14 +683,12 @@ Information about project "Runner":
 
       final String contents = config.readAsStringSync();
       expect(contents.contains('ARCHS=armv7'), isTrue);
-      expect(contents.contains('EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64 i386'), isTrue);
 
       final File buildPhaseScript = fs.file('path/to/project/ios/Flutter/flutter_export_environment.sh');
       expect(buildPhaseScript.existsSync(), isTrue);
 
       final String buildPhaseScriptContents = buildPhaseScript.readAsStringSync();
       expect(buildPhaseScriptContents.contains('ARCHS=armv7'), isTrue);
-      expect(buildPhaseScriptContents.contains('"EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64 i386"'), isTrue);
     });
 
     testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -41,7 +41,10 @@ void main() {
 
     // Config is updated if command succeeded.
     expect(generatedConfig, exists);
-    expect(generatedConfig.readAsStringSync(), contains('DART_OBFUSCATION=true'));
+    expect(generatedConfig.readAsStringSync(), allOf(
+      contains('DART_OBFUSCATION=true'),
+      isNot(contains('EXCLUDED_ARCHS')),
+    ));
 
     // file that only exists if app was fully built.
     final File frameworkPlist = fileSystem.file(


### PR DESCRIPTION
Reverts flutter/flutter#73458

```
2021-01-07T14:01:30.728056: stdout:     note: Using new build systemnote: Planning buildnote: Constructing build descriptionwarning: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 6.1, but the range of supported deployment target versions is 2.0 to 6.0.99. (in target 'watch' from project 'Runner')warning: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 6.1, but the range of supported deployment target versions is 2.0 to 6.0.99. (in target 'watch Extension' from project 'Runner')warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'device_info' from project 'Pods')warning: There are no architectures to compile for because all architectures in VALID_ARCHS (x86_64) are also in EXCLUDED_ARCHS (x86_64, i386). (in target 'device_info' from project 'Pods')warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'Runner' from project 'Runner')warning: There are no architectures to compile for because all architectures in VALID_ARCHS (i386, x86_64) are also in EXCLUDED_ARCHS (x86_64, i386). (in target 'Runner' from project 'Runner')warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'Pods-Runner' from project 'Pods')warning: There are no architectures to compile for because all architectures in VALID_ARCHS (i386, x86_64) are also in EXCLUDED_ARCHS (x86_64, i386). (in target 'Pods-Runner' from project 'Pods')warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'Flutter' from project 'Pods')
stdout: 
```