### PR TITLE
TextField and last input character should visible on the screen when the cursor is not shown

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2125,7 +2125,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return Offset(pixelPerfectOffsetX, pixelPerfectOffsetY);
   }
 
-  void _tryPaintCaret(Canvas canvas, Offset effectiveOffset, TextPosition textPosition) {
+  void _paintCaretIfNeeded(Canvas canvas, Offset effectiveOffset, TextPosition textPosition) {
     assert(_textLayoutLastMaxWidth == constraints.maxWidth &&
            _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).');
@@ -2365,7 +2365,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (canShowCaret) {
       assert(selection != null);
-      _tryPaintCaret(context.canvas, effectiveOffset, selection!.extent);
+      _paintCaretIfNeeded(context.canvas, effectiveOffset, selection!.extent);
       _updateCaretRect();
     }
 
@@ -2374,7 +2374,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (_floatingCursorOn) {
       if (_resetFloatingCursorAnimationValue == null) {
-        _tryPaintCaret(context.canvas, effectiveOffset, _floatingCursorTextPosition);
+        _paintCaretIfNeeded(context.canvas, effectiveOffset, _floatingCursorTextPosition);
         _updateCaretRect();
       }
       _paintFloatingCaret(context.canvas, _floatingCursorOffset);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -383,6 +383,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextSelectionDelegate textSelectionDelegate;
 
   Rect? _lastCaretRect;
+  late Rect _currentCaretRect;
 
   /// Track whether position of the start of the selected text is within the viewport.
   ///
@@ -2124,7 +2125,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return Offset(pixelPerfectOffsetX, pixelPerfectOffsetY);
   }
 
-  void _paintCaret(Canvas canvas, Offset effectiveOffset, TextPosition textPosition) {
+  void _tryPaintCaret(Canvas canvas, Offset effectiveOffset, TextPosition textPosition) {
     assert(_textLayoutLastMaxWidth == constraints.maxWidth &&
            _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).');
@@ -2171,6 +2172,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     caretRect = caretRect.shift(_getPixelPerfectCursorOffset(caretRect));
+    _currentCaretRect = caretRect;
+
+    if (!_showCursor.value)
+      return;
 
     if (cursorRadius == null) {
       canvas.drawRect(caretRect, paint);
@@ -2178,11 +2183,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final RRect caretRRect = RRect.fromRectAndRadius(caretRect, cursorRadius!);
       canvas.drawRRect(caretRRect, paint);
     }
+  }
 
-    if (caretRect != _lastCaretRect) {
-      _lastCaretRect = caretRect;
+  void _updateCaretRect() {
+    if (_currentCaretRect != _lastCaretRect) {
+      _lastCaretRect = _currentCaretRect;
       if (onCaretChanged != null)
-        onCaretChanged!(caretRect);
+        onCaretChanged!(_currentCaretRect);
     }
   }
 
@@ -2333,11 +2340,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final Offset effectiveOffset = offset + _paintOffset;
 
     bool showSelection = false;
-    bool showCaret = false;
+    bool canShowCaret = false;
 
     if (selection != null && !_floatingCursorOn) {
-      if (selection!.isCollapsed && _showCursor.value && cursorColor != null)
-        showCaret = true;
+      if (selection!.isCollapsed && cursorColor != null)
+        canShowCaret = true;
       else if (!selection!.isCollapsed && _selectionColor != null)
         showSelection = true;
       _updateSelectionExtentsVisibility(effectiveOffset);
@@ -2356,17 +2363,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (paintCursorAboveText)
       _textPainter.paint(context.canvas, effectiveOffset);
 
-    if (showCaret) {
+    if (canShowCaret) {
       assert(selection != null);
-      _paintCaret(context.canvas, effectiveOffset, selection!.extent);
+      _tryPaintCaret(context.canvas, effectiveOffset, selection!.extent);
+      _updateCaretRect();
     }
 
     if (!paintCursorAboveText)
       _textPainter.paint(context.canvas, effectiveOffset);
 
     if (_floatingCursorOn) {
-      if (_resetFloatingCursorAnimationValue == null)
-        _paintCaret(context.canvas, effectiveOffset, _floatingCursorTextPosition);
+      if (_resetFloatingCursorAnimationValue == null) {
+        _tryPaintCaret(context.canvas, effectiveOffset, _floatingCursorTextPosition);
+        _updateCaretRect();
+      }
       _paintFloatingCaret(context.canvas, _floatingCursorOffset);
     }
   }


### PR DESCRIPTION
This patch fixes two bugs when setting `showCursor` to false,
1. The `TextField` did not bring into view when it under a scrollable widget.
2. The last input character did not remain on the screen when entering some long text.


Fixes #74566 
