### PR TITLE
Mark linux_web_tool_tests not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -394,7 +394,7 @@
          "name": "Linux web_tool_tests",
          "repo": "flutter",
          "task_name": "linux_web_tool_tests",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Linux web_benchmarks_canvaskit",


### PR DESCRIPTION
linux_web_tool_tests doesn't look flaky, enable to catch regressions now by closing the tree.

Introduced in https://github.com/flutter/flutter/pull/70412.