### PR TITLE
Implemented copyWith method as per issue #74613 

### DIFF
--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -327,8 +327,8 @@ class BorderRadius extends BorderRadiusGeometry {
     this.bottomRight = Radius.zero,
   });
 
-  /// Creates a border radius by overriding the previous values and
-  /// returing a new object
+  /// Returns a copy of this BorderRadius with the given fields replaced with
+  /// the new values.
   BorderRadius copyWith({
     Radius? topLeft,
     Radius? topRight,
@@ -336,10 +336,10 @@ class BorderRadius extends BorderRadiusGeometry {
     Radius? bottomRight,
   }) {
     return BorderRadius.only(
-      topLeft: topLeft ?? _topLeft,
-      topRight: topRight ?? _topRight,
-      bottomLeft: bottomLeft ?? _bottomLeft,
-      bottomRight: bottomRight ?? _bottomRight,
+      topLeft: topLeft ?? this.topLeft,
+      topRight: topRight ?? this.topRight,
+      bottomLeft: bottomLeft ?? this.bottomLeft,
+      bottomRight: bottomRight ?? this.bottomRight,
     );
   }
   /// A border radius with all zero radii.

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -329,7 +329,6 @@ class BorderRadius extends BorderRadiusGeometry {
 
   /// Creates a border radius by overriding the previous values and
   /// returing a new object
-  
   BorderRadius copyWith({
     Radius? topLeft,
     Radius? topRight,

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -327,19 +327,22 @@ class BorderRadius extends BorderRadiusGeometry {
     this.bottomRight = Radius.zero,
   });
 
-  /// Creates a border radius with the given set of parameters
-  const BorderRadius.copyWith({
-    Radius topLeft = Radius.zero,
-    Radius topRight = Radius.zero,
-    Radius bottomLeft = Radius.zero,
-    Radius bottomRight = Radius.zero,
-    }) : this.only(
-      topLeft:topLeft,
-      topRight:topRight,
-      bottomLeft:bottomLeft,
-      bottomRight:bottomRight
+  /// Creates a border radius by overriding the previous values and
+  /// returing a new object
+  
+  BorderRadius copyWith({
+    Radius? topLeft,
+    Radius? topRight,
+    Radius? bottomLeft,
+    Radius? bottomRight,
+  }) {
+    return BorderRadius.only(
+      topLeft: topLeft ?? _topLeft,
+      topRight: topRight ?? _topRight,
+      bottomLeft: bottomLeft ?? _bottomLeft,
+      bottomRight: bottomRight ?? _bottomRight,
     );
-
+  }
   /// A border radius with all zero radii.
   static const BorderRadius zero = BorderRadius.all(Radius.zero);
 
@@ -504,6 +507,7 @@ class BorderRadius extends BorderRadiusGeometry {
 
   @override
   BorderRadius resolve(TextDirection? direction) => this;
+
 }
 
 /// An immutable set of radii for each corner of a rectangle, but with the

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -506,7 +506,6 @@ class BorderRadius extends BorderRadiusGeometry {
 
   @override
   BorderRadius resolve(TextDirection? direction) => this;
-
 }
 
 /// An immutable set of radii for each corner of a rectangle, but with the

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';
@@ -326,6 +327,19 @@ class BorderRadius extends BorderRadiusGeometry {
     this.bottomLeft = Radius.zero,
     this.bottomRight = Radius.zero,
   });
+
+  /// Creates a border radius with the given set of parameters
+  const BorderRadius.copyWith({
+    Radius topLeft = Radius.zero,
+    Radius topRight = Radius.zero,
+    Radius bottomLeft = Radius.zero,
+    Radius bottomRight = Radius.zero,
+    }) : this.only(
+      topLeft:topLeft,
+      topRight:topRight,
+      bottomLeft:bottomLeft,
+      bottomRight:bottomRight
+    );
 
   /// A border radius with all zero radii.
   static const BorderRadius zero = BorderRadius.all(Radius.zero);

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -980,8 +980,7 @@ class ScrollAction extends Action<ScrollIntent> {
   bool isEnabled(ScrollIntent intent) {
     final FocusNode? focus = primaryFocus;
     final bool contextIsValid = focus != null && focus.context != null;
-    //had to check for focus!=null because it was giving error
-    if (contextIsValid && focus!=null) {
+    if (contextIsValid) {
       // Check for primary scrollable within the current context
       if (Scrollable.of(focus.context!) != null)
         return true;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -980,7 +980,8 @@ class ScrollAction extends Action<ScrollIntent> {
   bool isEnabled(ScrollIntent intent) {
     final FocusNode? focus = primaryFocus;
     final bool contextIsValid = focus != null && focus.context != null;
-    if (contextIsValid) {
+    //had to check for focus!=null because it was giving error
+    if (contextIsValid && focus!=null) {
       // Check for primary scrollable within the current context
       if (Scrollable.of(focus.context!) != null)
         return true;

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -536,14 +536,14 @@ void main() {
     expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
     expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
-  
+
   test('BorderRadius copyWith, merge, ==, hashCode basics', () {
     const BorderRadius firstRadius = BorderRadius.all(Radius.circular(5.0));
     final BorderRadius secondRadius = firstRadius.copyWith();
     expect(firstRadius, secondRadius);
     expect(firstRadius.hashCode, secondRadius.hashCode);
   });
-  
+
   test('BorderRadius copyWith parameters', () {
     const Radius radius = Radius.circular(10);
     const BorderRadius borderRadius = BorderRadius.all(radius);

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -536,12 +536,14 @@ void main() {
     expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
     expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
+  
   test('BorderRadius copyWith, merge, ==, hashCode basics', () {
     const BorderRadius firstRadius = BorderRadius.all(Radius.circular(5.0));
     final BorderRadius secondRadius = firstRadius.copyWith();
     expect(firstRadius, secondRadius);
     expect(firstRadius.hashCode, secondRadius.hashCode);
   });
+  
   test('BorderRadius copyWith parameters', () {
     const Radius radius = Radius.circular(10);
     const BorderRadius borderRadius = BorderRadius.all(radius);

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -543,7 +543,7 @@ void main() {
       bottomLeft: Radius.elliptical(50.0, 60.0),
       bottomRight: Radius.elliptical(40.0, 80.0)
     );
-    BorderRadius secondRadius = firstRadius.copyWith(bottomRight: Radius.zero);
+    final BorderRadius secondRadius = firstRadius.copyWith(bottomRight: Radius.zero);
     expect(firstRadius.topLeft, secondRadius.topLeft);
     expect(firstRadius.topRight, secondRadius.topRight);
     expect(firstRadius.bottomLeft, secondRadius.bottomLeft);

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -536,4 +536,25 @@ void main() {
     expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
     expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
+  
+  test('BorderRadius copyWith', () {
+    const BorderRadius firstRadius = BorderRadius.only(
+      topLeft: Radius.elliptical(10.0, 20.0),
+      topRight: Radius.elliptical(30.0, 40.0),
+      bottomLeft: Radius.elliptical(50.0, 60.0),
+      bottomRight: Radius.elliptical(40.0, 80.0)
+    );
+
+    BorderRadius secondRadius = firstRadius.copyWith(bottomRight: Radius.zero);
+    expect(firstRadius.topLeft, secondRadius.topLeft);
+    expect(firstRadius.topRight, secondRadius.topRight);
+    expect(firstRadius.bottomLeft, secondRadius.bottomLeft);
+    expect(firstRadius.bottomRight, isNot(secondRadius.topLeft));
+    
+
+  });
+  
+
+
+
 }

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -536,7 +536,6 @@ void main() {
     expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
     expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
-  
   test('BorderRadius copyWith', () {
     const BorderRadius firstRadius = BorderRadius.only(
       topLeft: Radius.elliptical(10.0, 20.0),

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -544,17 +544,10 @@ void main() {
       bottomLeft: Radius.elliptical(50.0, 60.0),
       bottomRight: Radius.elliptical(40.0, 80.0)
     );
-
     BorderRadius secondRadius = firstRadius.copyWith(bottomRight: Radius.zero);
     expect(firstRadius.topLeft, secondRadius.topLeft);
     expect(firstRadius.topRight, secondRadius.topRight);
     expect(firstRadius.bottomLeft, secondRadius.bottomLeft);
     expect(firstRadius.bottomRight, isNot(secondRadius.topLeft));
-    
-
   });
-  
-
-
-
 }

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -536,17 +536,22 @@ void main() {
     expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
     expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
-  test('BorderRadius copyWith', () {
-    const BorderRadius firstRadius = BorderRadius.only(
-      topLeft: Radius.elliptical(10.0, 20.0),
-      topRight: Radius.elliptical(30.0, 40.0),
-      bottomLeft: Radius.elliptical(50.0, 60.0),
-      bottomRight: Radius.elliptical(40.0, 80.0)
-    );
-    final BorderRadius secondRadius = firstRadius.copyWith(bottomRight: Radius.zero);
-    expect(firstRadius.topLeft, secondRadius.topLeft);
-    expect(firstRadius.topRight, secondRadius.topRight);
-    expect(firstRadius.bottomLeft, secondRadius.bottomLeft);
-    expect(firstRadius.bottomRight, isNot(secondRadius.topLeft));
+  test('BorderRadius copyWith, merge, ==, hashCode basics', () {
+    const BorderRadius firstRadius = BorderRadius.all(Radius.circular(5.0));
+    final BorderRadius secondRadius = firstRadius.copyWith();
+    expect(firstRadius, secondRadius);
+    expect(firstRadius.hashCode, secondRadius.hashCode);
+  });
+  test('BorderRadius copyWith parameters', () {
+    const Radius radius = Radius.circular(10);
+    const BorderRadius borderRadius = BorderRadius.all(radius);
+    expect(borderRadius.copyWith(topLeft: Radius.zero).topLeft, Radius.zero);
+    expect(borderRadius.copyWith(topLeft: Radius.zero).copyWith(topLeft: radius), borderRadius);
+    expect(borderRadius.copyWith(topRight: Radius.zero).topRight, Radius.zero);
+    expect(borderRadius.copyWith(topRight: Radius.zero).copyWith(topRight: radius), borderRadius);
+    expect(borderRadius.copyWith(bottomLeft: Radius.zero).bottomLeft, Radius.zero);
+    expect(borderRadius.copyWith(bottomLeft: Radius.zero).copyWith(bottomLeft: radius), borderRadius);
+    expect(borderRadius.copyWith(bottomRight: Radius.zero).bottomRight, Radius.zero);
+    expect(borderRadius.copyWith(bottomRight: Radius.zero).copyWith(bottomRight: radius), borderRadius);
   });
 }


### PR DESCRIPTION
Earlier copyWith method wasn't present in BorderRadius class so Implemented BorderRadius.copyWith method and it fixed the issue #74613

Fixes #74613

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
