### PR TITLE
Remove MockProcessManager from channel_test and other tests

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -11,7 +10,6 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
@@ -45,7 +43,7 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => null,
       DeviceManager: () => NoDevicesManager(),
-      ProcessManager: () => MockProcessManager(),
+      ProcessManager: () => FakeProcessManager.any(),
       Cache: () => cache,
       Artifacts: () => Artifacts.test(),
     });
@@ -57,7 +55,7 @@ void main() {
       expect(platformTypes, <String>['android', 'web']);
     }, overrides: <Type, Generator>{
       DeviceManager: () => _FakeDeviceManager(),
-      ProcessManager: () => MockProcessManager(),
+      ProcessManager: () => FakeProcessManager.any(),
       Cache: () => cache,
       Artifacts: () => Artifacts.test(),
     });
@@ -106,7 +104,7 @@ void main() {
       );
     }, overrides: <Type, Generator>{
       DeviceManager: () => _FakeDeviceManager(),
-      ProcessManager: () => MockProcessManager(),
+      ProcessManager: () => FakeProcessManager.any(),
       Cache: () => cache,
       Artifacts: () => Artifacts.test(),
     });
@@ -127,37 +125,9 @@ webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulato
       );
     }, overrides: <Type, Generator>{
       DeviceManager: () => _FakeDeviceManager(),
-      ProcessManager: () => MockProcessManager(),
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
-}
-
-class MockProcessManager extends Mock implements ProcessManager {
-  @override
-  Future<ProcessResult> run(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
-    bool includeParentEnvironment = true,
-    bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
-  }) async {
-    return ProcessResult(0, 0, '', '');
-  }
-
-  @override
-  ProcessResult runSync(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
-    bool includeParentEnvironment = true,
-    bool runInShell = false,
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
-  }) {
-    return ProcessResult(0, 0, '', '');
-  }
 }
 
 class _FakeDeviceManager extends DeviceManager {

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' hide File;
-
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -11,16 +9,18 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/commands/channel.dart';
 import 'package:flutter_tools/src/version.dart';
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/mocks.dart';
 
 void main() {
   group('channel', () {
-    final MockProcessManager mockProcessManager = MockProcessManager();
+    FakeProcessManager fakeProcessManager;
+
+    setUp(() {
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
+    });
 
     setUpAll(() {
       Cache.disableLocking();
@@ -49,38 +49,21 @@ void main() {
     });
 
     testUsingContext('sorted by stability', () async {
-      final Process processAll = createMockProcess(
-          stdout: 'origin/beta\n'
-                  'origin/master\n'
-                  'origin/dev\n'
-                  'origin/stable\n');
-      final Process processWithExtra = createMockProcess(
-          stdout: 'origin/beta\n'
-                  'origin/master\n'
-                  'origin/dependabot/bundler\n'
-                  'origin/dev\n'
-                  'origin/v1.4.5-hotfixes\n'
-                  'origin/stable\n');
-      final Process processWithMissing = createMockProcess(
-          stdout: 'origin/beta\n'
-                  'origin/dependabot/bundler\n'
-                  'origin/v1.4.5-hotfixes\n'
-                  'origin/stable\n');
-
       final ChannelCommand command = ChannelCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
-      when(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(processAll));
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['git', 'branch', '-r'],
+          stdout: 'origin/beta\n'
+              'origin/master\n'
+              'origin/dev\n'
+              'origin/stable\n',
+        ),
+      );
+
       await runner.run(<String>['channel']);
-      verify(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       expect(testLogger.errorText, hasLength(0));
       // format the status text for a simpler assertion.
       final Iterable<String> rows = testLogger.statusText
@@ -91,17 +74,22 @@ void main() {
       // clear buffer for next process
       testLogger.clear();
 
-      when(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(processWithExtra));
+      // Extra branches.
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['git', 'branch', '-r'],
+          stdout: 'origin/beta\n'
+              'origin/master\n'
+              'origin/dependabot/bundler\n'
+              'origin/dev\n'
+              'origin/v1.4.5-hotfixes\n'
+              'origin/stable\n',
+        ),
+      );
+
       await runner.run(<String>['channel']);
-      verify(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(rows, containsAllInOrder(kOfficialChannels));
       expect(testLogger.errorText, hasLength(0));
       // format the status text for a simpler assertion.
       final Iterable<String> rows2 = testLogger.statusText
@@ -112,17 +100,19 @@ void main() {
       // clear buffer for next process
       testLogger.clear();
 
-      when(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(processWithMissing));
+      // Missing branches.
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['git', 'branch', '-r'],
+          stdout: 'origin/beta\n'
+              'origin/dependabot/bundler\n'
+              'origin/v1.4.5-hotfixes\n'
+              'origin/stable\n',
+        ),
+      );
+
       await runner.run(<String>['channel']);
-      verify(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       expect(testLogger.errorText, hasLength(0));
       // check if available official channels are in order of stability
       int prev = -1;
@@ -136,33 +126,28 @@ void main() {
       }
 
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
+      FileSystem: () => MemoryFileSystem.test(),
     });
 
     testUsingContext('removes duplicates', () async {
-      final Process process = createMockProcess(
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['git', 'branch', '-r'],
           stdout: 'origin/dev\n'
-                  'origin/beta\n'
-                  'origin/stable\n'
-                  'upstream/dev\n'
-                  'upstream/beta\n'
-                  'upstream/stable\n');
-      when(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(process));
+              'origin/beta\n'
+              'origin/stable\n'
+              'upstream/dev\n'
+              'upstream/beta\n'
+              'upstream/stable\n',
+        ),
+      );
 
       final ChannelCommand command = ChannelCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel']);
 
-      verify(mockProcessManager.start(
-        <String>['git', 'branch', '-r'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       expect(testLogger.errorText, hasLength(0));
 
       // format the status text for a simpler assertion.
@@ -174,126 +159,70 @@ void main() {
 
       expect(rows, <String>['dev', 'beta', 'stable']);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
+      FileSystem: () => MemoryFileSystem.test(),
     });
 
     testUsingContext('can switch channels', () async {
-      when(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'fetch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+        ),
+        const FakeCommand(
+            command: <String>['git', 'checkout', 'beta', '--']
+        ),
+      ]);
 
       final ChannelCommand command = ChannelCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
 
-      verify(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       expect(
         testLogger.statusText,
         containsIgnoringWhitespace("Switching to flutter channel 'beta'..."),
       );
       expect(testLogger.errorText, hasLength(0));
 
-      when(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/stable'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'checkout', 'stable', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'fetch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/stable'],
+        ),
+        const FakeCommand(
+            command: <String>['git', 'checkout', 'stable', '--']
+        ),
+      ]);
 
       await runner.run(<String>['channel', 'stable']);
 
-      verify(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/stable'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'checkout', 'stable', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
     });
 
     testUsingContext('switching channels prompts to run flutter upgrade', () async {
-      when(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'fetch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+        ),
+        const FakeCommand(
+            command: <String>['git', 'checkout', 'beta', '--']
+        ),
+      ]);
 
       final ChannelCommand command = ChannelCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
-
-      verify(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
 
       expect(
         testLogger.statusText,
@@ -306,29 +235,26 @@ void main() {
           "from this channel, run 'flutter upgrade'"),
       );
       expect(testLogger.errorText, hasLength(0));
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
     });
 
     // This verifies that bug https://github.com/flutter/flutter/issues/21134
     // doesn't return.
     testUsingContext('removes version stamp file when switching channels', () async {
-      when(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
-      when(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) => Future<Process>.value(createMockProcess()));
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'fetch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'checkout', 'beta', '--']
+        ),
+      ]);
 
       final File versionCheckFile = globals.cache.getStampFileFor(
         VersionCheckStamp.flutterVersionCheckStampFile,
@@ -348,32 +274,13 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
 
-      verify(mockProcessManager.start(
-        <String>['git', 'fetch'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-      verify(mockProcessManager.start(
-        <String>['git', 'checkout', 'beta', '--'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).called(1);
-
       expect(testLogger.statusText, isNot(contains('A new version of Flutter')));
       expect(testLogger.errorText, hasLength(0));
       expect(versionCheckFile.existsSync(), isFalse);
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => fakeProcessManager,
     });
   });
 }
-
-class MockProcessManager extends Mock implements ProcessManager {}
-
-class MockProcess extends Mock implements Process {}

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -31,7 +31,6 @@ void main() {
     // Create an l10n.yaml file
     fileSystem.file('l10n.yaml').createSync();
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Artifacts artifacts = Artifacts.test();
     final Environment environment = Environment.test(
@@ -39,7 +38,7 @@ void main() {
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: artifacts,
-      processManager: mockProcessManager,
+      processManager: FakeProcessManager.any(),
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
@@ -72,7 +71,7 @@ void main() {
     // Create an l10n.yaml file
     fileSystem.file('l10n.yaml').writeAsStringSync('synthetic-package: true');
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Artifacts artifacts = Artifacts.test();
     final Environment environment = Environment.test(
@@ -80,7 +79,7 @@ void main() {
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: artifacts,
-      processManager: mockProcessManager,
+      processManager: fakeProcessManager,
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
@@ -113,14 +112,13 @@ void main() {
     // Create an l10n.yaml file
     fileSystem.file('l10n.yaml').writeAsStringSync('synthetic-package: null');
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Environment environment = Environment.test(
       fileSystem.currentDirectory,
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: Artifacts.test(),
-      processManager: mockProcessManager,
+      processManager: FakeProcessManager.any(),
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
@@ -150,14 +148,13 @@ void main() {
     );
     pubspecFile.writeAsStringSync(content);
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Environment environment = Environment.test(
       fileSystem.currentDirectory,
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: Artifacts.test(),
-      processManager: mockProcessManager,
+      processManager: FakeProcessManager.any(),
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
@@ -187,14 +184,13 @@ void main() {
     // Create an l10n.yaml file
     fileSystem.file('l10n.yaml').writeAsStringSync('helloWorld');
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Environment environment = Environment.test(
       fileSystem.currentDirectory,
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: Artifacts.test(),
-      processManager: mockProcessManager,
+      processManager: FakeProcessManager.any(),
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
@@ -227,14 +223,13 @@ void main() {
     // Create an l10n.yaml file
     fileSystem.file('l10n.yaml').writeAsStringSync('synthetic-package: nonBoolValue');
 
-    final FakeProcessManager mockProcessManager = FakeProcessManager.any();
     final BufferLogger mockBufferLogger = BufferLogger.test();
     final Environment environment = Environment.test(
       fileSystem.currentDirectory,
       fileSystem: fileSystem,
       logger: mockBufferLogger,
       artifacts: Artifacts.test(),
-      processManager: mockProcessManager,
+      processManager: FakeProcessManager.any(),
     );
     final BuildSystem buildSystem = MockBuildSystem();
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -18,7 +18,6 @@ import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config.dart';
@@ -580,17 +579,6 @@ class MockIOSDevice extends Mock implements IOSDevice {
   bool isSupportedForProject(FlutterProject flutterProject) => true;
 }
 
-class MockIOSSimulator extends Mock implements IOSSimulator {
-  @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
-
-  @override
-  bool isSupported() => true;
-
-  @override
-  bool isSupportedForProject(FlutterProject flutterProject) => true;
-}
-
 /// Common functionality for tracking mock interaction.
 class BasicMock {
   final List<String> messages = <String>[];
@@ -709,9 +697,6 @@ class MockStdIn extends Mock implements IOSink {
 }
 
 class MockStream extends Mock implements Stream<List<int>> {}
-
-class MockDevToolsServer extends Mock implements HttpServer {}
-class MockInternetAddress extends Mock implements InternetAddress {}
 
 class AlwaysTrueBotDetector implements BotDetector {
   const AlwaysTrueBotDetector();


### PR DESCRIPTION
Replace `MockProcessManager` with `FakeProcessManager` in a few tests.
Removes mockito usage from devices_test, android_studio_validator_test, and channel_test.
Remove dead mocks.dart `Mock`s for luck.

Part of https://github.com/flutter/flutter/issues/71511