### PR TITLE
Turn off mac_build_gallery during infra investigation

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -472,7 +472,7 @@
          "name": "Mac build_gallery",
          "repo": "flutter",
          "task_name": "mac_build_gallery",
-         "flaky": false
+         "flaky": true
       },
       {
          "name": "Mac customer_testing",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -217,7 +217,7 @@
          "name":"Mac build_gallery",
          "repo":"flutter",
          "task_name":"mac_build_gallery",
-         "enabled":true
+         "enabled":false
       },
       {
          "name":"Mac framework_tests",


### PR DESCRIPTION
Turn off `mac_build_gallery` temporarily while infra issue is being investigated.
https://github.com/flutter/flutter/issues/73721