### PR TITLE
Return the existing DevTools server from DevToolsLauncher.serve if one is already running.

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -172,7 +172,9 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
 
   @override
   Future<DevToolsServerAddress> serve() async {
-    await launch(null);
+    if (activeDevToolsServer == null) {
+      await launch(null);
+    }
     return activeDevToolsServer;
   }
 

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -120,6 +120,55 @@ void main() {
     expect(address.port, 9100);
   });
 
+  testWithoutContext('DevtoolsLauncher does launch a new DevTools instance if one is already active', () async {
+    final Completer<void> completer = Completer<void>();
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: platform,
+      persistentToolState: persistentToolState,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'pub',
+            'global',
+            'activate',
+            'devtools',
+          ],
+          stdout: 'Activated DevTools 0.9.5',
+        ),
+        const FakeCommand(
+          command: <String>[
+            'pub',
+            'global',
+            'list',
+          ],
+          stdout: 'devtools 0.9.6',
+        ),
+        FakeCommand(
+          command: const <String>[
+            'pub',
+            'global',
+            'run',
+            'devtools',
+            '--no-launch-browser',
+          ],
+          stdout: 'Serving DevTools at http://127.0.0.1:9100\n',
+          completer: completer,
+        ),
+      ]),
+    );
+
+    DevToolsServerAddress address = await launcher.serve();
+    expect(address.host, '127.0.0.1');
+    expect(address.port, 9100);
+
+    // Call `serve` again and verify that the already running server is returned.
+    address = await launcher.serve();
+    expect(address.host, '127.0.0.1');
+    expect(address.port, 9100);
+  });
+
   testWithoutContext('DevtoolsLauncher does not activate DevTools if it was recently activated', () async {
     persistentToolState.lastDevToolsActivationTime = DateTime.now();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -120,7 +120,7 @@ void main() {
     expect(address.port, 9100);
   });
 
-  testWithoutContext('DevtoolsLauncher does launch a new DevTools instance if one is already active', () async {
+  testWithoutContext('DevtoolsLauncher does not launch a new DevTools instance if one is already active', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
       pubExecutable: 'pub',


### PR DESCRIPTION
This will allow IDE's to grab an already running instance of DevTools over the flutter daemon @helin24 

FYI @jonahwilliams 