### PR TITLE
[flutter_tools] delete old directories when unzipping ontop of them

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1789,6 +1789,11 @@ class ArtifactUpdater {
       } finally {
         status.stop();
       }
+      /// Unzipping multiple file into a directory will not remove old files
+      /// from previous versions that are not present in the new bundle.
+      if (location.existsSync()) {
+        location.deleteSync(recursive: true);
+      }
       _ensureExists(location);
 
       try {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1791,12 +1791,16 @@ class ArtifactUpdater {
       }
       /// Unzipping multiple file into a directory will not remove old files
       /// from previous versions that are not present in the new bundle.
-      if (location.existsSync()) {
-        location.deleteSync(recursive: true);
+      final Directory destination = location.childDirectory(
+        tempFile.fileSystem.path.basenameWithoutExtension(tempFile.path)
+      );
+      if (destination.existsSync()) {
+        destination.deleteSync(recursive: true);
       }
       _ensureExists(location);
 
       try {
+        print(tempFile.path);
         extractor(tempFile, location);
       } on Exception catch (err) {
         retries -= 1;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1794,9 +1794,7 @@ class ArtifactUpdater {
       final Directory destination = location.childDirectory(
         tempFile.fileSystem.path.basenameWithoutExtension(tempFile.path)
       );
-      if (destination.existsSync()) {
-        destination.deleteSync(recursive: true);
-      }
+      ErrorHandlingFileSystem.deleteIfExists(destination, recursive: true);
       _ensureExists(location);
 
       try {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1800,7 +1800,6 @@ class ArtifactUpdater {
       _ensureExists(location);
 
       try {
-        print(tempFile.path);
         extractor(tempFile, location);
       } on Exception catch (err) {
         retries -= 1;

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -44,6 +44,32 @@ void main() {
     expect(fileSystem.file('out/test'), exists);
   });
 
+  testWithoutContext('ArtifactUpdater can download a zip archive and delete stale files', () async {
+    final MockOperatingSystemUtils operatingSystemUtils = MockOperatingSystemUtils();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    final BufferLogger logger = BufferLogger.test();
+    final ArtifactUpdater artifactUpdater = ArtifactUpdater(
+      fileSystem: fileSystem,
+      logger: logger,
+      operatingSystemUtils: operatingSystemUtils,
+      platform: testPlatform,
+      httpClient: MockHttpClient(),
+      tempStorage: fileSystem.currentDirectory.childDirectory('temp')
+        ..createSync(),
+    );
+    // Create a stale file
+    fileSystem.file('out/foo').createSync(recursive: true);
+
+    await artifactUpdater.downloadZipArchive(
+      'test message',
+      Uri.parse('http:///test.zip'),
+      fileSystem.currentDirectory.childDirectory('out'),
+    );
+    expect(logger.statusText, contains('test message'));
+    expect(fileSystem.file('out/test'), exists);
+    expect(fileSystem.file('out/foo'), isNot(exists));
+  });
+
   testWithoutContext('ArtifactUpdater will not validate the md5 hash if the '
     'x-goog-hash header is present but missing an md5 entry', () async {
     final MockOperatingSystemUtils operatingSystemUtils = MockOperatingSystemUtils();

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -57,8 +57,10 @@ void main() {
       tempStorage: fileSystem.currentDirectory.childDirectory('temp')
         ..createSync(),
     );
-    // Create a stale file
-    fileSystem.file('out/foo').createSync(recursive: true);
+    // Unrelated file from another cache.
+    fileSystem.file('out/bar').createSync(recursive: true);
+    // Stale file from current cache.
+    fileSystem.file('out/test/foo.txt').createSync(recursive: true);
 
     await artifactUpdater.downloadZipArchive(
       'test message',
@@ -67,7 +69,8 @@ void main() {
     );
     expect(logger.statusText, contains('test message'));
     expect(fileSystem.file('out/test'), exists);
-    expect(fileSystem.file('out/foo'), isNot(exists));
+    expect(fileSystem.file('out/bar'), exists);
+    expect(fileSystem.file('out/test/foo.txt'), isNot(exists));
   });
 
   testWithoutContext('ArtifactUpdater will not validate the md5 hash if the '


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/74772

stale files from previous SDKs were getting left in the cache, confusing the analyzer.