### PR TITLE
Remove unused semantics tap action for readonly textfield and selecta…

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1186,7 +1186,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
 
     return Semantics(
       enabled: enabled,
-      onTap: !enabled ? null : () {
+      onTap: !enabled || widget.readOnly ? null : () {
         if (!controller.selection.isValid) {
           controller.selection = TextSelection.collapsed(offset: controller.text.length);
         }

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -652,11 +652,6 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
     );
 
     return Semantics(
-      onTap: () {
-        if (!_controller.selection.isValid)
-          _controller.selection = TextSelection.collapsed(offset: _controller.text.length);
-        _effectiveFocusNode.requestFocus();
-      },
       onLongPress: () {
         _effectiveFocusNode.requestFocus();
       },

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1282,7 +1282,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
             return Semantics(
               maxValueLength: semanticsMaxValueLength,
               currentValueLength: _currentLength,
-              onTap: () {
+              onTap: widget.readOnly ? null : () {
                 if (!_effectiveController.selection.isValid)
                   _effectiveController.selection = TextSelection.collapsed(offset: _effectiveController.text.length);
                 _requestKeyboard();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/gestures.dart' show DragStartBehavior, PointerDeviceKind
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
+import '../widgets/semantics_tester.dart';
 
 class MockClipboard {
   Object _clipboardData = <String, dynamic>{
@@ -1588,6 +1589,25 @@ void main() {
       expect(find.byType(CupertinoButton), findsNWidgets(3));
     },
   );
+
+  testWidgets('Readonly text field does not have tap action', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: CupertinoTextField(
+            maxLength: 10,
+            readOnly: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, isNot(includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap])));
+
+    semantics.dispose();
+  });
 
   testWidgets(
     'double tap selects word and first tap of double tap moves cursor',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3945,6 +3945,27 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('Readonly text field does not have tap action', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextField(
+              maxLength: 10,
+              readOnly: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, isNot(includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap])));
+
+    semantics.dispose();
+  });
+
   testWidgets('Disabled text field hides helper and counter', (WidgetTester tester) async {
     const String helperText = 'helper text';
     const String counterText = 'counter text';

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1937,7 +1937,6 @@ void main() {
           textDirection: TextDirection.ltr,
           value: 'Guten Tag',
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
           ],
           flags: <SemanticsFlag>[
@@ -1963,7 +1962,6 @@ void main() {
           value: 'Guten Tag',
           textSelection: const TextSelection.collapsed(offset: 9),
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorBackwardByWord,
@@ -1990,7 +1988,6 @@ void main() {
           textSelection: const TextSelection.collapsed(offset: 4),
           value: 'Guten Tag',
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorForwardByCharacter,
@@ -2019,7 +2016,6 @@ void main() {
           textSelection: const TextSelection.collapsed(offset: 0),
           value: 'Guten Tag',
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorForwardByCharacter,
             SemanticsAction.moveCursorForwardByWord,
@@ -2062,7 +2058,6 @@ void main() {
           value: 'Guten Tag',
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             // Absent the following because enableInteractiveSelection: false
             // SemanticsAction.moveCursorBackwardByCharacter,
@@ -2108,7 +2103,6 @@ void main() {
           value: 'Hello',
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
           ],
           flags: <SemanticsFlag>[
@@ -2135,7 +2129,6 @@ void main() {
           textSelection: const TextSelection.collapsed(offset: 5),
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorBackwardByWord,
@@ -2162,7 +2155,6 @@ void main() {
           textSelection: const TextSelection(baseOffset: 5, extentOffset: 3),
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorForwardByCharacter,
@@ -2218,7 +2210,6 @@ void main() {
           textSelection: const TextSelection.collapsed(offset: 5),
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorBackwardByWord,
@@ -2265,7 +2256,6 @@ void main() {
           textSelection: const TextSelection(baseOffset: 0, extentOffset: 5),
           textDirection: TextDirection.ltr,
           actions: <SemanticsAction>[
-            SemanticsAction.tap,
             SemanticsAction.longPress,
             SemanticsAction.moveCursorBackwardByCharacter,
             SemanticsAction.moveCursorBackwardByWord,
@@ -2315,7 +2305,7 @@ void main() {
               SemanticsFlag.isTextField,
               SemanticsFlag.isMultiline,
             ],
-            actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.longPress],
+            actions: <SemanticsAction>[SemanticsAction.longPress],
             value: testValue,
             textDirection: TextDirection.ltr,
           ),
@@ -2324,7 +2314,7 @@ void main() {
       ignoreRect: true, ignoreTransform: true,
     ));
 
-    semanticsOwner.performAction(inputFieldId, SemanticsAction.tap);
+    semanticsOwner.performAction(inputFieldId, SemanticsAction.longPress);
     await tester.pump();
 
     expect(semantics, hasSemantics(
@@ -2339,7 +2329,6 @@ void main() {
               SemanticsFlag.isFocused,
             ],
             actions: <SemanticsAction>[
-              SemanticsAction.tap,
               SemanticsAction.longPress,
               SemanticsAction.moveCursorBackwardByCharacter,
               SemanticsAction.moveCursorBackwardByWord,


### PR DESCRIPTION
…ble text

The android native behavior for readonly/selectable text are all over the place. some of them have `semantics long press` but some of them do not. What's in common is none of them has `semantics tap`.

I took a look at the code, and it seems like these semantics tap action does not make sense for read only text field neither, so i think it may be safe to remove them.



fixes https://github.com/flutter/flutter/issues/73911

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
