### PR TITLE
Fail ColdRunner.attach() eagerly when device connection fails

### DIFF
--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -152,7 +152,7 @@ class ColdRunner extends ResidentRunner {
         serveDevToolsGracefully(
           devToolsServerAddress: debuggingOptions.devToolsServerAddress,
         ),
-      ]);
+      ], eagerError: true);
     } on Exception catch (error) {
       globals.printError('Error connecting to the service protocol: $error');
       return 2;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/74542

`connectToServiceProtocol` fails immediately, but `serveDevToolsGracefully` then takes 2+ seconds to fail.

https://github.com/flutter/flutter/blob/b45088c0cf343c3e325d71072c59c375e603cc7b/packages/flutter_tools/lib/src/run_cold.dart#L76-L83

`test/general.shard/cold_test.dart: Exits with code 2 when when HttpException is thrown during VM service connection` went from 3 seconds to 100ms.

Found with https://github.com/flutter/flutter/pull/74531