### PR TITLE
Expose clipBehavior in simple dialog

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -736,9 +736,11 @@ class SimpleDialog extends StatelessWidget {
     this.backgroundColor,
     this.elevation,
     this.semanticLabel,
+    this.clipBehavior = Clip.none,
     this.shape,
   }) : assert(titlePadding != null),
        assert(contentPadding != null),
+       assert(clipBehavior != null),
        super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
@@ -803,6 +805,9 @@ class SimpleDialog extends StatelessWidget {
   ///  * [SemanticsConfiguration.namesRoute], for a description of how this
   ///    value is used.
   final String? semanticLabel;
+
+  /// {@macro flutter.material.dialog.clipBehavior}
+  final Clip clipBehavior;
 
   /// {@macro flutter.material.dialog.shape}
   final ShapeBorder? shape;
@@ -890,6 +895,7 @@ class SimpleDialog extends StatelessWidget {
     return Dialog(
       backgroundColor: backgroundColor,
       elevation: elevation,
+      clipBehavior: clipBehavior,
       shape: shape,
       child: dialogChild,
     );

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -172,6 +172,24 @@ void main() {
     expect(materialWidget.clipBehavior, Clip.antiAlias);
   });
 
+   testWidgets('Custom simpleDialog clipBehavior', (WidgetTester tester) async {
+    const SimpleDialog dialog = SimpleDialog(
+      title: Text('Simple Dialog'),
+      clipBehavior: Clip.antiAlias,
+    );
+    await tester.pumpWidget(_buildAppWithDialog(dialog));
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Material materialWidget = tester.widget<Material>(
+      find.descendant(of: find.byType(SimpleDialog),
+      matching: find.byType(Material),
+      ),
+    );
+    expect(materialWidget.clipBehavior, Clip.antiAlias);
+  });
+
   testWidgets('Custom dialog shape', (WidgetTester tester) async {
     const RoundedRectangleBorder customBorder =
       RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));


### PR DESCRIPTION
## Description

* Modified
	- adding ```clipBehavior``` property to the ```simpleDialog```. 
* Earlier
	- There is no way to customize ```clipBehavior```.

## Related PR:

Earlier this /pull/50775 having modifications related to ```clipBehavior``` of Alert Dialog has been merged.

## Issue
fixes #74414

## Tests
I added tests to the dialog_test.dart that tests clipBehaviour properties. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
