### PR TITLE
TextFormField does not get blurred when tapped outside of the widget.

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -348,6 +348,7 @@ class TextField extends StatefulWidget {
     this.autofocus = false,
     this.obscuringCharacter = '•',
     this.obscureText = false,
+    this.forceSubmitOnFocusLost = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -531,6 +532,9 @@ class TextField extends StatefulWidget {
 
   /// {@macro flutter.widgets.editableText.obscureText}
   final bool obscureText;
+
+  /// {@macro flutter.widgets.editableText.forceSubmitOnFocusLost}
+  final bool forceSubmitOnFocusLost;
 
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
@@ -1190,6 +1194,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           autofocus: widget.autofocus,
           obscuringCharacter: widget.obscuringCharacter,
           obscureText: widget.obscureText,
+          forceSubmitOnFocusLost: widget.forceSubmitOnFocusLost,
           autocorrect: widget.autocorrect,
           smartDashesType: widget.smartDashesType,
           smartQuotesType: widget.smartQuotesType,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -348,6 +348,7 @@ class TextField extends StatefulWidget {
     this.autofocus = false,
     this.obscuringCharacter = '•',
     this.obscureText = false,
+    this.forceCloseConnectionOnBlur = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -531,6 +532,9 @@ class TextField extends StatefulWidget {
 
   /// {@macro flutter.widgets.editableText.obscureText}
   final bool obscureText;
+
+  /// {@macro flutter.widgets.editableText.forceCloseConnectionOnBlur}
+  final bool forceCloseConnectionOnBlur;
 
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
@@ -1190,6 +1194,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           autofocus: widget.autofocus,
           obscuringCharacter: widget.obscuringCharacter,
           obscureText: widget.obscureText,
+          forceCloseConnectionOnBlur: widget.forceCloseConnectionOnBlur,
           autocorrect: widget.autocorrect,
           smartDashesType: widget.smartDashesType,
           smartQuotesType: widget.smartQuotesType,

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -454,6 +454,7 @@ class TextInputConfiguration {
     this.inputType = TextInputType.text,
     this.readOnly = false,
     this.obscureText = false,
+    this.forceSubmitOnFocusLost = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -465,6 +466,7 @@ class TextInputConfiguration {
     this.autofillConfiguration,
   }) : assert(inputType != null),
        assert(obscureText != null),
+       assert(forceSubmitOnFocusLost != null),
        smartDashesType = smartDashesType ?? (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
        smartQuotesType = smartQuotesType ?? (obscureText ? SmartQuotesType.disabled : SmartQuotesType.enabled),
        assert(autocorrect != null),
@@ -485,6 +487,13 @@ class TextInputConfiguration {
   ///
   /// Defaults to false.
   final bool obscureText;
+
+  // In Flutter for Web, the onSubmitted callback is not triggered by default
+  // when the user clicks away from the TextField.
+  // If the user clicks on an area other than the input field itself, then
+  // force the input field to lose focus. The connection will close and the
+  // onSubmitted callback on the TextField will be invoked.
+  final bool forceSubmitOnFocusLost;
 
   /// Whether to enable autocorrection.
   ///
@@ -593,6 +602,7 @@ class TextInputConfiguration {
       'inputType': inputType.toJson(),
       'readOnly': readOnly,
       'obscureText': obscureText,
+      'forceSubmitOnFocusLost': forceSubmitOnFocusLost,
       'autocorrect': autocorrect,
       'smartDashesType': smartDashesType.index.toString(),
       'smartQuotesType': smartQuotesType.index.toString(),

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -454,6 +454,7 @@ class TextInputConfiguration {
     this.inputType = TextInputType.text,
     this.readOnly = false,
     this.obscureText = false,
+    this.forceCloseConnectionOnBlur = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -465,6 +466,7 @@ class TextInputConfiguration {
     this.autofillConfiguration,
   }) : assert(inputType != null),
        assert(obscureText != null),
+       assert(forceCloseConnectionOnBlur != null),
        smartDashesType = smartDashesType ?? (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
        smartQuotesType = smartQuotesType ?? (obscureText ? SmartQuotesType.disabled : SmartQuotesType.enabled),
        assert(autocorrect != null),
@@ -485,6 +487,22 @@ class TextInputConfiguration {
   ///
   /// Defaults to false.
   final bool obscureText;
+
+  /// Previously, Flutter for Web behaved like a web page. If user clicked on an
+  /// area other than the input field itself, the input field was blurred, thus
+  /// the connection was closed.
+  /// This behavior was changed for Desktop Browsers.
+  /// https://github.com/flutter/engine/pull/18743
+  ///
+  /// Now only, pressing enter or tab changes the focus of the input fields.
+  ///
+  /// This created a regression for applications that relied on the old behavior
+  /// https://github.com/flutter/flutter/issues/64245
+  ///
+  /// This flag provides a workaround to the regression allowing developers to
+  /// optionally force the connection to close on blur, as suggested in the comments
+  /// https://github.com/flutter/flutter/issues/64245#issuecomment-681815149
+  final bool forceCloseConnectionOnBlur;
 
   /// Whether to enable autocorrection.
   ///
@@ -593,6 +611,7 @@ class TextInputConfiguration {
       'inputType': inputType.toJson(),
       'readOnly': readOnly,
       'obscureText': obscureText,
+      'forceCloseConnectionOnBlur': forceCloseConnectionOnBlur,
       'autocorrect': autocorrect,
       'smartDashesType': smartDashesType.index.toString(),
       'smartQuotesType': smartQuotesType.index.toString(),

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -418,6 +418,7 @@ class EditableText extends StatefulWidget {
     this.readOnly = false,
     this.obscuringCharacter = '•',
     this.obscureText = false,
+    this.forceSubmitOnFocusLost = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -554,6 +555,9 @@ class EditableText extends StatefulWidget {
   /// Defaults to false. Cannot be null.
   /// {@endtemplate}
   final bool obscureText;
+
+  /// {@macro flutter.services.TextInputConfiguration.forceSubmitOnFocusLost}
+  final bool forceSubmitOnFocusLost;
 
   /// {@macro flutter.dart:ui.textHeightBehavior}
   final TextHeightBehavior? textHeightBehavior;
@@ -2514,6 +2518,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       inputType: widget.keyboardType,
       readOnly: widget.readOnly,
       obscureText: widget.obscureText,
+      forceSubmitOnFocusLost: widget.forceSubmitOnFocusLost,
       autocorrect: widget.autocorrect,
       smartDashesType: widget.smartDashesType,
       smartQuotesType: widget.smartQuotesType,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -418,6 +418,7 @@ class EditableText extends StatefulWidget {
     this.readOnly = false,
     this.obscuringCharacter = '•',
     this.obscureText = false,
+    this.forceCloseConnectionOnBlur = false,
     this.autocorrect = true,
     SmartDashesType? smartDashesType,
     SmartQuotesType? smartQuotesType,
@@ -554,6 +555,9 @@ class EditableText extends StatefulWidget {
   /// Defaults to false. Cannot be null.
   /// {@endtemplate}
   final bool obscureText;
+
+  /// {@macro flutter.services.TextInputConfiguration.forceCloseConnectionOnBlur}
+  final bool forceCloseConnectionOnBlur;
 
   /// {@macro flutter.dart:ui.textHeightBehavior}
   final TextHeightBehavior? textHeightBehavior;
@@ -2514,6 +2518,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       inputType: widget.keyboardType,
       readOnly: widget.readOnly,
       obscureText: widget.obscureText,
+      forceCloseConnectionOnBlur: widget.forceCloseConnectionOnBlur,
       autocorrect: widget.autocorrect,
       smartDashesType: widget.smartDashesType,
       smartQuotesType: widget.smartQuotesType,


### PR DESCRIPTION
This PR adds support the optional argument (forceSubmitOnFocusLost) to TextField. This is needed to complete work on https://github.com/flutter/engine/pull/22517. This PR was requested during review https://github.com/flutter/engine/pull/22517#pullrequestreview-571695229.

This fixes the following regression:
Fixes https://github.com/flutter/flutter/issues/64245

This fix was proposed in the comments of this issue here:
https://github.com/flutter/flutter/issues/64245#issuecomment-681815149

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
