### PR TITLE
Generate dSYM files during iOS archive

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -190,13 +190,23 @@ Future<void> main() async {
           ]);
         });
 
-        checkDirectoryExists(path.join(
+        final String archivePath = path.join(
           flutterProject.rootPath,
           'build',
           'ios',
           'archive',
           'Runner.xcarchive',
+        );
+
+        checkDirectoryExists(path.join(
+          archivePath,
           'Products',
+        ));
+
+        checkDirectoryExists(path.join(
+          archivePath,
+          'dSYMs',
+          'Runner.app.dSYM',
         ));
       });
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -223,7 +223,8 @@ Future<XcodeBuildResult> buildXcodeProject({
       buildCommands.addAll(<String>[
         '-workspace', globals.fs.path.basename(entity.path),
         '-scheme', scheme,
-        'BUILD_DIR=${globals.fs.path.absolute(getIosBuildDirectory())}',
+        if (buildAction != XcodeBuildAction.archive) // dSYM files aren't copied to the archive if BUILD_DIR is set.
+          'BUILD_DIR=${globals.fs.path.absolute(getIosBuildDirectory())}',
       ]);
       break;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -92,7 +92,6 @@ void main() {
           '-quiet',
         '-workspace', 'Runner.xcworkspace',
         '-scheme', 'Runner',
-        'BUILD_DIR=/build/ios',
         '-sdk', 'iphoneos',
         'FLUTTER_SUPPRESS_ANALYTICS=true',
         'COMPILER_INDEX_STORE_ENABLE=NO',


### PR DESCRIPTION
Passing in the Xcode build setting `BUILD_DIR` somehow prevents the symbols from being archived.  Opt out of caching intermediate files in the ios build directory since it's not needed for archive, and the eventual archive is copied to known location `build/ios/archive`.

Fixes https://github.com/flutter/flutter/issues/73414
See https://github.com/flutter/flutter/issues/73414#issuecomment-757085098 for more details.

Updated unit test, added an integration test.