### PR TITLE
Remove deprecated Layer.findAll

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -376,39 +376,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   ///  * [find], which is similar but returns the first annotation found at the
   ///    given position.
-  ///  * [findAllAnnotations], which is similar but returns an
-  ///    [AnnotationResult], which contains more information, such as the local
-  ///    position of the event related to each annotation, and is equally fast,
-  ///    hence is preferred over [findAll].
-  ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
-  @Deprecated(
-    'Use findAllAnnotations(...).annotations instead. '
-    'This feature was deprecated after v1.10.14.'
-  )
-  Iterable<S> findAll<S extends Object>(Offset localPosition) {
-    final AnnotationResult<S> result = findAllAnnotations(localPosition);
-    return result.entries.map((AnnotationEntry<S> entry) => entry.annotation);
-  }
-
-  /// Search this layer and its subtree for all annotations of type `S` under
-  /// the point described by `localPosition`.
-  ///
-  /// Returns a result with empty entries if no matching annotations are found.
-  ///
-  /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// false` and returns the annotations of its result. Prefer overriding
-  /// [findAnnotations] instead of this method, because during an annotation
-  /// search, only [findAnnotations] is recursively called, while custom
-  /// behavior in this method is ignored.
-  ///
-  /// ## About layer annotations
-  ///
-  /// {@macro flutter.rendering.Layer.findAnnotations.aboutAnnotations}
-  ///
-  /// See also:
-  ///
-  ///  * [find], which is similar but returns the first annotation found at the
-  ///    given position.
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
   AnnotationResult<S> findAllAnnotations<S extends Object>(Offset localPosition) {
     final AnnotationResult<S> result = AnnotationResult<S>();


### PR DESCRIPTION
## Description

This removes the deprecated `findAll` method from the `Layer` class that has reached the EOL . 
Instead, users should call `Layer.findAllAnnotations(...).annotations`.

Part of deprecations that are slated for removal for next release in https://flutter.dev/go/deprecation-lifetime

More context: https://medium.com/flutter/deprecation-lifetime-in-flutter-e4d76ee738ad

## Related Issues

Deprecated in https://github.com/flutter/flutter/pull/42953
https://github.com/flutter/flutter/issues/73910

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
