### PR TITLE
Swap the Shortcuts widget with its child in TextField

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1290,12 +1290,12 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       semanticsMaxValueLength = null;
     }
 
-    return Shortcuts(
-      shortcuts: scrollShortcutOverrides,
-      child: MouseRegion(
-        cursor: effectiveMouseCursor,
-        onEnter: (PointerEnterEvent event) => _handleHover(true),
-        onExit: (PointerExitEvent event) => _handleHover(false),
+    return MouseRegion(
+      cursor: effectiveMouseCursor,
+      onEnter: (PointerEnterEvent event) => _handleHover(true),
+      onExit: (PointerExitEvent event) => _handleHover(false),
+      child: Shortcuts(
+        shortcuts: scrollShortcutOverrides,
         child: IgnorePointer(
           ignoring: !_isEnabled,
           child: AnimatedBuilder(


### PR DESCRIPTION
For some reason, putting a `Shortcuts` widget above `MouseRegion` caused a Google screenshot test to fail (see details in the Google bug report: [b/178250923](http://b/178250923)).

Swapping the widgets fixes the screenshot test.