### PR TITLE
Removed the color field from AppBarTheme

### DIFF
--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -188,10 +188,12 @@ class AppBarTheme with Diagnosticable {
     SystemUiOverlayStyle? systemOverlayStyle,
     bool? backwardsCompatibility,
   }) {
+    assert(
+      color == null || backgroundColor == null,
+      'The color and backgroundColor parameters mean the same thing. Only specify one.');
     return AppBarTheme(
       brightness: brightness ?? this.brightness,
-      color: color ?? this.color,
-      backgroundColor: backgroundColor ?? this.backgroundColor,
+      backgroundColor: backgroundColor ?? color ?? this.backgroundColor,
       foregroundColor: foregroundColor ?? this.foregroundColor,
       elevation: elevation ?? this.elevation,
       shadowColor: shadowColor ?? this.shadowColor,

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -43,7 +43,10 @@ class AppBarTheme with Diagnosticable {
     this.titleTextStyle,
     this.systemOverlayStyle,
     this.backwardsCompatibility,
-  }) : backgroundColor = backgroundColor ?? color;
+  }) :  assert(
+          color == null || backgroundColor == null,
+          'The color and backgroundColor parameters mean the same thing. Only specify one.'),
+        backgroundColor = backgroundColor ?? color;
 
   /// This property is obsolete, please use [systemOverlayStyle] instead.
   ///
@@ -65,7 +68,8 @@ class AppBarTheme with Diagnosticable {
   /// See also:
   ///
   ///  * [backgroundColor], which serves this same purpose
-  ///    as this property, but has a consistent name.
+  ///    as this property, but has a name that's consistent with
+  ///    [AppBar.backgroundColor].
   ///  * [AppBar.backwardsCompatibility], which forces [AppBar] to depend
   ///    on this obsolete property.
   Color? get color => backgroundColor;

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -29,8 +29,8 @@ class AppBarTheme with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.appBarTheme].
   const AppBarTheme({
     this.brightness,
-    this.color,
-    this.backgroundColor,
+    Color? color,
+    Color? backgroundColor,
     this.foregroundColor,
     this.elevation,
     this.shadowColor,
@@ -43,7 +43,7 @@ class AppBarTheme with Diagnosticable {
     this.titleTextStyle,
     this.systemOverlayStyle,
     this.backwardsCompatibility,
-  });
+  }) : backgroundColor = backgroundColor ?? color;
 
   /// This property is obsolete, please use [systemOverlayStyle] instead.
   ///
@@ -68,7 +68,7 @@ class AppBarTheme with Diagnosticable {
   ///    as this property, but has a consistent name.
   ///  * [AppBar.backwardsCompatibility], which forces [AppBar] to depend
   ///    on this obsolete property.
-  final Color? color;
+  Color? get color => backgroundColor;
 
   /// Overrides the default value of [AppBar.backgroundColor] in all
   /// descendant [AppBar] widgets.
@@ -78,7 +78,6 @@ class AppBarTheme with Diagnosticable {
   ///  * [foregroundColor], which overrides the default value for
   ///    [AppBar.foregroundColor] in all descendant widgets.
   final Color? backgroundColor;
-
 
   /// Overrides the default value of [AppBar.foregroundColor] in all
   /// descendant widgets.
@@ -218,7 +217,6 @@ class AppBarTheme with Diagnosticable {
     assert(t != null);
     return AppBarTheme(
       brightness: t < 0.5 ? a?.brightness : b?.brightness,
-      color: Color.lerp(a?.color, b?.color, t),
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       foregroundColor: Color.lerp(a?.foregroundColor, b?.foregroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
@@ -239,7 +237,6 @@ class AppBarTheme with Diagnosticable {
   int get hashCode {
     return hashValues(
       brightness,
-      color,
       backgroundColor,
       foregroundColor,
       elevation,
@@ -264,7 +261,6 @@ class AppBarTheme with Diagnosticable {
       return false;
     return other is AppBarTheme
         && other.brightness == brightness
-        && other.color == color
         && other.backgroundColor == backgroundColor
         && other.foregroundColor == foregroundColor
         && other.elevation == elevation
@@ -284,7 +280,6 @@ class AppBarTheme with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: null));
-    properties.add(ColorProperty('color', color, defaultValue: null));
     properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: null));
     properties.add(ColorProperty('foregroundColor', foregroundColor, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -442,7 +442,7 @@ void main() {
     const AppBarTheme(
       backwardsCompatibility: false,
       brightness: Brightness.dark,
-      color: Color(0xff000001),
+      backgroundColor: Color(0xff000001),
       elevation: 8.0,
       shadowColor: Color(0xff000002),
       centerTitle: true,
@@ -456,7 +456,7 @@ void main() {
 
     expect(description, <String>[
       'brightness: Brightness.dark',
-      'color: Color(0xff000001)',
+      'backgroundColor: Color(0xff000001)',
       'elevation: 8.0',
       'shadowColor: Color(0xff000002)',
       'centerTitle: true',


### PR DESCRIPTION
The old color and the new backgroundColor field mean the same thing. The backgroundColor field was added in https://github.com/flutter/flutter/pull/71184 for the sake of consistency with AppBar.backgroundColor, however the original color field was not removed. It's now gone and there's an assert for the error of specifying both.
