### PR TITLE
Swap MockStdio to FakeStdio in tests

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -225,7 +225,7 @@ void main() {
         FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
         DeviceManager: () => mockDeviceManager,
-        Stdio: () => MockStdio(),
+        Stdio: () => FakeStdio(hasFakeTerminal: true),
       });
 
       testUsingContext('shows unsupported devices when no supported devices are found',  () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -15,12 +15,12 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
+import '../../src/fakes.dart';
 
 
 void main() {
   MemoryFileSystem fileSystem;
-  MockStdio stdio;
+  FakeStdio stdio;
   SymbolizeCommand command;
   MockDwarfSymbolizationService mockDwarfSymbolizationService;
 
@@ -30,7 +30,7 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
-    stdio = MockStdio();
+    stdio = FakeStdio();
     mockDwarfSymbolizationService = MockDwarfSymbolizationService();
     command = SymbolizeCommand(
       stdio: stdio,

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -24,7 +24,7 @@ import 'package:usage/usage_io.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/mocks.dart';
+import '../src/fakes.dart';
 
 void main() {
   setUpAll(() {
@@ -150,7 +150,7 @@ void main() {
 
   group('analytics with mocks', () {
     MemoryFileSystem memoryFileSystem;
-    MockStdio mockStdio;
+    FakeStdio fakeStdio;
     Usage mockUsage;
     SystemClock mockClock;
     Doctor mockDoctor;
@@ -158,7 +158,7 @@ void main() {
 
     setUp(() {
       memoryFileSystem = MemoryFileSystem.test();
-      mockStdio = MockStdio();
+      fakeStdio = FakeStdio();
       mockUsage = MockUsage();
       mockClock = MockClock();
       mockDoctor = MockDoctor();
@@ -264,7 +264,7 @@ void main() {
           'FLUTTER_ANALYTICS_LOG_FILE': 'analytics.log',
         },
       ),
-      Stdio: () => mockStdio,
+      Stdio: () => fakeStdio,
     });
 
     testUsingContext('event sends localtime', () async {
@@ -294,7 +294,7 @@ void main() {
           'FLUTTER_ANALYTICS_LOG_FILE': 'analytics.log',
         },
       ),
-      Stdio: () => mockStdio,
+      Stdio: () => fakeStdio,
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -16,7 +16,8 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart' show MockAndroidSdk, MockProcess, MockProcessManager, MockStdio;
+import '../../src/fakes.dart';
+import '../../src/mocks.dart' show MockAndroidSdk, MockProcess, MockProcessManager;
 import '../../src/testbed.dart';
 
 class MockAndroidSdkVersion extends Mock implements AndroidSdkVersion {}
@@ -27,7 +28,7 @@ void main() {
   Logger logger;
   MemoryFileSystem fileSystem;
   MockProcessManager processManager;
-  MockStdio stdio;
+  FakeStdio stdio;
 
   setUp(() {
     sdk = MockAndroidSdk();
@@ -35,7 +36,7 @@ void main() {
     fileSystem.directory('/home/me').createSync(recursive: true);
     logger = BufferLogger.test();
     processManager = MockProcessManager();
-    stdio = MockStdio();
+    stdio = FakeStdio();
   });
 
   MockProcess Function(List<String>) processMetaFactory(List<String> stdout) {

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
-import '../src/mocks.dart';
+import '../src/fakes.dart';
 
 final Platform testPlatform = FakePlatform(environment: const <String, String>{});
 
@@ -140,7 +140,7 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Logger logger = StdoutLogger(
       terminal: Terminal.test(supportsColor: true),
-      stdio: MockStdio(),
+      stdio: FakeStdio(),
       outputPreferences: OutputPreferences.test(),
     );
     final ArtifactUpdater artifactUpdater = ArtifactUpdater(

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -14,12 +14,10 @@ import 'package:mockito/mockito.dart';
 import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
-import '../../src/mocks.dart';
 
 void main() {
   group('BotDetector', () {
     FakePlatform fakePlatform;
-    MockStdio mockStdio;
     MockHttpClient mockHttpClient;
     MockHttpClientRequest mockHttpClientRequest;
     MockHttpHeaders mockHttpHeaders;
@@ -28,7 +26,6 @@ void main() {
 
     setUp(() {
       fakePlatform = FakePlatform()..environment = <String, String>{};
-      mockStdio = MockStdio();
       mockHttpClient = MockHttpClient();
       mockHttpClientRequest = MockHttpClientRequest();
       mockHttpHeaders = MockHttpHeaders();
@@ -56,17 +53,6 @@ void main() {
         fakePlatform.environment['FLUTTER_HOST'] = 'foo';
         fakePlatform.environment['TRAVIS'] = 'true';
 
-        expect(await botDetector.isRunningOnBot, isFalse);
-        expect(persistentToolState.isRunningOnBot, isFalse);
-      });
-
-      testWithoutContext('returns false with and without a terminal attached', () async {
-        when(mockHttpClient.getUrl(any)).thenAnswer((_) {
-          throw const SocketException('HTTP connection timed out');
-        });
-        mockStdio.stdout.hasTerminal = true;
-        expect(await botDetector.isRunningOnBot, isFalse);
-        mockStdio.stdout.hasTerminal = false;
         expect(await botDetector.isRunningOnBot, isFalse);
         expect(persistentToolState.isRunningOnBot, isFalse);
       });

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/base/terminal.dart' show AnsiTerminal, OutputP
 import 'package:meta/meta.dart';
 
 import '../../src/common.dart';
-import '../../src/mocks.dart' show MockStdio;
+import '../../src/fakes.dart';
 
 CommandHelp _createCommandHelp({
   @required bool ansi,
@@ -21,7 +21,7 @@ CommandHelp _createCommandHelp({
   return CommandHelp(
     logger: BufferLogger.test(),
     terminal: AnsiTerminal(
-      stdio:  MockStdio(),
+      stdio: FakeStdio(),
       platform: platform,
     ),
     platform: platform,

--- a/packages/flutter_tools/test/general.shard/base/net_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/net_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
-import '../../src/mocks.dart' show MockStdio;
+import '../../src/fakes.dart';
 
 void main() {
   BufferLogger testLogger;
@@ -24,7 +24,7 @@ void main() {
   setUp(() {
     testLogger = BufferLogger(
       terminal: AnsiTerminal(
-        stdio: MockStdio(),
+        stdio: FakeStdio(),
         platform: FakePlatform(stdoutSupportsAnsi: false),
       ),
       outputPreferences: OutputPreferences.test(),

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -14,9 +14,9 @@ import 'package:process/process.dart';
 import 'package:fake_async/fake_async.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import '../../src/mocks.dart' show MockProcess,
                                    MockProcessManager,
-                                   MockStdio,
                                    flakyProcessFactory;
 
 void main() {
@@ -84,7 +84,7 @@ void main() {
       mockProcessManager = MockProcessManager();
       mockLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: MockStdio(),
+          stdio: FakeStdio(),
           platform: FakePlatform(stdoutSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
@@ -260,7 +260,7 @@ void main() {
       mockProcessManager = MockProcessManager();
       testLogger = BufferLogger(
         terminal: AnsiTerminal(
-          stdio: MockStdio(),
+          stdio: FakeStdio(),
           platform: FakePlatform(stdinSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -20,6 +20,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fakes.dart';
 import '../../../src/mocks.dart' as mocks;
 
 final Platform kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false);
@@ -88,7 +89,7 @@ void main() {
     fileSystem = MemoryFileSystem.test();
     logger = BufferLogger(
       terminal: AnsiTerminal(
-        stdio: mocks.MockStdio(),
+        stdio: FakeStdio(),
         platform: kNoAnsiPlatform,
       ),
       outputPreferences: OutputPreferences.test(showColor: false),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -18,6 +18,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import 'utils.dart';
 
 const String _kFlutterRoot = '/flutter/flutter';
@@ -250,21 +251,4 @@ class FakeFlutterCommand extends FlutterCommand {
 
   @override
   String get name => 'fake';
-}
-
-class FakeStdio extends Stdio {
-  FakeStdio({this.hasFakeTerminal});
-
-  final bool hasFakeTerminal;
-
-  @override
-  bool get hasTerminal => hasFakeTerminal;
-
-  @override
-  int get terminalColumns => hasFakeTerminal ? 80 : null;
-
-  @override
-  int get terminalLines => hasFakeTerminal ? 24 : null;
-  @override
-  bool get supportsAnsiEscapes => hasFakeTerminal;
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -62,4 +63,21 @@ class FakeDyldEnvironmentArtifact extends ArtifactSet {
   @override
   Future<void> update(ArtifactUpdater artifactUpdater, Logger logger, FileSystem fileSystem, OperatingSystemUtils operatingSystemUtils) async {
   }
+}
+
+class FakeStdio extends Stdio {
+  FakeStdio({this.hasFakeTerminal});
+
+  final bool hasFakeTerminal;
+
+  @override
+  bool get hasTerminal => hasFakeTerminal;
+
+  @override
+  int get terminalColumns => hasFakeTerminal ? 80 : null;
+
+  @override
+  int get terminalLines => hasFakeTerminal ? 24 : null;
+  @override
+  bool get supportsAnsiEscapes => hasFakeTerminal;
 }


### PR DESCRIPTION
- Mock `FakeStdio` from `flutter_command_runner_test.dart` to `fakes.dart` to be used in more places.
- Swap where easy.
- Remove `returns false with and without a terminal attached` test, it wasn't actually testing anything related to the terminal as of #36208

Part of https://github.com/flutter/flutter/issues/71511