### PR TITLE
Revert "Mark firebase tests as flaky"

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -148,19 +148,19 @@
          "name": "Linux firebase_abstract_method_smoke_test",
          "repo": "flutter",
          "task_name": "linux_firebase_abstract_method_smoke_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux firebase_android_embedding_v2_smoke_test",
          "repo": "flutter",
          "task_name": "linux_firebase_android_embedding_v2_smoke_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux firebase_release_smoke_test",
          "repo": "flutter",
          "task_name": "linux_firebase_release_smoke_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux flutter_gallery__back_button_memory",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -49,19 +49,19 @@
          "name":"Linux firebase_abstract_method_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_abstract_method_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux firebase_android_embedding_v2_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_android_embedding_v2_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux firebase_release_smoke_test",
          "repo":"flutter",
          "task_name":"linux_firebase_release_smoke_test",
-         "enabled":false
+         "enabled":true
       },
       {
          "name":"Linux fuchsia_precache",


### PR DESCRIPTION
Reverts flutter/flutter#73586

Firebase tests are now passing, the recipe change was reverted.
https://github.com/flutter/flutter/issues/73581#issuecomment-756948302