### PR TITLE
Don't leak exceptions thrown by message channels

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -104,10 +104,10 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
   Future<ByteData?>? send(String channel, ByteData? message) {
     final Future<ByteData?>? resultFuture = delegate.send(channel, message);
     if (resultFuture != null) {
-      // Removes the future itself from the [_pendingMessages] list when it
-      // completes.
       _pendingMessages.add(resultFuture);
-      resultFuture.whenComplete(() => _pendingMessages.remove(resultFuture));
+      resultFuture
+        .catchError((Object error) { /* errors are the responsibility of the caller */ })
+        .whenComplete(() => _pendingMessages.remove(resultFuture));
     }
     return resultFuture;
   }

--- a/packages/flutter_test/test/test_default_binary_messenger_test.dart
+++ b/packages/flutter_test/test/test_default_binary_messenger_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestDelegate extends BinaryMessenger {
+  @override
+  Future<ByteData?>? send(String channel, ByteData? message) async {
+    expect(channel, '');
+    expect(message, isNull);
+    throw 'Vic Fontaine';
+  }
+
+  // Rest of the API isn't needed for this test.
+  @override
+  Future<void> handlePlatformMessage(String channel, ByteData? data, ui.PlatformMessageResponseCallback? callback) => throw UnimplementedError();
+  @override
+  void setMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
+  @override
+  bool checkMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
+  @override
+  void setMockMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
+  @override
+  bool checkMockMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('Caught exceptions are caught by the test framework', (WidgetTester tester) async {
+    final BinaryMessenger delegate = TestDelegate();
+    final Future<ByteData?>? future = delegate.send('', null);
+    expect(future, isNotNull);
+    await future!.catchError((Object error) { });
+    try {
+      await TestDefaultBinaryMessenger(delegate).send('', null);
+      expect(true, isFalse); // should not reach here
+    } catch (error) {
+      expect(error, 'Vic Fontaine');
+    }
+  });
+}


### PR DESCRIPTION
The test framework previously made it impossible to actually catch all exceptions from the message channels system, because it "forked" the future chain and didn't catch exceptions on its end of the fork. This catches the exceptions on the forked branch. Originally I tried flattening the chain but that causes Zone issues in some tests with FakeAsync.

This unblocks https://github.com/flutter/packages/pull/265 which, somehow, I don't even remember how, is part of the yak shave to fixing https://github.com/flutter/flutter/issues/64830.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
