### PR TITLE
Revert "Prevent text from overflowing in OutlineButton and OutlinedButton label."

### DIFF
--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -266,7 +266,7 @@ class _OutlineButtonWithIcon extends OutlineButton with MaterialButtonWithIconMi
            children: <Widget>[
              icon,
              const SizedBox(width: 8.0),
-             Flexible(child: label),
+             label,
            ],
          ),
        );

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -345,7 +345,7 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: <Widget>[icon, SizedBox(width: gap), label],
     );
   }
 }

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -1222,22 +1222,6 @@ void main() {
     expect(box.size, equals(const Size(76, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
-
-  testWidgets('Text does not overflow in OutlineButton label', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MouseRegion(
-          cursor: SystemMouseCursors.forbidden,
-          child: OutlineButton.icon(
-            icon: const Icon(Icons.add),
-            label: const Text('this is a very long text used to check whether an overflow occurs or not'),
-            onPressed: () {},
-          ),
-        ),
-      ),
-    );
-  });
 }
 
 PhysicalModelLayer _findPhysicalLayer(Element element) {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1212,22 +1212,6 @@ void main() {
     );
     expect(paddingWidget.padding, const EdgeInsets.all(22));
   });
-
-  testWidgets('Text does not overflow in OutlinedButton label', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MouseRegion(
-          cursor: SystemMouseCursors.forbidden,
-          child: OutlinedButton.icon(
-            icon: const Icon(Icons.add),
-            label: const Text('this is a very long text used to check whether an overflow occurs or not'),
-            onPressed: () {},
-          ),
-        ),
-      ),
-    );
-  });
 }
 
 PhysicalModelLayer _findPhysicalLayer(Element element) {


### PR DESCRIPTION
Reverts flutter/flutter#70872

See internal issue b/177037597 and https://github.com/flutter/flutter/pull/70872#issuecomment-758097237

