### PR TITLE
Rephrase null safety mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -67,7 +67,7 @@ abstract class BuildSubCommand extends FlutterCommand {
       globals.printStatus('💪 Building with sound null safety 💪', emphasis: true);
     } else {
       globals.printStatus(
-        'Building with unsound null safety',
+        'Building without sound null safety',
         emphasis: true,
       );
       globals.printStatus(

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -67,7 +67,7 @@ void main() {
     );
 
     FakeBuildSubCommand().test(unsound);
-    expect(testLogger.statusText, contains('Building with unsound null safety'));
+    expect(testLogger.statusText, contains('Building without sound null safety'));
 
     testLogger.clear();
     FakeBuildSubCommand().test(sound);


### PR DESCRIPTION
The new "compiling with unsound null safety" mode output was intended for the case where an app opts into null safety, but has a language version marker in the entry point opting that file out (thus resulting in unsoundness). However, we also show it for apps that don't opt into null safety at all (e.g. existing apps still on a Dart 2.9 constraint, but compiled with a 2.12 SDK). This is an artefact of how language versioning works; the entry point in both cases uses a version below 2.12.

Changing language versioning, or making more advanced heuristics, would be complicated at this point. I suggest we rather rework the message to work for both cases: "Building without sound null safety"

cc @jonahwilliams @leafpetersen WDYT?