### PR TITLE
[flutter_tools] check if process manager can find adb

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -64,7 +64,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
-    if (_androidSdk == null || _androidSdk.adbPath == null) {
+    if (_doesNotHaveAdb()) {
       return <AndroidDevice>[];
     }
     String text;
@@ -88,7 +88,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async {
-    if (_androidSdk == null || _androidSdk.adbPath == null) {
+    if (_doesNotHaveAdb()) {
       return <String>[];
     }
 
@@ -102,6 +102,12 @@ class AndroidDevices extends PollingDeviceDiscovery {
       diagnostics: diagnostics,
     );
     return diagnostics;
+  }
+
+  bool _doesNotHaveAdb() {
+    return _androidSdk == null ||
+      _androidSdk.adbPath == null ||
+      !_processManager.canRun(_androidSdk.adbPath);
   }
 
   // 015d172c98400a03       device usb:340787200X product:nakasi model:Nexus_7 device:grouper

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -44,6 +44,25 @@ void main() {
     expect(await androidDevices.getDiagnostics(), isEmpty);
   });
 
+  testWithoutContext('AndroidDevices returns empty device list and diagnostics when adb cannot be run', () async {
+    final AndroidDevices androidDevices = AndroidDevices(
+      androidSdk: FakeAndroidSdk(null),
+      logger: BufferLogger.test(),
+      androidWorkflow: AndroidWorkflow(
+        androidSdk: FakeAndroidSdk('adb'),
+        featureFlags: TestFeatureFlags(),
+      ),
+      // Will throw an exception if anything other than canRun is invoked
+      processManager: FakeProcessManger(),
+      fileSystem: MemoryFileSystem.test(),
+      platform: FakePlatform(),
+      userMessages: UserMessages(),
+    );
+
+    expect(await androidDevices.pollingGetDevices(), isEmpty);
+    expect(await androidDevices.getDiagnostics(), isEmpty);
+  });
+
   testWithoutContext('AndroidDevices returns empty device list and diagnostics on null Android SDK', () async {
     final AndroidDevices androidDevices = AndroidDevices(
       androidSdk: null,
@@ -217,4 +236,11 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 
   @override
   final String adbPath;
+}
+
+class FakeProcessManger extends Fake implements ProcessManager {
+  @override
+  bool canRun(dynamic executable, {String workingDirectory}) {
+    return false;
+  }
 }


### PR DESCRIPTION
While the Android SDK checks if the adb executable is present, this is not the same logic as what the ProcessManager class does to look up the executable. In some cases, the AndroidSDK can find the executable while the ProcessManager fails to locate it.

Pending a longer term fix of package:process resolution, don't invoke adb unless the ProcessManager can locate the executable.