### PR TITLE
[flutter] throw more specific error messages if a lerp'd type does not conform to Tween

### DIFF
--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -268,7 +268,9 @@ class Tween<T extends dynamic> extends Animatable<T> {
         throw FlutterError.fromParts(<DiagnosticsNode>[
           ErrorSummary('Cannot lerp between "$begin" and "$end".'),
           ErrorDescription(
-            'The type ${begin.runtimeType} might not fully implement `+`, `-`, and/or `*`.',
+            'The type ${begin.runtimeType} might not fully implement `+`, `-`, and/or `*`. '
+            'See "Types with special considerations" at https://api.flutter.dev/flutter/animation/Tween-class.html '
+            'for more information.',
           ),
           if (begin is Color || end is Color)
             ErrorHint('To lerp colors, consider ColorTween instead.')
@@ -285,7 +287,9 @@ class Tween<T extends dynamic> extends Animatable<T> {
           ErrorSummary('Cannot lerp between "$begin" and "$end".'),
           ErrorDescription(
             'The type ${begin.runtimeType} returned a ${result.runtimeType} after '
-            'multiplication with a double value.'
+            'multiplication with a double value. '
+            'See "Types with special considerations" at https://api.flutter.dev/flutter/animation/Tween-class.html '
+            'for more information.',
           ),
           if (begin is int || end is int)
             ErrorHint('To lerp int values, consider IntTween or StepTween instead.')

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -266,22 +266,34 @@ class Tween<T extends dynamic> extends Animatable<T> {
         return true;
       } on NoSuchMethodError {
         throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('Cannot tween between $begin and $end.'),
+          ErrorSummary('Cannot lerp between "$begin" and "$end".'),
           ErrorDescription(
-            'The type ${begin.runtimeType} does not fully implement `+`, `-`, and/or `*`.',
+            'The type ${begin.runtimeType} might not fully implement `+`, `-`, and/or `*`.',
           ),
           if (begin is Color || end is Color)
-            ErrorHint('To tween colors, use ColorTween instead.')
+            ErrorHint('To lerp colors, consider ColorTween instead.')
+          else if (begin is Rect || end is Rect)
+            ErrorHint('To lerp rects, consider RectTween instead.')
+          else
+            ErrorHint(
+              'There may be a dedicated "${begin.runtimeType}Tween" for this type, '
+              'or you may need to create one.'
+            ),
         ]);
       } on TypeError {
         throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('Cannot tween between $begin and $end.'),
+          ErrorSummary('Cannot lerp between "$begin" and "$end".'),
           ErrorDescription(
             'The type ${begin.runtimeType} returned a ${result.runtimeType} after '
             'multiplication with a double value.'
           ),
           if (begin is int || end is int)
-            ErrorHint('To tween int values, use IntTween instead.')
+            ErrorHint('To lerp int values, consider IntTween or StepTween instead.')
+          else
+            ErrorHint(
+              'There may be a dedicated "${begin.runtimeType}Tween" for this type, '
+              'or you may need to create one.'
+            ),
         ]);
       }
     }());

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -256,6 +256,35 @@ class Tween<T extends dynamic> extends Animatable<T> {
   T lerp(double t) {
     assert(begin != null);
     assert(end != null);
+    assert(() {
+      // Assertions that attempt to catch common cases of tweening types
+      // that do not conform to the Tween requirements.
+      dynamic? result;
+      try {
+        result = begin + (end - begin) * t;
+        result as T;
+        return true;
+      } on NoSuchMethodError {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('Cannot tween between $begin and $end.'),
+          ErrorDescription(
+            'The type ${begin.runtimeType} does not fully implement `+`, `-`, and/or `*`.',
+          ),
+          if (begin is Color || end is Color)
+            ErrorHint('To tween colors, use ColorTween instead.')
+        ]);
+      } on TypeError {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('Cannot tween between $begin and $end.'),
+          ErrorDescription(
+            'The type ${begin.runtimeType} returned a ${result.runtimeType} after '
+            'multiplication with a double value.'
+          ),
+          if (begin is int || end is int)
+            ErrorHint('To tween int values, use IntTween instead.')
+        ]);
+      }
+    }());
     return begin + (end - begin) * t as T;
   }
 

--- a/packages/flutter/test/animation/tween_test.dart
+++ b/packages/flutter/test/animation/tween_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+const String kApiDocsLink = 'See "Types with special considerations" at https://api.flutter.dev/flutter/animation/Tween-class.html for more information.';
+
 void main() {
   test('throws flutter error when tweening types that do not fully satisfy tween requirements - Object', () {
     final Tween<Object> objectTween = Tween<Object>(
@@ -27,7 +29,7 @@ void main() {
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
       'Cannot lerp between "Instance of \'Object\'" and "Instance of \'Object\'".',
-      'The type Object might not fully implement `+`, `-`, and/or `*`.',
+      'The type Object might not fully implement `+`, `-`, and/or `*`. $kApiDocsLink',
       'There may be a dedicated "ObjectTween" for this type, or you may need to create one.'
     ]);
   });
@@ -51,7 +53,7 @@ void main() {
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
       'Cannot lerp between "Color(0xff000000)" and "Color(0xffffffff)".',
-      'The type Color might not fully implement `+`, `-`, and/or `*`.',
+      'The type Color might not fully implement `+`, `-`, and/or `*`. $kApiDocsLink',
       'To lerp colors, consider ColorTween instead.',
     ]);
   });
@@ -75,7 +77,7 @@ void main() {
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
       'Cannot lerp between "Rect.fromLTRB(0.0, 0.0, 10.0, 10.0)" and "Rect.fromLTRB(2.0, 2.0, 4.0, 4.0)".',
-      'The type Rect might not fully implement `+`, `-`, and/or `*`.',
+      'The type Rect might not fully implement `+`, `-`, and/or `*`. $kApiDocsLink',
       'To lerp rects, consider RectTween instead.',
     ]);
   });
@@ -99,7 +101,7 @@ void main() {
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
       'Cannot lerp between "0" and "1".',
-      'The type int returned a double after multiplication with a double value.',
+      'The type int returned a double after multiplication with a double value. $kApiDocsLink',
       'To lerp int values, consider IntTween or StepTween instead.',
     ]);
   });

--- a/packages/flutter/test/animation/tween_test.dart
+++ b/packages/flutter/test/animation/tween_test.dart
@@ -8,6 +8,77 @@ import 'package:flutter/widgets.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 void main() {
+  test('throws flutter error when tweening types that do not fully satisfy tween requirements - Object', () {
+    final Tween<Object> objetTween = Tween<Object>(
+      begin: Object(),
+      end: Object(),
+    );
+
+    FlutterError? error;
+    try {
+      objetTween.transform(0.1);
+    } on FlutterError catch (err) {
+      error = err;
+    }
+
+    if (error == null) {
+      fail('Expected Tween.transform to throw a FlutterError');
+    }
+
+    expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
+      'Cannot tween between Instance of \'Object\' and Instance of \'Object\'.',
+      'The type Object does not fully implement `+`, `-`, and/or `*`.',
+    ]);
+  });
+
+  test('throws flutter error when tweening types that do not fully satisfy tween requirements - Color', () {
+    final Tween<Color> colorTween = Tween<Color>(
+      begin: const Color(0xFF000000),
+      end: const Color(0xFFFFFFFF),
+    );
+
+    FlutterError? error;
+    try {
+      colorTween.transform(0.1);
+    } on FlutterError catch (err) {
+      error = err;
+    }
+
+    if (error == null) {
+      fail('Expected Tween.transform to throw a FlutterError');
+    }
+
+    expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
+      'Cannot tween between Color(0xff000000) and Color(0xffffffff).',
+      'The type Color does not fully implement `+`, `-`, and/or `*`.',
+      'To tween colors, use ColorTween instead.',
+    ]);
+  });
+
+  test('throws flutter error when tweening types that do not fully satisfy tween requirements - int', () {
+    final Tween<int> colorTween = Tween<int>(
+      begin: 0,
+      end: 1,
+    );
+
+    FlutterError? error;
+    try {
+      colorTween.transform(0.1);
+    } on FlutterError catch (err) {
+      error = err;
+    }
+
+    if (error == null) {
+      fail('Expected Tween.transform to throw a FlutterError');
+    }
+
+    expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
+      'Cannot tween between 0 and 1.',
+      'The type int returned a double after multiplication with a double value.',
+      'To tween int values, use IntTween instead.',
+    ]);
+  });
+
   test('Can chain tweens', () {
     final Tween<double> tween = Tween<double>(begin: 0.30, end: 0.50);
     expect(tween, hasOneLineDescription);

--- a/packages/flutter/test/animation/tween_test.dart
+++ b/packages/flutter/test/animation/tween_test.dart
@@ -9,14 +9,14 @@ import 'package:vector_math/vector_math_64.dart';
 
 void main() {
   test('throws flutter error when tweening types that do not fully satisfy tween requirements - Object', () {
-    final Tween<Object> objetTween = Tween<Object>(
+    final Tween<Object> objectTween = Tween<Object>(
       begin: Object(),
       end: Object(),
     );
 
     FlutterError? error;
     try {
-      objetTween.transform(0.1);
+      objectTween.transform(0.1);
     } on FlutterError catch (err) {
       error = err;
     }
@@ -26,8 +26,9 @@ void main() {
     }
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
-      'Cannot tween between Instance of \'Object\' and Instance of \'Object\'.',
-      'The type Object does not fully implement `+`, `-`, and/or `*`.',
+      'Cannot lerp between "Instance of \'Object\'" and "Instance of \'Object\'".',
+      'The type Object might not fully implement `+`, `-`, and/or `*`.',
+      'There may be a dedicated "ObjectTween" for this type, or you may need to create one.'
     ]);
   });
 
@@ -49,9 +50,33 @@ void main() {
     }
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
-      'Cannot tween between Color(0xff000000) and Color(0xffffffff).',
-      'The type Color does not fully implement `+`, `-`, and/or `*`.',
-      'To tween colors, use ColorTween instead.',
+      'Cannot lerp between "Color(0xff000000)" and "Color(0xffffffff)".',
+      'The type Color might not fully implement `+`, `-`, and/or `*`.',
+      'To lerp colors, consider ColorTween instead.',
+    ]);
+  });
+
+  test('throws flutter error when tweening types that do not fully satisfy tween requirements - Rect', () {
+    final Tween<Rect> rectTween = Tween<Rect>(
+      begin: const Rect.fromLTWH(0, 0, 10, 10),
+      end: const Rect.fromLTWH(2, 2, 2, 2)
+    );
+
+    FlutterError? error;
+    try {
+      rectTween.transform(0.1);
+    } on FlutterError catch (err) {
+      error = err;
+    }
+
+    if (error == null) {
+      fail('Expected Tween.transform to throw a FlutterError');
+    }
+
+    expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
+      'Cannot lerp between "Rect.fromLTRB(0.0, 0.0, 10.0, 10.0)" and "Rect.fromLTRB(2.0, 2.0, 4.0, 4.0)".',
+      'The type Rect might not fully implement `+`, `-`, and/or `*`.',
+      'To lerp rects, consider RectTween instead.',
     ]);
   });
 
@@ -73,9 +98,9 @@ void main() {
     }
 
     expect(error.diagnostics.map((DiagnosticsNode node) => node.toString()), <String>[
-      'Cannot tween between 0 and 1.',
+      'Cannot lerp between "0" and "1".',
       'The type int returned a double after multiplication with a double value.',
-      'To tween int values, use IntTween instead.',
+      'To lerp int values, consider IntTween or StepTween instead.',
     ]);
   });
 


### PR DESCRIPTION
I'm not quite sure how verbose I should make these messages. I want to avoid just repeating everything that the tween docs contain.

For example:

```dart
var tween = Tween(begin: Colors.red, end: Colors.blue);
tween.transform(0.1);
```

Will throw a NoSuchMethodError since color does not have an operator -/+/* method.

During development mode, this is caught and surfaced as a flutter error.