### PR TITLE
Replace MockProcessManager with FakeProcessManager in process_test where possible

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -15,8 +15,8 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart' show MockProcess,
                                    MockProcessManager,
+                                   MockStdio,
                                    flakyProcessFactory;
-import '../runner/flutter_command_runner_test.dart' show FakeStdio;
 
 void main() {
   group('process exceptions', () {
@@ -88,7 +88,7 @@ void main() {
       mockProcessManager = MockProcessManager();
       mockLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: FakeStdio(),
+          stdio: MockStdio(),
           platform: FakePlatform(stdoutSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
@@ -278,7 +278,7 @@ void main() {
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       testLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: FakeStdio(),
+          stdio: MockStdio(),
           platform: FakePlatform(stdinSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -10,31 +10,35 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 import 'package:fake_async/fake_async.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart' show MockProcess,
                                    MockProcessManager,
-                                   MockStdio,
                                    flakyProcessFactory;
+import '../runner/flutter_command_runner_test.dart' show FakeStdio;
 
 void main() {
   group('process exceptions', () {
-    ProcessManager mockProcessManager;
+    FakeProcessManager fakeProcessManager;
     ProcessUtils processUtils;
 
     setUp(() {
-      mockProcessManager = PlainMockProcessManager();
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       processUtils = ProcessUtils(
-        processManager: mockProcessManager,
+        processManager: fakeProcessManager,
         logger: BufferLogger.test(),
       );
     });
 
     testWithoutContext('runAsync throwOnError: exceptions should be ProcessException objects', () async {
-      when(mockProcessManager.run(<String>['false'])).thenAnswer(
-          (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(0, 1, '', '')));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'false',
+        ],
+        exitCode: 1,
+      ));
+
       expect(() async => await processUtils.run(<String>['false'], throwOnError: true),
              throwsA(isA<ProcessException>()));
     });
@@ -84,7 +88,7 @@ void main() {
       mockProcessManager = MockProcessManager();
       mockLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: MockStdio(),
+          stdio: FakeStdio(),
           platform: FakePlatform(stdoutSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
@@ -119,7 +123,7 @@ void main() {
   group('run', () {
     const Duration delay = Duration(seconds: 2);
     MockProcessManager flakyProcessManager;
-    ProcessManager mockProcessManager;
+    FakeProcessManager fakeProcessManager;
     ProcessUtils processUtils;
     ProcessUtils flakyProcessUtils;
 
@@ -127,9 +131,9 @@ void main() {
       // MockProcessManager has an implementation of start() that returns the
       // result of processFactory.
       flakyProcessManager = MockProcessManager();
-      mockProcessManager = MockProcessManager();
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       processUtils = ProcessUtils(
-        processManager: mockProcessManager,
+        processManager: fakeProcessManager,
         logger: BufferLogger.test(),
       );
       flakyProcessUtils = ProcessUtils(
@@ -139,31 +143,42 @@ void main() {
     });
 
     testWithoutContext(' succeeds on success', () async {
-      when(mockProcessManager.run(<String>['whoohoo'])).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
-      });
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'whoohoo',
+        ],
+      ));
       expect((await processUtils.run(<String>['whoohoo'])).exitCode, 0);
     });
 
     testWithoutContext(' fails on failure', () async {
-      when(mockProcessManager.run(<String>['boohoo'])).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
-      });
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'boohoo',
+        ],
+        exitCode: 1,
+      ));
       expect((await processUtils.run(<String>['boohoo'])).exitCode, 1);
     });
 
     testWithoutContext(' throws on failure with throwOnError', () async {
-      when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
-      });
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 1,
+      ));
       expect(() => processUtils.run(<String>['kaboom'], throwOnError: true),
              throwsA(isA<ProcessException>()));
     });
 
     testWithoutContext(' does not throw on allowed Failures', () async {
-      when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
-      });
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 1,
+      ));
       expect(
         (await processUtils.run(
           <String>['kaboom'],
@@ -175,9 +190,12 @@ void main() {
     });
 
     testWithoutContext(' throws on disallowed failure', () async {
-      when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 2, '', ''));
-      });
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 2,
+      ));
       expect(
         () => processUtils.run(
           <String>['kaboom'],
@@ -252,44 +270,53 @@ void main() {
   });
 
   group('runSync', () {
-    ProcessManager mockProcessManager;
+    FakeProcessManager fakeProcessManager;
     ProcessUtils processUtils;
     BufferLogger testLogger;
 
     setUp(() {
-      mockProcessManager = MockProcessManager();
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       testLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: MockStdio(),
+          stdio: FakeStdio(),
           platform: FakePlatform(stdinSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
       );
       processUtils = ProcessUtils(
-        processManager: mockProcessManager,
+        processManager: fakeProcessManager,
         logger: testLogger,
       );
     });
 
     testWithoutContext(' succeeds on success', () async {
-      when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
-        ProcessResult(0, 0, '', '')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'whoohoo',
+        ],
+      ));
       expect(processUtils.runSync(<String>['whoohoo']).exitCode, 0);
     });
 
     testWithoutContext(' fails on failure', () async {
-      when(mockProcessManager.runSync(<String>['boohoo'])).thenReturn(
-        ProcessResult(0, 1, '', '')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'boohoo',
+        ],
+        exitCode: 1,
+      ));
       expect(processUtils.runSync(<String>['boohoo']).exitCode, 1);
     });
 
     testWithoutContext('throws on failure with throwOnError', () async {
       const String stderr = 'Something went wrong.';
-      when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
-        ProcessResult(0, 1, '', stderr),
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 1,
+        stderr: stderr,
+      ));
       try {
         processUtils.runSync(<String>['kaboom'], throwOnError: true);
         fail('ProcessException expected.');
@@ -301,9 +328,13 @@ void main() {
 
     testWithoutContext('throws with stderr in exception on failure with verboseExceptions', () async {
       const String stderr = 'Something went wrong.';
-      when(mockProcessManager.runSync(<String>['verybad'])).thenReturn(
-        ProcessResult(0, 1, '', stderr),
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'verybad',
+        ],
+        exitCode: 1,
+        stderr: stderr,
+      ));
       expect(
         () => processUtils.runSync(
           <String>['verybad'],
@@ -315,9 +346,12 @@ void main() {
     });
 
     testWithoutContext(' does not throw on allowed Failures', () async {
-      when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
-        ProcessResult(0, 1, '', '')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 1,
+      ));
       expect(
         processUtils.runSync(
           <String>['kaboom'],
@@ -328,9 +362,12 @@ void main() {
     });
 
     testWithoutContext(' throws on disallowed failure', () async {
-      when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
-        ProcessResult(0, 2, '', '')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 2,
+      ));
       expect(
         () => processUtils.runSync(
           <String>['kaboom'],
@@ -341,18 +378,27 @@ void main() {
     });
 
     testWithoutContext(' prints stdout and stderr to trace on success', () async {
-      when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
-        ProcessResult(0, 0, 'stdout', 'stderr')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'whoohoo',
+        ],
+        stdout: 'stdout',
+        stderr: 'stderr',
+      ));
       expect(processUtils.runSync(<String>['whoohoo']).exitCode, 0);
       expect(testLogger.traceText, contains('stdout'));
       expect(testLogger.traceText, contains('stderr'));
     });
 
     testWithoutContext(' prints stdout to status and stderr to error on failure with throwOnError', () async {
-      when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
-        ProcessResult(0, 1, 'stdout', 'stderr')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'kaboom',
+        ],
+        exitCode: 1,
+        stdout: 'stdout',
+        stderr: 'stderr',
+      ));
       expect(() => processUtils.runSync(<String>['kaboom'], throwOnError: true),
              throwsA(isA<ProcessException>()));
       expect(testLogger.statusText, contains('stdout'));
@@ -360,9 +406,13 @@ void main() {
     });
 
     testWithoutContext(' does not print stdout with hideStdout', () async {
-      when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
-        ProcessResult(0, 0, 'stdout', 'stderr')
-      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
+          'whoohoo',
+        ],
+        stdout: 'stdout',
+        stderr: 'stderr',
+      ));
       expect(processUtils.runSync(<String>['whoohoo'], hideStdout: true).exitCode, 0);
       expect(testLogger.traceText.contains('stdout'), isFalse);
       expect(testLogger.traceText, contains('stderr'));
@@ -472,7 +522,4 @@ void main() {
       );
     });
   });
-
 }
-
-class PlainMockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
Swapped out the low-hanging fruit. Punting on the `canRun`, flaky process manager, and `runSync` process exception tests.

Part of https://github.com/flutter/flutter/issues/71511