### PR TITLE
Handle 'Existing VM service clients' error from old VM service instances

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -72,14 +72,17 @@ class DartDevelopmentService {
             e.message.split(' ').firstWhere((String e) => e.startsWith('http'))
           );
         } on StateError {
+          if (e.message.contains('Existing VM service clients prevent DDS from taking control.')) {
+            throwToolExit('${e.message}. Please rebuild your application with a newer version of Flutter.');
+            return;
+          }
           logger.printError(
             'DDS has failed to start and there is not an existing DDS instance '
-            'available to connect to. Please comment on '
-            'https://github.com/flutter/flutter/issues/72385 with output from '
-            '"flutter doctor -v" and the following error message:\n\n ${e.message}.'
+            'available to connect to. Please file an issue at https://github.com/flutter/flutter/issues '
+            'with the following error message:\n\n ${e.message}.'
           );
-          // Wrap the DDS error message in a StateError so it can be collected
-          // by the crash handler.
+          // DDS was unable to start for an unknown reason. Raise a StateError
+          // so it can be reported by the crash reporter.
           throw StateError(e.message);
         }
       }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -275,6 +275,9 @@ class FlutterDevice {
             existingDds = true;
           }
         } on Exception catch (e, st) {
+          if (e is ToolExit) {
+            rethrow;
+          }
           handleError(e, st);
           return;
         }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -274,10 +274,9 @@ class FlutterDevice {
           } else {
             existingDds = true;
           }
+        } on ToolExit {
+          rethrow;
         } on Exception catch (e, st) {
-          if (e is ToolExit) {
-            rethrow;
-          }
           handleError(e, st);
           return;
         }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2860,6 +2860,47 @@ void main() {
     }) async => mockVMService,
   }));
 
+  testUsingContext('Handle existing VM service clients DDS error', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final MockDevice mockDevice = MockDevice();
+    when(mockDevice.dds).thenReturn(DartDevelopmentService(logger: testLogger));
+    ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) {
+      throw FakeDartDevelopmentServiceException(message:
+        'Existing VM service clients prevent DDS from taking control.',
+      );
+    };
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      mockDevice,
+      observatoryUris: Stream<Uri>.value(testUri),
+    );
+    bool caught = false;
+    final Completer<void>done = Completer<void>();
+    runZonedGuarded(() {
+      flutterDevice.connect(allowExistingDdsInstance: true).then((_) => done.complete());
+    }, (Object e, StackTrace st) {
+      expect(e is ToolExit, true);
+      expect((e as ToolExit).message,
+        contains('Existing VM service clients prevent DDS from taking control.',
+      ));
+      done.complete();
+      caught = true;
+    });
+    await done.future;
+    if (!caught) {
+      fail('Expected ToolExit to be thrown.');
+    }
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources reloadSources,
+      Restart restart,
+      CompileExpression compileExpression,
+      GetSkSLMethod getSkSLMethod,
+      PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
+      io.CompressionOptions compression,
+      Device device,
+    }) async => mockVMService,
+  }));
+
   testUsingContext('Failed DDS start outputs error message', () => testbed.run(() async {
     // See https://github.com/flutter/flutter/issues/72385 for context.
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);


### PR DESCRIPTION
`flutter attach` can still result in a `Existing VM service clients prevent DDS from taking control` if the target application is running an older version of the VM service. This change handles this case so the tool can exit gracefully instead of spamming the crash reporter.