### PR TITLE
[flutter_tools] do not crash if target file cannot be read for language version

### DIFF
--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -24,7 +24,17 @@ final LanguageVersion nullSafeVersion = LanguageVersion(2, 12);
 /// https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/feature-specification.md#individual-library-language-version-override
 LanguageVersion determineLanguageVersion(File file, Package package) {
   int blockCommentDepth = 0;
-  for (final String line in file.readAsLinesSync()) {
+  // If reading the file fails, default to a null-safe version. The
+  // command will likely fail later in the process with a better error
+  // message.
+  List<String> lines;
+  try {
+    lines = file.readAsLinesSync();
+  } on FileSystemException {
+    return nullSafeVersion;
+  }
+
+  for (final String line in lines) {
     final String trimmedLine = line.trim();
     if (trimmedLine.isEmpty) {
       continue;

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -4,8 +4,10 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/dart/language_version.dart';
 import 'package:package_config/package_config.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 
@@ -249,4 +251,22 @@ library funstuff;
 
     expect(determineLanguageVersion(file, package), LanguageVersion(2, 7));
   });
+
+
+  testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
+    final Package package = Package(
+      'foo',
+      Uri.parse('file://foo/'),
+      languageVersion: LanguageVersion(2, 7),
+    );
+
+    expect(determineLanguageVersion(FakeFile(), package), nullSafeVersion);
+  });
+}
+
+class FakeFile extends Fake implements File {
+  @override
+  List<String> readAsLinesSync({ Encoding encoding = utf8ForTesting }) {
+    throw const FileSystemException();
+  }
 }


### PR DESCRIPTION
The flutter tool needs to parse the provided target file for a language version. If this file cannot be read, it currently crashes.

Instead, fallback to a default language version. The tool will likely exit at a later time with a more informative error.
