### PR TITLE
increase the value of debugImageOverheadAllowance from 1024 bytes to 128kb

### DIFF
--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -157,11 +157,13 @@ PaintImageCallback? debugOnPaintImage;
 /// This has no effect unless asserts are enabled.
 bool debugInvertOversizedImages = false;
 
+const int _imageOverheadAllowanceDefault = 128 * 1024;
+
 /// The number of bytes an image must use before it triggers inversion when
 /// [debugInvertOversizedImages] is true.
 ///
-/// Default is 1024 (1kb).
-int debugImageOverheadAllowance = 1024;
+/// Default is 128kb.
+int debugImageOverheadAllowance = _imageOverheadAllowanceDefault;
 
 /// Returns true if none of the painting library debug variables have been changed.
 ///
@@ -180,7 +182,7 @@ bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOv
         debugNetworkImageHttpClientProvider != null ||
         debugOnPaintImage != null ||
         debugInvertOversizedImages == true ||
-        debugImageOverheadAllowance != 1024) {
+        debugImageOverheadAllowance != _imageOverheadAllowanceDefault) {
       throw FlutterError(reason);
     }
     return true;


### PR DESCRIPTION
This PR increases the value of `debugImageOverheadAllowance` from 104 bytes to 128kb. Before this the feature to invert oversized images would trigger on more images than we likely really wanted.

This PR adds one new test, to test the default value of 'debugImageOverheadAllowance'.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
