### PR TITLE
Manually close tree while devicelab staging is failing

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   await task(createHotModeTest(deviceIdOverride: 'macos'));
+
+  // TODO(fujino): https://github.com/flutter/flutter/issues/74431
+  throw TaskResult.failure(
+      'Tree was manually closed for Android version of this test https://github.com/flutter/flutter/issues/74431');
 }


### PR DESCRIPTION
Devicelab tests are failing in staging but not running in cocoon, thus not blocking tree. Manually red the tree until the test is fixed https://github.com/flutter/flutter/issues/74431

Post-submit test failure to not fail PR tests https://github.com/flutter/flutter/pull/74433.