### PR TITLE
[flutter_tools] add 483 to non-recoverable errors

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -692,6 +692,8 @@ void _handleWindowsException(Exception e, String message, int errorCode) {
   const int kDeviceFull = 112;
   const int kUserMappedSectionOpened = 1224;
   const int kAccessDenied = 5;
+  const int kFatalDeviceHardwareError = 483;
+
   // Catch errors and bail when:
   String errorMessage;
   switch (errorCode) {
@@ -713,6 +715,11 @@ void _handleWindowsException(Exception e, String message, int errorCode) {
         '\n$e\n'
         'Do you have an antivirus program running? '
         'Try disabling your antivirus program and try again.';
+      break;
+    case kFatalDeviceHardwareError:
+      errorMessage =
+        '$message. There is a problem with the device driver '
+        'that this file or directory is stored on.';
       break;
     default:
       // Caller must rethrow the exception.

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -173,6 +173,7 @@ void main() {
     const int kDeviceFull = 112;
     const int kUserMappedSectionOpened = 1224;
     const int kUserPermissionDenied = 5;
+    const int kFatalDeviceHardwareError =  483;
     MockFileSystem mockFileSystem;
     ErrorHandlingFileSystem fs;
 
@@ -268,6 +269,29 @@ void main() {
       expect(() => file.writeAsBytesSync(<int>[0]),
              throwsToolExit(message: expectedMessage));
       expect(() => file.writeAsStringSync(''),
+             throwsToolExit(message: expectedMessage));
+    });
+
+    testWithoutContext('when the device driver has a fatal error', () async {
+      setupWriteMocks(
+        mockFileSystem: mockFileSystem,
+        fs: fs,
+        errorCode: kFatalDeviceHardwareError,
+      );
+
+      final File file = fs.file('file');
+
+      const String expectedMessage = 'There is a problem with the device driver '
+        'that this file or directory is stored on';
+      expect(() async => await file.writeAsBytes(<int>[0]),
+             throwsToolExit(message: expectedMessage));
+      expect(() async => await file.writeAsString(''),
+             throwsToolExit(message: expectedMessage));
+      expect(() => file.writeAsBytesSync(<int>[0]),
+             throwsToolExit(message: expectedMessage));
+      expect(() => file.writeAsStringSync(''),
+             throwsToolExit(message: expectedMessage));
+      expect(() => file.openSync(),
              throwsToolExit(message: expectedMessage));
     });
 


### PR DESCRIPTION
This is a fatal drive error, so have the tool exit with a specific message.

Fixes https://github.com/flutter/flutter/issues/72388
