### PR TITLE
[flutter_tools] pub get skips example dir if there is no pubspec.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -164,7 +164,7 @@ class PackagesGetCommand extends FlutterCommand {
     await rootProject.regeneratePlatformSpecificTooling();
 
     // Get/upgrade packages in example app as well
-    if (rootProject.hasExampleApp) {
+    if (rootProject.hasExampleApp && rootProject.example.pubspecFile.existsSync()) {
       final FlutterProject exampleProject = rootProject.example;
       await _runPubGet(exampleProject.directory.path, exampleProject);
       await exampleProject.regeneratePlatformSpecificTooling();

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
@@ -74,6 +74,26 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
     FileSystem: () => fileSystem,
   });
+
+  testUsingContext('pub get skips example directory if it dooes not contain a pubspec.yaml', () async {
+    fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();
+    fileSystem.currentDirectory.childDirectory('example').createSync(recursive: true);
+
+    final PackagesGetCommand command = PackagesGetCommand('get', false);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+
+    await commandRunner.run(<String>['get']);
+
+    expect(await command.usageValues, <CustomDimensions, Object>{
+      CustomDimensions.commandPackagesNumberPlugins: '0',
+      CustomDimensions.commandPackagesProjectModule: 'false',
+      CustomDimensions.commandPackagesAndroidEmbeddingVersion: 'v1'
+    });
+  }, overrides: <Type, Generator>{
+    Pub: () => pub,
+    ProcessManager: () => FakeProcessManager.any(),
+    FileSystem: () => fileSystem,
+  });
 }
 
 class FakePub extends Fake implements Pub {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/70090

Confirmed test fails without this change, since it attempts to parse a package_config that does not get written by the FakePub.