### PR TITLE
Add canRun override to FakeProcessManager

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -55,10 +55,12 @@ final Platform macPlatform = FakePlatform(
 void main() {
   MockFlutterVersion mockFlutterVersion;
   BufferLogger logger;
+  FakeProcessManager fakeProcessManager;
 
   setUp(() {
     mockFlutterVersion = MockFlutterVersion();
     logger = BufferLogger.test();
+    fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
   });
 
   testWithoutContext('ValidationMessage equality and hashCode includes contextUrl', () {
@@ -606,7 +608,6 @@ void main() {
     }, overrides: noColorTerminalOverride);
   });
 
-
   group('grouped validator merging results', () {
     final PassingGroupedValidator installed = PassingGroupedValidator('Category');
     final PartialGroupedValidator partial = PartialGroupedValidator('Category');
@@ -659,14 +660,12 @@ void main() {
   });
 
   testUsingContext('WebWorkflow is a part of validator workflows if enabled', () async {
-    when(globals.processManager.canRun(any)).thenReturn(true);
-
     expect(DoctorValidatorsProvider.defaultInstance.workflows,
       contains(isA<WebWorkflow>()));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
     FileSystem: () => MemoryFileSystem.test(),
-    ProcessManager: () => MockProcessManager(),
+    ProcessManager: () => fakeProcessManager,
   });
 
   testUsingContext('Fetches tags to get the right version', () async {
@@ -1057,7 +1056,6 @@ class VsCodeValidatorTestTargets extends VsCodeValidator {
   static final String missingExtensions = globals.fs.path.join('test', 'data', 'vscode', 'notExtensions');
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
 class MockPlistParser extends Mock implements PlistParser {}
 class MockDeviceManager extends Mock implements DeviceManager {}
 class MockDevice extends Mock implements Device {

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -48,9 +48,9 @@ void main() {
 
   testWithoutContext('AndroidDevices returns empty device list and diagnostics when adb cannot be run', () async {
     final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
-    fakeProcessManager.canRunSucceeds = false;
+    fakeProcessManager.excludedExecutables.add('adb');
     final AndroidDevices androidDevices = AndroidDevices(
-      androidSdk: FakeAndroidSdk(null),
+      androidSdk: FakeAndroidSdk(),
       logger: BufferLogger.test(),
       androidWorkflow: AndroidWorkflow(
         androidSdk: FakeAndroidSdk('adb'),

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -47,6 +47,8 @@ void main() {
   });
 
   testWithoutContext('AndroidDevices returns empty device list and diagnostics when adb cannot be run', () async {
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
+    fakeProcessManager.canRunSucceeds = false;
     final AndroidDevices androidDevices = AndroidDevices(
       androidSdk: FakeAndroidSdk(null),
       logger: BufferLogger.test(),
@@ -54,8 +56,7 @@ void main() {
         androidSdk: FakeAndroidSdk('adb'),
         featureFlags: TestFeatureFlags(),
       ),
-      // Will throw an exception if anything other than canRun is invoked
-      processManager: FakeProcessManger(),
+      processManager: fakeProcessManager,
       fileSystem: MemoryFileSystem.test(),
       platform: FakePlatform(),
       userMessages: UserMessages(),
@@ -63,6 +64,7 @@ void main() {
 
     expect(await androidDevices.pollingGetDevices(), isEmpty);
     expect(await androidDevices.getDiagnostics(), isEmpty);
+    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
   });
 
   testWithoutContext('AndroidDevices returns empty device list and diagnostics on null Android SDK', () async {
@@ -238,11 +240,4 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 
   @override
   final String adbPath;
-}
-
-class FakeProcessManger extends Fake implements ProcessManager {
-  @override
-  bool canRun(dynamic executable, {String workingDirectory}) {
-    return false;
-  }
 }

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -8,6 +8,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart' show ProcessResult;
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:meta/meta.dart';
@@ -18,14 +19,16 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 
+class MockProcessManager extends Mock implements ProcessManager {}
+
 void main() {
   MemoryFileSystem fileSystem;
-  FakeProcessManager fakeProcessManager;
+  MockProcessManager processManager;
   Config config;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
-    fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
+    processManager = MockProcessManager();
     config = Config.test(
       'test',
       directory: fileSystem.currentDirectory,
@@ -122,20 +125,20 @@ void main() {
       config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      fakeProcessManager.addCommands(<FakeCommand>[
-        const FakeCommand(
-          command: <String>['/usr/libexec/java_home', '-v', '1.8'],
-        ),
-        FakeCommand(
-          command: <String>[sdk.sdkManagerPath, '--version'],
-          stdout: '26.1.1\n',
-        ),
-      ]);
+      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(true);
+      when(processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
+          environment: argThat(isNotNull,  named: 'environment')))
+          .thenReturn(ProcessResult(1, 0, '26.1.1\n', ''));
+      when(processManager.runSync(
+        <String>['/usr/libexec/java_home', '-v', '1.8'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).thenReturn(ProcessResult(0, 0, '', ''));
 
       expect(sdk.sdkManagerVersion, '26.1.1');
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
-      ProcessManager: () => fakeProcessManager,
+      ProcessManager: () => processManager,
       Config: () => config,
     });
 
@@ -146,6 +149,7 @@ void main() {
       config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+      when(processManager.canRun(sdk.adbPath)).thenReturn(true);
 
       final List<String> validationIssues = sdk.validateSdkWellFormed();
       expect(validationIssues.first, 'No valid Android SDK platforms found in'
@@ -154,7 +158,7 @@ void main() {
         '  - android-23');
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
-      ProcessManager: () => fakeProcessManager,
+      ProcessManager: () => processManager,
       Config: () => config,
       Platform: () => FakePlatform(operatingSystem: 'linux'),
     });
@@ -164,22 +168,20 @@ void main() {
       config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      fakeProcessManager.addCommands(<FakeCommand>[
-        const FakeCommand(
-          command: <String>['/usr/libexec/java_home', '-v', '1.8'],
-        ),
-        FakeCommand(
-          command: <String>[sdk.sdkManagerPath, '--version'],
-          stdout: '26.1.1\n',
-          stderr: 'Mystery error',
-          exitCode: 1,
-        ),
-      ]);
+      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(true);
+      when(processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
+          environment: argThat(isNotNull,  named: 'environment')))
+          .thenReturn(ProcessResult(1, 1, '26.1.1\n', 'Mystery error'));
+      when(processManager.runSync(
+        <String>['/usr/libexec/java_home', '-v', '1.8'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).thenReturn(ProcessResult(0, 0, '', ''));
 
       expect(sdk.sdkManagerVersion, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
-      ProcessManager: () => fakeProcessManager,
+      ProcessManager: () => processManager,
       Config: () => config,
     });
 
@@ -188,11 +190,11 @@ void main() {
       config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      fakeProcessManager.canRunSucceeds = false;
+      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(false);
       expect(() => sdk.sdkManagerVersion, throwsToolExit());
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
-      ProcessManager: () => fakeProcessManager,
+      ProcessManager: () => processManager,
       Config: () => config,
     });
   });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -763,11 +763,7 @@ class FakeDownloadedArtifact extends CachedArtifact {
 }
 
 class MockArtifactUpdater extends Mock implements ArtifactUpdater {}
-class MockProcessManager extends Mock implements ProcessManager {}
-class MockFileSystem extends Mock implements FileSystem {}
 class MockFile extends Mock implements File {}
-class MockDirectory extends Mock implements Directory {}
-class MockRandomAccessFile extends Mock implements RandomAccessFile {}
 class MockCachedArtifact extends Mock implements CachedArtifact {}
 class MockIosUsbArtifacts extends Mock implements IosUsbArtifacts {}
 class MockInternetAddress extends Mock implements InternetAddress {}

--- a/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
@@ -50,7 +50,7 @@ void main() {
   });
 
   testWithoutContext('WebValidator Can notice missing macOS executable ', () async {
-    fakeProcessManager.canRunSucceeds = false;
+    fakeProcessManager.excludedExecutables.add(kMacOSExecutable);
 
     final ValidationResult result = await webValidator.validate();
 
@@ -58,7 +58,7 @@ void main() {
   });
 
   testWithoutContext('WebValidator does not warn about CHROME_EXECUTABLE unless it cant find chrome ', () async {
-    fakeProcessManager.canRunSucceeds = false;
+    fakeProcessManager.excludedExecutables.add(kMacOSExecutable);
 
     final ValidationResult result = await webValidator.validate();
 

--- a/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_validator_test.dart
@@ -11,22 +11,20 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
 import 'package:flutter_tools/src/web/web_validator.dart';
-import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
 
 void main() {
   Platform platform;
-  ProcessManager processManager;
+  FakeProcessManager fakeProcessManager;
   ChromiumLauncher chromeLauncher;
   FileSystem fileSystem;
   ChromiumValidator webValidator;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
-    processManager = MockProcessManager();
+    fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
     platform = FakePlatform(
       operatingSystem: 'macos',
       environment: <String, String>{},
@@ -34,7 +32,7 @@ void main() {
     chromeLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
       platform: platform,
-      processManager: processManager,
+      processManager: fakeProcessManager,
       operatingSystemUtils: null,
       browserFinder: findChromeExecutable,
       logger: BufferLogger.test(),
@@ -46,15 +44,13 @@ void main() {
   });
 
   testWithoutContext('WebValidator can find executable on macOS', () async {
-    when(processManager.canRun(kMacOSExecutable)).thenReturn(true);
-
     final ValidationResult result = await webValidator.validate();
 
     expect(result.type, ValidationType.installed);
   });
 
   testWithoutContext('WebValidator Can notice missing macOS executable ', () async {
-    when(processManager.canRun(kMacOSExecutable)).thenReturn(false);
+    fakeProcessManager.canRunSucceeds = false;
 
     final ValidationResult result = await webValidator.validate();
 
@@ -62,7 +58,7 @@ void main() {
   });
 
   testWithoutContext('WebValidator does not warn about CHROME_EXECUTABLE unless it cant find chrome ', () async {
-    when(processManager.canRun(kMacOSExecutable)).thenReturn(false);
+    fakeProcessManager.canRunSucceeds = false;
 
     final ValidationResult result = await webValidator.validate();
 
@@ -73,5 +69,3 @@ void main() {
     expect(result.type, ValidationType.missing);
   });
 }
-
-class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -302,7 +302,9 @@ abstract class FakeProcessManager implements ProcessManager {
   }
 
   @override
-  bool canRun(dynamic executable, {String workingDirectory}) => true;
+  bool canRun(dynamic executable, {String workingDirectory}) => canRunSucceeds;
+
+  bool canRunSucceeds = true;
 
   @override
   bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.sigterm]) {

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -301,10 +301,11 @@ abstract class FakeProcessManager implements ProcessManager {
     );
   }
 
+  /// Returns false if executable in [excludedExecutables].
   @override
-  bool canRun(dynamic executable, {String workingDirectory}) => canRunSucceeds;
+  bool canRun(dynamic executable, {String workingDirectory}) => !excludedExecutables.contains(executable);
 
-  bool canRunSucceeds = true;
+  Set<String> excludedExecutables = <String>{};
 
   @override
   bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.sigterm]) {


### PR DESCRIPTION
Add `canRunSucceeds` property to `FakeProcessManager`, replace `MockProcessManager` where it only needed that functionality (to return `false` from `canRun`).

Part of https://github.com/flutter/flutter/issues/71511