### PR TITLE
Imagefiltered callback mechanism to generate ImageFilter objects from RenderObject bounds

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -28,7 +28,6 @@ class FilteredChildAnimationPage extends StatefulWidget {
 class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage> with SingleTickerProviderStateMixin {
   AnimationController _controller;
   final GlobalKey _childKey = GlobalKey(debugLabel: 'child to animate');
-  Offset _childCenter = Offset.zero;
 
   FilterType _filterType;
   bool _complexChild;
@@ -40,10 +39,6 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
     _filterType = widget.initialFilterType;
     _complexChild = widget.initialComplexChild;
     _useRepaintBoundary = widget.initialUseRepaintBoundary;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final RenderBox childBox = _childKey.currentContext.findRenderObject() as RenderBox;
-      _childCenter = childBox.paintBounds.center;
-    });
     _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2));
     _controller.repeat();
   }
@@ -124,11 +119,11 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
         break;
       case FilterType.rotateFilter:
         builder = (BuildContext context, Widget child) => ImageFiltered(
-          imageFilter: ImageFilter.matrix((
+          imageFilterCallback: (Rect bounds) => ImageFilter.matrix((
               Matrix4.identity()
-                ..translate(_childCenter.dx, _childCenter.dy)
+                ..translate(bounds.center.dx, bounds.center.dy)
                 ..rotateZ(_controller.value * 2.0 * pi)
-                ..translate(- _childCenter.dx, - _childCenter.dy)
+                ..translate(- bounds.center.dx, - bounds.center.dy)
           ).storage),
           child: child,
         );

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -119,12 +119,14 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
         break;
       case FilterType.rotateFilter:
         builder = (BuildContext context, Widget child) => ImageFiltered(
-          imageFilterCallback: (Rect bounds) => ImageFilter.matrix((
-              Matrix4.identity()
-                ..translate(bounds.center.dx, bounds.center.dy)
-                ..rotateZ(_controller.value * 2.0 * pi)
-                ..translate(- bounds.center.dx, - bounds.center.dy)
-          ).storage),
+          imageFilterCallback: (Rect bounds) => ImageFilter.matrix(
+            (
+                Matrix4.identity()
+                  ..translate(bounds.center.dx, bounds.center.dy)
+                  ..rotateZ(_controller.value * 2.0 * pi)
+                  ..translate(- bounds.center.dx, - bounds.center.dy)
+            ).storage,
+          ),
           child: child,
         );
         break;

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -9,12 +9,17 @@ import 'package:flutter/rendering.dart';
 
 import 'framework.dart';
 
+/// Signature for a function that creates an [ImageFilter] for a given [Rect].
+///
+/// Used by [RenderImageFiltered] and the [ImageFiltered] widget.
+typedef ImageFilterCallback = ImageFilter Function(Rect bounds);
+
 /// Applies an [ImageFilter] to its child.
 ///
 /// See also:
 ///
 /// * [BackdropFilter], which applies an [ImageFilter] to everything
-///   beneath its child.
+///   behind its child.
 /// * [ColorFiltered], which applies a [ColorFilter] to its child.
 @immutable
 class ImageFiltered extends SingleChildRenderObjectWidget {
@@ -23,20 +28,34 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   /// The [imageFilter] must not be null.
   const ImageFiltered({
     Key? key,
-    required this.imageFilter,
+    this.imageFilter,
+    this.imageFilterCallback,
     Widget? child,
-  }) : assert(imageFilter != null),
+  }) : assert(imageFilter != null || imageFilterCallback != null,
+              'One of imageFilter or imageFilterCallback should be non-null'),
+       assert(imageFilter == null || imageFilterCallback == null,
+              'Only one of imageFilter or imageFilterCallback should be non-null'),
        super(key: key, child: child);
 
   /// The image filter to apply to the child of this widget.
-  final ImageFilter imageFilter;
+  final ImageFilter? imageFilter;
+
+  /// The callback
+  final ImageFilterCallback? imageFilterCallback;
 
   @override
-  RenderObject createRenderObject(BuildContext context) => _ImageFilterRenderObject(imageFilter);
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderImageFiltered(
+      imageFilter: imageFilter,
+      imageFilterCallback: imageFilterCallback,
+    );
+  }
 
   @override
-  void updateRenderObject(BuildContext context, _ImageFilterRenderObject renderObject) {
-    renderObject.imageFilter = imageFilter;
+  void updateRenderObject(BuildContext context, RenderImageFiltered renderObject) {
+    renderObject
+      ..imageFilter = imageFilter
+      ..imageFilterCallback = imageFilterCallback;
   }
 
   @override
@@ -46,15 +65,49 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   }
 }
 
-class _ImageFilterRenderObject extends RenderProxyBox {
-  _ImageFilterRenderObject(this._imageFilter);
+/// Applies an [ImageFilter] to its child.
+class RenderImageFiltered extends RenderProxyBox {
+  /// Creates a [RenderObject] that applies an [ImageFilter] to its child.
+  ///
+  /// One of the [imageFilter] or [imageFilterCallback] should not be null here
+  /// or whenever the [paint] method is invoked.
+  /// The [imageFilter] will be used if it is not null, otherwise the filter
+  /// will be obtained from the [imageFilterCallback].
+  RenderImageFiltered({
+    required ImageFilter? imageFilter,
+    required ImageFilterCallback? imageFilterCallback,
+  })
+      : assert(imageFilter != null || imageFilterCallback != null),
+        _imageFilter = imageFilter,
+        _imageFilterCallback = imageFilterCallback;
 
-  ImageFilter get imageFilter => _imageFilter;
-  ImageFilter _imageFilter;
-  set imageFilter(ImageFilter value) {
-    assert(value != null);
+  /// The [ImageFilter] to apply to this child, or null if the filter will be supplied
+  /// instead by the [imageFilterCallback].
+  ///
+  /// If the [imageFilter] is set to null here, then either it or the [imageFilterCallback]
+  /// should be set to a non-null value before [paint] is called.
+  ImageFilter? get imageFilter => _imageFilter;
+  ImageFilter? _imageFilter;
+  set imageFilter(ImageFilter? value) {
     if (value != _imageFilter) {
       _imageFilter = value;
+      markNeedsPaint();
+    }
+  }
+
+  /// Called to create the [ImageFilter] to apply to the child if the [imageFilter]
+  /// property is null.
+  ///
+  /// The image filter callback is called with the current bounds of the child so that
+  /// it can customize the filter to the size and location of the child.
+  ///
+  /// If the [imageFilterCallback] is set to null here, then either it or the [imageFilter]
+  /// should be set to a non-null value before [paint] is called.
+  ImageFilterCallback? get imageFilterCallback => _imageFilterCallback;
+  ImageFilterCallback? _imageFilterCallback;
+  set imageFilterCallback(ImageFilterCallback? value) {
+    if (value != _imageFilterCallback) {
+      _imageFilterCallback = value;
       markNeedsPaint();
     }
   }
@@ -62,16 +115,25 @@ class _ImageFilterRenderObject extends RenderProxyBox {
   @override
   bool get alwaysNeedsCompositing => child != null;
 
+  ImageFilter? _previousFilter;
+
   @override
   void paint(PaintingContext context, Offset offset) {
-    assert(imageFilter != null);
+    assert(imageFilter != null || imageFilterCallback != null);
+    ImageFilter newFilter = imageFilter ?? imageFilterCallback!(offset & size);
+    if (_previousFilter == newFilter) {
+      // Reuse the previous value if it is the same filter so that native layers
+      // can detect the stability for caching and dirty region calculations.
+      newFilter = _previousFilter!;
+    } else {
+      _previousFilter = newFilter;
+    }
     if (layer == null) {
-      layer = ImageFilterLayer(imageFilter: imageFilter);
+      layer = ImageFilterLayer(imageFilter: newFilter);
     } else {
       final ImageFilterLayer filterLayer = layer! as ImageFilterLayer;
-      filterLayer.imageFilter = imageFilter;
+      filterLayer.imageFilter = newFilter;
     }
     context.pushLayer(layer!, super.paint, offset);
-    assert(layer != null);
   }
 }

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'framework.dart';
+
+// Examples can assume:
+// late AnimationController controller;
 
 /// Applies an [ImageFilter] to its child.
 ///
@@ -21,7 +24,7 @@ import 'framework.dart';
 ///
 /// ```dart
 /// ImageFiltered(
-///   imageFilter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
+///   imageFilter: ui.ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
 ///   child: const Text('I am blurry'),
 /// )
 /// ```
@@ -34,16 +37,16 @@ import 'framework.dart';
 ///
 /// ```dart
 /// ImageFiltered(
-///   imageFilterCallback: (Rect bounds) => ImageFilter.matrix(
+///   imageFilterCallback: (Rect bounds) => ui.ImageFilter.matrix(
 ///     (
 ///       Matrix4.identity()
 ///         ..translate(bounds.center.dx, bounds.center.dy)
-///         ..rotateZ(_rotationController.value * pi * 2.0)
+///         ..rotateZ(controller.value * math.pi * 2.0)
 ///         ..translate(- bounds.center.dx, - bounds.center.dy)
 ///     ).storage,
 ///   ),
 ///   child: Text('<Insert complicated rendering child here>'),
-/// );
+/// )
 /// ```
 /// {@end-tool}
 ///
@@ -87,7 +90,7 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   /// The image filter to apply to the child of this widget, or null if the
   /// [imageFilterCallback] is being used to construct a customized filter
   /// for every layout.
-  final ImageFilter? imageFilter;
+  final ui.ImageFilter? imageFilter;
 
   /// The callback to be used to generate an [ImageFilter] after layout that
   /// might need to be computed based on the bounds of the child, or null if
@@ -112,6 +115,6 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<ImageFilter>('imageFilter', imageFilter));
+    properties.add(DiagnosticsProperty<ui.ImageFilter>('imageFilter', imageFilter));
   }
 }

--- a/packages/flutter/test/widgets/image_filtered_test.dart
+++ b/packages/flutter/test/widgets/image_filtered_test.dart
@@ -1,0 +1,76 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+ImageFilter createFilter(Rect bounds) {
+  return ImageFilter.matrix((Matrix4.identity()
+    ..translate(bounds.center.dx, bounds.center.dy)
+    ..rotateZ(pi / 4.0)
+    ..translate(- bounds.center.dx, - bounds.center.dy)
+  ).storage);
+}
+
+void main() {
+  testWidgets('Can be constructed with filter', (WidgetTester tester) async {
+    const Widget child = SizedBox(width: 100.0, height: 100.0);
+    await tester.pumpWidget(ImageFiltered(
+      child: child,
+      imageFilter: createFilter(Offset.zero & const Size(100.0, 100.0)),
+    ));
+  }, skip: isBrowser);
+
+  testWidgets('Can be constructed with filter callback', (WidgetTester tester) async {
+    const Widget child = SizedBox(width: 100.0, height: 100.0);
+    await tester.pumpWidget(const ImageFiltered(
+      child: child,
+      imageFilterCallback: createFilter,
+    ));
+  }, skip: isBrowser);
+
+  testWidgets('Must include filter or callback', (WidgetTester tester) async {
+    const Widget child = SizedBox(width: 100.0, height: 100.0);
+    expect(() => ImageFiltered(child: child), throwsAssertionError);
+  }, skip: isBrowser);
+
+  testWidgets('Must not include both filter and callback', (WidgetTester tester) async {
+    const Widget child = SizedBox(width: 100.0, height: 100.0);
+    expect(() => ImageFiltered(
+      child: child,
+      imageFilter: createFilter(Offset.zero & const Size(100.0, 100.0)),
+      imageFilterCallback: createFilter,
+    ), throwsAssertionError);
+  }, skip: isBrowser);
+
+  testWidgets('Bounds rect includes offset', (WidgetTester tester) async {
+    late Rect callbackBounds;
+    ImageFilter recordFilterBounds(Rect bounds) {
+      callbackBounds = bounds;
+      return createFilter(bounds);
+    }
+
+    final Widget widget = Align(
+      alignment: Alignment.topLeft,
+      child: SizedBox(
+        width: 400.0,
+        height: 400.0,
+        child: Center(
+          child: ImageFiltered(
+            imageFilterCallback: recordFilterBounds,
+            child: const SizedBox(width: 100.0, height: 100.0),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpWidget(widget);
+
+    // The filter bounds rectangle should reflect the position of the centered SizedBox.
+    expect(callbackBounds.center, equals(const Offset(200.0, 200.0)));
+    expect(callbackBounds.size, equals(const Size(100.0, 100.0)));
+  }, skip: isBrowser);
+}


### PR DESCRIPTION
This PR adds a callback mechanism to `ImageFiltered` nearly identical to the similar mechanism in the `ShaderMask` widget. Since `ImageFilter.matrix` objects frequently need to be constructed relative to the coordinate system in which they will be operating, it was not easy to use the facility to construct a matrix that would rotate (or scale) a widget around its center point. This same issue was encountered with the `ShaderMask` widget where the gradients that it would frequently get used with would require knowing the bounds in which the gradient would be defined.

The solution is the same in either case, using a callback that receives the bounds of the child from the `RenderObject` at the time of constructing layers so that it can create a custom filter on the fly. In the case of `ImageFiltered`, though, which is probably more often used with such coordinate space origin-agnostic filters like a blur filter, and due to backwards compatibility with the original definition that took a filter directly in the constructor, it makes sense to offer both facilities. The developer can then choose to just instantiate it with the filter for cases like using it with a blur, or they can choose to use the callback mechanism instead for cases like creating a matrix filter that operates around the center of a child.

Tests for `ImageFiltered` are also added for both new and old functionality, and the benchmark that tests the performance of the matrix filter is updated to use. the new mechanism. The performance should not be noticeably different, but the ease of use is improved. Note that not many lines of code were saved using the callback, but the prior solution required knowing how to install a frame callback which is an obscure mechanism to require for such a simple goal.

Here are some benchmark results from before and after the new mechanism was added and also after the benchmark was modified to use the new mechanism as opposed to the old workaround:

![average_frame _build_graph](https://user-images.githubusercontent.com/50503328/104074023-0092e980-51c4-11eb-9ff3-872c2d350b93.png)
![average_frame_rasterizer_chart](https://user-images.githubusercontent.com/50503328/104074027-0688ca80-51c4-11eb-946c-8b9d73e7b126.png)
(Note that the long bars in the rasterizer graph are due to the occasional likelihood that we get stuck waiting for vsync on every frame - a condition that can happen even on fast benchmarks and which locks the app into always waiting at least one vsync interval for every frame. The 3rd run of the "before" benchmark got locked into this condition early on and stayed locked for the entire run. The 3rd run of the "callback" benchmark get locked in only temporarily and recovered. These results are included for completeness, but aren't much of a concern until/unless we can find a way to avoid the condition which plagues many of our benchmarks.)