### PR TITLE
Re-enable a ensureVisible test case

### DIFF
--- a/packages/flutter/test/widgets/ensure_visible_test.dart
+++ b/packages/flutter/test/widgets/ensure_visible_test.dart
@@ -446,7 +446,6 @@ void main() {
       expect(tester.getBottomRight(findKey(3)).dx, equals(700.0));
     });
 
-    // TODO(abarth): Unskip this test. See https://github.com/flutter/flutter/issues/7919
     testWidgets('ListView ensureVisible negative child', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));
       Future<void> prepare(double offset) async {
@@ -503,7 +502,7 @@ void main() {
       Scrollable.ensureVisible(findContext(2));
       await tester.pump();
       expect(getOffset(), equals(-400.0));
-    }, skip: true); // https://github.com/flutter/flutter/issues/7919
+    });
 
     testWidgets('ListView ensureVisible rotated child', (WidgetTester tester) async {
       BuildContext findContext(int i) => tester.element(findKey(i));


### PR DESCRIPTION
This test was close by #7920 and tracking by #7919.
But I can not found more details about the failures and I couldn't reproduce it after several years.

Now it can be passed on the latest master channel, so I want to open it, and if it fails in the future, I will follow up and solve it.

Fixes #7919