### PR TITLE
Added `showTooltip`flag for `BottomNavigationBar`

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -274,6 +274,7 @@ class BottomNavigationBar extends StatefulWidget {
     this.unselectedLabelStyle,
     this.showSelectedLabels,
     this.showUnselectedLabels,
+    this.showTooltip = true,
     this.mouseCursor,
   }) : assert(items != null),
        assert(items.length >= 2),
@@ -291,6 +292,7 @@ class BottomNavigationBar extends StatefulWidget {
        ),
        assert(selectedFontSize != null && selectedFontSize >= 0.0),
        assert(unselectedFontSize != null && unselectedFontSize >= 0.0),
+       assert(showTooltip != null),
        selectedItemColor = selectedItemColor ?? fixedColor,
        super(key: key);
 
@@ -404,6 +406,11 @@ class BottomNavigationBar extends StatefulWidget {
   /// Whether the labels are shown for the selected [BottomNavigationBarItem].
   final bool? showSelectedLabels;
 
+  /// Whether the tooltip is shown when long pressed on the [BottomNavigationBarItem].
+  ///
+  /// Defaults to true.
+  final bool showTooltip;
+
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// tiles.
   ///
@@ -433,6 +440,7 @@ class _BottomNavigationTile extends StatelessWidget {
     required this.showSelectedLabels,
     required this.showUnselectedLabels,
     this.indexLabel,
+    required this.showTooltip,
     required this.mouseCursor,
     }) : assert(type != null),
          assert(item != null),
@@ -457,6 +465,7 @@ class _BottomNavigationTile extends StatelessWidget {
   final String? indexLabel;
   final bool showSelectedLabels;
   final bool showUnselectedLabels;
+  final bool showTooltip;
   final MouseCursor mouseCursor;
 
   @override
@@ -478,9 +487,6 @@ class _BottomNavigationTile extends StatelessWidget {
     // The amount that the unselected icons are bigger than the selected icon,
     // (or zero if the unselected icons are not any bigger than the selected icon).
     final double unselectedIconDiff = math.max(unselectedIconSize - selectedIconSize, 0);
-
-    // The effective tool tip message to be shown on the BottomNavigationBarItem.
-    final String? effectiveTooltip = item.tooltip == '' ? null : item.tooltip ?? item.label;
 
     // Defines the padding for the animating icons + labels.
     //
@@ -572,14 +578,19 @@ class _BottomNavigationTile extends StatelessWidget {
       ),
     );
 
-    if (effectiveTooltip != null) {
-      result = Tooltip(
-        message: effectiveTooltip,
-        preferBelow: false,
-        verticalOffset: selectedIconSize + selectedFontSize,
-        excludeFromSemantics: true,
-        child: result,
-      );
+    if (showTooltip) {
+      // The effective tool tip message to be shown on the BottomNavigationBarItem.
+      final String? effectiveTooltip = item.tooltip == '' ? null : item.tooltip ?? item.label;
+
+      if(effectiveTooltip != null){
+        result = Tooltip(
+          message: effectiveTooltip,
+          preferBelow: false,
+          verticalOffset: selectedIconSize + selectedFontSize,
+          excludeFromSemantics: true,
+          child: result,
+        );
+      }
     }
 
     result = Semantics(
@@ -979,6 +990,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         showSelectedLabels: widget.showSelectedLabels ?? bottomTheme.showSelectedLabels ?? true,
         showUnselectedLabels: widget.showUnselectedLabels ?? bottomTheme.showUnselectedLabels ?? _defaultShowUnselected,
         indexLabel: localizations.tabLabel(tabIndex: i + 1, tabCount: widget.items.length),
+        showTooltip: widget.showTooltip,
         mouseCursor: effectiveMouseCursor,
       ));
     }
@@ -1000,7 +1012,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     assert(debugCheckHasDirectionality(context));
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasMediaQuery(context));
-    assert(Overlay.of(context, debugRequiredFor: widget) != null);
+    assert(!widget.showTooltip || Overlay.of(context, debugRequiredFor: widget) != null);
 
     final BottomNavigationBarThemeData bottomTheme = BottomNavigationBarTheme.of(context);
 

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -99,8 +99,8 @@ class BottomNavigationBarItem {
   /// The text to display in the tooltip for this [BottomNavigationBarItem], when
   /// the user long presses the item.
   ///
-  /// The [Tooltip] will only appear on an item in a Material design [BottomNavigationBar], and
-  /// when the string is not empty.
+  /// The [Tooltip] will only appear on an item in a Material design [BottomNavigationBar],
+  /// when [BottomNavigationBar.showTooltip] is true and the string is not empty.
   ///
   /// Defaults to null, in which case the [label] text will be used.
   final String? tooltip;

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1152,6 +1152,141 @@ void main() {
     expect(tester.getSize(find.text(label).last), equals(const Size(168.0, 56.0)));
   });
 
+  testWidgets('BottomNavigationBar does not show tool tips when showTooltip is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            showTooltip: false,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                label: 'A',
+                tooltip: 'A tooltip',
+                icon: Icon(Icons.ac_unit),
+              ),
+              BottomNavigationBarItem(
+                label: 'B',
+                icon: Icon(Icons.battery_alert),
+              ),
+              BottomNavigationBarItem(
+                label: 'C',
+                icon: Icon(Icons.cake),
+                tooltip: '',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('A'), findsOneWidget);
+    await tester.longPress(find.text('A'));
+    expect(find.byTooltip('A tooltip'), findsNothing);
+
+    expect(find.text('B'), findsOneWidget);
+    await tester.longPress(find.text('B'));
+    expect(find.byTooltip('B'), findsNothing);
+
+    expect(find.text('C'), findsOneWidget);
+    await tester.longPress(find.text('C'));
+    expect(find.byTooltip('C'), findsNothing);
+  });
+
+  testWidgets('BottomNavigationBar requires Overlay ancestor when showTooltip is true', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Scaffold(
+              bottomNavigationBar: BottomNavigationBar(
+                items: const <BottomNavigationBarItem>[
+                  BottomNavigationBarItem(
+                    label: 'A',
+                    tooltip: 'A tooltip',
+                    icon: Icon(Icons.ac_unit),
+                  ),
+                  BottomNavigationBarItem(
+                    label: 'B',
+                    icon: Icon(Icons.battery_alert),
+                  ),
+                  BottomNavigationBarItem(
+                    label: 'C',
+                    icon: Icon(Icons.cake),
+                    tooltip: '',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final dynamic exception = await tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('No Overlay widget found.'));
+  });
+
+  testWidgets('BottomNavigationBar does not require Overlay ancestor when showTooltip is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Scaffold(
+              bottomNavigationBar: BottomNavigationBar(
+                showTooltip: false,
+                items: const <BottomNavigationBarItem>[
+                  BottomNavigationBarItem(
+                    label: 'A',
+                    tooltip: 'A tooltip',
+                    icon: Icon(Icons.ac_unit),
+                  ),
+                  BottomNavigationBarItem(
+                    label: 'B',
+                    icon: Icon(Icons.battery_alert),
+                  ),
+                  BottomNavigationBarItem(
+                    label: 'C',
+                    icon: Icon(Icons.cake),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final dynamic exception = await tester.takeException();
+    expect(exception, isNull);
+
+    expect(find.text('A'), findsOneWidget);
+    await tester.longPress(find.text('A'));
+    expect(find.byTooltip('A tooltip'), findsNothing);
+
+    expect(find.text('B'), findsOneWidget);
+    await tester.longPress(find.text('B'));
+    expect(find.byTooltip('B'), findsNothing);
+
+    expect(find.text('C'), findsOneWidget);
+    await tester.longPress(find.text('C'));
+    expect(find.byTooltip('C'), findsNothing);
+  });
+
   testWidgets('Different behaviour of tool tip in BottomNavigationBarItem', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Currently, BottomNavigationBar requires an Overlay ancestor, in order to show tool tip. 
This PR adds a `showTooltip` flag, where setting the flag as false will let the BottomNavigatorBar build without Overlay ascestor.

Fixes #74895

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.