### PR TITLE
ChoiceChip's default "selected" style in dark mode theme is unreadabl…

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -416,7 +416,7 @@ class ThemeData with Diagnosticable {
     bottomAppBarTheme ??= const BottomAppBarTheme();
     cardTheme ??= const CardTheme();
     chipTheme ??= ChipThemeData.fromDefaults(
-      secondaryColor: primaryColor,
+      secondaryColor: isDark ? Colors.tealAccent[200]! : primaryColor,
       brightness: colorScheme.brightness,
       labelStyle: textTheme.bodyText1!,
     );

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -61,7 +61,21 @@ void main() {
 
     expect(chipTheme.backgroundColor, equals(Colors.black.withAlpha(0x1f)));
     expect(chipTheme.selectedColor, equals(Colors.black.withAlpha(0x3d)));
+    expect(chipTheme.secondarySelectedColor, equals(Colors.red.withAlpha(0x3d)));
     expect(chipTheme.deleteIconColor, equals(Colors.black.withAlpha(0xde)));
+  });
+
+  testWidgets('Chip theme is built by ThemeData with dark mode enabled', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      platform: TargetPlatform.android,
+      brightness: Brightness.dark,
+    );
+    final ChipThemeData chipTheme = theme.chipTheme;
+
+    expect(chipTheme.backgroundColor, equals(Colors.white.withAlpha(0x1f)));
+    expect(chipTheme.selectedColor, equals(Colors.white.withAlpha(0x3d)));
+    expect(chipTheme.secondarySelectedColor, equals(Colors.tealAccent[200]!.withAlpha(0x3d)));
+    expect(chipTheme.deleteIconColor, equals(Colors.white.withAlpha(0xde)));
   });
 
   testWidgets('Chip uses ThemeData chip theme if present', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #49984

During the `ChipThemeData.fromDefaults()` creation the `secondaryColor`, which is used for the `secondarySelectedColor` and the `secondaryLabelStyle`, is now adjusted if dark mode is selected. I used the same fallback logic as already applied to the `toggleableActiveColor`. https://github.com/flutter/flutter/blob/8f1c648d79b4d9eec82961aae285bc086eff803c/packages/flutter/lib/src/material/theme_data.dart#L323
This should adhere to the Material guide lines (https://material.io/design/interaction/states.html#activated). The following test app was used to test the behavior.

```
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        brightness: Brightness.light,
      ),
      darkTheme: ThemeData(
        brightness: Brightness.dark,
      ),
      themeMode: ThemeMode.dark,
      home: Scaffold(
        body: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            crossAxisAlignment: CrossAxisAlignment.center,
            children: <Widget>[
              ChoiceChip(
                label: const Text('Selected'),
                selected: true,
                onSelected: (bool selected) { },
              ),
              ChoiceChip(
                label: const Text('Idle'),
                selected: false,
                onSelected: (bool selected) { },
              ),
              ChoiceChip(
                label: const Text('Disabled'),
                selected: false,
              ),
              Switch(value: false, onChanged: (value) => false),
              Switch(value: true, onChanged: (value) => true)
            ],
          ),
        ),
      ),
    );
  }
}
```

This results in the following UI:

Light theme:
![Screenshot_1611558157](https://user-images.githubusercontent.com/7944013/105671946-dccde400-5ee3-11eb-91e8-ea3577c56ade.png)

Dark theme:
![Screenshot_1611558138](https://user-images.githubusercontent.com/7944013/105671951-df303e00-5ee3-11eb-9f01-3214334fad3a.png)


Fixes:
- https://github.com/flutter/flutter/issues/49984

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`). **(No changes required)**
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
