### PR TITLE
Add tracing test to check default streams

### DIFF
--- a/dev/tracing_tests/test/default_streams_test.dart
+++ b/dev/tracing_tests/test/default_streams_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:developer' as developer;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+// This test ensures that the engine starts the VM with the timeline streams
+// for "Dart", "Embedder", and "GC" recorded from startup.
+
+void main() {
+  VmService vmService;
+
+  setUpAll(() async {
+    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+
+    if (info.serverUri == null) {
+      fail('This test _must_ be run with --enable-vmservice.');
+    }
+
+    vmService = await vmServiceConnectUri(
+      'ws://localhost:${info.serverUri.port}${info.serverUri.path}ws',
+    );
+  });
+
+  tearDownAll(() {
+    vmService.dispose();
+  });
+
+  test('Image cache tracing', () async {
+    final TimelineFlags flags = await vmService.getVMTimelineFlags();
+    expect(flags.recordedStreams, containsAll(<String>[
+      'Dart',
+      'Embedder',
+      'GC',
+    ]));
+  }, skip: isBrowser); // uses dart:isolate and io
+}


### PR DESCRIPTION
This PR adds a test that ensures the default streams add in https://github.com/flutter/engine/pull/23729 are enabled.

Related https://github.com/flutter/flutter/issues/70794

