### PR TITLE
Revert "Fix _LateInitializationError for RenderObjectElement.renderObject"

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5463,8 +5463,8 @@ abstract class RenderObjectElement extends Element {
 
   /// The underlying [RenderObject] for this element.
   @override
-  RenderObject get renderObject => _renderObject!;
-  RenderObject? _renderObject;
+  RenderObject get renderObject => _renderObject;
+  late RenderObject _renderObject;
 
   bool _debugDoingBuild = false;
   @override
@@ -5566,7 +5566,7 @@ abstract class RenderObjectElement extends Element {
 
   void _debugUpdateRenderObjectOwner() {
     assert(() {
-      renderObject.debugCreator = DebugCreator(this);
+      _renderObject.debugCreator = DebugCreator(this);
       return true;
     }());
   }
@@ -6058,7 +6058,7 @@ abstract class RenderObjectElement extends Element {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<RenderObject>('renderObject', _renderObject, defaultValue: null));
+    properties.add(DiagnosticsProperty<RenderObject>('renderObject', renderObject, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1494,12 +1494,6 @@ void main() {
     expect(GestureBinding.instance!.pointerRouter.debugGlobalRouteCount, pointerRouterCount);
     expect(RawKeyboard.instance.keyEventHandler, same(rawKeyEventHandler));
   });
-
-  testWidgets('Can access debugFillProperties without _LateInitializationError', (WidgetTester tester) async {
-    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    TestRenderObjectElement().debugFillProperties(builder);
-    expect(builder.properties.any((DiagnosticsNode property) => property.name == 'renderObject' && property.value == null), isTrue);
-  });
 }
 
 class _FakeFocusManager implements FocusManager {
@@ -1842,8 +1836,4 @@ class FakeLeafRenderObject extends RenderBox {
   void performLayout() {
     size = constraints.biggest;
   }
-}
-
-class TestRenderObjectElement extends RenderObjectElement {
-  TestRenderObjectElement() : super(Table());
 }


### PR DESCRIPTION
Reverts flutter/flutter#70974

It's causing firebase failures: https://firebase.corp.google.com/project/flutter-infra/testlab/histories/bh.60bf482010a9daf5/matrices/6563812529682595606/executions/bs.8d783fd815b67b2b