### PR TITLE
[flutter_tools] use less path manipulation in Android SDK class

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -43,8 +43,8 @@ class AndroidSdk {
   static const String _javaHomeEnvironmentVariable = 'JAVA_HOME';
   static const String _javaExecutable = 'java';
 
-  /// The path to the Android SDK.
-  final String directory;
+  /// The Android SDK root directory.
+  final Directory directory;
 
   List<AndroidSdkVersion> _sdkVersions;
   AndroidSdkVersion _latestVersion;
@@ -55,9 +55,8 @@ class AndroidSdk {
   /// the expectation that it will be downloaded later, e.g. by gradle or the
   /// sdkmanager. The [licensesAvailable] property should be used to determine
   /// whether the licenses are at least possibly accepted.
-  bool get platformToolsAvailable =>
-    globals.fs.directory(globals.fs.path.join(directory, 'cmdline-tools')).existsSync() ||
-    globals.fs.directory(globals.fs.path.join(directory, 'platform-tools')).existsSync();
+  bool get platformToolsAvailable => directory.childDirectory('cmdline-tools').existsSync()
+     || directory.childDirectory('platform-tools').existsSync();
 
   /// Whether the `licenses` directory exists in the Android SDK.
   ///
@@ -66,7 +65,7 @@ class AndroidSdk {
   /// from another workstation such as in CI scenarios. If these files are valid
   /// gradle or the sdkmanager will be able to download and use other parts of
   /// the SDK on demand.
-  bool get licensesAvailable => globals.fs.directory(globals.fs.path.join(directory, 'licenses')).existsSync();
+  bool get licensesAvailable => directory.childDirectory('licenses').existsSync();
 
   static AndroidSdk locateAndroidSdk() {
     String findAndroidHomeDir() {
@@ -147,7 +146,7 @@ class AndroidSdk {
       return null;
     }
 
-    return AndroidSdk(androidHomeDir);
+    return AndroidSdk(globals.fs.directory(androidHomeDir));
   }
 
   static bool validSdkDirectory(String dir) {
@@ -198,7 +197,7 @@ class AndroidSdk {
     );
   }
 
-  Directory get _platformsDir => globals.fs.directory(globals.fs.path.join(directory, 'platforms'));
+  Directory get _platformsDir => directory.childDirectory('platforms');
 
   Iterable<Directory> get _platforms {
     Iterable<Directory> platforms = <Directory>[];
@@ -234,9 +233,13 @@ class AndroidSdk {
   }
 
   String getPlatformToolsPath(String binaryName) {
-    final String path = globals.fs.path.join(directory, 'platform-tools', binaryName);
-    if (globals.fs.file(path).existsSync()) {
-      return path;
+    final File cmdlineToolsBinary = directory.childDirectory('cmdline-tools').childFile(binaryName);
+    if (cmdlineToolsBinary.existsSync()) {
+      return cmdlineToolsBinary.path;
+    }
+    final File platformToolBinary = directory.childDirectory('platform-tools').childFile(binaryName);
+    if (platformToolBinary.existsSync()) {
+      return platformToolBinary.path;
     }
     return null;
   }
@@ -247,9 +250,9 @@ class AndroidSdk {
     // try both.
     final List<String> searchFolders = <String>['emulator', 'tools'];
     for (final String folder in searchFolders) {
-      final String path = globals.fs.path.join(directory, folder, binaryName);
-      if (globals.fs.file(path).existsSync()) {
-        return path;
+      final File file = directory.childDirectory(folder).childFile(binaryName);
+      if (file.existsSync()) {
+        return file.path;
       }
     }
     return null;
@@ -257,9 +260,9 @@ class AndroidSdk {
 
   String getAvdManagerPath() {
     final String binaryName = globals.platform.isWindows ? 'avdmanager.bat' : 'avdmanager';
-    final String path = globals.fs.path.join(directory, 'tools', 'bin', binaryName);
-    if (globals.fs.file(path).existsSync()) {
-      return path;
+    final File file = directory.childDirectory('tools').childDirectory('bin').childFile(binaryName);
+    if (file.existsSync()) {
+      return file.path;
     }
     return null;
   }
@@ -271,7 +274,7 @@ class AndroidSdk {
   void reinitialize() {
     List<Version> buildTools = <Version>[]; // 19.1.0, 22.0.1, ...
 
-    final Directory buildToolsDir = globals.fs.directory(globals.fs.path.join(directory, 'build-tools'));
+    final Directory buildToolsDir = directory.childDirectory('build-tools');
     if (buildToolsDir.existsSync()) {
       buildTools = buildToolsDir
         .listSync()
@@ -337,17 +340,22 @@ class AndroidSdk {
   /// The sdkmanager was previously in the tools directory but this component
   /// was marked as obsolete in 3.6.
   String get sdkManagerPath {
-    final File cmdlineTool = globals.fs.file(
-      globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin',
-        globals.platform.isWindows
-          ? 'sdkmanager.bat'
-          : 'sdkmanager'
-      ),
-    );
+    final String executable = globals.platform.isWindows
+      ? 'sdkmanager.bat'
+      : 'sdkmanager';
+    final File cmdlineTool = directory
+      .childDirectory('cmdline-tools')
+      .childDirectory('latest')
+      .childDirectory('bin')
+      .childFile(executable);
     if (cmdlineTool.existsSync()) {
       return cmdlineTool.path;
     }
-    return globals.fs.path.join(directory, 'tools', 'bin', 'sdkmanager');
+    return directory
+      .childDirectory('tools')
+      .childDirectory('bin')
+      .childFile(executable)
+      .path;
   }
 
   /// First try Java bundled with Android Studio, then sniff JAVA_HOME, then fallback to PATH.
@@ -475,11 +483,11 @@ class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {
   }
 
   String getPlatformsPath(String itemName) {
-    return _fileSystem.path.join(sdk.directory, 'platforms', platformName, itemName);
+    return sdk.directory.childDirectory('platforms').childDirectory(platformName).childFile(itemName).path;
   }
 
   String getBuildToolsPath(String binaryName) {
-    return _fileSystem.path.join(sdk.directory, 'build-tools', buildToolsVersionName, binaryName);
+   return sdk.directory.childDirectory('build-tools').childDirectory(buildToolsVersionName).childFile(binaryName).path;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -181,7 +181,7 @@ class AndroidValidator extends DoctorValidator {
       return ValidationResult(ValidationType.partial, messages);
     }
 
-    messages.add(ValidationMessage(_userMessages.androidSdkLocation(_androidSdk.directory)));
+    messages.add(ValidationMessage(_userMessages.androidSdkLocation(_androidSdk.directory?.path)));
 
     String sdkVersionText;
     if (_androidSdk.latestVersion != null) {

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -238,7 +238,7 @@ void updateLocalProperties({
   }
 
   if (globals.androidSdk != null) {
-    changeIfNecessary('sdk.dir', globals.fsUtils.escapePath(globals.androidSdk.directory));
+    changeIfNecessary('sdk.dir', globals.fsUtils.escapePath(globals.androidSdk.directory.path));
   }
 
   changeIfNecessary('flutter.sdk', globals.fsUtils.escapePath(Cache.flutterRoot));
@@ -269,7 +269,7 @@ void updateLocalProperties({
 void writeLocalProperties(File properties) {
   final SettingsFile settings = SettingsFile();
   if (globals.androidSdk != null) {
-    settings.values['sdk.dir'] = globals.fsUtils.escapePath(globals.androidSdk.directory);
+    settings.values['sdk.dir'] = globals.fsUtils.escapePath(globals.androidSdk.directory.path);
   }
   settings.writeContents(properties);
 }

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -178,7 +178,7 @@ class ConfigCommand extends FlutterCommand {
       results['android-studio-dir'] = androidStudio.directory;
     }
     if (results['android-sdk'] == null && globals.androidSdk != null) {
-      results['android-sdk'] = globals.androidSdk.directory;
+      results['android-sdk'] = globals.androidSdk.directory.path;
     }
 
     globals.printStatus(const JsonEncoder.withIndent('  ').convert(results));

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -8,6 +8,7 @@ import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/config.dart';
@@ -314,7 +315,7 @@ class MockAndroidStudio extends Mock implements AndroidStudio, Comparable<Androi
 
 class MockAndroidSdk extends Mock implements AndroidSdk {
   @override
-  String get directory => 'path/to/android/sdk';
+  Directory get directory => globals.fs.directory('path/to/android/sdk');
 }
 
 class MockFlutterVersion extends Mock implements FlutterVersion {}

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -225,7 +225,7 @@ void main() {
       when(mockProcessManager.canRun(any)).thenReturn(false);
 
       mockAndroidSdk = MockAndroidSdk();
-      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+      when(mockAndroidSdk.directory).thenReturn(globals.fs.directory('irrelevant'));
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -172,7 +172,7 @@ void main() {
       });
 
       mockAndroidSdk = MockAndroidSdk();
-      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+      when(mockAndroidSdk.directory).thenReturn(globals.fs.directory('irrelevant'));
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
@@ -156,7 +156,7 @@ void main() {
       when(mockAndroidSdk.licensesAvailable).thenReturn(true);
       when(mockAndroidSdk.platformToolsAvailable).thenReturn(true);
       when(mockAndroidSdk.validateSdkWellFormed()).thenReturn(const <String>[]);
-      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+      when(mockAndroidSdk.directory).thenReturn(globals.fs.directory('irrelevant'));
     });
 
     tearDown(() {

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -76,10 +76,10 @@ void main() {
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
       fileSystem.file(
-        fileSystem.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+        fileSystem.path.join(sdk.directory.path, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
       ).createSync(recursive: true);
 
-      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager'));
+      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory.path, 'cmdline-tools', 'latest', 'bin', 'sdkmanager'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -93,11 +93,11 @@ void main() {
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
       fileSystem.file(
-        fileSystem.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager.bat')
+        fileSystem.path.join(sdk.directory.path, 'cmdline-tools', 'latest', 'bin', 'sdkmanager.bat')
       ).createSync(recursive: true);
 
       expect(sdk.sdkManagerPath,
-        fileSystem.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager.bat'));
+        fileSystem.path.join(sdk.directory.path, 'cmdline-tools', 'latest', 'bin', 'sdkmanager.bat'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -105,17 +105,32 @@ void main() {
       Config: () => config,
     });
 
-    testUsingContext('returns sdkmanager path under tools if cmdline doesnt exist', () {
+    testUsingContext("returns sdkmanager path under tools if cmdline doesn't exist", () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
 
-      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory, 'tools', 'bin', 'sdkmanager'));
+      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory.path, 'tools', 'bin', 'sdkmanager'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       Config: () => config,
+      Platform: () => FakePlatform(operatingSystem: 'linux'),
+    });
+
+    testUsingContext("returns sdkmanager path under tools if cmdline doesn't exist on windows", () {
+      sdkDir = MockAndroidSdk.createSdkDirectory();
+      config.setValue('android-sdk', sdkDir.path);
+
+      final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+
+      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory.path, 'tools', 'bin', 'sdkmanager.bat'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Config: () => config,
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
     });
 
     testUsingContext('returns sdkmanager version', () {

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -841,7 +841,7 @@ flutter:
       fs = MemoryFileSystem.test();
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       mockAndroidSdk = MockAndroidSdk();
-      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+      when(mockAndroidSdk.directory).thenReturn(fs.directory('irrelevant'));
     });
 
     testUsingContext('calls gradle', () async {
@@ -1025,7 +1025,7 @@ plugin1=${plugin1.path}
       mockProcessManager = MockProcessManager();
       android = fakePlatform('android');
 
-      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+      when(mockAndroidSdk.directory).thenReturn(fileSystem.directory('irrelevant'));
 
       final Directory rootDirectory = fileSystem.currentDirectory;
       cache = Cache.test(


### PR DESCRIPTION
The extensive use of path manipulation in the android SDK class leads to a lot of global usage. In general, path manipulation is harder to spot bugs in.

In the interest of eventually making the Android SDK class easier to understand, replace the root path with a root directory and refactor a limit set of functionality to prefer `childDirectory` and `childFIle`.