### PR TITLE
Expand Stack fix to more exporting libraries

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,7 +15,7 @@ transforms:
   - title: 'Migrate to clipBehavior'
     date: 2020-09-22
     element:
-      uris: [ 'widgets.dart' ]
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
       field: 'overflow'
       inClass: 'Stack'
     changes:
@@ -26,7 +26,7 @@ transforms:
   - title: 'Migrate to clipBehavior'
     date: 2020-09-22
     element:
-      uris: [ 'widgets.dart' ]
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
       constructor: ''
       inClass: 'Stack'
     oneOf:

--- a/packages/flutter/test_fixes/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino.dart
@@ -27,4 +27,9 @@ void main() {
   buildContext.ancestorStateOfType(TypeMatcher<targetType>());
   buildContext.rootAncestorStateOfType(TypeMatcher<targetType>());
   buildContext.ancestorRenderObjectOfType(TypeMatcher<targetType>());
+
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  const Stack stack = Stack(overflow: Overflow.visible);
+  const Stack stack = Stack(overflow: Overflow.clip);
+  final behavior = stack.overflow;
 }

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -27,4 +27,9 @@ void main() {
   buildContext.findAncestorStateOfType<targetType>();
   buildContext.findRootAncestorStateOfType<targetType>();
   buildContext.findAncestorRenderObjectOfType<targetType>();
+
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  const Stack stack = Stack(clipBehavior: Clip.none);
+  const Stack stack = Stack(clipBehavior: Clip.hardEdge);
+  final behavior = stack.clipBehavior;
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -26,4 +26,9 @@ void main() {
   buildContext.ancestorStateOfType(TypeMatcher<targetType>());
   buildContext.rootAncestorStateOfType(TypeMatcher<targetType>());
   buildContext.ancestorRenderObjectOfType(TypeMatcher<targetType>());
+
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  const Stack stack = Stack(overflow: Overflow.visible);
+  const Stack stack = Stack(overflow: Overflow.clip);
+  final behavior = stack.overflow;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -26,4 +26,9 @@ void main() {
   buildContext.findAncestorStateOfType<targetType>();
   buildContext.findRootAncestorStateOfType<targetType>();
   buildContext.findAncestorRenderObjectOfType<targetType>();
+
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  const Stack stack = Stack(clipBehavior: Clip.none);
+  const Stack stack = Stack(clipBehavior: Clip.hardEdge);
+  final behavior = stack.clipBehavior;
 }


### PR DESCRIPTION
This adds on the the dart fix for the Stack deprecation, since the material and cupertino libraries export the widgets library, they should be included in this fix.

Nice catch @goderbauer!

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
