### PR TITLE
Mark smoke-catalina not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -499,7 +499,6 @@ tasks:
       A some test that runs on macOS Catalina, which is a clone of the Dart VM hot patching performance benchmarking.
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
-    flaky: true # https://github.com/flutter/flutter/issues/71178
 
   smoke_catalina_start_up:
     description: >


### PR DESCRIPTION
This reverts commit 99bc4de73c8422e21b7d65764af506ef21ec75ea.

Working theory was a transient device issue?  Hasn't flaked in awhile.

Fixes https://github.com/flutter/flutter/issues/71178