### PR TITLE
Build x86_64 iOS apps with simulator local engines

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -208,6 +208,7 @@ List<String> _xcodeBuildSettingsLines({
       if (localEngineName.endsWith('_arm')) {
         arch = 'armv7';
       } else if (localEngineName.contains('_sim')) {
+        // Apple Silicon ARM simulators not yet supported.
         arch = 'x86_64';
       } else {
         arch = 'arm64';

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -191,7 +191,9 @@ List<String> _xcodeBuildSettingsLines({
     final LocalEngineArtifacts localEngineArtifacts = globals.artifacts as LocalEngineArtifacts;
     final String engineOutPath = localEngineArtifacts.engineOutPath;
     xcodeBuildSettings.add('FLUTTER_ENGINE=${globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath))}');
-    xcodeBuildSettings.add('LOCAL_ENGINE=${globals.fs.path.basename(engineOutPath)}');
+
+    final String localEngineName = globals.fs.path.basename(engineOutPath);
+    xcodeBuildSettings.add('LOCAL_ENGINE=$localEngineName');
 
     // Tell Xcode not to build universal binaries for local engines, which are
     // single-architecture.
@@ -202,7 +204,14 @@ List<String> _xcodeBuildSettingsLines({
     //
     // Skip this step for macOS builds.
     if (!useMacOSConfig) {
-      final String arch = engineOutPath.endsWith('_arm') ? 'armv7' : 'arm64';
+      String arch;
+      if (localEngineName.endsWith('_arm')) {
+        arch = 'armv7';
+      } else if (localEngineName.contains('_sim')) {
+        arch = 'x86_64';
+      } else {
+        arch = 'arm64';
+      }
       xcodeBuildSettings.add('ARCHS=$arch');
     }
   }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -691,6 +691,34 @@ Information about project "Runner":
       expect(buildPhaseScriptContents.contains('ARCHS=armv7'), isTrue);
     });
 
+    testUsingOsxContext('sets ARCHS=x86_64 when sim local engine is set', () async {
+      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
+          platform: TargetPlatform.ios,
+          mode: anyNamed('mode'),
+          environmentType: anyNamed('environmentType')))
+          .thenReturn('engine');
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_debug_sim_unopt'));
+
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
+      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      await updateGeneratedXcodeProperties(
+        project: project,
+        buildInfo: buildInfo,
+      );
+
+      final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
+      expect(config.existsSync(), isTrue);
+
+      final String contents = config.readAsStringSync();
+      expect(contents.contains('ARCHS=x86_64'), isTrue);
+
+      final File buildPhaseScript = fs.file('path/to/project/ios/Flutter/flutter_export_environment.sh');
+      expect(buildPhaseScript.existsSync(), isTrue);
+
+      final String buildPhaseScriptContents = buildPhaseScript.readAsStringSync();
+      expect(buildPhaseScriptContents.contains('ARCHS=x86_64'), isTrue);
+    });
+
     testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
               platform: TargetPlatform.ios,


### PR DESCRIPTION
For local engine simulator builds specify `ARCHS=x86_64` instead of `ARCHS=arm64`.  This was causing problems in host add-to-apps where the environment `ARCHS` variable was incorrectly overriding the Xcode build setting when passed back into `assemble`.

We'll have to change this parsing when local engines start to support arm64 simulators.

Fixes https://github.com/flutter/flutter/issues/73982