### PR TITLE
[flutter_tools] add error handling wrapping for File.createSync

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -264,6 +264,17 @@ class ErrorHandlingFile
   }
 
   @override
+  void createSync({bool recursive = false}) {
+    _runSync<void>(
+      () => delegate.createSync(
+        recursive: recursive,
+      ),
+      platform: _platform,
+      failureMessage: 'Flutter failed to create file at "${delegate.path}"',
+    );
+  }
+
+  @override
   RandomAccessFile openSync({FileMode mode = FileMode.read}) {
     return _runSync<RandomAccessFile>(
       () => delegate.openSync(

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -76,7 +76,7 @@ void setupWriteMocks({
   when(mockFile.openSync(
     mode: anyNamed('mode'),
   )).thenThrow(FileSystemException('', '', OSError('', errorCode)));
-  when(mockFile.create(recursive: anyNamed('recursive')))
+  when(mockFile.createSync(recursive: anyNamed('recursive')))
     .thenThrow(FileSystemException('', '', OSError('', errorCode)));
 }
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -76,6 +76,8 @@ void setupWriteMocks({
   when(mockFile.openSync(
     mode: anyNamed('mode'),
   )).thenThrow(FileSystemException('', '', OSError('', errorCode)));
+  when(mockFile.create(recursive: anyNamed('recursive')))
+    .thenThrow(FileSystemException('', '', OSError('', errorCode)));
 }
 
 void setupReadMocks({
@@ -230,6 +232,8 @@ void main() {
              throwsToolExit(message: expectedMessage));
       expect(() => file.openSync(),
              throwsToolExit(message: expectedMessage));
+      expect(() => file.createSync(),
+             throwsToolExit(message: expectedMessage));
     });
 
     testWithoutContext('when writing to a full device', () async {
@@ -292,6 +296,8 @@ void main() {
       expect(() => file.writeAsStringSync(''),
              throwsToolExit(message: expectedMessage));
       expect(() => file.openSync(),
+             throwsToolExit(message: expectedMessage));
+      expect(() => file.createSync(),
              throwsToolExit(message: expectedMessage));
     });
 
@@ -389,6 +395,8 @@ void main() {
       expect(() => file.writeAsStringSync(''),
              throwsToolExit(message: expectedMessage));
       expect(() => file.openSync(),
+             throwsToolExit(message: expectedMessage));
+      expect(() => file.createSync(),
              throwsToolExit(message: expectedMessage));
     });
 


### PR DESCRIPTION
Otherwise our error handling file system doesn't work for creating files.