### PR TITLE
iOS "Bold Text" more correct fontWeight handling

### DIFF
--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -519,8 +519,20 @@ class Text extends StatelessWidget {
     TextStyle? effectiveTextStyle = style;
     if (style == null || style!.inherit)
       effectiveTextStyle = defaultTextStyle.style.merge(style);
-    if (MediaQuery.boldTextOverride(context))
-      effectiveTextStyle = effectiveTextStyle!.merge(const TextStyle(fontWeight: FontWeight.bold));
+    if (MediaQuery.boldTextOverride(context)) {
+      List<FontWeight> weights = FontWeight.values;
+      FontWeight? weight = effectiveTextStyle!.fontWeight;
+
+      int index = weights.indexOf(weight);
+      if (index == -1) {
+        weight = FontWeight.bold;
+      } else {
+        index = min(weights.length - 1, index + 1);
+        weight = FontWeight.values.elementAt(index);
+      }
+
+      effectiveTextStyle = effectiveTextStyle!.merge(TextStyle(fontWeight: weight))
+    }
     Widget result = RichText(
       textAlign: textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start,
       textDirection: textDirection, // RichText uses Directionality.of to obtain a default if this is null.


### PR DESCRIPTION
Currently when "Bold Text" is enabled on iOS all weights in Flutter are replaced with FontWeight.bold which is incorrect.

Here's font weight difference on Native/Flutter iOS apps with "Bold Text" Off and On:
| Native | Flutter |
|:----:|:----:|
| <img src="https://i.imgur.com/RntntPx.jpg" height="250" /> | <img src="https://i.imgur.com/SLnhBb8.jpg" height="250" /> |

This PR fixes it by gradually uplifting the weight.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.