### PR TITLE
Tests that module/plugin/package templates can be migrated to null-safety

### DIFF
--- a/packages/flutter_tools/templates/package/test/projectName_test.dart.tmpl
+++ b/packages/flutter_tools/templates/package/test/projectName_test.dart.tmpl
@@ -8,6 +8,5 @@ void main() {
     expect(calculator.addOne(2), 3);
     expect(calculator.addOne(-7), -6);
     expect(calculator.addOne(0), 1);
-    expect(() => calculator.addOne(null), throwsNoSuchMethodError);
   });
 }

--- a/packages/flutter_tools/test/integration.shard/migrate_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_test.dart
@@ -8,43 +8,69 @@ import 'package:flutter_tools/src/base/io.dart';
 import '../src/common.dart';
 import 'test_utils.dart';
 
-/// Verifies that `dart migrate` will run successfully on the default `flutter create`
-/// template.
 void main() {
+  /// Verifies that `dart migrate` will run successfully on the default `flutter create`
+  /// template.
   testWithoutContext('dart migrate succeeds on flutter create template', () async {
-    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
-    final String dartBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'dart.bat' : 'dart');
-
     Directory tempDir;
     try {
-      tempDir = createResolvedTempDirectorySync('dart_migrate_test.');
-      final ProcessResult createResult = await processManager.run(<String>[
-        flutterBin,
-        'create',
-        'foo',
-      ], workingDirectory: tempDir.path);
-      if (createResult.exitCode != 0) {
-        fail('flutter create did not work: ${createResult.stdout}${createResult.stderr}');
-      }
-
-      final ProcessResult migrateResult = await processManager.run(<String>[
-        dartBin,
-        'migrate',
-        '--apply-changes',
-      ], workingDirectory: fileSystem.path.join(tempDir.path, 'foo'));
-      if (migrateResult.exitCode != 0) {
-        fail('dart migrate did not work: ${migrateResult.stdout}${migrateResult.stderr}');
-      }
-
-      final ProcessResult analyzeResult = await processManager.run(<String>[
-        flutterBin,
-        'analyze',
-      ], workingDirectory: fileSystem.path.join(tempDir.path, 'foo'));
-      if (analyzeResult.exitCode != 0) {
-        fail('flutter analyze had errors: ${analyzeResult.stdout}${analyzeResult.stderr}');
-      }
+      tempDir = await _createProject(tempDir);
+      await _migrate(tempDir);
+      await _analyze(tempDir);
     } finally {
       tempDir?.deleteSync(recursive: true);
     }
   });
+
+  /// Verifies that `dart migrate` will run successfully on the module template
+  /// used by `flutter create --template=module`.
+  testWithoutContext('dart migrate succeeds on module template', () async {
+    Directory tempDir;
+    try {
+      tempDir = await _createProject(tempDir, <String>['--template=module']);
+      await _migrate(tempDir);
+      await _analyze(tempDir);
+    } finally {
+      tempDir?.deleteSync(recursive: true);
+    }
+  }, timeout: const Timeout(Duration(minutes: 1)));
 }
+
+Future<Directory> _createProject(Directory tempDir, [List<String> extraAgs]) async {
+  tempDir = createResolvedTempDirectorySync('dart_migrate_test.');
+  final ProcessResult createResult = await processManager.run(<String>[
+    _flutterBin,
+    'create',
+    if (extraAgs != null)
+      ...extraAgs,
+    'foo',
+  ], workingDirectory: tempDir.path);
+  if (createResult.exitCode != 0) {
+    fail('flutter create did not work: ${createResult.stdout}${createResult.stderr}');
+  }
+  return tempDir;
+}
+
+Future<void> _migrate(Directory tempDir) async {
+  final ProcessResult migrateResult = await processManager.run(<String>[
+    _dartBin,
+    'migrate',
+    '--apply-changes',
+  ], workingDirectory: fileSystem.path.join(tempDir.path, 'foo'));
+  if (migrateResult.exitCode != 0) {
+    fail('dart migrate did not work: ${migrateResult.stdout}${migrateResult.stderr}');
+  }
+}
+
+Future<void> _analyze(Directory tempDir) async {
+  final ProcessResult analyzeResult = await processManager.run(<String>[
+    _flutterBin,
+    'analyze',
+  ], workingDirectory: fileSystem.path.join(tempDir.path, 'foo'));
+  if (analyzeResult.exitCode != 0) {
+    fail('flutter analyze had errors: ${analyzeResult.stdout}${analyzeResult.stderr}');
+  }
+}
+
+String get _flutterBin => fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
+String get _dartBin => fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'dart.bat' : 'dart');

--- a/packages/flutter_tools/test/integration.shard/migrate_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_test.dart
@@ -34,6 +34,32 @@ void main() {
       tempDir?.deleteSync(recursive: true);
     }
   }, timeout: const Timeout(Duration(minutes: 1)));
+
+  /// Verifies that `dart migrate` will run successfully on the module template
+  /// used by `flutter create --template=plugin`.
+  testWithoutContext('dart migrate succeeds on plugin template', () async {
+    Directory tempDir;
+    try {
+      tempDir = await _createProject(tempDir, <String>['--template=plugin']);
+      await _migrate(tempDir);
+      await _analyze(tempDir);
+    } finally {
+      tempDir?.deleteSync(recursive: true);
+    }
+  });
+
+  /// Verifies that `dart migrate` will run successfully on the module template
+  /// used by `flutter create --template=package`.
+  testWithoutContext('dart migrate succeeds on package template', () async {
+    Directory tempDir;
+    try {
+      tempDir = await _createProject(tempDir, <String>['--template=package']);
+      await _migrate(tempDir);
+      await _analyze(tempDir);
+    } finally {
+      tempDir?.deleteSync(recursive: true);
+    }
+  });
 }
 
 Future<Directory> _createProject(Directory tempDir, [List<String> extraAgs]) async {


### PR DESCRIPTION
With https://github.com/flutter/flutter/pull/74068 in place, the app and module template can be migrated to null-safety with the `dart migrate` tool. This adds a test to ensure that we don't regress this.

Sometimes after the next stable release we will migrate the actual templates to null safety. Until then, migrating them with `dart migrate` should be supported. See also https://github.com/flutter/flutter/issues/67447#issuecomment-759100279.

For https://github.com/flutter/flutter/issues/67447. 