### PR TITLE
Remove vestigial nullOk parameter from Localizations.localeOf

### DIFF
--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -387,7 +387,7 @@ class Localizations extends StatefulWidget {
       mergedDelegates.insertAll(0, delegates);
     return Localizations(
       key: key,
-      locale: locale ?? Localizations.localeOf(context)!,
+      locale: locale ?? Localizations.localeOf(context),
       delegates: mergedDelegates,
       child: child,
     );
@@ -409,13 +409,10 @@ class Localizations extends StatefulWidget {
   /// corresponds to [BuildContext] `context`.
   ///
   /// If no [Localizations] widget is in scope then the [Localizations.localeOf]
-  /// method will throw an exception, unless the `nullOk` argument is set to
-  /// true, in which case it returns null.
-  static Locale? localeOf(BuildContext context, { bool nullOk = false }) {
+  /// method will throw an exception.
+  static Locale localeOf(BuildContext context) {
     assert(context != null);
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();
-    if (nullOk && scope == null)
-      return null;
     assert(() {
       if (scope == null) {
         throw FlutterError(
@@ -424,21 +421,21 @@ class Localizations extends StatefulWidget {
           'be that of a widget that is a descendant of a Localizations widget.'
         );
       }
-      if (!nullOk && scope.localizationsState.locale == null) {
+      if (scope.localizationsState.locale == null) {
         throw FlutterError(
           'Localizations.localeOf found a Localizations widget that had a unexpected null locale.\n'
         );
       }
       return true;
     }());
-    return scope!.localizationsState.locale;
+    return scope!.localizationsState.locale!;
   }
 
   /// The locale of the Localizations widget for the widget tree that
   /// corresponds to [BuildContext] `context`.
   ///
   /// If no [Localizations] widget is in scope then this function will return
-  /// null. Equivalent to calling [localeOf] with `nullOk` set to true.
+  /// null.
   static Locale? maybeLocaleOf(BuildContext context) {
     assert(context != null);
     final _LocalizationsScope? scope = context.dependOnInheritedWidgetOfExactType<_LocalizationsScope>();

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -575,7 +575,7 @@ void main() {
             context: context,
             child: Builder(
               builder: (BuildContext context) {
-                final Locale locale = Localizations.localeOf(context)!;
+                final Locale locale = Localizations.localeOf(context);
                 final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
                 return Text('$locale $direction');
               },
@@ -616,7 +616,7 @@ void main() {
             ],
             child: Builder(
               builder: (BuildContext context) {
-                final Locale locale = Localizations.localeOf(context)!;
+                final Locale locale = Localizations.localeOf(context);
                 final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
                 return Text('$locale $direction');
               },
@@ -652,7 +652,7 @@ void main() {
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           final TextDirection direction = WidgetsLocalizations.of(context).textDirection;
           return Text('$locale $direction');
         },
@@ -760,7 +760,7 @@ void main() {
           Locale('ja'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -783,7 +783,7 @@ void main() {
           Locale('zh', 'TW'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -815,7 +815,7 @@ void main() {
           Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -956,7 +956,7 @@ void main() {
           Locale.fromSubtags(languageCode: 'zh'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1096,7 +1096,7 @@ void main() {
           Locale('it', 'IT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1119,7 +1119,7 @@ void main() {
           Locale('it', 'IT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1152,7 +1152,7 @@ void main() {
           Locale('pt', 'PT'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1219,7 +1219,7 @@ void main() {
           Locale('de', 'DE'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1283,7 +1283,7 @@ void main() {
           Locale('vi'),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )
@@ -1435,7 +1435,7 @@ void main() {
           return const Locale('en', 'US');
         },
         buildContent: (BuildContext context) {
-          final Locale locale = Localizations.localeOf(context)!;
+          final Locale locale = Localizations.localeOf(context);
           return Text('$locale');
         },
       )


### PR DESCRIPTION
## Description

This removes the `nullOk` parameter on the `Localizations.localeOf` method. This was already changed to have a `maybeLocaleOf` method, but the `nullOk` parameter wasn't removed because some third party tests failed. Those have been updated, so this can go in now.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/68637

## Tests

- Updated the widgets_test

## Breaking Change

- [X] Yes, this is a breaking change that will require a migration guide.
  - [X] I wrote a [design doc](https://flutter.dev/go/eliminating-nullok-parameters)
   - [X] I submitted it for input from the developer relations team, specifically from: @RedBrogdon
   - [X] I wrote a migration guide: In https://github.com/flutter/website/pull/4921