### PR TITLE
[flutter_tools] handle JSON parsing error from createPluginSymlinks

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -1057,7 +1057,12 @@ void createPluginSymlinks(FlutterProject project, {bool force = false}) {
   Map<String, dynamic> platformPlugins;
   final String pluginFileContent = _readFileContent(project.flutterPluginsDependenciesFile);
   if (pluginFileContent != null) {
-    final Map<String, dynamic> pluginInfo = json.decode(pluginFileContent) as Map<String, dynamic>;
+    Map<String, dynamic> pluginInfo;
+    try {
+      pluginInfo = json.decode(pluginFileContent) as Map<String, dynamic>;
+    } on FormatException {
+      pluginInfo = <String, dynamic>{};
+    }
     platformPlugins = pluginInfo[_kFlutterPluginsPluginListKey] as Map<String, dynamic>;
   }
   platformPlugins ??= <String, dynamic>{};

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1203,6 +1203,18 @@ flutter:
         FeatureFlags: () => featureFlags,
       });
 
+      testUsingContext('Parsing of plugins handles invalid JSON', () async {
+        when(windowsProject.existsSync()).thenReturn(true);
+        createFakePlugin(fs);
+        flutterProject.flutterPluginsFile.writeAsStringSync('{');
+
+        expect(() => createPluginSymlinks(flutterProject), returnsNormally);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+      });
+
       testUsingContext('Existing symlinks are removed when no longer in use with force', () {
         when(linuxProject.existsSync()).thenReturn(true);
         when(windowsProject.existsSync()).thenReturn(true);


### PR DESCRIPTION
If the flutter plugins dependencies file is invalid JSON, treat it as being an empty file.
