### PR TITLE
fixes precision error during SliverGridRegularTileLayout

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -194,7 +194,7 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
 
   @override
   int getMinChildIndexForScrollOffset(double scrollOffset) {
-    return mainAxisStride > 0.0 ? crossAxisCount * (scrollOffset ~/ mainAxisStride) : 0;
+    return mainAxisStride > precisionErrorTolerance ? crossAxisCount * (scrollOffset ~/ mainAxisStride) : 0;
   }
 
   @override
@@ -497,6 +497,7 @@ class SliverGridDelegateWithMaxCrossAxisExtent extends SliverGridDelegate {
         constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1));
     final double childCrossAxisExtent = usableCrossAxisExtent / crossAxisCount;
     final double childMainAxisExtent = mainAxisExtent ?? childCrossAxisExtent / childAspectRatio;
+    print('usableCrossAxisExtent $usableCrossAxisExtent, childMainAxisExtent $childMainAxisExtent');
     return SliverGridRegularTileLayout(
       crossAxisCount: crossAxisCount,
       mainAxisStride: childMainAxisExtent + mainAxisSpacing,

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -497,7 +497,6 @@ class SliverGridDelegateWithMaxCrossAxisExtent extends SliverGridDelegate {
         constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1));
     final double childCrossAxisExtent = usableCrossAxisExtent / crossAxisCount;
     final double childMainAxisExtent = mainAxisExtent ?? childCrossAxisExtent / childAspectRatio;
-    print('usableCrossAxisExtent $usableCrossAxisExtent, childMainAxisExtent $childMainAxisExtent');
     return SliverGridRegularTileLayout(
       crossAxisCount: crossAxisCount,
       mainAxisStride: childMainAxisExtent + mainAxisSpacing,

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -315,6 +315,30 @@ void main() {
     expect(find.text('4'), findsNothing);
   });
 
+  testWidgets('SliverGridRegularTileLayout - can handle close to zero mainAxisStride', (WidgetTester tester) async {
+    const SliverGridDelegateWithMaxCrossAxisExtent delegate = SliverGridDelegateWithMaxCrossAxisExtent(
+      childAspectRatio: 1e300,
+      maxCrossAxisExtent: 500.0,
+    );
+    final SliverGridLayout layout = delegate.getLayout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.forward,
+        scrollOffset: 100.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 0.0,
+        crossAxisExtent: 500,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 0.0,
+        cacheOrigin: 0.0,
+      )
+    );
+    expect(layout.getMinChildIndexForScrollOffset(1000.0), 0.0);
+  });
+
   testWidgets('GridView - change maxChildCrossAxisExtent', (WidgetTester tester) async {
     final List<int> log = <int>[];
 


### PR DESCRIPTION
This pr does an precision error check before calculating the getMinChildIndexForScrollOffset


fixes https://github.com/flutter/flutter/issues/71693
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
