### PR TITLE
[flutter_tools] catch errors when getting cwd

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -102,7 +102,9 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
   static bool _noExitOnFailure = false;
 
   @override
-  Directory get currentDirectory => directory(delegate.currentDirectory);
+  Directory get currentDirectory {
+    return _runSync(() =>  directory(delegate.currentDirectory), platform: _platform);
+  }
 
   @override
   File file(dynamic path) => ErrorHandlingFile(
@@ -710,7 +712,7 @@ void _handleWindowsException(Exception e, String message, int errorCode) {
   switch (errorCode) {
     case kAccessDenied:
       errorMessage =
-        '$message. The flutter tool cannot access the file.\n'
+        '$message. The flutter tool cannot access the file or directory.\n'
         'Please ensure that the SDK and/or project is installed in a location '
         'that has read/write permissions for the current user.';
       break;

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -87,6 +87,7 @@ void setupReadMocks({
 }) {
   final MockFile mockFile = MockFile();
   when(mockFileSystem.file(any)).thenReturn(mockFile);
+  when(mockFileSystem.currentDirectory).thenThrow(FileSystemException('', '', OSError('', errorCode)));
   when(mockFile.readAsStringSync(
     encoding: anyNamed('encoding'),
   )).thenThrow(FileSystemException('', '', OSError('', errorCode)));
@@ -345,7 +346,7 @@ void main() {
              throwsToolExit(message: expectedMessage));
     });
 
-    testWithoutContext('When reading from a file without permission', () {
+    testWithoutContext('When reading from a file or directory without permission', () {
       setupReadMocks(
         mockFileSystem: mockFileSystem,
         fs: fs,
@@ -357,6 +358,8 @@ void main() {
       const String expectedMessage = 'Flutter failed to read a file at';
       expect(() => file.readAsStringSync(),
              throwsToolExit(message: expectedMessage));
+      expect(() => fs.currentDirectory,
+             throwsToolExit(message: 'The flutter tool cannot access the file or directory'));
     });
   });
 
@@ -579,7 +582,7 @@ void main() {
              throwsToolExit(message: expectedMessage));
     });
 
-    testWithoutContext('When reading from a file without permission', () {
+    testWithoutContext('When reading from a file or directory without permission', () {
       setupReadMocks(
         mockFileSystem: mockFileSystem,
         fs: fs,
@@ -591,6 +594,8 @@ void main() {
       const String expectedMessage = 'Flutter failed to read a file at';
       expect(() => file.readAsStringSync(),
              throwsToolExit(message: expectedMessage));
+      expect(() => fs.currentDirectory,
+             throwsToolExit(message: 'The flutter tool cannot access the file or directory'));
     });
   });
 


### PR DESCRIPTION
Catch permission and other errors when accessing the current working directory.
