### PR TITLE
Make `flutter create --sample` null-safe

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -236,6 +236,8 @@ class CreateCommand extends CreateBase {
       linux: featureFlags.isLinuxEnabled && platforms.contains('linux'),
       macos: featureFlags.isMacOSEnabled && platforms.contains('macos'),
       windows: featureFlags.isWindowsEnabled && platforms.contains('windows'),
+      // Enable null-safety for sample code, which is - unlike our regular templates - already migrated.
+      dartSdkVersionBounds: sampleCode != null ? '">=2.12.0-0 <3.0.0"' : '">=2.7.0 <3.0.0"'
     );
 
     final String relativeDirPath = globals.fs.path.relative(projectDirPath);

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -311,6 +311,7 @@ abstract class CreateBase extends FlutterCommand {
     String androidLanguage,
     String iosLanguage,
     String flutterRoot,
+    String dartSdkVersionBounds,
     bool withPluginHook = false,
     bool ios = false,
     bool android = false,
@@ -364,6 +365,7 @@ abstract class CreateBase extends FlutterCommand {
       'macos': macos,
       'windows': windows,
       'year': DateTime.now().year,
+      'dartSdkVersionBounds': dartSdkVersionBounds,
     };
   }
 

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -20,7 +20,7 @@ version: 1.0.0+1
 {{/withPluginHook}}
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: {{dartSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -18,7 +18,7 @@ description: {{description}}
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: {{dartSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ author:
 homepage:
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: {{dartSdkVersionBounds}}
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1602,6 +1602,20 @@ void main() {
     HttpClientFactory: () => () => MockHttpClient(200, result: 'void main() {}'),
   });
 
+  testUsingContext('null-safe sample-based project have no analyzer errors', () async {
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>['--no-pub', '--sample=foo.bar.Baz'],
+      <String>['lib/main.dart'],
+    );
+    expect(
+      projectDir.childDirectory('lib').childFile('main.dart').readAsStringSync(),
+      contains('String?'), // uses null-safe syntax
+    );
+  }, overrides: <Type, Generator>{
+    HttpClientFactory: () => () => MockHttpClient(200, result: 'void main() { String? foo; print(foo); }'),
+  });
+
   testUsingContext('can write samples index to disk', () async {
     final String outputFile = globals.fs.path.join(tempDir.path, 'flutter_samples.json');
     final CreateCommand command = CreateCommand();


### PR DESCRIPTION
`flutter create --sample=foo` created a project that wasn't enabled for null-safety even though all of our samples have been migrated to null-safety. This caused analyzer warnings regarding the NNBD syntax used in the samples.

This generates a null-safe project when `--sample` is used.

Fixes https://github.com/flutter/flutter/issues/74564.