### PR TITLE
Fix "RefreshIndicator.color didn't update at runtime"

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -239,6 +239,22 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   @override
+  void didUpdateWidget(covariant RefreshIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.color != widget.color) {
+      final ThemeData theme = Theme.of(context);
+      _valueColor = _positionController.drive(
+        ColorTween(
+          begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
+          end: (widget.color ?? theme.accentColor).withOpacity(1.0),
+        ).chain(CurveTween(
+            curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
+        )),
+      );
+    }
+  }
+
+  @override
   void dispose() {
     _positionController.dispose();
     _scaleController.dispose();

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -677,4 +677,52 @@ void main() {
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
     expect(find.byType(RefreshProgressIndicator), findsNothing);
   });
+
+  testWidgets('RefreshIndicator.color can be updated at runtime', (WidgetTester tester) async {
+    refreshCalled = false;
+    Color color1 = Colors.green;
+    final Color finalColor = Colors.red;
+    late StateSetter setState;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter stateSetter) {
+            setState = stateSetter;
+            return RefreshIndicator(
+              triggerMode: RefreshIndicatorTriggerMode.anywhere,
+              onRefresh: holdRefresh,
+              color: color1,
+              child: ListView(
+                reverse: true,
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const <Widget>[
+                  SizedBox(
+                    height: 200.0,
+                    child: Text('X'),
+                  ),
+                  SizedBox(
+                    height: 800.0,
+                    child: Text('Y'),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.pump();
+    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, color1.withOpacity(1.0));
+
+    setState(() {
+      color1 = finalColor;
+    });
+
+    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.pump();
+    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, finalColor.withOpacity(1.0));
+  });
 }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -680,8 +680,8 @@ void main() {
 
   testWidgets('RefreshIndicator.color can be updated at runtime', (WidgetTester tester) async {
     refreshCalled = false;
-    Color color1 = Colors.green;
-    final Color finalColor = Colors.red;
+    Color refreshIndicatorColor = Colors.green;
+    const Color red = Colors.red;
     late StateSetter setState;
 
     await tester.pumpWidget(
@@ -692,7 +692,7 @@ void main() {
             return RefreshIndicator(
               triggerMode: RefreshIndicatorTriggerMode.anywhere,
               onRefresh: holdRefresh,
-              color: color1,
+              color: refreshIndicatorColor,
               child: ListView(
                 reverse: true,
                 physics: const AlwaysScrollableScrollPhysics(),
@@ -715,14 +715,14 @@ void main() {
 
     await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
     await tester.pump();
-    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, color1.withOpacity(1.0));
+    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, refreshIndicatorColor.withOpacity(1.0));
 
     setState(() {
-      color1 = finalColor;
+      refreshIndicatorColor = red;
     });
 
     await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
     await tester.pump();
-    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, finalColor.withOpacity(1.0));
+    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, red.withOpacity(1.0));
   });
 }


### PR DESCRIPTION


*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/73555

### Tests
 - [x] Verify that `RefreshIndicator.color` can be updated at runtime

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].


