### PR TITLE
[flutter_tools] handle further devtools NPE

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1304,6 +1304,9 @@ abstract class ResidentRunner {
     }
     await waitForExtension(device.vmService, 'ext.flutter.activeDevToolsServerAddress');
     try {
+      if (_devToolsLauncher == null) {
+        return;
+      }
       unawaited(invokeFlutterExtensionRpcRawOnFirstIsolate(
         'ext.flutter.activeDevToolsServerAddress',
         device: device,


### PR DESCRIPTION
I've tried and failed to write a test for the timing issue here.

I think we could add a `postAttach` hook, and then invoke the unawaited calls in that method. That would give us a chance to override in the right way to allow unit testing, but I'm worried that will be extremely synthetic.
