### PR TITLE
Avoid relative paths in .dart_tool/package_config.json when generate:true

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:process/process.dart';
@@ -455,20 +457,28 @@ class _DefaultPub implements Pub {
     if (!generateSyntheticPackage) {
       return;
     }
-    final Package flutterGen = Package('flutter_gen', generatedDirectory.uri, languageVersion: LanguageVersion(2, 12));
     if (packageConfig.packages.any((Package package) => package.name == 'flutter_gen')) {
       return;
     }
-    final PackageConfig newPackageConfig = PackageConfig(
-      <Package>[
-        ...packageConfig.packages,
-        flutterGen,
-      ],
-    );
-    // There is no current API for saving a package_config without hitting the real filesystem.
-    if (packageConfigFile.fileSystem is LocalFileSystem) {
-      await savePackageConfig(newPackageConfig, packageConfigFile.parent.parent);
-    }
+
+    // TODO(jonahwillams): Using raw json manipulation here because
+    // writeAsStringSync always writes to local io, and it changes absolute
+    // paths to relative on round trip.
+    // See: https://github.com/dart-lang/package_config/issues/99,
+    // and: https://github.com/dart-lang/package_config/issues/100.
+
+    // Because [loadPackageConfigWithLogging] succeeded [packageConfigFile]
+    // surely exists and is correctly formatted.
+    final dynamic jsonContents =
+        json.decode(packageConfigFile.readAsStringSync());
+
+    jsonContents['packages'].add(<String, dynamic>{
+      'name': 'flutter_gen',
+      'rootUri': 'flutter_gen',
+      'languageVersion': '2.12',
+    });
+
+    packageConfigFile.writeAsStringSync(json.encode(jsonContents));
   }
 
   // Subset the package config file to only the parts that are relevant for

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -462,13 +462,13 @@ class _DefaultPub implements Pub {
     }
 
     // TODO(jonahwillams): Using raw json manipulation here because
-    // writeAsStringSync always writes to local io, and it changes absolute
+    // savePackageConfig always writes to local io, and it changes absolute
     // paths to relative on round trip.
     // See: https://github.com/dart-lang/package_config/issues/99,
     // and: https://github.com/dart-lang/package_config/issues/100.
 
     // Because [loadPackageConfigWithLogging] succeeded [packageConfigFile]
-    // surely exists and is correctly formatted.
+    // we can rely on the file to exist and be correctly formatted.
     final dynamic jsonContents =
         json.decode(packageConfigFile.readAsStringSync());
 

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
@@ -17,6 +16,7 @@ import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../cache.dart';
+import '../convert.dart';
 import '../dart/package_map.dart';
 import '../reporting/reporting.dart';
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/memory.dart';
@@ -10,6 +9,7 @@ import 'package:yaml/yaml.dart';
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/localizations/gen_l10n.dart';
 import 'package:flutter_tools/src/localizations/gen_l10n_types.dart';

--- a/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:file/file.dart';
 
 import '../src/common.dart';
@@ -27,5 +29,20 @@ void main() {
 
   testWithoutContext('can correctly reference flutter generated code.', () async {
     await flutter.run();
+    final dynamic jsonContent = json.decode(project.dir
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json')
+        .readAsStringSync());
+    final dynamic collection = jsonContent['packages'].firstWhere((dynamic e) => e.name == 'collection');
+    expect(
+      Uri.parse(collection['rootUri'] as String).isAbsolute,
+      isTrue,
+      reason: 'The generated package_config.json should use absolute root urls',
+    );
+    expect(
+      collection['packageUri'] as String,
+      'lib/',
+      reason: 'The generated package_config.json should have package urls ending with /'
+    );
   });
 }

--- a/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_gen_test.dart
@@ -33,7 +33,8 @@ void main() {
         .childDirectory('.dart_tool')
         .childFile('package_config.json')
         .readAsStringSync());
-    final dynamic collection = jsonContent['packages'].firstWhere((dynamic e) => e.name == 'collection');
+    final dynamic collection = jsonContent['packages']
+        .firstWhere((dynamic e) => e['name'] == 'collection');
     expect(
       Uri.parse(collection['rootUri'] as String).isAbsolute,
       isTrue,


### PR DESCRIPTION
Instead of using package:package_config to write the .dart_tool/package_config the original json is modified and rewritten.

The .dart_tool/package_config.json file is read twice to simplify control flow.

This works around https://github.com/dart-lang/tools/issues/1538 and https://github.com/dart-lang/tools/issues/1539 and will make it easier for pub to work around: https://github.com/flutter/flutter/issues/73870 / https://github.com/dart-lang/pub/issues/2806

This also avoids the issue of package:package_config writing directly to local filesystem.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
  **This PR doesn't on its own solve any current issues, but is a step towards solving: https://github.com/flutter/flutter/issues/73870**
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
