### PR TITLE
Enable hot reload test for Windows desktop

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  await task(createHotModeTest(deviceIdOverride: 'windows'));
+}

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -601,6 +601,12 @@
          "flaky": false
       },
       {
+         "name": "Windows hot_mode_dev_cycle_win_target__benchmark",
+         "repo": "flutter",
+         "task_name": "windows_hot_mode_dev_cycle_win_target__benchmark",
+         "flaky": false
+      },
+      {
          "name": "Windows module_custom_host_app_name_test",
          "repo": "flutter",
          "task_name": "win_module_custom_host_app_name_test",


### PR DESCRIPTION
Bring up the hot reload devicelab test for Windows desktop. This also serves as a test case for ensuring Windows desktop tests can be run successfully on devicelab, since this is the first Windows desktop devicelab test.

Part of https://github.com/flutter/flutter/issues/54295

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
