### PR TITLE
Allow 'flutter create' in dev and example directories

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -249,10 +249,16 @@ abstract class CreateBase extends FlutterCommand {
   @protected
   void validateProjectDir({bool overwrite = false}) {
     if (globals.fs.path.isWithin(flutterRoot, projectDirPath)) {
-      throwToolExit(
-          'Cannot create a project within the Flutter SDK. '
-          "Target directory '$projectDirPath' is within the Flutter SDK at '$flutterRoot'.",
-          exitCode: 2);
+      // Make exception for dev and examples to facilitate example project development.
+      final String examplesDirectory = globals.fs.path.join(flutterRoot, 'examples');
+      final String devDirectory = globals.fs.path.join(flutterRoot, 'dev');
+      if (!globals.fs.path.isWithin(examplesDirectory, projectDirPath) &&
+          !globals.fs.path.isWithin(devDirectory, projectDirPath)) {
+        throwToolExit(
+            'Cannot create a project within the Flutter SDK. '
+                "Target directory '$projectDirPath' is within the Flutter SDK at '$flutterRoot'.",
+            exitCode: 2);
+      }
     }
 
     // If the destination directory is actually a file, then we refuse to

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -185,6 +185,31 @@ void main() {
     ...noColorTerminalOverride,
   });
 
+  testUsingContext('cannot create a project in flutter root', () async {
+    Cache.flutterRoot = '../..';
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', globals.platform.isWindows ? 'flutter.bat' : 'flutter');
+    final ProcessResult exec = await Process.run(
+      flutterBin,
+      <String>[
+        'create',
+        'flutter_project',
+      ],
+      workingDirectory: Cache.flutterRoot,
+    );
+    expect(exec.exitCode, 2);
+    expect(exec.stderr, contains('Cannot create a project within the Flutter SDK'));
+  }, overrides: <Type, Generator>{
+    Pub: () => Pub(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      processManager: globals.processManager,
+      usage: globals.flutterUsage,
+      botDetector: globals.botDetector,
+      platform: globals.platform,
+    ),
+    ...noColorTerminalOverride,
+  });
+
   testUsingContext('Will create an app project if non-empty non-project directory exists without .metadata', () async {
     await projectDir.absolute.childDirectory('blag').create(recursive: true);
     await projectDir.absolute.childDirectory('.idea').create(recursive: true);


### PR DESCRIPTION
Allow `flutter create` in the Flutter SDK in `dev` and `example` directories.
Fixes https://github.com/flutter/flutter/issues/74839

I added a test for the original case to make sure that didn't regress, though I don't see a good way to test the new behavior without actually creating a real project directory in the test's Flutter SDK (the create command is pretty un-unit testable at the moment, I think we only have integration tests).