### PR TITLE
Remove deprecated RenderView.scheduleInitialFrame

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -107,19 +107,6 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   ///  * [SystemChrome.setSystemUIOverlayStyle], for imperatively setting the system ui style.
   bool automaticSystemUiAdjustment = true;
 
-  /// Bootstrap the rendering pipeline by scheduling the first frame.
-  ///
-  /// Deprecated. Call [prepareInitialFrame] followed by a call to
-  /// [PipelineOwner.requestVisualUpdate] on [owner] instead.
-  @Deprecated(
-    'Call prepareInitialFrame followed by owner.requestVisualUpdate() instead. '
-    'This feature was deprecated after v1.10.0.'
-  )
-  void scheduleInitialFrame() {
-    prepareInitialFrame();
-    owner!.requestVisualUpdate();
-  }
-
   /// Bootstrap the rendering pipeline by preparing the first frame.
   ///
   /// This should only be called once, and must be called before changing


### PR DESCRIPTION
## Description

This removes the deprecated `scheduleInitialFrame` method from the `RenderView` class that has reached the EOL . 
Instead, users should call:

```dart
prepareInitialFrame();	
owner!.requestVisualUpdate();
```

Part of deprecations that are slated for removal for next release in https://flutter.dev/go/deprecation-lifetime

More context: https://medium.com/flutter/deprecation-lifetime-in-flutter-e4d76ee738ad

## Related Issues

Deprecated in https://github.com/flutter/flutter/pull/39535
https://github.com/flutter/flutter/issues/73910

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
