### PR TITLE
web benchmark choose renderer explicitly

### DIFF
--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -29,12 +29,7 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
     await evalFlutter('build', options: <String>[
       'web',
       '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
-      if (!useCanvasKit)
-        '--dart-define=FLUTTER_WEB_USE_SKIA=false',
-      if (!useCanvasKit)
-        '--dart-define=FLUTTER_WEB_AUTO_DETECT=false',
-      if (useCanvasKit)
-        '--dart-define=FLUTTER_WEB_USE_SKIA=true',
+      '--web-renderer=${useCanvasKit ? 'canvaskit' : 'html'}',
       '--profile',
       '-t',
       'lib/web_benchmarks.dart',


### PR DESCRIPTION
Make the web benchmarks specify `--web-renderer` explicitly.