### PR TITLE
[flutter_tools] ensure allowExistingDdsInstance param is always non-null

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -222,7 +222,7 @@ class FlutterDevice {
     int ddsPort,
     bool disableServiceAuthCodes = false,
     bool disableDds = false,
-    bool allowExistingDdsInstance = false,
+    @required bool allowExistingDdsInstance,
     bool ipv6 = false,
   }) {
     final Completer<void> completer = Completer<void>();
@@ -1217,7 +1217,7 @@ abstract class ResidentRunner {
     Restart restart,
     CompileExpression compileExpression,
     GetSkSLMethod getSkSLMethod,
-    bool allowExistingDdsInstance,
+    @required bool allowExistingDdsInstance,
   }) async {
     if (!debuggingOptions.debuggingEnabled) {
       throw 'The service protocol is not enabled.';

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -73,7 +73,9 @@ class ColdRunner extends ResidentRunner {
     if (debuggingOptions.debuggingEnabled) {
       try {
         await Future.wait(<Future<void>>[
-          connectToServiceProtocol(),
+          connectToServiceProtocol(
+            allowExistingDdsInstance: false,
+          ),
           serveDevToolsGracefully(
             devToolsServerAddress: debuggingOptions.devToolsServerAddress,
           ),

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -197,6 +197,7 @@ void main() {
       restart: anyNamed('restart'),
       compileExpression: anyNamed('compileExpression'),
       getSkSLMethod: anyNamed('getSkSLMethod'),
+      allowExistingDdsInstance: anyNamed('allowExistingDdsInstance'),
     )).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.setupDevFS(any, any))
       .thenAnswer((Invocation invocation) async {
@@ -2815,7 +2816,7 @@ void main() {
       observatoryUris: Stream<Uri>.value(testUri),
     );
 
-    await flutterDevice.connect();
+    await flutterDevice.connect(allowExistingDdsInstance: true);
     verify(mockLogReader.connectedVMService = mockVMService);
   }, overrides: <Type, Generator>{
     VMServiceConnector: () => (Uri httpUri, {


### PR DESCRIPTION
Fixes crasher when running in profile mode crashes with AssertionError. This is caused by a common mistake when a named parameter without a default value is provided to a named parameter with a default, which instead provides null.


For example:
```dart
void foo({bool bar= false}) {
  if (bar) { ... }
}

void fizz({bool far}) {
  foo(bar: far);
}

void main() {
  fizz(far: false); // OK
  fizz(); // Runtime Error!
}

```