### PR TITLE
Remove workaround now that type promotion accounts for local boolean variables.

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -982,16 +982,6 @@ class ScrollAction extends Action<ScrollIntent> {
     final bool contextIsValid = focus != null && focus.context != null;
     if (contextIsValid) {
       // Check for primary scrollable within the current context
-      // After https://github.com/dart-lang/language/issues/1274 is implemented,
-      // `focus` will be promoted to non-nullable so we won't need to null check
-      // it (and it will cause a build failure to try to do so).  Until then, we
-      // need to null check it in a way that won't cause a build failure once
-      // the feature is implemented.  We can do that using an explicit "if"
-      // test.
-      // TODO(paulberry): remove this hack once the feature is implemented.
-      if (focus == null) { // ignore: dead_code
-        throw 'This throw is unreachable';
-      }
       if (Scrollable.of(focus.context!) != null)
         return true;
       // Check for fallback scrollable with context from PrimaryScrollController


### PR DESCRIPTION
This change removes a workaround that was introduced prior to landing
Dart language feature
https://github.com/dart-lang/language/issues/1274, which allows type
promotion in null safe code to account for local boolean variables.
The workaround ensured that the code would analyze the same regardless
of whether the feature was enabled, allowing for a smoother
transition.  Now that the feature has fully landed, the workaround
isn't needed anymore.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
