### PR TITLE
Replace MockXcode with Xcode.test in unit tests

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/memory.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -229,25 +230,78 @@ List<String> _xcodeBuildSettingsLines({
 
 /// Interpreter of Xcode projects.
 class XcodeProjectInterpreter {
-  XcodeProjectInterpreter({
+  factory XcodeProjectInterpreter({
     @required Platform platform,
     @required ProcessManager processManager,
     @required Logger logger,
     @required FileSystem fileSystem,
     @required Terminal terminal,
     @required Usage usage,
+  }) {
+    return XcodeProjectInterpreter._(
+      platform: platform,
+      processManager: processManager,
+      logger: logger,
+      fileSystem: fileSystem,
+      terminal: terminal,
+      usage: usage,
+    );
+  }
+
+  XcodeProjectInterpreter._({
+    @required Platform platform,
+    @required ProcessManager processManager,
+    @required Logger logger,
+    @required FileSystem fileSystem,
+    @required Terminal terminal,
+    @required Usage usage,
+    int majorVersion,
+    int minorVersion,
+    int patchVersion,
   }) : _platform = platform,
-      _fileSystem = fileSystem,
-      _terminal = terminal,
-      _logger = logger,
-      _processUtils = ProcessUtils(logger: logger, processManager: processManager),
-      _operatingSystemUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: logger,
-        platform: platform,
-        processManager: processManager,
-      ),
-      _usage = usage;
+        _fileSystem = fileSystem,
+        _terminal = terminal,
+        _logger = logger,
+        _processUtils = ProcessUtils(logger: logger, processManager: processManager),
+        _operatingSystemUtils = OperatingSystemUtils(
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        ),
+        _majorVersion = majorVersion,
+        _minorVersion = minorVersion,
+        _patchVersion = patchVersion,
+        _usage = usage;
+
+  /// Create an [XcodeProjectInterpreter] for testing.
+  ///
+  /// Defaults to installed with sufficient version,
+  /// a memory file system, fake platform, buffer logger,
+  /// test [Usage], and test [Terminal].
+  /// Set [majorVersion] to null to simulate Xcode not being installed.
+  factory XcodeProjectInterpreter.test({
+    @required ProcessManager processManager,
+    int majorVersion = 1000,
+    int minorVersion = 0,
+    int patchVersion = 0,
+  }) {
+    final Platform platform = FakePlatform(
+      operatingSystem: 'macos',
+      environment: <String, String>{},
+    );
+    return XcodeProjectInterpreter._(
+      fileSystem: MemoryFileSystem.test(),
+      platform: platform,
+      processManager: processManager,
+      usage: Usage.test(),
+      logger: BufferLogger.test(),
+      terminal: Terminal.test(),
+      majorVersion: majorVersion,
+      minorVersion: minorVersion,
+      patchVersion: patchVersion,
+    );
+  }
 
   final Platform _platform;
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:file/memory.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -55,6 +56,30 @@ class Xcode {
         _processUtils =
             ProcessUtils(logger: logger, processManager: processManager);
 
+  /// Create an [Xcode] for testing.
+  ///
+  /// Defaults to a memory file system, fake platform,
+  /// buffer logger, and test [XcodeProjectInterpreter].
+  @visibleForTesting
+  factory Xcode.test({
+    @required ProcessManager processManager,
+    XcodeProjectInterpreter xcodeProjectInterpreter,
+    Platform platform,
+    FileSystem fileSystem,
+  }) {
+    platform ??= FakePlatform(
+      operatingSystem: 'macos',
+      environment: <String, String>{},
+    );
+    return Xcode(
+      platform: platform,
+      processManager: processManager,
+      fileSystem: fileSystem ?? MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      xcodeProjectInterpreter: xcodeProjectInterpreter ?? XcodeProjectInterpreter.test(processManager: processManager),
+    );
+  }
+
   final Platform _platform;
   final ProcessUtils _processUtils;
   final FileSystem _fileSystem;
@@ -78,12 +103,7 @@ class Xcode {
     return _xcodeSelectPath;
   }
 
-  bool get isInstalled {
-    if (xcodeSelectPath == null || xcodeSelectPath.isEmpty) {
-      return false;
-    }
-    return _xcodeProjectInterpreter.isInstalled;
-  }
+  bool get isInstalled => _xcodeProjectInterpreter.isInstalled;
 
   Version get currentVersion => Version(
         _xcodeProjectInterpreter.majorVersion,


### PR DESCRIPTION
Replace `MockXcode` with an `Xcode.test()` factory.  
Also add an `XcodeProjectInterpreter.test()` factory to be used to replace `MockXcodeProjectInterpreter` in an upcoming PR.

Only actual behavior change is to delegate `Xcode.isInstalled` to `XcodeProjectInterpreter.isInstalled`, the extra selectPath step isn't needed.

Part of https://github.com/flutter/flutter/issues/71511