### PR TITLE
[integration_test] fix zip command

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -226,7 +226,7 @@ Execute this script at the root of your Flutter app:
 
 ```sh
 output="../build/ios_integ"
-product="$output/Build/Products"
+product="build/ios_integ/Build/Products"
 dev_target="14.3"
 
 # Pass --simulator if building for the simulator.
@@ -234,7 +234,10 @@ flutter build ios integration_test/foo_test.dart -release
 
 pushd ios
 xcodebuild -workspace Runner.xcworkspace -scheme Runner -config Flutter/Release.xcconfig -derivedDataPath $output -sdk iphoneos build-for-testing
-zip -r "$output/ios_tests.zip" "$product/Release-iphoneos" "$product/Runner_iphoneos$dev_target-arm64.xctestrun"
+popd
+
+pushd $product
+zip -r "ios_tests.zip" "Release-iphoneos" "Runner_iphoneos$dev_target-arm64.xctestrun"
 popd
 ```
 


### PR DESCRIPTION
The zip command previously added, was not accepted by Firebase Test Lab.
This patch fixes it.

I didn't created an issue for this, but I can if this really necessary.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
