### PR TITLE
[flutter_tools] add API for passing arbitrary flags to tester binary

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -63,6 +63,7 @@ FlutterPlatform installHook({
   PlatformPluginRegistration platformPluginRegistration,
   bool nullAssertions = false,
   @required BuildInfo buildInfo,
+  List<String> additionalArguments,
 }) {
   assert(testWrapper != null);
   assert(enableObservatory || (!startPaused && observatoryPort == null));
@@ -96,6 +97,7 @@ FlutterPlatform installHook({
     icudtlPath: icudtlPath,
     nullAssertions: nullAssertions,
     buildInfo: buildInfo,
+    additionalArguments: additionalArguments,
   );
   platformPluginRegistration(platform);
   return platform;
@@ -248,6 +250,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.flutterProject,
     this.icudtlPath,
     this.nullAssertions = false,
+    this.additionalArguments,
     @required this.buildInfo,
   }) : assert(shellPath != null);
 
@@ -270,6 +273,7 @@ class FlutterPlatform extends PlatformPlugin {
   final String icudtlPath;
   final bool nullAssertions;
   final BuildInfo buildInfo;
+  final List<String> additionalArguments;
 
   Directory fontsDirectory;
 
@@ -446,6 +450,7 @@ class FlutterPlatform extends PlatformPlugin {
         disableServiceAuthCodes: disableServiceAuthCodes,
         observatoryPort: disableDds ? explicitObservatoryPort : 0,
         serverPort: server.port,
+        additionalArguments: additionalArguments,
       );
       subprocessActive = true;
       finalizers.add(() async {
@@ -769,6 +774,7 @@ class FlutterPlatform extends PlatformPlugin {
     bool disableServiceAuthCodes = false,
     int observatoryPort,
     int serverPort,
+    List<String> additionalArguments,
   }) {
     assert(executable != null); // Please provide the path to the shell in the SKY_SHELL environment variable.
     assert(!startPaused || enableObservatory);
@@ -802,6 +808,7 @@ class FlutterPlatform extends PlatformPlugin {
       '--packages=$packages',
       if (nullAssertions)
         '--dart-flags=--null_assertions',
+      ...?additionalArguments,
       testPath,
     ];
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -53,6 +53,7 @@ abstract class FlutterTestRunner {
     @required BuildInfo buildInfo,
     String reporter,
     String timeout,
+    List<String> additionalArguments,
   });
 }
 
@@ -89,6 +90,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     @required BuildInfo buildInfo,
     String reporter,
     String timeout,
+    List<String> additionalArguments,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -201,6 +203,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       icudtlPath: icudtlPath,
       nullAssertions: nullAssertions,
       buildInfo: buildInfo,
+      additionalArguments: additionalArguments,
     );
 
     // Call package:test's main method in the appropriate directory.

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -190,6 +190,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     BuildInfo buildInfo,
     String reporter,
     String timeout,
+    List<String> additionalArguments,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     return exitCode;

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -223,6 +223,43 @@ void main() {
       expect(flutterPlatform.icudtlPath, equals('ghi'));
     });
   });
+
+  FakeProcessManager fakeProcessManager;
+
+  testUsingContext('Can pass additional arguments to tester binary', () async {
+    final TestFlutterPlatform platform =TestFlutterPlatform(<String>['--foo', '--bar']);
+    platform.loadChannel('test1.dart', MockSuitePlatform());
+    await null;
+
+    expect(fakeProcessManager.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () {
+      return fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            '/',
+            '--disable-observatory',
+            '--ipv6',
+            '--enable-checked-mode',
+            '--verify-entry-points',
+            '--enable-software-rendering',
+            '--skia-deterministic-rendering',
+            '--enable-dart-profiling',
+            '--non-interactive',
+            '--use-test-fonts',
+            '--packages=.dart_tool/package_config.json',
+            '--foo',
+            '--bar',
+            'example.dill'
+          ],
+          stdout: 'success',
+          stderr: 'failure',
+          exitCode: 0,
+        )
+      ]);
+    }
+  });
 }
 
 class MockSuitePlatform extends Mock implements SuitePlatform {}
@@ -239,7 +276,7 @@ class MockHttpServer extends Mock implements HttpServer {}
 //
 // Uses a mock HttpServer. We don't want to bind random ports in our CI hosts.
 class TestFlutterPlatform extends FlutterPlatform {
-  TestFlutterPlatform() : super(
+  TestFlutterPlatform([List<String> additionalArguments]) : super(
     buildInfo: const BuildInfo(BuildMode.debug, '', treeShakeIcons: false, packagesPath: '.dart_tool/package_config.json'),
     shellPath: '/',
     precompiledDillPath: 'example.dill',
@@ -250,6 +287,7 @@ class TestFlutterPlatform extends FlutterPlatform {
     enableObservatory: false,
     buildTestAssets: false,
     disableDds: true,
+    additionalArguments: additionalArguments,
   );
 
   @override
@@ -274,6 +312,7 @@ class TestObservatoryFlutterPlatform extends FlutterPlatform {
     buildTestAssets: false,
     disableServiceAuthCodes: false,
     disableDds: false,
+    additionalArguments: null,
   );
 
   final Completer<Uri> _ddsServiceUriCompleter = Completer<Uri>();

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -227,7 +227,7 @@ void main() {
   FakeProcessManager fakeProcessManager;
 
   testUsingContext('Can pass additional arguments to tester binary', () async {
-    final TestFlutterPlatform platform =TestFlutterPlatform(<String>['--foo', '--bar']);
+    final TestFlutterPlatform platform = TestFlutterPlatform(<String>['--foo', '--bar']);
     platform.loadChannel('test1.dart', MockSuitePlatform());
     await null;
 


### PR DESCRIPTION
To allow temporarily enabling SkParagraph for the purposes of testing in google3.
