### PR TITLE
BorderTween.lerp supports null begin/end values

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -143,7 +143,7 @@ class BorderRadiusTween extends Tween<BorderRadius> {
 /// [Border.lerp].
 ///
 /// See [Tween] for a discussion on how to use interpolation objects.
-class BorderTween extends Tween<Border> {
+class BorderTween extends Tween<Border?> {
   /// Creates a [Border] tween.
   ///
   /// The [begin] and [end] properties may be null; the null value
@@ -152,7 +152,11 @@ class BorderTween extends Tween<Border> {
 
   /// Returns the value this variable has at the given animation clock value.
   @override
-  Border lerp(double t) => Border.lerp(begin, end, t)!;
+  Border? lerp(double t) {
+    if (begin == null || end == null)
+      return t < 0.5 ? begin : end;
+    return Border.lerp(begin!, end!, t);
+  }
 }
 
 /// An interpolation between two [Matrix4]s.

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -1292,6 +1292,46 @@ void main() {
       initialTrailingTextToLargeTitleOffset.dy.abs(),
     );
   });
+
+  testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/71389
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(
+            middle: Text('Page 1'),
+            border: null,
+          ),
+          child: Placeholder(),
+        ),
+      ),
+    );
+
+    tester.state<NavigatorState>(find.byType(Navigator)).push(
+      CupertinoPageRoute<void>(
+        builder: (BuildContext context) {
+          return const CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              middle: Text('Page 2'),
+              border: null,
+            ),
+            child: Placeholder(),
+          );
+        },
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('Page 1'), findsNothing);
+    expect(find.text('Page 2'), findsOneWidget);
+
+    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('Page 1'), findsOneWidget);
+    expect(find.text('Page 2'), findsNothing);
+  });
 }
 
 class _ExpectStyles extends StatelessWidget {


### PR DESCRIPTION
The existing BorderTween constructor doc said:
```dart
  /// The [begin] and [end] properties may be null; the null value
  /// is treated as having no border.
```
But the class's lerp() method assumed that both values were non-null.

Fixes https://github.com/flutter/flutter/issues/71389
