### PR TITLE
Allow tests to override _DevFSHttpWriter._startWrite throttle time

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -228,15 +228,18 @@ class _DevFSHttpWriter implements DevFSWriter {
     @required OperatingSystemUtils osUtils,
     @required HttpClient httpClient,
     @required Logger logger,
+    Duration uploadRetryThrottle,
   })
     : httpAddress = serviceProtocol.httpAddress,
       _client = httpClient,
       _osUtils = osUtils,
+      _uploadRetryThrottle = uploadRetryThrottle,
       _logger = logger;
 
   final HttpClient _client;
   final OperatingSystemUtils _osUtils;
   final Logger _logger;
+  final Duration _uploadRetryThrottle;
 
   final String fsName;
   final Uri httpAddress;
@@ -320,7 +323,7 @@ class _DevFSHttpWriter implements DevFSWriter {
           if (retry > 0) {
             retry--;
             _logger.printTrace('trying again in a few - $retry more attempts left');
-            await Future<void>.delayed(const Duration(milliseconds: 500));
+            await Future<void>.delayed(_uploadRetryThrottle ?? const Duration(milliseconds: 500));
             continue;
           }
           _completer.completeError(error, trace);
@@ -364,6 +367,8 @@ class UpdateFSReport {
 
 class DevFS {
   /// Create a [DevFS] named [fsName] for the local files in [rootDirectory].
+  ///
+  /// Failed uploads are retried after [uploadRetryThrottle] duration, defaults to 500ms.
   DevFS(
     vm_service.VmService serviceProtocol,
     this.fsName,
@@ -372,6 +377,7 @@ class DevFS {
     @required Logger logger,
     @required FileSystem fileSystem,
     HttpClient httpClient,
+    Duration uploadRetryThrottle,
   }) : _vmService = serviceProtocol,
        _logger = logger,
        _fileSystem = fileSystem,
@@ -380,6 +386,7 @@ class DevFS {
         serviceProtocol,
         osUtils: osUtils,
         logger: logger,
+        uploadRetryThrottle: uploadRetryThrottle,
         httpClient: httpClient ?? ((context.get<HttpClientFactory>() == null)
           ? HttpClient()
           : context.get<HttpClientFactory>()())

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -138,6 +138,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       httpClient: httpClient,
+      uploadRetryThrottle: Duration.zero,
     );
     await devFS.create();
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/74544

`test/general.shard/devfs_test.dart: DevFS retries uploads when connection reset by peer` does from 3 seconds to 60ms

Found with https://github.com/flutter/flutter/pull/74531