### PR TITLE
Fix single ToggleButton border painting bugs

### DIFF
--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -891,12 +891,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
-          )
+          ),
       );
 
       await tester.pumpWidget(
@@ -919,12 +918,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
-          )
+          ),
       );
 
       await tester.pumpWidget(
@@ -946,12 +944,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
-          )
+          ),
       );
     },
   );
@@ -987,12 +984,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: borderColor,
             strokeWidth: customWidth,
-          )
+          ),
       );
 
       await tester.pumpWidget(
@@ -1017,12 +1013,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: selectedBorderColor,
             strokeWidth: customWidth,
-          )
+          ),
       );
 
       await tester.pumpWidget(
@@ -1046,12 +1041,11 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: disabledBorderColor,
             strokeWidth: customWidth,
-          )
+          ),
       );
     },
   );

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1477,7 +1477,7 @@ void main() {
           child: RepaintBoundary(
             child: ToggleButtons(
               borderRadius: const BorderRadius.all(Radius.circular(7.0)),
-              isSelected: const <bool>[false],
+              isSelected: const <bool>[true],
               onPressed: (int index) {},
               children: const <Widget>[
                 Text('First child'),
@@ -1525,7 +1525,7 @@ void main() {
                 bottomRight: Radius.elliptical(0, 10),
                 bottomLeft: Radius.elliptical(10, 0),
               ),
-              isSelected: const <bool>[false],
+              isSelected: const <bool>[true],
               onPressed: (int index) {},
               children: const <Widget>[
                 Text('First child'),

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1540,7 +1540,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('toggle_buttons.oneButton.boardsPaint2.png'),
     );
-  },);
+  });
 
   testWidgets('ToggleButtons implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -891,18 +891,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: theme.colorScheme.onSurface.withOpacity(0.12),
-            strokeWidth: defaultBorderWidth,
-          ),
       );
 
       await tester.pumpWidget(
@@ -925,18 +919,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: theme.colorScheme.onSurface.withOpacity(0.12),
-            strokeWidth: defaultBorderWidth,
-          ),
       );
 
       await tester.pumpWidget(
@@ -958,18 +946,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: theme.colorScheme.onSurface.withOpacity(0.12),
             strokeWidth: defaultBorderWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: theme.colorScheme.onSurface.withOpacity(0.12),
-            strokeWidth: defaultBorderWidth,
-          ),
       );
     },
   );
@@ -1005,18 +987,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: borderColor,
             strokeWidth: customWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: borderColor,
-            strokeWidth: customWidth,
-          ),
       );
 
       await tester.pumpWidget(
@@ -1041,18 +1017,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: selectedBorderColor,
             strokeWidth: customWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: selectedBorderColor,
-            strokeWidth: customWidth,
-          ),
       );
 
       await tester.pumpWidget(
@@ -1076,18 +1046,12 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
+          // If only one button, we can paint border with one path.
           ..path(
             style: PaintingStyle.stroke,
             color: disabledBorderColor,
             strokeWidth: customWidth,
           )
-          // leading side, top and bottom
-          ..path(
-            style: PaintingStyle.stroke,
-            color: disabledBorderColor,
-            strokeWidth: customWidth,
-          ),
       );
     },
   );
@@ -1509,6 +1473,80 @@ void main() {
       expect(tester.getCenter(find.text('First child')), const Offset(400.0, 349.0));
     },
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/73725
+  testWidgets('Border radius paint test when there is only one button', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: RepaintBoundary(
+            child: ToggleButtons(
+              borderRadius: const BorderRadius.all(Radius.circular(7.0)),
+              isSelected: const <bool>[false],
+              onPressed: (int index) {},
+              children: const <Widget>[
+                Text('First child'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The only button should be laid out at the center of the screen.
+    expect(tester.getCenter(find.text('First child')), const Offset(400.0, 300.0));
+
+    final List<RenderObject> toggleButtonRenderObject = tester.allRenderObjects.where((RenderObject object) {
+      return object.runtimeType.toString() == '_SelectToggleButtonRenderObject';
+    }).toSet().toList();
+
+    // The first button paints the left, top and right sides with a path.
+    expect(
+      toggleButtonRenderObject[0],
+      paints
+      // left side, top and right - enabled.
+        ..path(
+          style: PaintingStyle.stroke,
+          color: theme.colorScheme.onSurface.withOpacity(0.12),
+          strokeWidth: _defaultBorderWidth,
+        ),
+    );
+
+    await expectLater(
+      find.byType(RepaintBoundary),
+      matchesGoldenFile('toggle_buttons.oneButton.boardsPaint.png'),
+    );
+  },);
+
+  testWidgets('Border radius paint test when Radius.x or Radius.y equal 0.0', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Material(
+        child: boilerplate(
+          child: RepaintBoundary(
+            child: ToggleButtons(
+              borderRadius: const BorderRadius.only(
+                topRight: Radius.elliptical(10, 0),
+                topLeft: Radius.elliptical(0, 10),
+                bottomRight: Radius.elliptical(0, 10),
+                bottomLeft: Radius.elliptical(10, 0),
+              ),
+              isSelected: const <bool>[false],
+              onPressed: (int index) {},
+              children: const <Widget>[
+                Text('First child'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byType(RepaintBoundary),
+      matchesGoldenFile('toggle_buttons.oneButton.boardsPaint2.png'),
+    );
+  },);
 
   testWidgets('ToggleButtons implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1511,7 +1511,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('toggle_buttons.oneButton.boardsPaint.png'),
     );
-  },);
+  });
 
   testWidgets('Border radius paint test when Radius.x or Radius.y equal 0.0', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -476,13 +476,6 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
-          ..path(
-            style: PaintingStyle.stroke,
-            color: borderColor,
-            strokeWidth: customWidth,
-          )
-          // leading side, top and bottom
           ..path(
             style: PaintingStyle.stroke,
             color: borderColor,
@@ -516,13 +509,6 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
-          ..path(
-            style: PaintingStyle.stroke,
-            color: selectedBorderColor,
-            strokeWidth: customWidth,
-          )
-          // leading side, top and bottom
           ..path(
             style: PaintingStyle.stroke,
             color: selectedBorderColor,
@@ -555,13 +541,6 @@ void main() {
       expect(
         toggleButtonRenderObject,
         paints
-          // trailing side
-          ..path(
-            style: PaintingStyle.stroke,
-            color: disabledBorderColor,
-            strokeWidth: customWidth,
-          )
-          // leading side, top and bottom
           ..path(
             style: PaintingStyle.stroke,
             color: disabledBorderColor,


### PR DESCRIPTION
This patch fixes two bugs:
## 1, Does not apply border-radius when there is only one button
   ### Expected: 
![image](https://user-images.githubusercontent.com/61075224/104301450-9dc28a80-5502-11eb-9c81-4651ee786292.png)
   ### Actual:
![image](https://user-images.githubusercontent.com/61075224/104301490-adda6a00-5502-11eb-88b5-e8a6b1062c0c.png)

## 2, Border-radius paint incorrect when `Radius.x` or `Radius.y` equal 0.0
```dart
  borderRadius: BorderRadius.only(
    topRight: Radius.elliptical(10, 0),
    topLeft: Radius.elliptical(0, 10),
    bottomRight: Radius.elliptical(0, 10),
    bottomLeft: Radius.elliptical(10, 0),
  ),
```
   ### Expected: 
![image](https://user-images.githubusercontent.com/61075224/104301083-3278b880-5502-11eb-88a1-c8c9a345a141.png)
  ### Actual:
![image](https://user-images.githubusercontent.com/61075224/104301132-402e3e00-5502-11eb-9d75-23bbaa40baf9.png)

## Related Issues
Fixes #73725

