### PR TITLE
Fix a slider layout bug when the overlay size is smaller than the thumb size

### DIFF
--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1451,7 +1451,7 @@ abstract class BaseSliderTrackShape {
     assert(overlayWidth >= 0);
     assert(trackHeight >= 0);
 
-    final double trackLeft = offset.dx + overlayWidth / 2;
+    final double trackLeft = offset.dx + math.max(overlayWidth / 2, thumbWidth / 2);
     final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
     final double trackRight = trackLeft + parentBox.size.width - math.max(thumbWidth, overlayWidth);
     final double trackBottom = trackTop + trackHeight;

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -860,16 +860,35 @@ void main() {
 
     await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5));
 
-    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
+    final MaterialInkController material = Material.of(
+      tester.element(find.byType(Slider)),
+    )!;
 
-    // The track rectangle begins at 10 pixels and ends at 790 pixels which position at the center of the screen(width: 800.0)
-    expect(material,
+    // The track rectangle begins at 10 pixels from the left of the screen and ends 10 pixels from the right
+    // (790 pixels from the left). The main check here it that the track itself should be centered on
+    // the 800 pixel-wide screen.
+    expect(
+      material,
       paints
-        // active track RRect
-        ..rrect(rrect: RRect.fromLTRBAndCorners(10.0, 297.0, 400.0, 303.0, topLeft: const Radius.circular(3.0), bottomLeft: const Radius.circular(3.0)))
-        // inactive track RRect
-        ..rrect(rrect: RRect.fromLTRBAndCorners(400.0, 298.0, 790.0, 302.0, topRight: const Radius.circular(2.0), bottomRight: const Radius.circular(2.0)))
-        // thumb
+        // active track RRect. Starts 10 pixels from left of screen.
+        ..rrect(rrect: RRect.fromLTRBAndCorners(
+            10.0,
+            297.0,
+            400.0,
+            303.0,
+            topLeft: const Radius.circular(3.0),
+            bottomLeft: const Radius.circular(3.0),
+        ))
+        // inactive track RRect. Ends 10 pixels from right of screen.
+        ..rrect(rrect: RRect.fromLTRBAndCorners(
+            400.0,
+            298.0,
+            790.0,
+            302.0,
+            topRight: const Radius.circular(2.0),
+            bottomRight: const Radius.circular(2.0),
+        ))
+        // The thumb.
         ..circle(x: 400.0, y: 300.0, radius: 10.0, )
     );
   });

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -852,6 +852,7 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/74503
   testWidgets('The slider track layout correctly when the overlay size is smaller than the thumb size', (WidgetTester tester) async {
     final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
       overlayShape: SliderComponentShape.noOverlay,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -852,6 +852,27 @@ void main() {
     );
   });
 
+  testWidgets('The slider track layout correctly when the overlay size is smaller than the thumb size', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+      overlayShape: SliderComponentShape.noOverlay,
+    );
+
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5));
+
+    final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
+
+    // The track rectangle begins at 10 pixels and ends at 790 pixels which position at the center of the screen(width: 800.0)
+    expect(material,
+      paints
+        // active track RRect
+        ..rrect(rrect: RRect.fromLTRBAndCorners(10.0, 297.0, 400.0, 303.0, topLeft: const Radius.circular(3.0), bottomLeft: const Radius.circular(3.0)))
+        // inactive track RRect
+        ..rrect(rrect: RRect.fromLTRBAndCorners(400.0, 298.0, 790.0, 302.0, topRight: const Radius.circular(2.0), bottomRight: const Radius.circular(2.0)))
+        // thumb
+        ..circle(x: 400.0, y: 300.0, radius: 10.0, )
+    );
+  });
+
   // Only the thumb, overlay, and tick mark have special shortcuts to provide
   // no-op or empty shapes.
   //


### PR DESCRIPTION
As title.

Fixes #74503 