### PR TITLE
[flutter_tools] handle NPE in language analytics

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -283,7 +283,8 @@ class NullSafetyAnalysisEvent implements UsageEvent {
       if (package.name == currentPackage) {
         languageVersion = package.languageVersion;
       }
-      if (package.languageVersion.major >= nullSafeVersion.major &&
+      if (package.languageVersion != null &&
+          package.languageVersion.major >= nullSafeVersion.major &&
           package.languageVersion.minor >= nullSafeVersion.minor) {
         migrated += 1;
       }

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -96,6 +96,26 @@ void main() {
     })).called(1);
     verifyNever(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'language-version', label: anyNamed('label')));
   });
+
+  testWithoutContext('a null language version is treated as unmigrated', () {
+    final Usage usage = MockUsage();
+    final PackageConfig packageConfig = PackageConfig(<Package>[
+      Package('foo', Uri.parse('file:///foo/lib/'), languageVersion: null),
+    ]);
+
+    NullSafetyAnalysisEvent(
+      packageConfig,
+      NullSafetyMode.sound,
+      'something-unrelated',
+      usage,
+    ).send();
+
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'runtime-mode', label: 'NullSafetyMode.sound')).called(1);
+    verify(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'stats', parameters: <String, String>{
+      'cd49': '0', 'cd50': '1',
+    })).called(1);
+    verifyNever(usage.sendEvent(NullSafetyAnalysisEvent.kNullSafetyCategory, 'language-version', label: anyNamed('label')));
+  });
 }
 
 class FakeGroupedValidator extends GroupedValidator {


### PR DESCRIPTION
package.languageVersion is allowed to be null - treat this as unmigrated.