### PR TITLE
Added CupertinoButton alignment property

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -40,9 +40,11 @@ class CupertinoButton extends StatefulWidget {
     this.minSize = kMinInteractiveDimensionCupertino,
     this.pressedOpacity = 0.4,
     this.borderRadius = const BorderRadius.all(Radius.circular(8.0)),
+    this.alignment = Alignment.center,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
-       assert(disabledColor != null),
+        assert(disabledColor != null),
+        assert(alignment != null),
        _filled = false,
        super(key: key);
 
@@ -60,9 +62,11 @@ class CupertinoButton extends StatefulWidget {
     this.minSize = kMinInteractiveDimensionCupertino,
     this.pressedOpacity = 0.4,
     this.borderRadius = const BorderRadius.all(Radius.circular(8.0)),
+    this.alignment = Alignment.center,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        assert(disabledColor != null),
+        assert(alignment != null),
        color = null,
        _filled = true,
        super(key: key);
@@ -115,6 +119,16 @@ class CupertinoButton extends StatefulWidget {
   ///
   /// Defaults to round corners of 8 logical pixels.
   final BorderRadius? borderRadius;
+
+  /// The alignment of the button's [child].
+  ///
+  /// Typically buttons are sized to be just big enough to contain the child and its
+  /// [padding]. If the button's size is constrained to a fixed size, for example by
+  /// enclosing it with a [SizedBox], this property defines how the child is aligned
+  /// within the available space.
+  ///
+  /// Always defaults to [Alignment.center].
+  final AlignmentGeometry alignment;
 
   final bool _filled;
 
@@ -252,7 +266,8 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
                 padding: widget.padding ?? (backgroundColor != null
                   ? _kBackgroundButtonPadding
                   : _kButtonPadding),
-                child: Center(
+                child: Align(
+                  alignment: widget.alignment,
                   widthFactor: 1.0,
                   heightFactor: 1.0,
                   child: DefaultTextStyle(

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -43,8 +43,8 @@ class CupertinoButton extends StatefulWidget {
     this.alignment = Alignment.center,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
-        assert(disabledColor != null),
-        assert(alignment != null),
+       assert(disabledColor != null),
+       assert(alignment != null),
        _filled = false,
        super(key: key);
 
@@ -66,7 +66,7 @@ class CupertinoButton extends StatefulWidget {
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
        assert(disabledColor != null),
-        assert(alignment != null),
+       assert(alignment != null),
        color = null,
        _filled = true,
        super(key: key);

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -101,6 +101,33 @@ void main() {
   });
   */
 
+  testWidgets('Button child alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoButton(
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    Align align = tester.firstWidget<Align>(find.ancestor(of: find.text('button'), matching: find.byType(Align)));
+    expect(align.alignment, Alignment.center); // default
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoButton(
+          alignment: Alignment.centerLeft,
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    align = tester.firstWidget<Align>(find.ancestor(of: find.text('button'), matching: find.byType(Align)));
+    expect(align.alignment, Alignment.centerLeft);
+  });
+
   testWidgets('Button with background is wider', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(child: const CupertinoButton(
       child: Text('X', style: testStyle),


### PR DESCRIPTION
Added an AlignmentGeometry valued alignment property to CupertinoButton which defines how the button's child is aligned within the available space. This generally only applies with the button size is constrained to have a different size than it would have by default.

The following example constrains the width of 3 buttons to be 300. Their alignment parameter is center (same as the default), centerRight, and centerLeft.

<img width="324" alt="Screen Shot 2021-01-13 at 2 24 46 PM" src="https://user-images.githubusercontent.com/1377460/104518684-f0588100-55ac-11eb-8657-8dd7f0c18b31.png">

```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

class Home extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      child: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: <Widget>[
            SizedBox(
              width: 300,
              child: CupertinoButton.filled(
                alignment: Alignment.center,
                padding: EdgeInsets.all(16),
                onPressed: () { },
                child: Text('center'),
              ),
            ),
            SizedBox(height: 16),
            SizedBox(
              width: 300,
              child: CupertinoButton.filled(
                alignment: Alignment.centerRight,
                padding: EdgeInsets.all(16),
                onPressed: () { },
                child: Text('centerRight'),
              ),
            ),
            SizedBox(height: 16),
            SizedBox(
              width: 300,
              child: CupertinoButton.filled(
                alignment: Alignment.centerLeft,
                padding: EdgeInsets.all(16),
                onPressed: () { },
                child: Text('centerLeft'),
              ),
            ),
          ],
        ),
      ),
    );
  }
}

void main() {
  runApp(CupertinoApp(home: Home()));
}
```
