### PR TITLE
[flutter_tools] dont crash on invalid utf8 in pubspec

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -221,6 +221,12 @@ class FlutterProject {
     } on YamlException catch (e) {
       logger.printStatus('Error detected in pubspec.yaml:', emphasis: true);
       logger.printError('$e');
+    } on FormatException catch (e) {
+      logger.printError('Error detected while parsing pubspec.yaml:', emphasis: true);
+      logger.printError('$e');
+    } on FileSystemException catch (e) {
+      logger.printError('Error detected while reading pubspec.yaml:', emphasis: true);
+      logger.printError('$e');
     }
     if (manifest == null) {
       throwToolExit('Please correct the pubspec.yaml file at $path');

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -37,6 +37,22 @@ void main() {
         );
       });
 
+      testWithoutContext('invalid utf8 throws a tool exit', () {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final FlutterProjectFactory projectFactory = FlutterProjectFactory(
+          fileSystem: fileSystem,
+          logger: BufferLogger.test(),
+        );
+        fileSystem.file('pubspec.yaml').writeAsBytesSync(<int>[0xFFFE]);
+
+        /// Technically this should throw a FileSystemException but this is
+        /// currently a bug in package:file.
+        expect(
+          () => projectFactory.fromDirectory(fileSystem.currentDirectory),
+          throwsToolExit(),
+        );
+      });
+
       _testInMemory('fails on invalid pubspec.yaml', () async {
         final Directory directory = globals.fs.directory('myproject');
         directory.childFile('pubspec.yaml')


### PR DESCRIPTION
If the pubspec.yaml file is invalid utf8, don't crash when parsing it - instead using the existing errors.

Unfortunately the behavior differs here between the real file system and the memory filesystem: the latter throws a FormatError and the former a FileSystem exception.