### PR TITLE
Revert "Manually close tree while devicelab staging is failing (#74434)"

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -2,14 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   await task(createHotModeTest(deviceIdOverride: 'macos'));
-
-  // TODO(fujino): https://github.com/flutter/flutter/issues/74431
-  throw TaskResult.failure(
-      'Tree was manually closed for Android version of this test https://github.com/flutter/flutter/issues/74431');
 }


### PR DESCRIPTION
This reverts commit 444c954f439bb5dce0e9c130c7a37a424ccb5927.

Should NOT be landed until the framework `prod_builders.json` file has been updated with the mac/android devicelab tasks.

part of (but does not alone fix) https://github.com/flutter/flutter/issues/74431