### PR TITLE
Update the Focus widget to update the node's onKey handler when the widget updates

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -432,7 +432,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// arguments must not be null.
   FocusNode({
     String? debugLabel,
-    FocusOnKeyCallback? onKey,
+    this.onKey,
     bool skipTraversal = false,
     bool canRequestFocus = true,
     bool descendantsAreFocusable = true,
@@ -441,8 +441,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
         assert(descendantsAreFocusable != null),
         _skipTraversal = skipTraversal,
         _canRequestFocus = canRequestFocus,
-        _descendantsAreFocusable = descendantsAreFocusable,
-        _onKey = onKey {
+        _descendantsAreFocusable = descendantsAreFocusable {
     // Set it via the setter so that it does nothing on release builds.
     this.debugLabel = debugLabel;
   }
@@ -573,8 +572,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// [hasFocus] returns true).
   ///
   /// {@macro flutter.widgets.FocusNode.keyEvents}
-  FocusOnKeyCallback? get onKey => _onKey;
-  FocusOnKeyCallback? _onKey;
+  FocusOnKeyCallback? onKey;
 
   FocusManager? _manager;
   List<FocusNode>? _ancestors;
@@ -1028,7 +1026,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   @mustCallSuper
   FocusAttachment attach(BuildContext? context, {FocusOnKeyCallback? onKey}) {
     _context = context;
-    _onKey = onKey ?? _onKey;
+    this.onKey = onKey ?? this.onKey;
     _attachment = FocusAttachment._(this);
     return _attachment!;
   }

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -643,6 +643,9 @@ class _FocusState extends State<Focus> {
     }());
 
     if (oldWidget.focusNode == widget.focusNode) {
+      if (widget.onKey != focusNode.onKey) {
+        focusNode.onKey = widget.onKey;
+      }
       if (widget.skipTraversal != null) {
         focusNode.skipTraversal = widget.skipTraversal!;
       }


### PR DESCRIPTION
## Description

This updates the `onKey` handler of the `FocusNode` that the `Focus` widget manages when the widget is updated and the handler has changed. Also added a setter for `onKey` to the `FocusNode`.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/74562

## Tests

- Added a test to make sure that the `onKey` updates when the widget is updated.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.