### PR TITLE
Update Data Table Class with Borders Like Table Widgets (flutter#36837)

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -431,6 +431,7 @@ class DataTable extends StatelessWidget {
     this.showCheckboxColumn = true,
     this.showBottomBorder = false,
     this.dividerThickness,
+    this.border,
     required this.rows,
   }) : assert(columns != null),
        assert(columns.isNotEmpty),
@@ -641,6 +642,9 @@ class DataTable extends StatelessWidget {
   /// By default, a border is not shown at the bottom to allow for a border
   /// around the table defined by [decoration].
   final bool showBottomBorder;
+
+  /// The style to use when painting the boundary and interior divisions of the table.
+  final TableBorder? border;
 
   // Set by the constructor to the index of the only Column that is
   // non-numeric, if there is exactly one, otherwise null.
@@ -1016,6 +1020,7 @@ class DataTable extends StatelessWidget {
         child: Table(
           columnWidths: tableColumns.asMap(),
           children: tableRows,
+          border: border,
         ),
       ),
     );

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1496,4 +1496,75 @@ void main() {
       const Offset(width - borderVertical, height - borderHorizontal),
     );
   });
+
+  testWidgets('DataTable set interior border test',
+          (WidgetTester tester) async {
+        const List<DataColumn> columns = <DataColumn>[
+          DataColumn(label: Text('column1')),
+          DataColumn(label: Text('column2')),
+        ];
+
+        const List<DataCell> cells = <DataCell>[
+          DataCell(Text('cell1')),
+          DataCell(Text('cell2')),
+        ];
+
+        const List<DataRow> rows = <DataRow>[
+          DataRow(cells: cells),
+          DataRow(cells: cells),
+        ];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: DataTable(
+                border: TableBorder.all(width: 2),
+                columns: columns,
+                rows: rows,
+              ),
+            ),
+          ),
+        );
+
+        Table table = tester.widget(find.byType(Table));
+        TableBorder? tableRow = table.border;
+        expect(tableRow!.top.width, 2.0);
+        expect(tableRow.bottom.width, 2.0);
+
+        final Finder finder = find.byType(DataTable);
+        expect(tester.getSize(finder), equals(const Size(800, 600)));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: DataTable(
+                border: TableBorder.all(color: Colors.red),
+                columns: columns,
+                rows: rows,
+              ),
+            ),
+          ),
+        );
+
+        table = tester.widget(find.byType(Table));
+        tableRow = table.border;
+        expect(tableRow!.top.color, Colors.red);
+        expect(tableRow.bottom.width, 1);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: DataTable(
+                columns: columns,
+                rows: rows,
+              ),
+            ),
+          ),
+        );
+
+        table = tester.widget(find.byType(Table));
+        tableRow = table.border;
+        expect(tableRow?.bottom.width, null);
+        expect(tableRow?.top.color, null);
+      });
 }


### PR DESCRIPTION
Adds boundary and interior divisions to DataTable. 

fixes #36837
