### PR TITLE
PopupMenuButton has inconsistent theme in GridTile(#74977)

### DIFF
--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -69,7 +69,7 @@ class GridTileBar extends StatelessWidget {
 
     final ThemeData theme = Theme.of(context);
     final ThemeData darkTheme = ThemeData(
-      brightness: Brightness.dark,
+      brightness: Brightness.light,
       accentColor: theme.accentColor,
       accentColorBrightness: theme.accentColorBrightness,
     );


### PR DESCRIPTION
PopupMenuButton was showing different type of themes in appbar and in GridTile.

Resolved consistent PopupMenuButton theme in GridTile and AppBar.

fixes #74977

