### PR TITLE
[flutter_tools] provide correct sources and metadata for different base hrefs

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -552,6 +552,7 @@ class WebAssetServer implements AssetReader {
 
   @override
   Future<String> dartSourceContents(String serverPath) async {
+    serverPath = _stripBasePath(serverPath, basePath);
     final File result = _resolveDartFile(serverPath);
     if (result.existsSync()) {
       return result.readAsString();
@@ -561,18 +562,20 @@ class WebAssetServer implements AssetReader {
 
   @override
   Future<String> sourceMapContents(String serverPath) async {
+    serverPath = _stripBasePath(serverPath, basePath);
     return utf8.decode(_webMemoryFS.sourcemaps[serverPath]);
   }
 
   @override
   Future<String> metadataContents(String serverPath) async {
+    serverPath = _stripBasePath(serverPath, basePath);
     if (serverPath == 'main_module.ddc_merged_metadata') {
       return _webMemoryFS.mergedMetadata;
     }
     if (_webMemoryFS.metadataFiles.containsKey(serverPath)) {
       return utf8.decode(_webMemoryFS.metadataFiles[serverPath]);
     }
-    return null;
+    throw Exception('Could not find metadata contents for $serverPath');
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -1003,6 +1003,27 @@ void main() {
     expect(response.statusCode, 404);
   }));
 
+  test('WebAssetServer strips leading base href off off asset requests', () => testbed.run(() async {
+    const String htmlContent = '<html><head><base href="/foo/"></head><body id="test"></body></html>';
+    globals.fs.currentDirectory
+      .childDirectory('web')
+      .childFile('index.html')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(htmlContent);
+    final WebAssetServer webAssetServer = WebAssetServer(
+      MockHttpServer(),
+      PackageConfig.empty,
+      InternetAddress.anyIPv4,
+      <String, String>{},
+      <String, String>{},
+      NullSafetyMode.sound,
+    );
+
+    expect(await webAssetServer.metadataContents('foo/main_module.ddc_merged_metadata'), null);
+    // Not base href.
+    expect(() async  => await webAssetServer.metadataContents('bar/main_module.ddc_merged_metadata'), throwsException);
+  }));
+
   test('DevFS URI includes any specified base path.', () => testbed.run(() async {
     final File outputFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
       ..createSync(recursive: true);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/69964

When the base href is not `/`, dwds forwards requests for these resources with the base href attached, for example `foo/sources`. The tool needs to remove the leading href similar to the other resource handlers