### PR TITLE
WIP: Adjust Flutter's Cupertino widgets to match with Native UI

### DIFF
--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -380,19 +380,22 @@ class _CupertinoSearchTextFieldState extends State<CupertinoSearchTextField>
       padding: widget.suffixInsets,
     );
 
-    return CupertinoTextField(
-      controller: _effectiveController,
-      decoration: decoration,
-      style: widget.style,
-      prefix: prefix,
-      suffix: suffix,
-      suffixMode: widget.suffixMode,
-      placeholder: placeholder,
-      placeholderStyle: placeholderStyle,
-      padding: widget.padding,
-      onChanged: widget.onChanged,
-      onSubmitted: widget.onSubmitted,
-      focusNode: widget.focusNode,
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 8),
+      child: CupertinoTextField(
+        controller: _effectiveController,
+        decoration: decoration,
+        style: widget.style,
+        prefix: prefix,
+        suffix: suffix,
+        suffixMode: widget.suffixMode,
+        placeholder: placeholder,
+        placeholderStyle: placeholderStyle,
+        padding: widget.padding,
+        onChanged: widget.onChanged,
+        onSubmitted: widget.onSubmitted,
+        focusNode: widget.focusNode,
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -19,7 +19,7 @@ import 'theme.dart';
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 
 const TextStyle _kDefaultPlaceholderStyle = TextStyle(
-  fontWeight: FontWeight.w400,
+  fontWeight: FontWeight.w300,
   color: CupertinoColors.placeholderText,
 );
 
@@ -229,12 +229,9 @@ class CupertinoTextField extends StatefulWidget {
     this.controller,
     this.focusNode,
     this.decoration = _kDefaultRoundedBorderDecoration,
-    this.padding = const EdgeInsets.all(6.0),
+    this.padding = const EdgeInsets.symmetric(horizontal: 7.0, vertical: 6.0),
     this.placeholder,
-    this.placeholderStyle = const TextStyle(
-      fontWeight: FontWeight.w400,
-      color: CupertinoColors.placeholderText,
-    ),
+    this.placeholderStyle = _kDefaultPlaceholderStyle,
     this.prefix,
     this.prefixMode = OverlayVisibilityMode.always,
     this.suffix,


### PR DESCRIPTION
This is a Work In Progress.

## Description
This micro-tunes the Flutter's Cupertino widgets to make them tightly match with the native UIKit/SwiftUI.  

Updated widgets and changes are listed below:
- **CupertinoTextField**: Update placeholder's default Padding and Fontweight

## Related Issues
Fixes #72545

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
