### PR TITLE
Add verbose build flag to ios_app_with_extensions_test

### DIFF
--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -39,7 +39,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['ios', '--no-codesign', '--release'],
+          options: <String>['ios', '--no-codesign', '--release', '--verbose'],
         );
       });
 
@@ -93,7 +93,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['ios', '--debug', '--no-codesign'],
+          options: <String>['ios', '--debug', '--no-codesign', '--verbose'],
         );
       });
 


### PR DESCRIPTION
Need more logs to track down https://github.com/flutter/flutter/issues/73917.  Add `--verbose` flag to `flutter build`.