### PR TITLE
Block the tree on  mac_android test failures running on luci.

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -460,7 +460,7 @@
          "name": "Mac_android android_semantics_integration_test",
          "repo": "flutter",
          "task_name": "mac_android_android_semantics_integration_test",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Mac_android backdrop_filter_perf__timeline_summary",
@@ -586,7 +586,7 @@
          "name": "Mac_android hot_mode_dev_cycle__benchmark",
          "repo": "flutter",
          "task_name": "mac_android_hot_mode_dev_cycle__benchmark",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Mac_android hybrid_android_views_integration_test",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -451,6 +451,240 @@
          "flaky": false
       },
       {
+         "name": "Mac_android android_plugin_example_app_build_test",
+         "repo": "flutter",
+         "task_name": "mac_android_android_plugin_example_app_build_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android android_semantics_integration_test",
+         "repo": "flutter",
+         "task_name": "mac_android_android_semantics_integration_test",
+         "flaky": true
+      },
+      {
+         "name": "Mac_android backdrop_filter_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_backdrop_filter_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android channels_integration_test",
+         "repo": "flutter",
+         "task_name": "mac_android_channels_integration_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android color_filter_and_fade_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_color_filter_and_fade_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android complex_layout__start_up",
+         "repo": "flutter",
+         "task_name": "mac_android_complex_layout__start_up",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android complex_layout_scroll_perf__memory",
+         "repo": "flutter",
+         "task_name": "mac_android_complex_layout_scroll_perf__memory",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android complex_layout_scroll_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_complex_layout_scroll_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android cubic_bezier_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_cubic_bezier_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_cubic_bezier_perf_sksl_warmup__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android cull_opacity_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_cull_opacity_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android drive_perf_debug_warning",
+         "repo": "flutter",
+         "task_name": "mac_android_drive_perf_debug_warning",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android embedded_android_views_integration_test",
+         "repo": "flutter",
+         "task_name": "mac_android_embedded_android_views_integration_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android external_ui_integration_test",
+         "repo": "flutter",
+         "task_name": "mac_android_external_ui_integration_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android fading_child_animation_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_fading_child_animation_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android fast_scroll_large_images__memory",
+         "repo": "flutter",
+         "task_name": "mac_android_fast_scroll_large_images__memory",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android flavors_test",
+         "repo": "flutter",
+         "task_name": "mac_android_flavors_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android flutter_view__start_up",
+         "repo": "flutter",
+         "task_name": "mac_android_flutter_view__start_up",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android fullscreen_textfield_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_fullscreen_textfield_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android hello_world__memory",
+         "repo": "flutter",
+         "task_name": "mac_android_hello_world__memory",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android hello_world_android__compile",
+         "repo": "flutter",
+         "task_name": "mac_android_hello_world_android__compile",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android home_scroll_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_home_scroll_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android hot_mode_dev_cycle__benchmark",
+         "repo": "flutter",
+         "task_name": "mac_android_hot_mode_dev_cycle__benchmark",
+         "flaky": true
+      },
+      {
+         "name": "Mac_android hybrid_android_views_integration_test",
+         "repo": "flutter",
+         "task_name": "mac_android_hybrid_android_views_integration_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android imagefiltered_transform_animation_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_imagefiltered_transform_animation_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android integration_ui_driver",
+         "repo": "flutter",
+         "task_name": "mac_android_integration_ui_driver",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android integration_ui_keyboard_resize",
+         "repo": "flutter",
+         "task_name": "mac_android_integration_ui_keyboard_resize",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android integration_ui_screenshot",
+         "repo": "flutter",
+         "task_name": "mac_android_integration_ui_screenshot",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android integration_ui_textfield",
+         "repo": "flutter",
+         "task_name": "mac_android_integration_ui_textfield",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android microbenchmarks",
+         "repo": "flutter",
+         "task_name": "mac_android_microbenchmarks",
+         "flaky": true
+      },
+      {
+         "name": "Mac_android new_gallery__transition_perf",
+         "repo": "flutter",
+         "task_name": "mac_android_new_gallery__transition_perf",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android picture_cache_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_picture_cache_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android platform_channel_sample_test",
+         "repo": "flutter",
+         "task_name": "mac_android_platform_channel_sample_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android platform_interaction_test",
+         "repo": "flutter",
+         "task_name": "mac_android_platform_interaction_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android platform_view__start_up",
+         "repo": "flutter",
+         "task_name": "mac_android_platform_view__start_up",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android run_release_test",
+         "repo": "flutter",
+         "task_name": "mac_android_run_release_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android service_extensions_test",
+         "repo": "flutter",
+         "task_name": "mac_android_service_extensions_test",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android textfield_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_textfield_perf__timeline_summary",
+         "flaky": false
+      },
+      {
+         "name": "Mac_android tiles_scroll_perf__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_android_tiles_scroll_perf__timeline_summary",
+         "flaky": false
+      },
+      {
          "name": "Mac build_ios_framework_module_test",
          "repo": "flutter",
          "task_name": "mac_build_ios_framework_module_test",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -628,7 +628,7 @@
          "name": "Mac_android microbenchmarks",
          "repo": "flutter",
          "task_name": "mac_android_microbenchmarks",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Mac_android new_gallery__transition_perf",


### PR DESCRIPTION
Start blocking the tree on LUCI mac android failures. Mac android tests will now run exclusively on LUCI.

Bug: https://github.com/flutter/flutter/issues/74431

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
