### PR TITLE
Skip flutter_immediately_exit_test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_immediately_exit_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_immediately_exit_test.dart
@@ -40,6 +40,6 @@ void main() {
         );
       }
     });
-  }, skip: platform.isWindows, // Flaky on Windows: https://github.com/flutter/flutter/issues/74052
+  }, skip: true, // Flaky: https://github.com/flutter/flutter/issues/74052
   );
 }


### PR DESCRIPTION
Also seen on Linux, skip on all platforms.  Maybe be unrelated to https://github.com/flutter/flutter/issues/74052, investigating...


https://github.com/flutter/flutter/pull/74055