### PR TITLE
Remove nullOk from Actions.invoke, add Actions.maybeInvoke

### DIFF
--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -150,6 +150,84 @@ void main() {
       expect(result, isTrue);
       expect(invoked, isTrue);
     });
+    testWidgets('Actions widget can invoke actions with default dispatcher and maybeInvoke', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      bool invoked = false;
+
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{
+            TestIntent: TestAction(
+              onInvoke: (Intent intent) {
+                invoked = true;
+                return invoked;
+              },
+            ),
+          },
+          child: Container(key: containerKey),
+        ),
+      );
+
+      await tester.pump();
+      final Object? result = Actions.maybeInvoke(
+        containerKey.currentContext!,
+        const TestIntent(),
+      );
+      expect(result, isTrue);
+      expect(invoked, isTrue);
+    });
+    testWidgets('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      bool invoked = false;
+
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{
+            TestIntent: TestAction(
+              onInvoke: (Intent intent) {
+                invoked = true;
+                return invoked;
+              },
+            ),
+          },
+          child: Container(key: containerKey),
+        ),
+      );
+
+      await tester.pump();
+      final Object? result = Actions.maybeInvoke(
+        containerKey.currentContext!,
+        DoNothingIntent(),
+      );
+      expect(result, isNull);
+      expect(invoked, isFalse);
+    });
+    testWidgets('invoke throws when no action is found', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      bool invoked = false;
+
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{
+            TestIntent: TestAction(
+              onInvoke: (Intent intent) {
+                invoked = true;
+                return invoked;
+              },
+            ),
+          },
+          child: Container(key: containerKey),
+        ),
+      );
+
+      await tester.pump();
+      final Object? result = Actions.maybeInvoke(
+        containerKey.currentContext!,
+        DoNothingIntent(),
+      );
+      expect(result, isNull);
+      expect(invoked, isFalse);
+    });
     testWidgets('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;


### PR DESCRIPTION
## Description

This removes the `nullOk` parameter from `Actions.invoke`, and adds an `Actions.maybeInvoke` function. The difference is that invoke will now always (in debug mode) throw if an enabled action isn't found, and `maybeInvoke` will return null if an enabled action isn't found.  The `invoke` function can still return null as the result of the invocation, though, so I purposely didn't change the return value to `Object` from `Object?`.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/68637

## Tests

- Added tests for `maybeInvoke`, updated `invoke` tests.

## Breaking Change

- [X] Yes, this is a breaking change that will require a migration guide.
  - [X] I wrote a [design doc](https://flutter.dev/go/eliminating-nullok-parameters)
  - [X] I submitted it for input from the developer relations team, specifically from: @RedBrogdon
  - [X] I wrote a migration guide: In https://github.com/flutter/website/pull/4921