### PR TITLE
[flutter_tools] make cold runner call attach in profile mode

### DIFF
--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2652,6 +2652,7 @@ void main() {
   testUsingContext('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
+      listViews,
     ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     setWsAddress(testUri, fakeVmServiceHost.vmService);


### PR DESCRIPTION
Currently ColdRunner.run and ColdRunner.attach duplicate some logic. This accomadates the fact that release mode applications never "attach", since there is no VM service.

This is a restructuring that moves the shared attach like logic into ColdRunner.attach, and conditionally has ColdRunner.run invoke ColdRunner.attach when run in profile mode. Tested manually that this continues to work as expected.

Surprisingly we don't attach the log readers in release mode, even though we definitely could. Some work would need to be done in the log reader to handle vm service being null. I could handle this in a follow up PR.