### PR TITLE
New Reorderable list widgets

### DIFF
--- a/packages/flutter/lib/src/material/debug.dart
+++ b/packages/flutter/lib/src/material/debug.dart
@@ -51,7 +51,6 @@ bool debugCheckHasMaterial(BuildContext context) {
   return true;
 }
 
-
 /// Asserts that the given context has a [Localizations] ancestor that contains
 /// a [MaterialLocalizations] delegate.
 ///

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -143,6 +143,58 @@ class ReorderableListView extends StatefulWidget {
   /// this parameter false and wrap each list item, or a widget within
   /// each list item, with [ReorderableDragStartListener] or
   /// [ReorderableDelayedDragStartListener].
+  ///
+  /// The following sample specifies `buildDefaultDragHandles: false`, and
+  /// uses a [Card] at the leading edge of each item for the item's drag handle.
+  ///
+  /// {@tool dartpad --template=stateful_widget_scaffold}
+  ///
+  /// ```dart
+  /// final List<int> items = List<int>.generate(50, (int index) => index);
+  ///
+  /// Widget build(BuildContext context){
+  ///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
+  ///   final oddItemColor = colorScheme.primary.withOpacity(0.05);
+  ///   final evenItemColor = colorScheme.primary.withOpacity(0.15);
+  ///
+  ///   return ReorderableListView(
+  ///     buildDefaultDragHandles: false,
+  ///     children: <Widget>[
+  ///       for (int index = 0; index < items.length; index++)
+  ///         Container(
+  ///           key: Key('$index'),
+  ///           color: items[index].isOdd ? oddItemColor : evenItemColor,
+  ///           child: Row(
+  ///             children: <Widget>[
+  ///               Container(
+  ///                 width: 64,
+  ///                 height: 64,
+  ///                 padding: const EdgeInsets.all(8),
+  ///                 child: ReorderableDragStartListener(
+  ///                   index: index,
+  ///                   child: Card(
+  ///                     color: colorScheme.primary,
+  ///                     elevation: 2,
+  ///                   ),
+  ///                 ),
+  ///               ),
+  ///               Text('Item ${items[index]}'),
+  ///             ],
+  ///           ),
+  ///         ),
+  ///     ],
+  ///     onReorder: (oldIndex, newIndex) {
+  ///       setState(() {
+  ///         if (oldIndex < newIndex) {
+  ///           newIndex -= 1;
+  ///         }
+  ///         final int item = items.removeAt(oldIndex);
+  ///         items.insert(newIndex, item);
+  ///       });
+  ///     },
+  ///   );
+  /// }
+  /// ```
   final bool buildDefaultDragHandles;
 
   @override

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -3,10 +3,13 @@
 // found in the LICENSE file.
 
 
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
+import 'material.dart';
 import 'material_localizations.dart';
 
 /// A list whose items the user can interactively reorder by dragging.
@@ -199,6 +202,21 @@ class _ReorderableListViewState extends State<ReorderableListView> {
     );
   }
 
+  Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (BuildContext context, Widget? child) {
+        final double animValue = Curves.easeInOut.transform(animation.value);
+        final double elevation = lerpDouble(0, 6, animValue)!;
+          return Material(
+          child: child,
+          elevation: elevation,
+        );
+      },
+      child: child,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -244,6 +262,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
               itemBuilder: _itemBuilder,
               itemCount: widget.children.length,
               onReorder: widget.onReorder,
+              proxyDecorator: _proxyDecorator,
             ),
           ),
         ],

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -31,25 +31,30 @@ import 'theme.dart';
 /// {@tool dartpad --template=stateful_widget_scaffold}
 ///
 /// ```dart
-/// List<String> _list = List.generate(5, (i) => "${i}");
+/// final List<int> items = List<int>.generate(50, (int index) => index);
 ///
 /// Widget build(BuildContext context){
+///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
+///   final oddItemColor = colorScheme.primary.withOpacity(0.05);
+///   final evenItemColor = colorScheme.primary.withOpacity(0.15);
+///
 ///   return ReorderableListView(
-///     padding : const EdgeInsets.symmetric(horizontal:40),
-///     children:[
-///       for(var i=0 ; i<_list.length ; i++)
+///     padding: const EdgeInsets.symmetric(horizontal: 40),
+///     children: <Widget>[
+///       for (int index = 0; index < items.length; index++)
 ///         ListTile(
-///              key:Key('$i'),
-///              title: Text(_list[i]),
+///           key: Key('$index'),
+///           tileColor: items[index].isOdd ? oddItemColor : evenItemColor,
+///           title: Text('Item ${items[index]}'),
 ///         ),
 ///     ],
-///     onReorder: (oldIndex, newIndex){
-///       setState((){
-///         if(oldIndex < newIndex){
-///           newIndex-=1;
+///     onReorder: (int oldIndex, int newIndex) {
+///       setState(() {
+///         if (oldIndex < newIndex) {
+///           newIndex -= 1;
 ///         }
-///         final element = _list.removeAt(oldIndex);
-///         _list.insert(newIndex, element);
+///         final int item = items.removeAt(oldIndex);
+///         items.insert(newIndex, item);
 ///       });
 ///     },
 ///   );
@@ -313,8 +318,8 @@ class _ReorderableListContentState extends State<_ReorderableListContent> {
     }
 
     return KeyedSubtree(
-        key: itemGlobalKey,
-        child: itemWithSemantics,
+      key: itemGlobalKey,
+      child: itemWithSemantics,
     );
   }
 

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -186,10 +186,10 @@ class _ReorderableListContent extends StatefulWidget {
   final bool reverse;
 
   @override
-  __ReorderableListContentState createState() => __ReorderableListContentState();
+  _ReorderableListContentState createState() => _ReorderableListContentState();
 }
 
-class __ReorderableListContentState extends State<_ReorderableListContent> {
+class _ReorderableListContentState extends State<_ReorderableListContent> {
   Widget _wrapWithSemantics(Widget child, int index) {
     void reorder(int startIndex, int endIndex) {
       if (startIndex != endIndex)

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
-import 'material.dart';
 import 'material_localizations.dart';
 
 /// A list whose items the user can interactively reorder by dragging.
@@ -128,466 +126,129 @@ class ReorderableListView extends StatefulWidget {
   _ReorderableListViewState createState() => _ReorderableListViewState();
 }
 
-// This top-level state manages an Overlay that contains the list and
-// also any Draggables it creates.
-//
-// _ReorderableListContent manages the list itself and reorder operations.
-//
-// The Overlay doesn't properly keep state by building new overlay entries,
-// and so we cache a single OverlayEntry for use as the list layer.
-// That overlay entry then builds a _ReorderableListContent which may
-// insert Draggables into the Overlay above itself.
 class _ReorderableListViewState extends State<ReorderableListView> {
-  // We use an inner overlay so that the dragging list item doesn't draw outside of the list itself.
-  final GlobalKey _overlayKey = GlobalKey(debugLabel: '$ReorderableListView overlay key');
 
-  // This entry contains the scrolling list itself.
-  late OverlayEntry _listOverlayEntry;
+  Widget _wrapWithSemantics(Widget child, int index) {
 
-  @override
-  void initState() {
-    super.initState();
-    _listOverlayEntry = OverlayEntry(
-      opaque: true,
-      builder: (BuildContext context) {
-        return _ReorderableListContent(
-          header: widget.header,
-          children: widget.children,
-          scrollController: widget.scrollController,
-          scrollDirection: widget.scrollDirection,
-          onReorder: widget.onReorder,
-          padding: widget.padding,
-          reverse: widget.reverse,
-        );
-      },
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Overlay(
-      key: _overlayKey,
-      initialEntries: <OverlayEntry>[
-        _listOverlayEntry,
-    ]);
-  }
-}
-
-// This widget is responsible for the inside of the Overlay in the
-// ReorderableListView.
-class _ReorderableListContent extends StatefulWidget {
-  const _ReorderableListContent({
-    required this.header,
-    required this.children,
-    required this.scrollController,
-    required this.scrollDirection,
-    required this.padding,
-    required this.onReorder,
-    required this.reverse,
-  });
-
-  final Widget? header;
-  final List<Widget> children;
-  final ScrollController? scrollController;
-  final Axis scrollDirection;
-  final EdgeInsets? padding;
-  final ReorderCallback onReorder;
-  final bool reverse;
-
-  @override
-  _ReorderableListContentState createState() => _ReorderableListContentState();
-}
-
-class _ReorderableListContentState extends State<_ReorderableListContent> with TickerProviderStateMixin<_ReorderableListContent> {
-
-  // The extent along the [widget.scrollDirection] axis to allow a child to
-  // drop into when the user reorders list children.
-  //
-  // This value is used when the extents haven't yet been calculated from
-  // the currently dragging widget, such as when it first builds.
-  static const double _defaultDropAreaExtent = 100.0;
-
-  // How long an animation to reorder an element in the list takes.
-  static const Duration _reorderAnimationDuration = Duration(milliseconds: 200);
-
-  // How long an animation to scroll to an off-screen element in the
-  // list takes.
-  static const Duration _scrollAnimationDuration = Duration(milliseconds: 200);
-
-  // Controls scrolls and measures scroll progress.
-  late ScrollController _scrollController;
-
-  // This controls the entrance of the dragging widget into a new place.
-  late AnimationController _entranceController;
-
-  // This controls the 'ghost' of the dragging widget, which is left behind
-  // where the widget used to be.
-  late AnimationController _ghostController;
-
-  // The member of widget.children currently being dragged.
-  //
-  // Null if no drag is underway.
-  Key? _dragging;
-
-  // The last computed size of the feedback widget being dragged.
-  Size? _draggingFeedbackSize;
-
-  // The location that the dragging widget occupied before it started to drag.
-  int _dragStartIndex = 0;
-
-  // The index that the dragging widget most recently left.
-  // This is used to show an animation of the widget's position.
-  int _ghostIndex = 0;
-
-  // The index that the dragging widget currently occupies.
-  int _currentIndex = 0;
-
-  // The widget to move the dragging widget too after the current index.
-  int _nextIndex = 0;
-
-  // Whether or not we are currently scrolling this view to show a widget.
-  bool _scrolling = false;
-
-  double get _dropAreaExtent {
-    if (_draggingFeedbackSize == null) {
-      return _defaultDropAreaExtent;
-    }
-    final double dropAreaWithoutMargin;
-    switch (widget.scrollDirection) {
-      case Axis.horizontal:
-        dropAreaWithoutMargin = _draggingFeedbackSize!.width;
-        break;
-      case Axis.vertical:
-        dropAreaWithoutMargin = _draggingFeedbackSize!.height;
-        break;
-    }
-    return dropAreaWithoutMargin;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _entranceController = AnimationController(vsync: this, duration: _reorderAnimationDuration);
-    _ghostController = AnimationController(vsync: this, duration: _reorderAnimationDuration);
-    _entranceController.addStatusListener(_onEntranceStatusChanged);
-  }
-
-  @override
-  void didChangeDependencies() {
-    _scrollController = widget.scrollController ?? PrimaryScrollController.of(context) ?? ScrollController();
-    super.didChangeDependencies();
-  }
-
-  @override
-  void dispose() {
-    _entranceController.dispose();
-    _ghostController.dispose();
-    super.dispose();
-  }
-
-  // Animates the droppable space from _currentIndex to _nextIndex.
-  void _requestAnimationToNextIndex() {
-    if (_entranceController.isCompleted) {
-      _ghostIndex = _currentIndex;
-      if (_nextIndex == _currentIndex) {
-        return;
-      }
-      _currentIndex = _nextIndex;
-      _ghostController.reverse(from: 1.0);
-      _entranceController.forward(from: 0.0);
-    }
-  }
-
-  // Requests animation to the latest next index if it changes during an animation.
-  void _onEntranceStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
-      setState(() {
-        _requestAnimationToNextIndex();
-      });
-    }
-  }
-
-  // Scrolls to a target context if that context is not on the screen.
-  void _scrollTo(BuildContext context) {
-    if (_scrolling)
-      return;
-    final RenderObject contextObject = context.findRenderObject()!;
-    final RenderAbstractViewport viewport = RenderAbstractViewport.of(contextObject)!;
-    assert(viewport != null);
-    // If and only if the current scroll offset falls in-between the offsets
-    // necessary to reveal the selected context at the top or bottom of the
-    // screen, then it is already on-screen.
-    final double margin = _dropAreaExtent;
-    final double scrollOffset = _scrollController.offset;
-    final double topOffset = max(
-      _scrollController.position.minScrollExtent,
-      viewport.getOffsetToReveal(contextObject, 0.0).offset - margin,
-    );
-    final double bottomOffset = min(
-      _scrollController.position.maxScrollExtent,
-      viewport.getOffsetToReveal(contextObject, 1.0).offset + margin,
-    );
-    final bool onScreen = scrollOffset <= topOffset && scrollOffset >= bottomOffset;
-
-    // If the context is off screen, then we request a scroll to make it visible.
-    if (!onScreen) {
-      _scrolling = true;
-      _scrollController.position.animateTo(
-        scrollOffset < bottomOffset ? bottomOffset : topOffset,
-        duration: _scrollAnimationDuration,
-        curve: Curves.easeInOut,
-      ).then((void value) {
-        setState(() {
-          _scrolling = false;
-        });
-      });
-    }
-  }
-
-  // Wraps children in Row or Column, so that the children flow in
-  // the widget's scrollDirection.
-  Widget _buildContainerForScrollDirection({ required List<Widget> children }) {
-    switch (widget.scrollDirection) {
-      case Axis.horizontal:
-        return Row(children: children);
-      case Axis.vertical:
-        return Column(children: children);
-    }
-  }
-
-  // Wraps one of the widget's children in a DragTarget and Draggable.
-  // Handles up the logic for dragging and reordering items in the list.
-  Widget _wrap(Widget toWrap, int index, BoxConstraints constraints) {
-    assert(toWrap.key != null);
-    final _ReorderableListViewChildGlobalKey keyIndexGlobalKey = _ReorderableListViewChildGlobalKey(toWrap.key!, this);
-    // We pass the toWrapWithGlobalKey into the Draggable so that when a list
-    // item gets dragged, the accessibility framework can preserve the selected
-    // state of the dragging item.
-
-    // Starts dragging toWrap.
-    void onDragStarted() {
-      setState(() {
-        _dragging = toWrap.key;
-        _dragStartIndex = index;
-        _ghostIndex = index;
-        _currentIndex = index;
-        _entranceController.value = 1.0;
-        _draggingFeedbackSize = keyIndexGlobalKey.currentContext!.size;
-      });
-    }
-
-    // Places the value from startIndex one space before the element at endIndex.
     void reorder(int startIndex, int endIndex) {
       setState(() {
         if (startIndex != endIndex)
           widget.onReorder(startIndex, endIndex);
-        // Animates leftover space in the drop area closed.
-        _ghostController.reverse(from: 0);
-        _entranceController.reverse(from: 0);
-        _dragging = null;
       });
     }
 
-    // Drops toWrap into the last position it was hovering over.
-    void onDragEnded() {
-      reorder(_dragStartIndex, _currentIndex);
+    // First, determine which semantics actions apply.
+    final Map<CustomSemanticsAction, VoidCallback> semanticsActions = <CustomSemanticsAction, VoidCallback>{};
+
+    // Create the appropriate semantics actions.
+    void moveToStart() => reorder(index, 0);
+    void moveToEnd() => reorder(index, widget.children.length);
+    void moveBefore() => reorder(index, index - 1);
+    // To move after, we go to index+2 because we are moving it to the space
+    // before index+2, which is after the space at index+1.
+    void moveAfter() => reorder(index, index + 2);
+
+    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+
+    // If the item can move to before its current position in the list.
+    if (index > 0) {
+      semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToStart)] = moveToStart;
+      String reorderItemBefore = localizations.reorderItemUp;
+      if (widget.scrollDirection == Axis.horizontal) {
+        reorderItemBefore = Directionality.of(context) == TextDirection.ltr
+            ? localizations.reorderItemLeft
+            : localizations.reorderItemRight;
+      }
+      semanticsActions[CustomSemanticsAction(label: reorderItemBefore)] = moveBefore;
     }
 
-    Widget wrapWithSemantics() {
-      // First, determine which semantics actions apply.
-      final Map<CustomSemanticsAction, VoidCallback> semanticsActions = <CustomSemanticsAction, VoidCallback>{};
-
-      // Create the appropriate semantics actions.
-      void moveToStart() => reorder(index, 0);
-      void moveToEnd() => reorder(index, widget.children.length);
-      void moveBefore() => reorder(index, index - 1);
-      // To move after, we go to index+2 because we are moving it to the space
-      // before index+2, which is after the space at index+1.
-      void moveAfter() => reorder(index, index + 2);
-
-      final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-
-      // If the item can move to before its current position in the list.
-      if (index > 0) {
-        semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToStart)] = moveToStart;
-        String reorderItemBefore = localizations.reorderItemUp;
-        if (widget.scrollDirection == Axis.horizontal) {
-          reorderItemBefore = Directionality.of(context) == TextDirection.ltr
-              ? localizations.reorderItemLeft
-              : localizations.reorderItemRight;
-        }
-        semanticsActions[CustomSemanticsAction(label: reorderItemBefore)] = moveBefore;
+    // If the item can move to after its current position in the list.
+    if (index < widget.children.length - 1) {
+      String reorderItemAfter = localizations.reorderItemDown;
+      if (widget.scrollDirection == Axis.horizontal) {
+        reorderItemAfter = Directionality.of(context) == TextDirection.ltr
+            ? localizations.reorderItemRight
+            : localizations.reorderItemLeft;
       }
-
-      // If the item can move to after its current position in the list.
-      if (index < widget.children.length - 1) {
-        String reorderItemAfter = localizations.reorderItemDown;
-        if (widget.scrollDirection == Axis.horizontal) {
-          reorderItemAfter = Directionality.of(context) == TextDirection.ltr
-              ? localizations.reorderItemRight
-              : localizations.reorderItemLeft;
-        }
-        semanticsActions[CustomSemanticsAction(label: reorderItemAfter)] = moveAfter;
-        semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToEnd)] = moveToEnd;
-      }
-
-      // We pass toWrap with a GlobalKey into the Draggable so that when a list
-      // item gets dragged, the accessibility framework can preserve the selected
-      // state of the dragging item.
-      //
-      // We also apply the relevant custom accessibility actions for moving the item
-      // up, down, to the start, and to the end of the list.
-      return KeyedSubtree(
-        key: keyIndexGlobalKey,
-        child: MergeSemantics(
-          child: Semantics(
-            customSemanticsActions: semanticsActions,
-            child: toWrap,
-          ),
-        ),
-      );
+      semanticsActions[CustomSemanticsAction(label: reorderItemAfter)] = moveAfter;
+      semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToEnd)] = moveToEnd;
     }
 
-    Widget buildDragTarget(BuildContext context, List<Key?> acceptedCandidates, List<dynamic> rejectedCandidates) {
-      final Widget toWrapWithSemantics = wrapWithSemantics();
+    // We pass toWrap with a GlobalKey into the Draggable so that when a list
+    // item gets dragged, the accessibility framework can preserve the selected
+    // state of the dragging item.
+    //
+    // We also apply the relevant custom accessibility actions for moving the item
+    // up, down, to the start, and to the end of the list.
+    return MergeSemantics(
+      child: Semantics(
+        customSemanticsActions: semanticsActions,
+        child: child,
+      ),
+    );
+  }
 
-      // We build the draggable inside of a layout builder so that we can
-      // constrain the size of the feedback dragging widget.
-      Widget child = LongPressDraggable<Key>(
-        maxSimultaneousDrags: 1,
-        axis: widget.scrollDirection,
-        data: toWrap.key,
-        ignoringFeedbackSemantics: false,
-        feedback: Container(
-          alignment: Alignment.topLeft,
-          // These constraints will limit the cross axis of the drawn widget.
-          constraints: constraints,
-          child: Material(
-            elevation: 6.0,
-            child: toWrapWithSemantics,
-          ),
-        ),
-        child: _dragging == toWrap.key ? const SizedBox() : toWrapWithSemantics,
-        childWhenDragging: const SizedBox(),
-        dragAnchor: DragAnchor.child,
-        onDragStarted: onDragStarted,
-        // When the drag ends inside a DragTarget widget, the drag
-        // succeeds, and we reorder the widget into position appropriately.
-        onDragCompleted: onDragEnded,
-        // When the drag does not end inside a DragTarget widget, the
-        // drag fails, but we still reorder the widget to the last position it
-        // had been dragged to.
-        onDraggableCanceled: (Velocity velocity, Offset offset) {
-          onDragEnded();
-        },
-      );
+  Widget _itemBuilder(BuildContext context, int index) {
+    final Widget item = widget.children[index];
+    assert(item.key != null);
 
-      // The target for dropping at the end of the list doesn't need to be
-      // draggable.
-      if (index >= widget.children.length) {
-        child = toWrap;
-      }
-
-      // Determine the size of the drop area to show under the dragging widget.
-      final Widget spacing;
-      switch (widget.scrollDirection) {
-        case Axis.horizontal:
-          spacing = SizedBox(width: _dropAreaExtent);
-          break;
-        case Axis.vertical:
-          spacing = SizedBox(height: _dropAreaExtent);
-          break;
-      }
-
-      // We open up a space under where the dragging widget currently is to
-      // show it can be dropped.
-      if (_currentIndex == index) {
-        return _buildContainerForScrollDirection(children: <Widget>[
-          SizeTransition(
-            sizeFactor: _entranceController,
-            axis: widget.scrollDirection,
-            child: spacing,
-          ),
-          child,
-        ]);
-      }
-      // We close up the space under where the dragging widget previously was
-      // with the ghostController animation.
-      if (_ghostIndex == index) {
-        return _buildContainerForScrollDirection(children: <Widget>[
-          SizeTransition(
-            sizeFactor: _ghostController,
-            axis: widget.scrollDirection,
-            child: spacing,
-          ),
-          child,
-        ]);
-      }
-      return child;
-    }
-
-    // We wrap the drag target in a Builder so that we can scroll to its specific context.
-    return Builder(builder: (BuildContext context) {
-      return DragTarget<Key>(
-        builder: buildDragTarget,
-        onWillAccept: (Key? toAccept) {
-          setState(() {
-            _nextIndex = index;
-            _requestAnimationToNextIndex();
-          });
-          _scrollTo(context);
-          // If the target is not the original starting point, then we will accept the drop.
-          return _dragging == toAccept && toAccept != toWrap.key;
-        },
-        onAccept: (Key accepted) { },
-        onLeave: (Object? leaving) { },
-      );
-    });
+    return ReorderableDelayedDragStartListener(
+      key: _ReorderableListViewChildGlobalKey(item.key!, this),
+      child: _wrapWithSemantics(item, index),
+      index: index
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
-    // We use the layout builder to constrain the cross-axis size of dragging child widgets.
-    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
-      const Key endWidgetKey = Key('DraggableList - End Widget');
-      final Widget finalDropArea;
-      switch (widget.scrollDirection) {
-        case Axis.horizontal:
-          finalDropArea = SizedBox(
-            key: endWidgetKey,
-            width: _defaultDropAreaExtent,
-            height: constraints.maxHeight,
-          );
-          break;
-        case Axis.vertical:
-          finalDropArea = SizedBox(
-            key: endWidgetKey,
-            height: _defaultDropAreaExtent,
-            width: constraints.maxWidth,
-          );
-          break;
+
+    // If there is a header we can't just apply the padding to the list,
+    // so we wrap the CustomScrollView in the padding for the top, left and right
+    // and only add the padding from the bottom to the sliver list (or the equivalent
+    // for horizontal scrolling).
+    final EdgeInsets padding = widget.padding ?? const EdgeInsets.all(0);
+    late EdgeInsets outerPadding;
+    late EdgeInsets listPadding;
+    if (widget.scrollDirection == Axis.vertical) {
+      if (widget.reverse) {
+        outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, padding.bottom);
+        listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, 0);
+      } else {
+        outerPadding = EdgeInsets.fromLTRB(padding.left, padding.top, padding.right, 0);
+        listPadding = EdgeInsets.fromLTRB(0, 0, 0, padding.bottom);
       }
+    } else {
+      if (widget.reverse) {
+        outerPadding = EdgeInsets.fromLTRB(0, padding.top, padding.right, padding.bottom);
+        listPadding = EdgeInsets.fromLTRB(padding.left, 0, 0, 0);
+      } else {
+        outerPadding = EdgeInsets.fromLTRB(padding.left, padding.top, 0, padding.bottom);
+        listPadding = EdgeInsets.fromLTRB(0, 0, padding.right, 0);
+      }
+    }
 
-      // If the reorderable list only has one child element, reordering
-      // should not be allowed.
-      final bool hasMoreThanOneChildElement = widget.children.length > 1;
-
-      return SingleChildScrollView(
+    return Padding(
+      padding: outerPadding,
+      child: CustomScrollView(
         scrollDirection: widget.scrollDirection,
-        padding: widget.padding,
-        controller: _scrollController,
         reverse: widget.reverse,
-        child: _buildContainerForScrollDirection(
-          children: <Widget>[
-            if (widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
-            if (widget.header != null) widget.header!,
-            for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
-            if (!widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
-          ],
-        ),
-      );
-    });
+        controller: widget.scrollController,
+        slivers: <Widget>[
+          if (widget.header != null)
+            SliverToBoxAdapter(child: widget.header!),
+          SliverPadding(
+            padding: listPadding,
+            sliver: SliverReorderableList(
+              // key: _sliverReorderableListKey,
+              itemBuilder: _itemBuilder,
+              itemCount: widget.children.length,
+              onReorder: widget.onReorder,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -603,7 +264,7 @@ class _ReorderableListViewChildGlobalKey extends GlobalObjectKey {
 
   final Key subKey;
 
-  final _ReorderableListContentState state;
+  final _ReorderableListViewState state;
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -11,39 +11,6 @@ import 'debug.dart';
 import 'material.dart';
 import 'material_localizations.dart';
 
-// Examples can assume:
-// class MyDataObject { }
-
-/// The callback used by [ReorderableListView] to move an item to a new
-/// position in a list.
-///
-/// Implementations should remove the corresponding list item at [oldIndex]
-/// and reinsert it at [newIndex].
-///
-/// If [oldIndex] is before [newIndex], removing the item at [oldIndex] from the
-/// list will reduce the list's length by one. Implementations used by
-/// [ReorderableListView] will need to account for this when inserting before
-/// [newIndex].
-///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=3fB1mxOsqJE}
-///
-/// {@tool snippet}
-///
-/// ```dart
-/// final List<MyDataObject> backingList = <MyDataObject>[/* ... */];
-///
-/// void handleReorder(int oldIndex, int newIndex) {
-///   if (oldIndex < newIndex) {
-///     // removing the item at oldIndex will shorten the list by 1.
-///     newIndex -= 1;
-///   }
-///   final MyDataObject element = backingList.removeAt(oldIndex);
-///   backingList.insert(newIndex, element);
-/// }
-/// ```
-/// {@end-tool}
-typedef ReorderCallback = void Function(int oldIndex, int newIndex);
-
 /// A list whose items the user can interactively reorder by dragging.
 ///
 /// This class is appropriate for views with a small number of

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -196,6 +196,7 @@ class ReorderableListView extends StatefulWidget {
   ///   );
   /// }
   /// ```
+  ///{@end-tool}
   final bool buildDefaultDragHandles;
 
   /// A callback that allows the app to add an animated decoration around

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -75,6 +75,7 @@ class ReorderableListView extends StatefulWidget {
     this.padding,
     this.reverse = false,
     this.buildDefaultDragHandles = true,
+    this.proxyDecorator,
   }) : assert(scrollDirection != null),
        assert(onReorder != null),
        assert(children != null),
@@ -197,6 +198,13 @@ class ReorderableListView extends StatefulWidget {
   /// ```
   final bool buildDefaultDragHandles;
 
+  /// A callback that allows the app to add an animated decoration around
+  /// an item when it is being dragged.
+  ///
+  /// The this is null, a default decoration of a Material widget with
+  /// an animated elevation will be used.
+  final ReorderItemProxyDecorator? proxyDecorator;
+
   @override
   _ReorderableListViewState createState() => _ReorderableListViewState();
 }
@@ -220,6 +228,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
           onReorder: widget.onReorder,
           reverse: widget.reverse,
           buildDefaultDragHandles: widget.buildDefaultDragHandles,
+          proxyDecorator: widget.proxyDecorator,
         );
       }
     );
@@ -252,6 +261,7 @@ class _ReorderableListContent extends StatefulWidget {
     required this.onReorder,
     required this.reverse,
     required this.buildDefaultDragHandles,
+    required this.proxyDecorator,
   });
 
   final Widget? header;
@@ -262,6 +272,7 @@ class _ReorderableListContent extends StatefulWidget {
   final ReorderCallback onReorder;
   final bool reverse;
   final bool buildDefaultDragHandles;
+  final ReorderItemProxyDecorator? proxyDecorator;
 
   @override
   _ReorderableListContentState createState() => _ReorderableListContentState();
@@ -329,7 +340,8 @@ class _ReorderableListContentState extends State<_ReorderableListContent> {
     final Widget item = widget.children[index];
     assert(item.key != null);
 
-    // TODO(goderbauer): The semantics stuff should probably happen inside the ReorderableDelayedDragStartListener.
+    // TODO(goderbauer): The semantics stuff should probably happen inside
+    //   _ReorderableItem so the widget versions can have them as well.
     final Widget itemWithSemantics = _wrapWithSemantics(item, index);
     final Key itemGlobalKey = _ReorderableListViewChildGlobalKey(item.key!, this);
 
@@ -381,7 +393,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> {
       builder: (BuildContext context, Widget? child) {
         final double animValue = Curves.easeInOut.transform(animation.value);
         final double elevation = lerpDouble(0, 6, animValue)!;
-          return Material(
+        return Material(
           child: child,
           elevation: elevation,
         );
@@ -395,7 +407,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> {
     // If there is a header we can't just apply the padding to the list,
     // so we wrap the CustomScrollView in the padding for the top, left and right
     // and only add the padding from the bottom to the sliver list (or the equivalent
-    // for horizontal scrolling).
+    // for other axis directions).
     final EdgeInsets padding = widget.padding ?? const EdgeInsets.all(0);
     late EdgeInsets outerPadding;
     late EdgeInsets listPadding;
@@ -432,7 +444,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> {
               itemBuilder: _itemBuilder,
               itemCount: widget.children.length,
               onReorder: widget.onReorder,
-              proxyDecorator: _proxyDecorator,
+              proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
             ),
           ),
         ],

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -11,6 +11,7 @@ import 'basic.dart';
 import 'framework.dart';
 import 'localizations.dart';
 import 'media_query.dart';
+import 'overlay.dart';
 import 'table.dart';
 
 // Any changes to this file should be reflected in the debugAssertAllWidgetVarsUnset()
@@ -357,6 +358,40 @@ bool debugCheckHasWidgetsLocalizations(BuildContext context) {
         ),
         ...context.describeMissingAncestor(expectedAncestorType: WidgetsLocalizations)
       ]);
+    }
+    return true;
+  }());
+  return true;
+}
+
+/// Asserts that the given context has an [Overlay] ancestor.
+///
+/// To call this function, use the following pattern, typically in the
+/// relevant Widget's build method:
+///
+/// ```dart
+/// assert(debugCheckHasOverlay(context));
+/// ```
+///
+/// Does nothing if asserts are disabled. Always returns true.
+bool debugCheckHasOverlay(BuildContext context) {
+  assert(() {
+    if (context.widget is! Overlay && context.findAncestorWidgetOfExactType<Overlay>() == null) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('No Overlay widget found.'),
+        ErrorDescription(
+          '${context.widget.runtimeType} widgets require an Overlay '
+          'widget ancestor.\n'
+          'An overlay lets widgets float on top of other eidget children.'
+        ),
+        ErrorHint(
+          'To introduce an Overlay widget, you can either directly '
+          'include one, or use a widget that contains an Overlay itself, '
+          'such as a Navigator, WidgetApp, MaterialApp, or CupertinoApp.',
+        ),
+        ...context.describeMissingAncestor(expectedAncestorType: Overlay)
+      ]
+      );
     }
     return true;
   }());

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -382,7 +382,7 @@ bool debugCheckHasOverlay(BuildContext context) {
         ErrorDescription(
           '${context.widget.runtimeType} widgets require an Overlay '
           'widget ancestor.\n'
-          'An overlay lets widgets float on top of other eidget children.'
+          'An overlay lets widgets float on top of other widget children.'
         ),
         ErrorHint(
           'To introduce an Overlay widget, you can either directly '

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -770,10 +770,8 @@ class _ReorderableItemState extends State<_ReorderableItem> {
     if (_dragging) {
       return const SizedBox();
     }
-
-    final double translation = _offsetExtent(offset, _listState._scrollDirection);
     return Transform(
-      transform: Matrix4.translationValues(0.0, translation, 0.0),
+      transform: Matrix4.translationValues(offset.dx, offset.dy, 0.0),
       child: widget.child,
     );
   }
@@ -984,8 +982,8 @@ class _DragInfo extends Drag {
     required this.tickerProvider,
   }) {
     final RenderBox itemRenderBox = item.context.findRenderObject()! as RenderBox;
-    dragPosition = _restrictAxis(initialPosition, scrollDirection);
-    dragOffset = _restrictAxis(itemRenderBox.globalToLocal(initialPosition), scrollDirection);
+    dragPosition = initialPosition;
+    dragOffset = itemRenderBox.globalToLocal(initialPosition);
     itemSize = item.context.size!;
     itemExtent = _sizeExtent(itemSize, scrollDirection);
     scrollable = Scrollable.of(item.context);

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -495,6 +495,14 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   }
 
   @override
+  void didUpdateWidget(covariant SliverReorderableList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.itemCount != oldWidget.itemCount) {
+      cancelReorder();
+    }
+  }
+
+  @override
   void dispose() {
     _dragInfo?.dispose();
     super.dispose();
@@ -545,8 +553,11 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     _items[item.index] = item;
   }
 
-  void _unregisterItem(int index) {
-    _items.remove(index);
+  void _unregisterItem(int index, _ReorderableItemState item) {
+    final _ReorderableItemState? currentItem = _items[index];
+    if (currentItem == item) {
+      _items.remove(index);
+    }
   }
 
   Drag? _dragStart(Offset position) {
@@ -819,7 +830,7 @@ class _ReorderableItemState extends State<_ReorderableItem> {
   void didUpdateWidget(covariant _ReorderableItem oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.key != widget.key || oldWidget.index != widget.index) {
-      _listState._unregisterItem(oldWidget.index);
+      _listState._unregisterItem(oldWidget.index, this);
       _listState._registerItem(this);
     }
   }
@@ -837,7 +848,7 @@ class _ReorderableItemState extends State<_ReorderableItem> {
 
   @override
   void deactivate() {
-    _listState._unregisterItem(widget.index);
+    _listState._unregisterItem(index, this);
     super.deactivate();
   }
 

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -8,6 +8,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 import 'inherited_theme.dart';
 import 'overlay.dart';
@@ -279,7 +280,7 @@ class ReorderableList extends StatefulWidget {
 /// ...
 /// listKey.currentState.cancelReorder();
 /// ```
-class ReorderableListState extends State<ReorderableList> with TickerProviderStateMixin<ReorderableList> {
+class ReorderableListState extends State<ReorderableList> {
   final GlobalKey<SliverReorderableListState> _sliverReorderableListKey = GlobalKey();
 
   /// Initiate the dragging of the item at [index] that was started with
@@ -348,7 +349,7 @@ class ReorderableListState extends State<ReorderableList> with TickerProviderSta
 /// These will take care of recognizing the start of a drag gesture and call
 /// the list state's start item drag method.
 ///
-/// This widget's [SliverReorderableListState] can be used manually start a item
+/// This widget's [SliverReorderableListState] can be used to manually start an item
 /// reorder, or cancel a current drag. To refer to the
 /// [SliverReorderableListState] either provide a [GlobalKey] or use the static
 /// [SliverReorderableList.of] method from an item's build method.
@@ -363,7 +364,7 @@ class SliverReorderableList extends StatefulWidget {
   /// Creates a sliver list that allows the user to interactively reorder its
   /// items.
   ///
-  /// [itemCount] must be greater than or equal to zero.
+  /// The [itemCount] must be greater than or equal to zero.
   const SliverReorderableList({
     Key? key,
     required this.itemBuilder,
@@ -474,8 +475,7 @@ class SliverReorderableList extends StatefulWidget {
 /// refer to their [SliverReorderableList] with the static
 /// [SliverReorderableList.of] method.
 class SliverReorderableListState extends State<SliverReorderableList> with TickerProviderStateMixin {
-
-  Axis _scrollDirection = Axis.vertical;
+  late Axis _scrollDirection;
 
   final Map<int, _ReorderableItemState> _items = <int, _ReorderableItemState>{};
 
@@ -751,6 +751,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasOverlay(context));
     return SliverList(
       delegate: _createDelegate(),
     );
@@ -758,7 +759,6 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
 }
 
 class _ReorderableItem extends StatefulWidget {
-
   const _ReorderableItem({
     required Key key,
     required this.index,
@@ -775,7 +775,6 @@ class _ReorderableItem extends StatefulWidget {
 }
 
 class _ReorderableItemState extends State<_ReorderableItem> {
-
   late SliverReorderableListState _listState;
 
   Offset _startOffset = Offset.zero;
@@ -916,7 +915,6 @@ class _ReorderableItemState extends State<_ReorderableItem> {
 ///  * [ReorderableListView], a material design list that allows the user to
 ///    reorder its items.
 class ReorderableDragStartListener extends StatelessWidget {
-
   /// Creates a listener for an drag immediately following a pointer down
   /// event over the given child widget.
   ///
@@ -1011,7 +1009,6 @@ typedef _DragItemUpdate = void Function(_DragInfo item, Offset position, Offset 
 typedef _DragItemCallback = void Function(_DragInfo item);
 
 class _DragInfo extends Drag {
-
   _DragInfo({
     required this.item,
     Offset initialPosition = Offset.zero,

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1053,13 +1053,17 @@ class _DragInfo extends Drag {
   }
 
   Widget createProxy(BuildContext context) {
+    final OverlayState overlay = Overlay.of(context)!;
+    final RenderBox overlayBox = overlay.context.findRenderObject()! as RenderBox;
+    final Offset overlayOrigin = overlayBox.localToGlobal(Offset.zero);
+
     return item.widget.capturedThemes.wrap(
       _DragItemProxy(
         item: item,
         size: itemSize,
         animation: _proxyAnimation!,
         dropping: _dropped,
-        position: dragPosition - dragOffset,
+        position: dragPosition - dragOffset - overlayOrigin,
       )
     );
   }

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -605,7 +605,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
         // down by the gap.
         final int itemIndex = _items.length > 1 ? _insertIndex! - 1 : _insertIndex!;
         final RenderBox itemRenderBox =  _items[itemIndex]!.context.findRenderObject()! as RenderBox;
-        _finalDropPosition = itemRenderBox.localToGlobal(Offset.zero) + _extentOffset(_dragInfo!.itemExtent, _scrollDirection);
+        _finalDropPosition = itemRenderBox.localToGlobal(Offset.zero) + _extentOffset(item.itemExtent, _scrollDirection);
       }
     });
   }

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -600,8 +600,11 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
         final RenderBox itemRenderBox =  _items[_insertIndex!]!.context.findRenderObject()! as RenderBox;
         _finalDropPosition = itemRenderBox.localToGlobal(Offset.zero);
       } else {
-        // Inserting into the last spot on the list, so grab the second to last and move down by the gap
-        final RenderBox itemRenderBox =  _items[_insertIndex! - 1]!.context.findRenderObject()! as RenderBox;
+        // Inserting into the last spot on the list. If it's the only spot, put
+        // it back where it was. Otherwise, grab the second to last and move
+        // down by the gap.
+        final int itemIndex = _items.length > 1 ? _insertIndex! - 1 : _insertIndex!;
+        final RenderBox itemRenderBox =  _items[itemIndex]!.context.findRenderObject()! as RenderBox;
         _finalDropPosition = itemRenderBox.localToGlobal(Offset.zero) + _extentOffset(_dragInfo!.itemExtent, _scrollDirection);
       }
     });

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -709,7 +709,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       final double scrollStart = _offsetExtent(scrollOrigin, _scrollDirection);
       final double scrollEnd = scrollStart + _sizeExtent(scrollRenderBox.size, _scrollDirection);
 
-      final double dragStart = _offsetExtent(_dragInfo!.dragPosition, _scrollDirection);
+      final double dragStart = _offsetExtent(_dragInfo!.dragPosition - _dragInfo!.dragOffset, _scrollDirection);
       final double dragEnd = dragStart + _dragInfo!.itemExtent;
       if (dragStart < scrollStart && position.pixels > position.minScrollExtent) {
         final double overDrag = max(scrollStart - dragStart, overDragMax);

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
 import 'framework.dart';
+import 'inherited_theme.dart';
 import 'media_query.dart';
 import 'overlay.dart';
 import 'scroll_controller.dart';
@@ -687,10 +688,12 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       return SizedBox(height: _dragInfo!.itemExtent);
     }
     final Widget child = widget.itemBuilder(context, index);
+    final OverlayState overlay = Overlay.of(context)!;
     return _ReorderableItem(
       key: _ReorderableItemGlobalKey(child.key!, index, this),
       index: index,
       child: child,
+      capturedThemes: InheritedTheme.capture(from: context, to: overlay.context),
     );
   }
 
@@ -708,10 +711,12 @@ class _ReorderableItem extends StatefulWidget {
     required Key key,
     required this.index,
     required this.child,
+    required this.capturedThemes,
   }) : super(key: key);
 
   final int index;
   final Widget child;
+  final CapturedThemes capturedThemes;
 
   @override
   _ReorderableItemState createState() => _ReorderableItemState();
@@ -1048,12 +1053,14 @@ class _DragInfo extends Drag {
   }
 
   Widget createProxy(BuildContext context) {
-    return _DragItemProxy(
-      item: item,
-      size: itemSize,
-      animation: _proxyAnimation!,
-      dropping: _dropped,
-      position: dragPosition - dragOffset,
+    return item.widget.capturedThemes.wrap(
+      _DragItemProxy(
+        item: item,
+        size: itemSize,
+        animation: _proxyAnimation!,
+        dropping: _dropped,
+        position: dragPosition - dragOffset,
+      )
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -740,7 +740,12 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
 
   Widget _itemBuilder(BuildContext context, int index) {
     if (_dragInfo != null && index >= widget.itemCount) {
-      return SizedBox(height: _dragInfo!.itemExtent);
+      switch (_scrollDirection) {
+        case Axis.horizontal:
+          return SizedBox(width: _dragInfo!.itemExtent);
+        case Axis.vertical:
+          return SizedBox(height: _dragInfo!.itemExtent);
+      }
     }
     final Widget child = widget.itemBuilder(context, index);
     final OverlayState overlay = Overlay.of(context)!;

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1,0 +1,1173 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'media_query.dart';
+import 'overlay.dart';
+import 'scroll_controller.dart';
+import 'scroll_physics.dart';
+import 'scroll_position.dart';
+import 'scroll_view.dart';
+import 'scrollable.dart';
+import 'sliver.dart';
+import 'ticker_provider.dart';
+import 'transitions.dart';
+
+// Examples can assume:
+// class MyDataObject {}
+
+/// A callback used by [ReorderableList] to report that a list item has moved
+/// to a new position in the list.
+///
+/// Implementations should remove the corresponding list item at [oldIndex]
+/// and reinsert it at [newIndex].
+///
+/// If [oldIndex] is before [newIndex], removing the item at [oldIndex] from the
+/// list will reduce the list's length by one. Implementations will need to
+/// account for this when inserting before [newIndex].
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=3fB1mxOsqJE}
+///
+/// {@tool snippet}
+///
+/// ```dart
+/// final List<MyDataObject> backingList = <MyDataObject>[/* ... */];
+///
+/// void handleReorder(int oldIndex, int newIndex) {
+///   if (oldIndex < newIndex) {
+///     // removing the item at oldIndex will shorten the list by 1.
+///     newIndex -= 1;
+///   }
+///   final MyDataObject element = backingList.removeAt(oldIndex);
+///   backingList.insert(newIndex, element);
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [ReorderableList], a widget list that allows the user to reorder
+///    its items.
+///  * [SliverReorderableList], a sliver list that allows the user to reorder
+///    its items.
+///  * [ReorderableListView], a material design list that allows the user to
+///    reorder its items.
+typedef ReorderCallback = void Function(int oldIndex, int newIndex);
+
+/// A scrolling container that allows the user to interactively reorder the
+/// list items.
+///
+/// This widget is similar to one created by [ListView.builder], and uses
+/// an [IndexedWidgetBuilder] to create each item.
+///
+/// It is up to the application to wrap each child (or an internal part of the
+/// child such as a drag handle) with a drag listener that will recognize
+/// the start of an item drag and then start the reorder by calling
+/// [ReorderableListState.startItemDragReorder].
+///
+/// This is most easily achieved by wrapping each child in a
+/// [ReorderableDragStartListener] or a [ReorderableDelayedDragStartListener].
+/// These will take care of recognizing the start of a drag gesture and call
+/// the list state's start item drag method.
+///
+/// This widget's [ReorderableListState] can be used manually start a item
+/// reorder, or cancel a current drag. To refer to the
+/// [ReorderableListState] either provide a [GlobalKey] or use the static
+/// [ReorderableList.of] method from an item's build method.
+///
+/// See also:
+///
+///  * [SliverReorderableList], a sliver list that allows the user to reorder
+///    its items.
+///  * [ReorderableListView], a material design list that allows the user to
+///    reorder its items.
+class ReorderableList extends StatefulWidget {
+  /// Creates a scrolling container that allows the user to interactively
+  /// reorder the list items.
+  ///
+  /// [itemCount] must be greater than or equal to zero.
+  const ReorderableList({
+    Key? key,
+    required this.itemBuilder,
+    this.itemCount = 0,
+    required this.onReorder,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.controller,
+    this.primary,
+    this.physics,
+    this.shrinkWrap = false,
+    this.padding,
+  }) : assert(itemCount >= 0),
+       super(key: key);
+
+  /// Called, as needed, to build list item widgets.
+  ///
+  /// List items are only built when they're scrolled into view.
+  ///
+  /// The [IndexedWidgetBuilder] index parameter indicates the item's
+  /// position in the list. The value of the index parameter will equal to zero
+  /// and less than [itemCount]. All items in the list should have a
+  /// unique [Key], and should have some kind of listener to start the drag
+  /// (usually a [ReorderableDragStartListener] or
+  /// [ReorderableDelayedDragStartListener]).
+  final IndexedWidgetBuilder itemBuilder;
+
+  /// The number of items in the list.
+  final int itemCount;
+
+  /// A callback used by the list to report that a list item has been dragged
+  /// to a new location in the list and the application should update the order
+  /// of the items.
+  final ReorderCallback onReorder;
+
+  /// The axis along which the scroll view scrolls.
+  ///
+  /// Defaults to [Axis.vertical].
+  final Axis scrollDirection;
+
+  /// Whether the scroll view scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// [scrollDirection] is [Axis.horizontal], then the scroll view scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if [scrollDirection] is [Axis.vertical], then the scroll view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  final bool reverse;
+
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  ///
+  /// Must be null if [primary] is true.
+  ///
+  /// A [ScrollController] serves several purposes. It can be used to control
+  /// the initial scroll position (see [ScrollController.initialScrollOffset]).
+  /// It can be used to control whether the scroll view should automatically
+  /// save and restore its scroll position in the [PageStorage] (see
+  /// [ScrollController.keepScrollOffset]). It can be used to read the current
+  /// scroll position (see [ScrollController.offset]), or change it (see
+  /// [ScrollController.animateTo]).
+  final ScrollController? controller;
+
+  /// Whether this is the primary scroll view associated with the parent
+  /// [PrimaryScrollController].
+  ///
+  /// On iOS, this identifies the scroll view that will scroll to top in
+  /// response to a tap in the status bar.
+  ///
+  /// Defaults to true when [scrollDirection] is [Axis.vertical] and
+  /// [controller] is null.
+  final bool? primary;
+
+  /// How the scroll view should respond to user input.
+  ///
+  /// For example, determines how the scroll view continues to animate after the
+  /// user stops dragging the scroll view.
+  ///
+  /// Defaults to matching platform conventions.
+  final ScrollPhysics? physics;
+
+  /// Whether the extent of the scroll view in the [scrollDirection] should be
+  /// determined by the contents being viewed.
+  ///
+  /// If the scroll view does not shrink wrap, then the scroll view will expand
+  /// to the maximum allowed size in the [scrollDirection]. If the scroll view
+  /// has unbounded constraints in the [scrollDirection], then [shrinkWrap] must
+  /// be true.
+  ///
+  /// Shrink wrapping the content of the scroll view is significantly more
+  /// expensive than expanding to the maximum allowed size because the content
+  /// can expand and contract during scrolling, which means the size of the
+  /// scroll view needs to be recomputed whenever the scroll position changes.
+  ///
+  /// Defaults to false.
+  final bool shrinkWrap;
+
+  /// The amount of space by which to inset the children.
+  final EdgeInsetsGeometry? padding;
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// This method is typically used by [ReorderableList] item widgets that insert
+  /// or remove items in response to user input.
+  ///
+  /// If no [ReorderableList] surrounds the context given, then this function will
+  /// assert in debug mode and throw an exception in release mode.
+  ///
+  /// See also:
+  ///
+  ///  * [maybeOf], a similar function that will return null if no
+  ///    [ReorderableList] ancestor is found.
+  static ReorderableListState of(BuildContext context) {
+    assert(context != null);
+    final ReorderableListState? result = context.findAncestorStateOfType<ReorderableListState>();
+    assert((){
+      if (result == null) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary(
+            'ReorderableList.of() called with a context that does not contain a ReorderableList.'),
+          ErrorDescription(
+            'No ReorderableList ancestor could be found starting from the context that was passed to ReorderableList.of().'),
+          ErrorHint(
+            'This can happen when the context provided is from the same StatefulWidget that '
+            'built the ReorderableList. Please see the ReorderableList documentation for examples '
+            'of how to refer to an ReorderableListState object:'
+            '  https://api.flutter.dev/flutter/widgets/ReorderableListState-class.html'
+          ),
+          context.describeElement('The context used was')
+        ]);
+      }
+      return true;
+    }());
+    return result!;
+  }
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// This method is typically used by [ReorderableList] item widgets that insert
+  /// or remove items in response to user input.
+  ///
+  /// If no [ReorderableList] surrounds the context given, then this function will
+  /// return null.
+  ///
+  /// See also:
+  ///
+  ///  * [of], a similar function that will throw if no [ReorderableList] ancestor
+  ///    is found.
+  static ReorderableListState? maybeOf(BuildContext context) {
+    assert(context != null);
+    return context.findAncestorStateOfType<ReorderableListState>();
+  }
+
+  @override
+  ReorderableListState createState() => ReorderableListState();
+}
+
+/// The state for a list that allows the user to interactively reorder
+/// the list items.
+///
+/// An app that needs to start a new item drag or cancel an existing one
+/// can refer to the [ReorderableList]'s state with a global key:
+///
+/// ```dart
+/// GlobalKey<ReorderableListState> listKey = GlobalKey<ReorderableListState>();
+/// ...
+/// ReorderableList(key: listKey, ...);
+/// ...
+/// listKey.currentState.cancelReorder();
+/// ```
+class ReorderableListState extends State<ReorderableList> with TickerProviderStateMixin<ReorderableList> {
+  final GlobalKey<SliverReorderableListState> _sliverReorderableListKey = GlobalKey();
+
+  /// Initiate the dragging of the item at [index] that was started with
+  /// the pointer down [event].
+  ///
+  /// The given [recognizer] will be used to recognize and start the drag
+  /// item tracking and lead to either an item reorder, or a cancelled drag.
+  ///
+  /// Most applications will not use this directly, but will wrap the item
+  /// (or part of the item, like a drag handle) in either a
+  /// [ReorderableDragStartListener] or [ReorderableDelayedDragStartListener]
+  /// which call this for the application.
+  void startItemDragReorder({
+    required int index,
+    required PointerDownEvent event,
+    required MultiDragGestureRecognizer<MultiDragPointerState> recognizer,
+  }) {
+    _sliverReorderableListKey.currentState!.startItemDragReorder(index: index, event: event, recognizer: recognizer);
+  }
+
+  /// Cancel any item drag in progress.
+  ///
+  /// This should be called before any major changes to the item list
+  /// occur so that any item drags will not get confused by
+  /// changes to the underlying list.
+  ///
+  /// If no drag is active, this will do nothing.
+  void cancelReorder() {
+    _sliverReorderableListKey.currentState!.cancelReorder();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      scrollDirection: widget.scrollDirection,
+      reverse: widget.reverse,
+      controller: widget.controller,
+      primary: widget.primary,
+      physics: widget.physics,
+      shrinkWrap: widget.shrinkWrap,
+      slivers: <Widget>[
+        SliverPadding(
+          padding: widget.padding ?? const EdgeInsets.all(0),
+          sliver: SliverReorderableList(
+            key: _sliverReorderableListKey,
+            itemBuilder: widget.itemBuilder,
+            itemCount: widget.itemCount,
+            onReorder: widget.onReorder,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A sliver list that allows the user to interactively reorder the list items.
+///
+/// It is up to the application to wrap each child (or an internal part of the
+/// child) with a drag listener that will recognize the start of an item drag
+/// and then start the reorder by calling
+/// [SliverReorderableListState.startItemDragReorder].
+///
+/// This is most easily achieved by wrapping each child in a
+/// [ReorderableDragStartListener] or a [ReorderableDelayedDragStartListener].
+/// These will take care of recognizing the start of a drag gesture and call
+/// the list state's start item drag method.
+///
+/// This widget's [SliverReorderableListState] can be used manually start a item
+/// reorder, or cancel a current drag. To refer to the
+/// [SliverReorderableListState] either provide a [GlobalKey] or use the static
+/// [SliverReorderableList.of] method from an item's build method.
+///
+/// See also:
+///
+///  * [ReorderableList], a regular widget list that allows the user to reorder
+///    its items.
+///  * [ReorderableListView], a material design list that allows the user to
+///    reorder its items.
+class SliverReorderableList extends StatefulWidget {
+  /// Creates a sliver list that allows the user to interactively reorder its
+  /// items.
+  ///
+  /// [itemCount] must be greater than or equal to zero.
+  const SliverReorderableList({
+    Key? key,
+    required this.itemBuilder,
+    this.itemCount = 0,
+    required this.onReorder,
+  }) : assert(itemCount >= 0),
+       super(key: key);
+
+  /// Called, as needed, to build list item widgets.
+  ///
+  /// List items are only built when they're scrolled into view.
+  ///
+  /// The [IndexedWidgetBuilder] index parameter indicates the item's
+  /// position in the list. The value of the index parameter will equal to zero
+  /// and less than [itemCount]. All items in the list should have a
+  /// unique [Key], and should have some kind of listener to start the drag
+  /// (usually a [ReorderableDragStartListener] or
+  /// [ReorderableDelayedDragStartListener]).
+  final IndexedWidgetBuilder itemBuilder;
+
+  /// The number of items in the list.
+  final int itemCount;
+
+  /// A callback used by the list to report that a list item has been dragged
+  /// to a new location in the list and the application should update the order
+  /// of the items.
+  final ReorderCallback onReorder;
+
+  @override
+  SliverReorderableListState createState() => SliverReorderableListState();
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// This method is typically used by [SliverReorderableList] item widgets to
+  /// start or cancel an item drag operation.
+  ///
+  /// If no [SliverReorderableList] surrounds the context given, this function
+  /// will assert in debug mode and throw an exception in release mode.
+  ///
+  /// See also:
+  ///
+  ///  * [maybeOf], a similar function that will return null if no
+  ///    [SliverReorderableList] ancestor is found.
+  static SliverReorderableListState of(BuildContext context) {
+    assert(context != null);
+    final SliverReorderableListState? result = context.findAncestorStateOfType<SliverReorderableListState>();
+    assert((){
+      if (result == null) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary(
+              'SliverReorderableList.of() called with a context that does not contain a SliverReorderableList.'),
+          ErrorDescription(
+              'No SliverReorderableList ancestor could be found starting from the context that was passed to SliverReorderableList.of().'),
+          ErrorHint(
+              'This can happen when the context provided is from the same StatefulWidget that '
+              'built the SliverReorderableList. Please see the SliverReorderableList documentation for examples '
+              'of how to refer to an SliverReorderableList object:'
+              '  https://api.flutter.dev/flutter/widgets/SliverReorderableListState-class.html'
+          ),
+          context.describeElement('The context used was')
+        ]);
+      }
+      return true;
+    }());
+    return result!;
+  }
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// This method is typically used by [SliverReorderableList] item widgets that
+  /// insert or remove items in response to user input.
+  ///
+  /// If no [SliverReorderableList] surrounds the context given, this function
+  /// will return null.
+  ///
+  /// See also:
+  ///
+  ///  * [of], a similar function that will throw if no [SliverReorderableList]
+  ///    ancestor is found.
+  static SliverReorderableListState? maybeOf(BuildContext context) {
+    assert(context != null);
+    return context.findAncestorStateOfType<SliverReorderableListState>();
+  }
+}
+
+/// The state for a sliver list that allows the user to interactively reorder
+/// the list items.
+///
+/// An app that needs to start a new item drag or cancel an existing one
+/// can refer to the [SliverReorderableList]'s state with a global key:
+///
+/// ```dart
+/// GlobalKey<SliverReorderableListState> listKey = GlobalKey<SliverReorderableListState>();
+/// ...
+/// SliverReorderableList(key: listKey, ...);
+/// ...
+/// listKey.currentState.cancelReorder();
+/// ```
+///
+/// [ReorderableDragStartListener] and [ReorderableDelayedDragStartListener]
+/// refer to their [SliverReorderableList] with the static
+/// [SliverReorderableList.of] method.
+class SliverReorderableListState extends State<SliverReorderableList> with TickerProviderStateMixin {
+
+  Axis _scrollDirection = Axis.vertical;
+
+  final Map<int, _ReorderableItemState> _items = <int, _ReorderableItemState>{};
+
+  bool _reorderingDrag = false;
+  bool _autoScrolling = false;
+  OverlayEntry? _overlayEntry;
+  _ReorderableItemState? _dragItem;
+  _DragInfo? _dragInfo;
+  int? _insertIndex;
+  MultiDragGestureRecognizer<MultiDragPointerState>? _recognizer;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _scrollDirection = axisDirectionToAxis(Scrollable.of(context)!.axisDirection);
+  }
+
+  /// Initiate the dragging of the item at [index] that was started with
+  /// the pointer down [event].
+  ///
+  /// The given [recognizer] will be used to recognize and start the drag
+  /// item tracking and lead to either an item reorder, or a cancelled drag.
+  ///
+  /// Most applications will not use this directly, but will wrap the item
+  /// (or part of the item, like a drag handle) in either a
+  /// [ReorderableDragStartListener] or [ReorderableDelayedDragStartListener]
+  /// which call this for the application.
+  void startItemDragReorder({
+    required int index,
+    required PointerDownEvent event,
+    required MultiDragGestureRecognizer<MultiDragPointerState> recognizer,
+  }) {
+    assert(0 <= index && index < widget.itemCount);
+    setState(() {
+      if (_reorderingDrag) {
+        cancelReorder();
+      }
+      if (_items.containsKey(index)) {
+        _dragItem = _items[index]!;
+        _recognizer = recognizer
+          ..onStart = _dragStart
+          ..addPointer(event);
+      }
+      // TODO(darrenaustin): What to do if they ask to drag an item we haven't seen?
+    });
+  }
+
+  /// Cancel any item drag in progress.
+  ///
+  /// This should be called before any major changes to the item list
+  /// occur so that any item drags will not get confused by
+  /// changes to the underlying list.
+  ///
+  /// If no drag is active, this will do nothing.
+  void cancelReorder() {
+    _dragReset();
+  }
+
+  void _registerItem(_ReorderableItemState item) {
+    _items[item.index] = item;
+  }
+
+  void _unregisterItem(int index) {
+    _items.remove(index);
+  }
+
+  Drag? _dragStart(Offset position) {
+    final _ReorderableItemState item = _dragItem!;
+
+    _insertIndex = item.index;
+    _reorderingDrag = true;
+    _dragInfo = _DragInfo(
+      item: item,
+      initialPosition: position,
+      scrollDirection: _scrollDirection,
+      onUpdate: _dragUpdate,
+      onCancel: _dragCancel,
+      onEnd: _dragEnd,
+      onDropCompleted: _dropCompleted,
+      tickerProvider: this,
+    );
+
+    final OverlayState overlay = Overlay.of(context)!;
+    _overlayEntry = OverlayEntry(builder: _dragInfo!.createProxy);
+    overlay.insert(_overlayEntry!);
+
+    _dragInfo!.startDrag();
+
+    item.dragging = true;
+    for (final _ReorderableItemState childItem in _items.values) {
+      if (childItem == item || !childItem.mounted)
+        continue;
+      childItem.updateForGap(_insertIndex!, _dragInfo!.itemExtent, false);
+    }
+    return _dragInfo;
+  }
+
+  void _dragUpdate(_DragInfo item, Offset position, Offset delta) {
+    setState(() {
+      _overlayEntry?.markNeedsBuild();
+      _dragUpdateItems();
+      _autoScroll();
+    });
+  }
+
+  void _dragCancel(_DragInfo item) {
+    _dragReset();
+  }
+
+  void _dragEnd(_DragInfo item) {
+    setState(() {});
+  }
+
+  void _dropCompleted() {
+    final int fromIndex = _dragItem!.index;
+    final int toIndex = _insertIndex!;
+    widget.onReorder.call(fromIndex, toIndex);
+    _dragReset();
+  }
+
+  void _dragReset() {
+    setState(() {
+      if (_reorderingDrag) {
+        _reorderingDrag = false;
+        _dragItem!.dragging = false;
+        _dragItem = null;
+        _dragInfo?.dispose();
+        _dragInfo = null;
+        _resetItemGap();
+        _recognizer?.dispose();
+        _recognizer = null;
+        _overlayEntry?.remove();
+      }
+    });
+  }
+
+  void _resetItemGap() {
+    for (final _ReorderableItemState item in _items.values) {
+      item.resetGap();
+    }
+  }
+
+  void _dragUpdateItems() {
+    assert(_reorderingDrag);
+    assert(_dragItem != null);
+    assert(_dragInfo != null);
+    final _ReorderableItemState gapItem = _dragItem!;
+    final double gapExtent = _dragInfo!.itemExtent;
+    final double proxyItemStart = _offsetExtent(_dragInfo!.dragPosition - _dragInfo!.dragOffset, _scrollDirection);
+    final double proxyItemEnd = proxyItemStart + gapExtent;
+
+    int newIndex = _insertIndex!;
+    for (final _ReorderableItemState item in _items.values) {
+      if (item == gapItem || !item.mounted)
+        continue;
+
+      if (item.inStartHalf(proxyItemStart)) {
+        // The start of the proxy is in the beginning half of the item, so
+        // we should swap the item with the gap
+        newIndex = item.index;
+        break;
+      } else if (item.inEndHalf(proxyItemEnd)) {
+        // The end of the proxy is in the ending half of the item, so
+        // we should swap the item with the gap.
+        newIndex = item.index + 1;
+        break;
+      }
+    }
+
+    if (newIndex != _insertIndex) {
+      _insertIndex = newIndex;
+      for (final _ReorderableItemState item in _items.values) {
+        if (item == gapItem || !item.mounted)
+          continue;
+        item.updateForGap(newIndex, gapExtent, true);
+      }
+    }
+  }
+
+  Future<void> _autoScroll() async {
+    if (!_autoScrolling && _dragInfo != null && _dragInfo!.scrollable != null) {
+      final ScrollPosition position = _dragInfo!.scrollable!.position;
+      double? newOffset;
+      const int duration = 14; // in ms
+      const double step = 1.0;
+      const double overdragMax = 20.0;
+      const double overdragCoef = 10;
+
+      final MediaQueryData mediaQuery = MediaQuery.of(context);
+      final double start = _scrollDirection == Axis.vertical ? mediaQuery.padding.top : mediaQuery.padding.left;
+      final double end = position.viewportDimension - (_scrollDirection == Axis.vertical ? mediaQuery.padding.bottom : mediaQuery.padding.right);
+
+      final double dragStart = _offsetExtent(_dragInfo!.dragPosition, _scrollDirection);
+      final double dragEnd = dragStart + _dragInfo!.itemExtent;
+      if (dragStart < start && position.pixels > position.minScrollExtent) {
+        final double overdrag = max(start - dragStart, overdragMax);
+        newOffset = max(position.minScrollExtent, position.pixels - step * overdrag / overdragCoef);
+      } else if (dragEnd > end && position.pixels < position.maxScrollExtent) {
+        final double overdrag = max(dragEnd - end, overdragMax);
+        newOffset = min(position.maxScrollExtent, position.pixels + step * overdrag / overdragCoef);
+      }
+
+      if (newOffset != null && (newOffset - position.pixels).abs() >= 1.0) {
+        _autoScrolling = true;
+        await position.animateTo(newOffset,
+            duration: const Duration(milliseconds: duration),
+            curve: Curves.linear
+        );
+        _autoScrolling = false;
+        if (_dragItem != null) {
+          _dragUpdateItems();
+          _autoScroll();
+        }
+      }
+    }
+  }
+
+  SliverChildDelegate _createDelegate() {
+    return SliverChildBuilderDelegate(_itemBuilder, childCount: widget.itemCount + (_reorderingDrag ? 1 : 0));
+  }
+
+  Widget _itemBuilder(BuildContext context, int index) {
+    if (_dragInfo != null && index >= widget.itemCount) {
+      return SizedBox(height: _dragInfo!.itemExtent);
+    }
+    final Widget child = widget.itemBuilder(context, index);
+    return _ReorderableItem(
+      key: _ReorderableItemGlobalKey(child.key!, index, this),
+      index: index,
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverList(
+      delegate: _createDelegate(),
+    );
+  }
+}
+
+class _ReorderableItem extends StatefulWidget {
+
+  const _ReorderableItem({
+    required Key key,
+    required this.index,
+    required this.child,
+  }) : super(key: key);
+
+  final int index;
+  final Widget child;
+
+  @override
+  _ReorderableItemState createState() => _ReorderableItemState();
+}
+
+class _ReorderableItemState extends State<_ReorderableItem> {
+
+  late SliverReorderableListState _listState;
+
+  Offset _startOffset = Offset.zero;
+  Offset _targetOffset = Offset.zero;
+  AnimationController? _offsetAnimation;
+
+  Key get key => widget.key!;
+  int get index => widget.index;
+
+  bool get dragging => _dragging;
+  set dragging(bool dragging) {
+    if (mounted) {
+      setState(() {
+        _dragging = dragging;
+      });
+    }
+  }
+  bool _dragging = false;
+
+  @override
+  void initState() {
+    _listState = SliverReorderableList.of(context);
+    _listState._registerItem(this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _offsetAnimation?.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ReorderableItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.key != widget.key || oldWidget.index != widget.index) {
+      _listState._unregisterItem(oldWidget.index);
+      _listState._registerItem(this);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dragging) {
+      return const SizedBox();
+    }
+
+    final double translation = _offsetExtent(offset, _listState._scrollDirection);
+    return Transform(
+      transform: Matrix4.translationValues(0.0, translation, 0.0),
+      child: widget.child,
+    );
+  }
+
+  @override
+  void deactivate() {
+    _listState._unregisterItem(widget.index);
+    super.deactivate();
+  }
+
+  Offset get offset {
+    if (_offsetAnimation != null) {
+      final double animValue = Curves.easeIn.transform(_offsetAnimation!.value);
+      return (_targetOffset - _startOffset) * animValue + _startOffset;
+    }
+    return _targetOffset;
+  }
+
+  void updateForGap(int gapIndex, double gapExtent, bool animate) {
+    final Offset newTargetOffset = (gapIndex <= index)
+        ? _extentOffset(gapExtent, _listState._scrollDirection)
+        : Offset.zero;
+    if (newTargetOffset != _targetOffset) {
+      _targetOffset = newTargetOffset;
+      if (animate) {
+        if (_offsetAnimation == null) {
+          _offsetAnimation = AnimationController(
+            vsync: _listState,
+            duration: const Duration(milliseconds: 250),
+          )
+            ..addListener(_update)
+            ..addStatusListener((AnimationStatus status) {
+              if (status == AnimationStatus.completed) {
+                _startOffset = _targetOffset;
+                _offsetAnimation!.dispose();
+                _offsetAnimation = null;
+              }
+            })
+            ..forward();
+        } else {
+          _startOffset = offset;
+          _offsetAnimation!.forward(from: 0.0);
+        }
+      } else {
+        if (_offsetAnimation != null) {
+          _offsetAnimation!.dispose();
+          _offsetAnimation = null;
+        }
+        _startOffset = _targetOffset;
+      }
+      _update();
+    }
+  }
+
+  void resetGap() {
+    if (_offsetAnimation != null) {
+      _offsetAnimation!.dispose();
+      _offsetAnimation = null;
+    }
+    _startOffset = Offset.zero;
+    _targetOffset = Offset.zero;
+    _update();
+  }
+
+  bool inStartHalf(double position) {
+    final RenderBox itemRenderBox = context.findRenderObject()! as RenderBox;
+    final Offset itemPosition = itemRenderBox.localToGlobal(Offset.zero);
+    final double itemStart = _offsetExtent(itemPosition + _targetOffset, _listState._scrollDirection);
+    final double itemMiddle = itemStart + _sizeExtent(itemRenderBox.size, _listState._scrollDirection) / 2;
+    return itemStart <= position && position <= itemMiddle;
+  }
+
+  bool inEndHalf(double position) {
+    final RenderBox itemRenderBox = context.findRenderObject()! as RenderBox;
+    final Offset itemPosition = itemRenderBox.localToGlobal(Offset.zero);
+    final double itemExtent = _sizeExtent(itemRenderBox.size, _listState._scrollDirection);
+    final double itemEnd = _offsetExtent(itemPosition + _targetOffset, _listState._scrollDirection) + itemExtent;
+    final double itemMiddle = itemEnd - _sizeExtent(itemRenderBox.size, _listState._scrollDirection) / 2;
+    return itemMiddle <= position && position <= itemEnd;
+  }
+
+  void _update() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+}
+
+/// A wrapper widget that will recognize the start of a drag on a by a
+/// [PointerDownEvent], and immediately initiate dragging the wrapped
+/// item to a new location in a reorderable list.
+///
+/// See also:
+///
+///  * [ReorderableDelayedDragStartListener], a similar wrapper that will
+///    only recognize the start after a long press event.
+///  * [ReorderableList], a widget list that allows the user to reorder
+///    its items.
+///  * [SliverReorderableList], a sliver list that allows the user to reorder
+///    its items.
+///  * [ReorderableListView], a material design list that allows the user to
+///    reorder its items.
+class ReorderableDragStartListener extends StatelessWidget {
+
+  /// Creates a listener for an drag immediately following a pointer down
+  /// event over the given child widget.
+  ///
+  /// This is most commonly used to wrap part of a list item like a drag
+  /// handle.
+  const ReorderableDragStartListener({
+    Key? key,
+    required this.child,
+    required this.index,
+  }) : super(key: key);
+
+  /// The widget for which the application would like to respond to a tap and
+  /// drag gesture by starting a reordering drag on a reorderable list.
+  final Widget child;
+
+  /// The index of the associated item that will be dragged in the list.
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (PointerDownEvent event) => _startDragging(context, event),
+      child: child,
+    );
+  }
+
+  /// Provides the gesture recognizer used to indicate the start of a reordering
+  /// drag operation.
+  ///
+  /// By default this returns an [ImmediateMultiDragGestureRecognizer] but
+  /// subclasses can use this to customize the drag start gesture.
+  @protected
+  MultiDragGestureRecognizer<MultiDragPointerState> createRecognizer({
+    Object? debugOwner,
+    PointerDeviceKind? kind,
+  }) {
+    return ImmediateMultiDragGestureRecognizer(
+      debugOwner: debugOwner,
+      kind: kind,
+    );
+  }
+
+  void _startDragging(BuildContext context, PointerDownEvent event) {
+    final SliverReorderableListState? list = SliverReorderableList.maybeOf(context);
+    list?.startItemDragReorder(
+        index: index,
+        event: event,
+        recognizer: createRecognizer(debugOwner: this, kind: event.kind)
+    );
+  }
+}
+
+/// A wrapper widget that will recognize the start of a drag operation by
+/// looking for a long press event. Once it is recognized, it will start
+/// a drag operation on the wrapped item in the reorderable list.
+///
+/// See also:
+///
+///  * [ReorderableDragStartListener], a similar wrapper that will
+///    recognize the start of the drag immediately after a pointer down event.
+///  * [ReorderableList], a widget list that allows the user to reorder
+///    its items.
+///  * [SliverReorderableList], a sliver list that allows the user to reorder
+///    its items.
+///  * [ReorderableListView], a material design list that allows the user to
+///    reorder its items.
+class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
+  /// Creates a listener for an drag following a long press event over the
+  /// given child widget.
+  ///
+  /// This is most commonly used to wrap an entire list item in a reorderable
+  /// list.
+  const ReorderableDelayedDragStartListener({
+    Key? key,
+    required Widget child,
+    required int index,
+  }) : super(key: key, child: child, index: index);
+
+  @override
+  MultiDragGestureRecognizer<MultiDragPointerState> createRecognizer({
+    Object? debugOwner,
+    PointerDeviceKind? kind,
+  }) {
+    return DelayedMultiDragGestureRecognizer(
+      debugOwner: debugOwner,
+      kind: kind,
+    );
+  }
+}
+
+typedef _DragItemUpdate = void Function(_DragInfo item, Offset position, Offset delta);
+typedef _DragItemCallback = void Function(_DragInfo item);
+
+class _DragInfo extends Drag {
+
+  _DragInfo({
+    required this.item,
+    Offset initialPosition = Offset.zero,
+    this.scrollDirection = Axis.vertical,
+    this.onUpdate,
+    this.onEnd,
+    this.onCancel,
+    this.onDropCompleted,
+    required this.tickerProvider,
+  }) {
+    final RenderBox itemRenderBox = item.context.findRenderObject()! as RenderBox;
+    dragPosition = _restrictAxis(initialPosition, scrollDirection);
+    dragOffset = _restrictAxis(itemRenderBox.globalToLocal(initialPosition), scrollDirection);
+    itemSize = item.context.size!;
+    itemExtent = _sizeExtent(itemSize, scrollDirection);
+    scrollable = Scrollable.of(item.context);
+  }
+
+  final _ReorderableItemState item;
+  final Axis scrollDirection;
+  final _DragItemUpdate? onUpdate;
+  final _DragItemCallback? onEnd;
+  final _DragItemCallback? onCancel;
+  final VoidCallback? onDropCompleted;
+  final TickerProvider tickerProvider;
+
+  late Offset dragPosition;
+  late Offset dragOffset;
+  late Size itemSize;
+  late double itemExtent;
+  ScrollableState? scrollable;
+  AnimationController? _proxyAnimation;
+  bool _dropped = false;
+
+  void dispose() {
+    _proxyAnimation?.dispose();
+  }
+
+  void startDrag() {
+    _proxyAnimation = AnimationController(
+      vsync: tickerProvider,
+      duration: const Duration(milliseconds: 250),
+      reverseDuration: const Duration(milliseconds: 250),
+    )
+      ..addStatusListener((AnimationStatus status) {
+        if (status == AnimationStatus.dismissed && _dropped) {
+          _dropCompleted();
+        }
+      })
+      ..forward();
+  }
+
+  @override
+  void update(DragUpdateDetails details) {
+    final Offset delta = _restrictAxis(details.delta, scrollDirection);
+    dragPosition += delta;
+    onUpdate?.call(this, dragPosition, details.delta);
+  }
+
+  @override
+  void end(DragEndDetails details) {
+    _dropped = true;
+    _proxyAnimation?.reverse();
+    onEnd?.call(this);
+  }
+
+  @override
+  void cancel() {
+    _proxyAnimation?.dispose();
+    _proxyAnimation = null;
+    onCancel?.call(this);
+  }
+
+  void _dropCompleted() {
+    _proxyAnimation?.dispose();
+    _proxyAnimation = null;
+    onDropCompleted?.call();
+  }
+
+  Widget createProxy(BuildContext context) {
+    return _DragItemProxy(
+      item: item,
+      size: itemSize,
+      animation: _proxyAnimation!,
+      dropping: _dropped,
+      position: dragPosition - dragOffset,
+    );
+  }
+}
+
+class _DragItemProxy extends StatelessWidget {
+  const _DragItemProxy({
+    Key? key,
+    required this.item,
+    required this.position,
+    required this.size,
+    required this.animation,
+    required this.dropping,
+  }) : super(key: key);
+
+  final _ReorderableItemState item;
+  final Offset position;
+  final Size size;
+  final AnimationController animation;
+  final bool dropping;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+        animation: animation,
+        builder: (BuildContext context, Widget? child) {
+          // final double elevation = lerpDouble(0.0, 8.0, Curves.easeInOut.transform(animation.value))!;
+          final Offset effectivePosition = position;
+          // if (dropping && item.mounted) {
+          //   final _ReorderableListState reorderableState = _ReorderableListState.of(context)!;
+          //   final Offset itemPosition = reorderableState._itemTargetPosition(item);
+          //   effectivePosition = Offset.lerp(position, itemPosition, Curves.easeOut.transform(1 - animation.value))!;
+          // }
+          return Positioned(
+            // child: Container(
+            //   alignment: Alignment.topLeft,
+            //   constraints: constraints,
+            //   child: Material(
+            //     elevation: elevation,
+            //     child: item.buildProxy(context),
+            //   ),
+            // ),
+            child: SizedBox(
+              width: size.width,
+              height: size.height,
+              child: item.widget.child,
+            ),
+            left: effectivePosition.dx,
+            top: effectivePosition.dy,
+          );
+        }
+    );
+  }
+}
+
+double _sizeExtent(Size size, Axis scrollDirection) {
+  switch (scrollDirection) {
+    case Axis.horizontal:
+      return size.width;
+    case Axis.vertical:
+      return size.height;
+  }
+}
+
+double _offsetExtent(Offset offset, Axis scrollDirection) {
+  switch (scrollDirection) {
+    case Axis.horizontal:
+      return offset.dx;
+    case Axis.vertical:
+      return offset.dy;
+  }
+}
+
+Offset _extentOffset(double extent, Axis scrollDirection) {
+  switch (scrollDirection) {
+    case Axis.horizontal:
+      return Offset(extent, 0.0);
+    case Axis.vertical:
+      return Offset(0.0, extent);
+  }
+}
+
+Offset _restrictAxis(Offset offset, Axis scrollDirection) {
+  switch (scrollDirection) {
+    case Axis.horizontal:
+      return Offset(offset.dx, 0.0);
+    case Axis.vertical:
+      return Offset(0.0, offset.dy);
+  }
+}
+
+// A global key that takes its identity from the object and uses a value of a
+// particular type to identify itself.
+//
+// The difference with GlobalObjectKey is that it uses [==] instead of [identical]
+// of the objects used to generate widgets.
+@optionalTypeArgs
+class _ReorderableItemGlobalKey extends GlobalObjectKey {
+
+  const _ReorderableItemGlobalKey(this.subKey, this.index, this.state) : super(subKey);
+
+  final Key subKey;
+  final int index;
+  final SliverReorderableListState state;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is _ReorderableItemGlobalKey
+        && other.subKey == subKey
+        && other.index == index
+        && other.state == state;
+  }
+
+  @override
+  int get hashCode => hashValues(subKey, index, state);
+}

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -89,7 +89,7 @@ typedef ReorderItemProxyDecorator = Widget Function(Widget child, int index, Ani
 /// by wrapping each child in a [ReorderableDragStartListener] or a
 /// [ReorderableDelayedDragStartListener]. These will take care of recognizing
 /// the start of a drag gesture and call the list state's
-/// [ReorderableListState.startDrag] method.
+/// [ReorderableListState.startItemDragReorder] method.
 ///
 /// This widget's [ReorderableListState] can be used to manually start an item
 /// reorder, or cancel a current drag. To refer to the

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -759,6 +759,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       }
     }
     final Widget child = widget.itemBuilder(context, index);
+    assert(child.key != null, 'All list items must have a key');
     final OverlayState overlay = Overlay.of(context)!;
     return _ReorderableItem(
       key: _ReorderableItemGlobalKey(child.key!, index, this),

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -83,6 +83,7 @@ export 'src/widgets/platform_view.dart';
 export 'src/widgets/preferred_size.dart';
 export 'src/widgets/primary_scroll_controller.dart';
 export 'src/widgets/raw_keyboard_listener.dart';
+export 'src/widgets/reorderable_list.dart';
 export 'src/widgets/restoration.dart';
 export 'src/widgets/restoration_properties.dart';
 export 'src/widgets/router.dart';

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -173,46 +174,44 @@ void main() {
           ),
         ));
 
-        Element getContentElement() {
-          final SingleChildScrollView listScrollView = tester.widget(find.byType(SingleChildScrollView));
-          final Widget scrollContents = listScrollView.child!;
-          final Element contentElement = tester.element(find.byElementPredicate((Element element) => element.widget == scrollContents));
-          return contentElement;
+        double getListHeight() {
+          final RenderSliverList listScrollView = tester.renderObject(find.byType(SliverList));
+          return listScrollView.geometry!.maxPaintExtent;
         }
 
-        const double kDraggingListHeight = 292.0;
+        const double kDraggingListHeight = 4 * itemHeight;
         // Drag a normal text item
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
 
         // Move it
         await drag.moveTo(tester.getCenter(find.text('Last item')));
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
 
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
 
         // Drag a tall item
         drag = await tester.startGesture(tester.getCenter(find.text('Tall item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
         // Move it
         await drag.moveTo(tester.getCenter(find.text('Last item')));
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
+        expect(getListHeight(), kDraggingListHeight);
 
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.height, kDraggingListHeight);
-      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
+        expect(getListHeight(), kDraggingListHeight);
+      });
 
       testWidgets('Vertical drop area golden', (WidgetTester tester) async {
         final Widget reorderableListView = ReorderableListView(
@@ -253,7 +252,7 @@ void main() {
           find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.vertical.drop_area.png'),
         );
-      }, skip: true); // TODO(darrenaustin): need to update the golden
+      });
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {
@@ -349,8 +348,8 @@ void main() {
         }
 
         await tester.pumpWidget(buildWithScrollController(primary));
-        SingleChildScrollView scrollView = tester.widget(
-          find.byType(SingleChildScrollView),
+        Scrollable scrollView = tester.widget(
+          find.byType(Scrollable),
         );
         expect(scrollView.controller, primary);
 
@@ -358,10 +357,10 @@ void main() {
         final ScrollController primary2 = ScrollController();
         await tester.pumpWidget(buildWithScrollController(primary2));
         scrollView = tester.widget(
-          find.byType(SingleChildScrollView),
+          find.byType(Scrollable),
         );
         expect(scrollView.controller, primary2);
-      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
+      });
 
       testWidgets('Test custom ScrollController behavior when set', (WidgetTester tester) async {
         const Key firstBox = Key('C');
@@ -451,12 +450,7 @@ void main() {
         } catch (e) {
           fail('Expected no error, but got $e');
         }
-        // Expect that we have build *a* ScrollController for use in the view.
-        final SingleChildScrollView scrollView = tester.widget(
-          find.byType(SingleChildScrollView),
-        );
-        expect(scrollView.controller, isNotNull);
-      }, skip: true); // TODO(darrenaustin): we now need an overlay, perhaps the SliverReorderableList should provide one?
+      });
 
       group('Accessibility (a11y/Semantics)', () {
         Map<CustomSemanticsAction, VoidCallback> getSemanticsActions(int index) {
@@ -760,46 +754,44 @@ void main() {
           ),
         ));
 
-        Element getContentElement() {
-          final SingleChildScrollView listScrollView = tester.widget(find.byType(SingleChildScrollView));
-          final Widget scrollContents = listScrollView.child!;
-          final Element contentElement = tester.element(find.byElementPredicate((Element element) => element.widget == scrollContents));
-          return contentElement;
+        double getListWidth() {
+          final RenderSliverList listScrollView = tester.renderObject(find.byType(SliverList));
+          return listScrollView.geometry!.maxPaintExtent;
         }
 
-        const double kDraggingListWidth = 292.0;
+        const double kDraggingListWidth = 4 * itemHeight;
         // Drag a normal text item
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
         TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Normal item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
 
         // Move it
         await drag.moveTo(tester.getCenter(find.text('Last item')));
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
 
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
 
         // Drag a tall item
         drag = await tester.startGesture(tester.getCenter(find.text('Tall item')));
         await tester.pump(kLongPressTimeout + kPressTimeout);
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
         // Move it
         await drag.moveTo(tester.getCenter(find.text('Last item')));
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
+        expect(getListWidth(), kDraggingListWidth);
 
         // Drop it
         await drag.up();
         await tester.pumpAndSettle();
-        expect(getContentElement().size!.width, kDraggingListWidth);
-      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
+        expect(getListWidth(), kDraggingListWidth);
+      }, skip: true); // TODO(goderbauer): list shrinks to 3 * itemhight when item is dragged.
 
       testWidgets('Horizontal drop area golden', (WidgetTester tester) async {
         final Widget reorderableListView = ReorderableListView(
@@ -840,7 +832,7 @@ void main() {
           find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.horizontal.drop_area.png'),
         );
-      }, skip: true); // TODO(darrenaustin): need to update the golden
+      });
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -90,6 +90,7 @@ void main() {
         await drag.moveTo(tester.getCenter(find.text('Item 4')));
         expect(listItems, orderedEquals(originalListItems));
         await drag.up();
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 1', 'Item 4']));
       });
 
@@ -101,6 +102,7 @@ void main() {
           tester.getCenter(find.text('Item 1')),
           tester.getCenter(find.text('Item 4')) + const Offset(0.0, itemHeight * 2),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
       });
 
@@ -112,6 +114,7 @@ void main() {
           tester.getCenter(find.text('Item 4')),
           tester.getCenter(find.text('Item 1')),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
       });
 
@@ -123,6 +126,7 @@ void main() {
           tester.getCenter(find.text('Item 3')),
           tester.getCenter(find.text('Item 2')),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 1', 'Item 3', 'Item 2', 'Item 4']));
       });
 
@@ -135,6 +139,7 @@ void main() {
           tester.getCenter(find.text('Item 1')),
           tester.getCenter(find.text('Item 4')) + const Offset(0.0, itemHeight * 2),
         );
+        await tester.pumpAndSettle();
         expect(find.text('Header Text'), findsOneWidget);
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
       });
@@ -207,7 +212,7 @@ void main() {
         await drag.up();
         await tester.pumpAndSettle();
         expect(getContentElement().size!.height, kDraggingListHeight);
-      });
+      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
 
       testWidgets('Vertical drop area golden', (WidgetTester tester) async {
         final Widget reorderableListView = ReorderableListView(
@@ -248,7 +253,7 @@ void main() {
           find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.vertical.drop_area.png'),
         );
-      });
+      }, skip: true); // TODO(darrenaustin): need to update the golden
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {
@@ -356,7 +361,7 @@ void main() {
           find.byType(SingleChildScrollView),
         );
         expect(scrollView.controller, primary2);
-      });
+      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
 
       testWidgets('Test custom ScrollController behavior when set', (WidgetTester tester) async {
         const Key firstBox = Key('C');
@@ -415,7 +420,7 @@ void main() {
         // shifted by 80.0.
         // Final offset: 40.0 + 80.0 = 120.0
         expect(customController.offset, 120.0);
-      });
+      }, skip: true); // TODO(darrenaustin): not sure why this doesn't work with the new implementation
 
       testWidgets('Still builds when no PrimaryScrollController is available', (WidgetTester tester) async {
         final Widget reorderableList = ReorderableListView(
@@ -451,7 +456,7 @@ void main() {
           find.byType(SingleChildScrollView),
         );
         expect(scrollView.controller, isNotNull);
-      });
+      }, skip: true); // TODO(darrenaustin): we now need an overlay, perhaps the SliverReorderableList should provide one?
 
       group('Accessibility (a11y/Semantics)', () {
         Map<CustomSemanticsAction, VoidCallback> getSemanticsActions(int index) {
@@ -675,6 +680,7 @@ void main() {
           tester.getCenter(find.text('Item 1')),
           tester.getCenter(find.text('Item 4')) + const Offset(itemHeight * 2, 0.0),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
       });
 
@@ -686,6 +692,7 @@ void main() {
           tester.getCenter(find.text('Item 4')),
           tester.getCenter(find.text('Item 1')),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
       });
 
@@ -697,6 +704,7 @@ void main() {
           tester.getCenter(find.text('Item 3')),
           tester.getCenter(find.text('Item 2')),
         );
+        await tester.pumpAndSettle();
         expect(listItems, orderedEquals(<String>['Item 1', 'Item 3', 'Item 2', 'Item 4']));
       });
 
@@ -718,6 +726,7 @@ void main() {
           tester.getCenter(find.text('Item 4')),
           tester.getCenter(find.text('Item 3')),
         );
+        await tester.pumpAndSettle();
         expect(find.text('Header Text'), findsOneWidget);
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 4', 'Item 3', 'Item 1']));
       });
@@ -790,7 +799,7 @@ void main() {
         await drag.up();
         await tester.pumpAndSettle();
         expect(getContentElement().size!.width, kDraggingListWidth);
-      });
+      }, skip: true); // TODO(darrenaustin): depended on the SingleChildScrollView in the implementation
 
       testWidgets('Horizontal drop area golden', (WidgetTester tester) async {
         final Widget reorderableListView = ReorderableListView(
@@ -831,7 +840,7 @@ void main() {
           find.byKey(const Key('blue')),
           matchesGoldenFile('reorderable_list_test.horizontal.drop_area.png'),
         );
-      });
+      }, skip: true); // TODO(darrenaustin): need to update the golden
 
       testWidgets('Preserves children states when the list parent changes the order', (WidgetTester tester) async {
         _StatefulState findState(Key key) {
@@ -1171,7 +1180,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(
         home: reorderableListView,
       ));
-      expect(tester.getCenter(find.text('A')).dy, lessThan(tester.getCenter(find.text('B')).dy));
+      expect(tester.getCenter(find.text('A')).dy, greaterThan(tester.getCenter(find.text('B')).dy));
     });
 
     testWidgets('Animation test when placing an item in place', (WidgetTester tester) async {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -371,7 +371,7 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: SizedBox(
-                height: 200,
+                height: 150,
                 child: ReorderableListView(
                   scrollController: customController,
                   onReorder: (int oldIndex, int newIndex) { },
@@ -418,8 +418,11 @@ void main() {
         // First 20.0 px always ignored, so scroll offset is only
         // shifted by 80.0.
         // Final offset: 40.0 + 80.0 = 120.0
+        // The total distance available to scroll is 300.0 - 150.0 = 150.0, or
+        // height of the ReorderableListView minus height of the SizedBox. Since
+        // The final offset is less than this, it's not limited.
         expect(customController.offset, 120.0);
-      }, skip: true); // TODO(darrenaustin): not sure why this doesn't work with the new implementation
+      });
 
       testWidgets('Still builds when no PrimaryScrollController is available', (WidgetTester tester) async {
         final Widget reorderableList = ReorderableListView(

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -794,7 +794,7 @@ void main() {
         await drag.up();
         await tester.pumpAndSettle();
         expect(getListWidth(), kDraggingListWidth);
-      }, skip: true); // TODO(goderbauer): list shrinks to 3 * itemhight when item is dragged.
+      });
 
       testWidgets('Horizontal drop area golden', (WidgetTester tester) async {
         final Widget reorderableListView = ReorderableListView(

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-
 void main() {
   testWidgets('ReorderableList, drag and drop, fixed height items', (WidgetTester tester) async {
     final List<int> items = List<int>.generate(8, (int index) => index);
@@ -74,56 +73,124 @@ void main() {
     expect(tester.getTopLeft(find.text('item 3')), const Offset(0, 300));
     expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
   });
+
+  testWidgets('ReorderableList, items inherit DefaultTextStyle, IconTheme', (WidgetTester tester) async {
+    const Color textColor = Color(0xffffffff);
+    const Color iconColor = Color(0xff0000ff);
+
+    TextStyle getIconStyle() {
+      return tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(Icon),
+          matching: find.byType(RichText),
+        ),
+      ).text.style!;
+    }
+
+    TextStyle getTextStyle() {
+      return tester.widget<RichText>(
+        find.descendant(
+          of: find.text('item 0'),
+          matching: find.byType(RichText),
+        ),
+      ).text.style!;
+    }
+
+    // This SliverReorderableList has just one item: "item 0".
+    await tester.pumpWidget(
+      TestList(
+        items: List<int>.from(<int>[0]),
+        textColor: textColor,
+        iconColor: iconColor,
+      ),
+    );
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(getIconStyle().color, iconColor);
+    expect(getTextStyle().color, textColor);
+
+    // Dragging item 0 causes it to be reparented in the overlay. The item
+    // should still inherit the IconTheme and DefaultTextStyle because they are
+    // InheritedThemes.
+    final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('item 0')));
+    await tester.pump(kPressTimeout);
+    await drag.moveBy(const Offset(0, 50));
+    await tester.pump(kPressTimeout);
+    expect(tester.getTopLeft(find.text('item 0')), const Offset(0, 50));
+    expect(getIconStyle().color, iconColor);
+    expect(getTextStyle().color, textColor);
+
+    // Drag is complete, item 0 returns to where it was.
+    await drag.up();
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(getIconStyle().color, iconColor);
+    expect(getTextStyle().color, textColor);
+  });
 }
 
 class TestList extends StatefulWidget {
   const TestList({
     Key? key,
+    this.textColor,
+    this.iconColor,
     required this.items,
   }) : super(key: key);
 
   final List<int> items;
+  final Color? textColor;
+  final Color? iconColor;
 
   @override
   _TestListState createState() => _TestListState();
 }
-
 
 class _TestListState extends State<TestList> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: StatefulBuilder(
-          builder: (BuildContext outerContext, StateSetter setState) {
-            final List<int> items = widget.items;
-            return CustomScrollView(
-              slivers: <Widget>[
-                SliverReorderableList(
-                  itemBuilder: (BuildContext context, int index) {
-                    return Container(
-                      key: ValueKey<int>(items[index]),
-                      height: 100,
-                      color: items[index].isOdd ? Colors.red : Colors.green,
-                      child: ReorderableDragStartListener(
-                        index: index,
-                        child: Text('item ${items[index]}'),
+        body: DefaultTextStyle(
+          style: TextStyle(color: widget.textColor),
+          child: IconTheme(
+            data: IconThemeData(color: widget.iconColor),
+            child: StatefulBuilder(
+                builder: (BuildContext outerContext, StateSetter setState) {
+                  final List<int> items = widget.items;
+                  return CustomScrollView(
+                    slivers: <Widget>[
+                      SliverReorderableList(
+                        itemBuilder: (BuildContext context, int index) {
+                          return Container(
+                            key: ValueKey<int>(items[index]),
+                            height: 100,
+                            color: items[index].isOdd ? Colors.red : Colors.green,
+                            child: ReorderableDragStartListener(
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: <Widget>[
+                                  Text('item ${items[index]}'),
+                                  const Icon(Icons.drag_handle),
+                                ],
+                              ),
+                              index: index,
+                            ),
+                          );
+                        },
+                        itemCount: items.length,
+                        onReorder: (int fromIndex, int toIndex) {
+                          setState(() {
+                            if (toIndex > fromIndex) {
+                              toIndex -= 1;
+                            }
+                            items.insert(toIndex, items.removeAt(fromIndex));
+                          });
+                        },
                       ),
-                    );
-                  },
-                  itemCount: items.length,
-                  onReorder: (int fromIndex, int toIndex) {
-                    setState(() {
-                      if (toIndex > fromIndex) {
-                        toIndex -= 1;
-                      }
-                      items.insert(toIndex, items.removeAt(fromIndex));
-                    });
-                  },
-                ),
-              ],
-            );
-          }
+                    ],
+                  );
+                }
+            ),
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+
+void main() {
+  testWidgets('ReorderableList, drag and drop, fixed height items', (WidgetTester tester) async {
+    final List<int> items = List<int>.generate(8, (int index) => index);
+
+    Future<void> pressDragRelease(Offset start, Offset delta) async {
+      final TestGesture drag = await tester.startGesture(start);
+      await tester.pump(kPressTimeout);
+      await drag.moveBy(delta);
+      await tester.pump(kPressTimeout);
+      await drag.up();
+      await tester.pumpAndSettle();
+    }
+
+    void check({ List<int> visible = const <int>[], List<int> hidden = const <int>[] }) {
+      for (final int i in visible) {
+        expect(find.text('item $i'), findsOneWidget);
+      }
+      for (final int i in hidden) {
+        expect(find.text('item $i'), findsNothing);
+      }
+    }
+
+    // The SliverReorderableList is 800x600, 8 items, each item is 800x100 with
+    // an "item $index" text widget at the item's origin.  Drags are initiated by
+    // a simple press on the text widget.
+    await tester.pumpWidget(TestList(items: items));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+
+    // Drag item 0 downwards less than halfway and let it snap back. List
+    // should remain as it is.
+    await pressDragRelease(const Offset(12, 50), const Offset(12, 60));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(tester.getTopLeft(find.text('item 1')), const Offset(0, 100));
+    expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Drag item 0 downwards more than halfway to displace item 1.
+    await pressDragRelease(tester.getCenter(find.text('item 0')), const Offset(0, 151));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+    expect(tester.getTopLeft(find.text('item 1')), Offset.zero);
+    expect(tester.getTopLeft(find.text('item 0')), const Offset(0, 100));
+    expect(items, orderedEquals(<int>[1, 0, 2, 3, 4, 5, 6, 7]));
+
+    // Drag item 0 back to where it was.
+    await pressDragRelease(tester.getCenter(find.text('item 0')), const Offset(0, -51));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(tester.getTopLeft(find.text('item 1')), const Offset(0, 100));
+    expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Drag item 1 to item 3
+    await pressDragRelease(tester.getCenter(find.text('item 1')), const Offset(0, 251));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(tester.getTopLeft(find.text('item 1')), const Offset(0, 300));
+    expect(tester.getTopLeft(find.text('item 3')), const Offset(0, 200));
+    expect(items, orderedEquals(<int>[0, 2, 3, 1, 4, 5, 6, 7]));
+
+    // Drag item 1 back to where it was
+    await pressDragRelease(tester.getCenter(find.text('item 1')), const Offset(0, -200));
+    check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
+    expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
+    expect(tester.getTopLeft(find.text('item 1')), const Offset(0, 100));
+    expect(tester.getTopLeft(find.text('item 3')), const Offset(0, 300));
+    expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
+  });
+}
+
+class TestList extends StatefulWidget {
+  const TestList({
+    Key? key,
+    required this.items,
+  }) : super(key: key);
+
+  final List<int> items;
+
+  @override
+  _TestListState createState() => _TestListState();
+}
+
+
+class _TestListState extends State<TestList> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: StatefulBuilder(
+          builder: (BuildContext outerContext, StateSetter setState) {
+            final List<int> items = widget.items;
+            return CustomScrollView(
+              slivers: <Widget>[
+                SliverReorderableList(
+                  itemBuilder: (BuildContext context, int index) {
+                    return Container(
+                      key: ValueKey<int>(items[index]),
+                      height: 100,
+                      color: items[index].isOdd ? Colors.red : Colors.green,
+                      child: ReorderableDragStartListener(
+                        index: index,
+                        child: Text('item ${items[index]}'),
+                      ),
+                    );
+                  },
+                  itemCount: items.length,
+                  onReorder: (int fromIndex, int toIndex) {
+                    setState(() {
+                      if (toIndex > fromIndex) {
+                        toIndex -= 1;
+                      }
+                      items.insert(toIndex, items.removeAt(fromIndex));
+                    });
+                  },
+                ),
+              ],
+            );
+          }
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 void main() {
-  testWidgets('ReorderableList, drag and drop, fixed height items', (WidgetTester tester) async {
+  testWidgets('SliverReorderableList, drag and drop, fixed height items', (WidgetTester tester) async {
     final List<int> items = List<int>.generate(8, (int index) => index);
 
     Future<void> pressDragRelease(Offset start, Offset delta) async {
@@ -74,7 +74,7 @@ void main() {
     expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
   });
 
-  testWidgets('ReorderableList, items inherit DefaultTextStyle, IconTheme', (WidgetTester tester) async {
+  testWidgets('SliverReorderableList, items inherit DefaultTextStyle, IconTheme', (WidgetTester tester) async {
     const Color textColor = Color(0xffffffff);
     const Color iconColor = Color(0xff0000ff);
 


### PR DESCRIPTION
## Description

To address some of the shortcomings described in #66080, this PR adds two new Reorderable lists widgets and overhauls the current `ReorderableListView` to fix a lot of problems.

There are now the following:

* **ReorderableList** - a lower level flexible widget that allows the user to interactively move items around the list. It is design-language agnostic and lives in the widgets package.
* **SliverReorderableList** - a SliverList version of the `ReorderableList`, also in the widgets package.
* **ReorderableListView** - A Material Design implementation of the reorderable list updated to use the SliverRerorderableList internally.

The `ReorderableList` and `SliverReorderableList` allow you to customize how the drag operation starts. This is be done by wrapping each item in a drag listener that will tell the list to start dragging. We have provided two such listeners for the common cases:

* **ReorderableDragStartListener** which triggers the drag from a single pointer down event (useful for wrapping just a drag handle instead of the whole item).
* **ReorderableDelayedDragStartListener** which triggers after a long press.

Or you can subclass `ReorderableDragStartListener` and build your own listener.

One of these is required by the two widget lists, but the material `ReorderableListView` will automatically wrap the child in a delayed listener for mobile and adds a default 'dragHandle' on top of each item by default on desktops. These can be turned off if you want to build your own.

While this doesn't address all the issues, hopefully it will be a good improvement on what is currently there and make it easier for you to build what you need. We can follow this up with more enhancements in the future.

### Updated Material `ReorderableListView`

![ReorderableListView](https://user-images.githubusercontent.com/19588/105544930-57162280-5cb0-11eb-9dee-9ed693cd4718.gif)

### `ReorderableList` with toggle for drag handles and refresh indicator

![ReorderableList](https://user-images.githubusercontent.com/19588/105546017-a872e180-5cb1-11eb-8393-12e2f16c0894.gif)

### A horizontal list with custom proxy decorator

![Horizontal](https://user-images.githubusercontent.com/19588/105545101-917fbf80-5cb0-11eb-84cb-8e4ac28f11a8.gif)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
