### PR TITLE
Swap mockito import for test/fake

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -72,14 +72,14 @@ void main() {
       const int devicePort = 499;
       const int hostPort = 42;
 
-      FakeDeviceLogReader mockLogReader;
+      FakeDeviceLogReader fakeLogReader;
       MockPortForwarder portForwarder;
       MockDartDevelopmentService mockDds;
       MockAndroidDevice device;
       MockHttpClient httpClient;
 
       setUp(() {
-        mockLogReader = FakeDeviceLogReader();
+        fakeLogReader = FakeDeviceLogReader();
         portForwarder = MockPortForwarder();
         device = MockAndroidDevice();
         mockDds = MockDartDevelopmentService();
@@ -112,16 +112,16 @@ void main() {
       });
 
       tearDown(() {
-        mockLogReader.dispose();
+        fakeLogReader.dispose();
       });
 
       testUsingContext('finds observatory port and forwards', () async {
         when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
           .thenAnswer((_) {
             // Now that the reader is used, start writing messages to it.
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
-            return mockLogReader;
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+            return fakeLogReader;
           });
         testDeviceManager.addDevice(device);
         final Completer<void> completer = Completer<void>();
@@ -136,7 +136,7 @@ void main() {
         verify(
           portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')),
         ).called(1);
-        await mockLogReader.dispose();
+        await fakeLogReader.dispose();
         await expectLoggerInterruptEndsTask(task, logger);
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
@@ -149,10 +149,10 @@ void main() {
         when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
           .thenAnswer((_) {
             // Now that the reader is used, start writing messages to it.
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http:/:/127.0.0.1:$devicePort');
-            mockLogReader.dispose();
-            return mockLogReader;
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine('Observatory listening on http:/:/127.0.0.1:$devicePort');
+            fakeLogReader.dispose();
+            return fakeLogReader;
           });
         testDeviceManager.addDevice(device);
         expect(createTestCommandRunner(AttachCommand()).run(<String>['attach']),
@@ -167,9 +167,9 @@ void main() {
         when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
           .thenAnswer((_) {
             // Now that the reader is used, start writing messages to it.
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
-            return mockLogReader;
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+            return fakeLogReader;
           });
         testDeviceManager.addDevice(device);
 
@@ -247,9 +247,9 @@ void main() {
         when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
           .thenAnswer((_) {
             // Now that the reader is used, start writing messages to it.
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
-            return mockLogReader;
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+            return fakeLogReader;
           });
         testDeviceManager.addDevice(device);
 
@@ -270,9 +270,9 @@ void main() {
         when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
           .thenAnswer((_) {
             // Now that the reader is used, start writing messages to it.
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
-            return mockLogReader;
+            fakeLogReader.addLine('Foo');
+            fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+            return fakeLogReader;
           });
         testDeviceManager.addDevice(device);
 
@@ -293,7 +293,7 @@ void main() {
     testUsingContext('selects specified target', () async {
       const int devicePort = 499;
       const int hostPort = 42;
-      final FakeDeviceLogReader mockLogReader = FakeDeviceLogReader();
+      final FakeDeviceLogReader fakeLogReader = FakeDeviceLogReader();
       final MockPortForwarder portForwarder = MockPortForwarder();
       final MockDartDevelopmentService mockDds = MockDartDevelopmentService();
       final MockAndroidDevice device = MockAndroidDevice();
@@ -330,10 +330,10 @@ void main() {
       when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
         .thenAnswer((_) {
           // Now that the reader is used, start writing messages to it.
-          mockLogReader.addLine('Foo');
-          mockLogReader.addLine(
+          fakeLogReader.addLine('Foo');
+          fakeLogReader.addLine(
               'Observatory listening on http://127.0.0.1:$devicePort');
-          return mockLogReader;
+          return fakeLogReader;
         });
       final File foo = globals.fs.file('lib/foo.dart')
         ..createSync();
@@ -375,7 +375,7 @@ void main() {
     testUsingContext('fallbacks to protocol observatory if MDNS failed on iOS', () async {
       const int devicePort = 499;
       const int hostPort = 42;
-      final FakeDeviceLogReader mockLogReader = FakeDeviceLogReader();
+      final FakeDeviceLogReader fakeLogReader = FakeDeviceLogReader();
       final MockPortForwarder portForwarder = MockPortForwarder();
       final MockDartDevelopmentService mockDds = MockDartDevelopmentService();
       final MockIOSDevice device = MockIOSDevice();
@@ -388,7 +388,7 @@ void main() {
       final Completer<void> noopCompleter = Completer<void>();
       when(mockDds.done).thenAnswer((_) => noopCompleter.future);
       when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
-        .thenAnswer((_) => mockLogReader);
+        .thenAnswer((_) => fakeLogReader);
       when(portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')))
         .thenAnswer((_) async => hostPort);
       when(portForwarder.forwardedPorts)

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -239,7 +239,7 @@ flutter:
       ]),
       id: 'emulator-5555',
       androidConsoleSocketFactory: (String host, int port) async =>
-        MockWorkingAndroidConsoleSocket('dummyEmulatorId'),
+        FakeWorkingAndroidConsoleSocket('dummyEmulatorId'),
     );
 
     expect(await device.emulatorId, equals('dummyEmulatorId'));
@@ -311,7 +311,7 @@ flutter:
         )
       ]),
       androidConsoleSocketFactory: (String host, int port) async =>
-        MockUnresponsiveAndroidConsoleSocket(),
+        FakeUnresponsiveAndroidConsoleSocket(),
     );
 
     expect(await device.emulatorId, isNull);
@@ -326,7 +326,7 @@ flutter:
         )
       ]),
       androidConsoleSocketFactory: (String host, int port) async =>
-        MockDisconnectingAndroidConsoleSocket()
+        FakeDisconnectingAndroidConsoleSocket()
     );
 
     expect(await device.emulatorId, isNull);
@@ -478,7 +478,6 @@ AndroidDevice setUpAndroidDevice({
 }
 
 class MockAndroidSdk extends Mock implements AndroidSdk {}
-class MockProcessManager extends Mock implements ProcessManager {}
 
 const String kAdbShellGetprop = '''
 [dalvik.vm.dex2oat-Xms]: [64m]
@@ -640,8 +639,8 @@ const String kAdbShellGetprop = '''
 
 /// A mock Android Console that presents a connection banner and responds to
 /// "avd name" requests with the supplied name.
-class MockWorkingAndroidConsoleSocket extends Fake implements Socket {
-  MockWorkingAndroidConsoleSocket(this.avdName) {
+class FakeWorkingAndroidConsoleSocket extends Fake implements Socket {
+  FakeWorkingAndroidConsoleSocket(this.avdName) {
     _controller.add('Android Console: Welcome!\n');
     // Include OK in the same packet here. In the response to "avd name"
     // it's sent alone to ensure both are handled.
@@ -672,7 +671,7 @@ class MockWorkingAndroidConsoleSocket extends Fake implements Socket {
 }
 
 /// An Android console socket that drops all input and returns no output.
-class MockUnresponsiveAndroidConsoleSocket extends Fake implements Socket {
+class FakeUnresponsiveAndroidConsoleSocket extends Fake implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
@@ -686,8 +685,8 @@ class MockUnresponsiveAndroidConsoleSocket extends Fake implements Socket {
 }
 
 /// An Android console socket that drops all input and returns no output.
-class MockDisconnectingAndroidConsoleSocket extends Fake implements Socket {
-  MockDisconnectingAndroidConsoleSocket() {
+class FakeDisconnectingAndroidConsoleSocket extends Fake implements Socket {
+  FakeDisconnectingAndroidConsoleSocket() {
     _controller.add('Android Console: Welcome!\n');
     // Include OK in the same packet here. In the response to "avd name"
     // it's sent alone to ensure both are handled.

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -16,8 +16,8 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/project.dart';
 
 import 'package:meta/meta.dart';
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
+import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -13,9 +13,9 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/drive/drive_service.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:process/process.dart';
+import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -62,17 +62,17 @@ void main() {
 
     group('Observatory and DDS setup', () {
       Platform fakePlatform;
-      ProcessManager mockProcessManager;
+      ProcessManager fakeProcessManager;
       FlutterPlatform flutterPlatform;
       final Map<Type, Generator> contextOverrides = <Type, Generator>{
         Platform: () => fakePlatform,
-        ProcessManager: () => mockProcessManager,
+        ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
       };
 
       setUp(() {
         fakePlatform = FakePlatform(operatingSystem: 'linux', environment: <String, String>{});
-        mockProcessManager = FakeProcessManager.list(<FakeCommand>[
+        fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>[
               '/',


### PR DESCRIPTION
Fake is implemented in `mockito` and `test/fake`. Swap to `test/fake` where only `Fake` is being used from mockito (no mocks).
Also rename some fake variables that were misnamed as mocks.

Part of https://github.com/flutter/flutter/issues/71511