### PR TITLE
[flutter_tools] unforward can fail with multiple emulators

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -1311,8 +1311,9 @@ class AndroidDevicePortForwarder extends DevicePortForwarder {
     );
     // The port may have already been unforwarded, for example if there
     // are multiple attach process already connected.
-    if (runResult.exitCode == 0 || runResult
-      .stderr.contains("listener '$tcpLine' not found")) {
+    if (runResult.exitCode == 0 ||
+      runResult.stderr.contains("listener '$tcpLine' not found") ||
+      runResult.stderr.contains('error: more than one device/emulator')) {
       return;
     }
     runResult.throwException('Process exited abnormally:\n$runResult');

--- a/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
@@ -142,6 +142,24 @@ void main() {
     await forwarder.unforward(ForwardedPort(456, 23));
   });
 
+  testWithoutContext('failures to unforward port due to multiple emulators do not throw', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['adb', '-s', '192.168.56.101:5555', 'forward', '--remove', 'tcp:456'],
+        stderr: 'error: more than one device/emulator',
+        exitCode: 1,
+      )
+    ]);
+    final AndroidDevicePortForwarder forwarder = AndroidDevicePortForwarder(
+      adbPath: 'adb',
+      deviceId: '192.168.56.101:5555',
+      processManager: processManager,
+      logger: BufferLogger.test(),
+    );
+
+    await forwarder.unforward(ForwardedPort(456, 23));
+  });
+
   testWithoutContext('failures to unforward port throw exception if stderr is not recognized', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(


### PR DESCRIPTION
Apparently unforward can fail if there are multiple emulators. Exiting normally is preferable in this case, because at least we'll tear down everything else correctly.