### PR TITLE
Split tools_tests subshards into separate shards to support sub-sub-sharding

### DIFF
--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart' as fs;
 import 'package:file/memory.dart';
 import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as path;
+import 'package:process/process.dart';
 
 import '../test.dart';
 import 'common.dart';
@@ -78,6 +79,46 @@ void main() {
       pluginsVersionFile.writeAsStringSync('\n$kSampleHash\n');
       final String actualHash = await getFlutterPluginsVersion(fileSystem: memoryFileSystem, pluginsVersionFile: pluginsVersionFile.path);
       expect(actualHash, kSampleHash);
+    });
+  });
+
+  group('test.dart script', () {
+    const ProcessManager processManager = LocalProcessManager();
+
+    Future<ProcessResult> runScript(
+        [Map<String, String> environment, List<String> otherArgs = const <String>[]]) async {
+      final String dart = path.absolute(
+          path.join('..', '..', 'bin', 'cache', 'dart-sdk', 'bin', 'dart'));
+      final ProcessResult scriptProcess = processManager.runSync(<String>[
+        dart,
+        'test.dart',
+        ...otherArgs,
+      ], environment: environment);
+      return scriptProcess;
+    }
+
+    test('subshards tests correctly', () async {
+      ProcessResult result = await runScript(
+        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '1_3'},
+      );
+      expect(result.exitCode, 0);
+      // There are currently 6 smoke tests. This shard should contain test 1 and 2.
+      expect(result.stdout, contains('Selecting subshard 1 of 3 (range 1-2 of 6)'));
+
+      result = await runScript(
+        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '5_6'},
+      );
+      expect(result.exitCode, 0);
+      // This shard should contain only test 5.
+      expect(result.stdout, contains('Selecting subshard 5 of 6 (range 5-5 of 6)'));
+    });
+
+    test('exits with code 1 when SUBSHARD index greater than total', () async {
+      final ProcessResult result = await runScript(
+        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '100_99'},
+      );
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('Invalid subshard name'));
     });
   });
 }


### PR DESCRIPTION
1. Add `tool_general_tests`, `tool_command_tests`, and `tool_integration_tests` top-level shards.
2. Support new subshard naming convention in `web_long_running_tests` and `build_tests`.  Instead of `0`, `1`, `2_last` with the total count (3) stored in a framework repo constant, which requires an infra commit and framework repo commit to change, instead support `1_3`, `2_3`, `3_3` subshard names where the total number is encoded in the name.  This allows shard numbers to be changed in the config without a corresponding framework commit.
Use one-indexing for sanity so it's not (0 of 2, 1 of 2).
3. Adopt subshard with new names in `tool_integration_tests`.
3. Keep fallback to old naming convention so we don't have an outage between this commit and when future recipe config change propagates.  This PR will test that I haven't regressed this logic on the existing try job config.  Once the new config is working, I will remove the old naming parsing logic.
4. Add `smoke_test` shard and support subsharding there.  Add integration tests using this shard to test the subsharding logic.

Infra side at https://github.com/flutter/infra/pull/339
Framework part of https://github.com/flutter/flutter/issues/75003