### PR TITLE
[flutter_tools] no-op maven artifacts if Android SDK is absent

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1136,6 +1136,8 @@ class AndroidGenSnapshotArtifacts extends EngineCachedArtifact {
 }
 
 /// A cached artifact containing the Maven dependencies used to build Android projects.
+///
+/// This is a no-op if the android SDK is not available.
 class AndroidMavenArtifacts extends ArtifactSet {
   AndroidMavenArtifacts(this.cache, {
     @required Platform platform,
@@ -1152,6 +1154,9 @@ class AndroidMavenArtifacts extends ArtifactSet {
     FileSystem fileSystem,
     OperatingSystemUtils operatingSystemUtils,
   ) async {
+    if (globals.androidSdk == null) {
+      return;
+    }
     final Directory tempDir = cache.getRoot().createTempSync(
       'flutter_gradle_wrapper.',
     );

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/gradle_utils.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show InternetAddress, SocketException;
@@ -653,24 +654,23 @@ void main() {
 
   group('AndroidMavenArtifacts', () {
     MemoryFileSystem memoryFileSystem;
-    MockProcessManager processManager;
     Cache cache;
 
     setUp(() {
       memoryFileSystem = MemoryFileSystem.test();
-      processManager = MockProcessManager();
       cache = Cache.test(
         fileSystem: memoryFileSystem,
         processManager: FakeProcessManager.any(),
       );
     });
 
-    testWithoutContext('development artifact', () async {
+    testWithoutContext('AndroidMavenArtifacts has a specified development artifact', () async {
       final AndroidMavenArtifacts mavenArtifacts = AndroidMavenArtifacts(cache, platform: FakePlatform(operatingSystem: 'linux'));
       expect(mavenArtifacts.developmentArtifact, DevelopmentArtifact.androidMaven);
     });
 
-    testUsingContext('update', () async {
+    testUsingContext('AndroidMavenArtifacts can invoke Gradle resolve dependencies if Android SDK is present', () async {
+      Cache.flutterRoot = '';
       final AndroidMavenArtifacts mavenArtifacts = AndroidMavenArtifacts(cache, platform: FakePlatform(operatingSystem: 'linux'));
       expect(await mavenArtifacts.isUpToDate(memoryFileSystem), isFalse);
 
@@ -678,16 +678,28 @@ void main() {
       gradleWrapperDir.childFile('gradlew').writeAsStringSync('irrelevant');
       gradleWrapperDir.childFile('gradlew.bat').writeAsStringSync('irrelevant');
 
-      when(processManager.run(any, environment: captureAnyNamed('environment')))
-        .thenAnswer((Invocation invocation) {
-          final List<String> args = invocation.positionalArguments[0] as List<String>;
-          expect(args.length, 6);
-          expect(args[1], '-b');
-          expect(args[2].endsWith('resolve_dependencies.gradle'), isTrue);
-          expect(args[5], 'resolveDependencies');
-          expect(invocation.namedArguments[#environment], gradleEnvironment);
-          return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
-        });
+      await mavenArtifacts.update(MockArtifactUpdater(), BufferLogger.test(), memoryFileSystem, MockOperatingSystemUtils());
+
+      expect(await mavenArtifacts.isUpToDate(memoryFileSystem), isFalse);
+    }, overrides: <Type, Generator>{
+      Cache: () => cache,
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          '/cache/bin/cache/flutter_gradle_wrapper.rand0/gradlew',
+          '-b',
+          'packages/flutter_tools/gradle/resolve_dependencies.gradle',
+          '--project-cache-dir',
+          'cache/bin/cache/flutter_gradle_wrapper.rand0',
+          'resolveDependencies',
+        ])
+      ]),
+      AndroidSdk: () => FakeAndroidSdk()
+    });
+
+    testUsingContext('AndroidMavenArtifacts is a no-op if the Android SDK is absent', () async {
+      final AndroidMavenArtifacts mavenArtifacts = AndroidMavenArtifacts(cache, platform: FakePlatform(operatingSystem: 'linux'));
+      expect(await mavenArtifacts.isUpToDate(memoryFileSystem), isFalse);
 
       await mavenArtifacts.update(MockArtifactUpdater(), BufferLogger.test(), memoryFileSystem, MockOperatingSystemUtils());
 
@@ -695,7 +707,8 @@ void main() {
     }, overrides: <Type, Generator>{
       Cache: () => cache,
       FileSystem: () => memoryFileSystem,
-      ProcessManager: () => processManager,
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[]),
+      AndroidSdk: () => null // Android SDK was not located.
     });
   });
 }
@@ -782,3 +795,4 @@ class FakeCache extends Cache {
     return stampFile;
   }
 }
+class FakeAndroidSdk extends Fake implements AndroidSdk {}

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
-import 'package:flutter_tools/src/android/gradle_utils.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show InternetAddress, SocketException;
 import 'package:flutter_tools/src/base/io.dart';


### PR DESCRIPTION
Before invoking gradle to download maven/android artifacts, check if the Android SDK was located. If not, the gradle invocation will confusingly fail - so just skip it.

Also updates the test to use the FakeProcessManager


Fixes https://github.com/flutter/flutter/issues/71107