### PR TITLE
[flutter_tools] open chrome to correct base URL when base url is specified in index.html

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -707,9 +707,9 @@ class WebDevFS implements DevFS {
       webAssetServer.webRenderer = WebRendererMode.canvaskit;
     }
     if (hostname == 'any') {
-      _baseUri = Uri.http('localhost:$selectedPort', '');
+      _baseUri = Uri.http('localhost:$selectedPort', webAssetServer.basePath);
     } else {
-      _baseUri = Uri.http('$hostname:$selectedPort', '');
+      _baseUri = Uri.http('$hostname:$selectedPort', webAssetServer.basePath);
     }
     return _baseUri;
   }


### PR DESCRIPTION
part of the work in https://github.com/flutter/flutter/issues/69964

If the flutter web app specifies a different base URL in the index.html, make sure we open chrome/edge to that URL. This does not fix the crash, which happens entirely in dwds, but it does make it work correctly in release mode.
