### PR TITLE
Fix typo ' to ` in template

### DIFF
--- a/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
@@ -1,6 +1,6 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint {{projectName}}.podspec' to validate before publishing.
+# Run `pod lib lint {{projectName}}.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
   s.name             = '{{projectName}}'

--- a/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
@@ -1,6 +1,6 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint {{projectName}}.podspec' to validate before publishing.
+# Run `pod lib lint {{projectName}}.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
   s.name             = '{{projectName}}'

--- a/packages/flutter_tools/templates/plugin/macos.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/macos.tmpl/projectName.podspec.tmpl
@@ -1,6 +1,6 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint {{projectName}}.podspec' to validate before publishing.
+# Run `pod lib lint {{projectName}}.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
   s.name             = '{{projectName}}'


### PR DESCRIPTION
Fixed typo in the comment line of the output template.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.