### PR TITLE
manually close tree while devicelab staging is failing

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -123,6 +123,8 @@ Future<void> run(List<String> arguments) async {
   } finally {
     outDir.deleteSync(recursive: true);
   }
+  // TODO(fujino): https://github.com/flutter/flutter/issues/74431
+  exitWithError(<String>['Tree was manually closed for https://github.com/flutter/flutter/issues/74431']);
 }
 
 


### PR DESCRIPTION
Devicelab tests are failing in staging but not running in cocoon, thus not blocking tree. Manually red the tree until the test is fixed.