### PR TITLE
[flutter_tools] ensure unstable compiler features are not available on stable

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -306,7 +306,7 @@ const Feature singleWidgetReload = Feature(
     enabledByDefault: false,
   ),
   stable: FeatureChannelSetting(
-    available: true,
+    available: false,
     enabledByDefault: false,
   ),
 );
@@ -329,7 +329,7 @@ const Feature experimentalInvalidationStrategy = Feature(
     enabledByDefault: false,
   ),
   stable: FeatureChannelSetting(
-    available: true,
+    available: false,
     enabledByDefault: false,
   ),
 );


### PR DESCRIPTION
We haven't advertised these, but there are still some known issues floating around - so ensure they cannot be enabled on stable.