### PR TITLE
[test.dart] Add a flag to skip engine hash validation on 3H builder

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -155,16 +155,12 @@ bool _shouldRunWindows() {
 Future<void> _validateEngineHash() async {
   final String overrideFlag = Platform.environment['FLUTTER_SKIP_ENGINE_CHECK']
       ?? 'false';
-  // TODO(karlklose): remove the bot name check once the 3H builder recipe uses
-  //                  FLUTTER_SKIP_ENGINE_CHECK.
-  final String luciBotId = Platform.environment['SWARMING_BOT_ID'] ?? '';
-  if (luciBotId.startsWith('luci-dart-') || overrideFlag.toLowerCase() == 'true') {
+  if (overrideFlag.toLowerCase() == 'true') {
     // The Dart HHH bots intentionally modify the local artifact cache
     // and then use this script to run Flutter's test suites.
     // Because the artifacts have been changed, this particular test will return
     // a false positive and should be skipped.
-    print('${yellow}Skipping Flutter Engine Version Validation for swarming '
-          'bot $luciBotId.');
+    print('${yellow}Skipping Flutter Engine Version Validation');
     return;
   }
   final String expectedVersion = File(engineVersionFile).readAsStringSync().trim();

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -153,8 +153,12 @@ bool _shouldRunWindows() {
 /// Verify the Flutter Engine is the revision in
 /// bin/cache/internal/engine.version.
 Future<void> _validateEngineHash() async {
+  final String overrideFlag = Platform.environment['FLUTTER_SKIP_ENGINE_CHECK']
+      ?? 'false';
+  // TODO(karlklose): remove the bot name check once the 3H builder recipe uses
+  //                  FLUTTER_SKIP_ENGINE_CHECK.
   final String luciBotId = Platform.environment['SWARMING_BOT_ID'] ?? '';
-  if (luciBotId.startsWith('luci-dart-')) {
+  if (luciBotId.startsWith('luci-dart-') || overrideFlag.toLowerCase() == 'true') {
     // The Dart HHH bots intentionally modify the local artifact cache
     // and then use this script to run Flutter's test suites.
     // Because the artifacts have been changed, this particular test will return


### PR DESCRIPTION
The dart triple-HEAD builder (https://ci.chromium.org/p/dart/builders/ci.sandbox/flutter-engine-linux) uses a modified engine to run the tests and therefore needs to skip the engine version check.

This used to be done by looking at the builder name, which is prone to break if we run the tests on a different swarming bot.

This PR adds a specific flag that can be set by the recipe to skip the check instead.