### PR TITLE
[web] benchmark and optimize defaultTargetPlatform

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_default_target_platform.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_default_target_platform.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'recorder.dart';
+
+/// Benchmarks the performance of the [defaultTargetPlatform] getter.
+///
+/// The getter relies on the expensive `window.matchMedia` and if not properly
+/// cached can cause performance issues.
+class BenchDefaultTargetPlatform extends RawRecorder {
+  BenchDefaultTargetPlatform() : super(name: benchmarkName);
+
+  static const String benchmarkName = 'default_target_platform';
+
+  /// A dummy counter just to make sure the compiler doesn't inline the
+  /// benchmark and make it a no-op.
+  int counter = 0;
+
+  @override
+  void body(Profile profile) {
+    profile.record('runtime', () {
+      for (int i = 0; i < 10000; i++) {
+        counter += defaultTargetPlatform.index;
+      }
+    }, reported: true);
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -15,6 +15,7 @@ import 'src/web/bench_build_material_checkbox.dart';
 import 'src/web/bench_card_infinite_scroll.dart';
 import 'src/web/bench_child_layers.dart';
 import 'src/web/bench_clipped_out_pictures.dart';
+import 'src/web/bench_default_target_platform.dart';
 import 'src/web/bench_draw_rect.dart';
 import 'src/web/bench_dynamic_clip_on_static_picture.dart';
 import 'src/web/bench_mouse_region_grid_hover.dart';
@@ -37,6 +38,7 @@ const bool isCanvasKit = bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultVal
 /// When adding a new benchmark, add it to this map. Make sure that the name
 /// of your benchmark is unique.
 final Map<String, RecorderFactory> benchmarks = <String, RecorderFactory>{
+  BenchDefaultTargetPlatform.benchmarkName: () => BenchDefaultTargetPlatform(),
   BenchBuildImage.benchmarkName: () => BenchBuildImage(),
   BenchCardInfiniteScroll.benchmarkName: () => BenchCardInfiniteScroll.forward(),
   BenchCardInfiniteScroll.benchmarkNameBackward: () => BenchCardInfiniteScroll.backward(),

--- a/packages/flutter/lib/src/foundation/_platform_web.dart
+++ b/packages/flutter/lib/src/foundation/_platform_web.dart
@@ -10,13 +10,16 @@ platform.TargetPlatform get defaultTargetPlatform {
   // To get a better guess at the targetPlatform we need to be able to reference
   // the window, but that won't be available until we fix the platforms
   // configuration for Flutter.
-  platform.TargetPlatform result = _browserPlatform();
-  if (platform.debugDefaultTargetPlatformOverride != null)
-    result = platform.debugDefaultTargetPlatformOverride!;
-  return result;
+  return platform.debugDefaultTargetPlatformOverride ?? _browserPlatform;
 }
 
-platform.TargetPlatform _browserPlatform() {
+// Lazy-initialized and forever cached current browser platform.
+//
+// Computing the platform is expensive as it uses `window.matchMedia`, which
+// needs to parse and evaluate a CSS selector. On some devices this takes up to
+// 0.20ms. As `defaultTargetPlatform` is routinely called dozens of times per
+// frame this value should be cached.
+final platform.TargetPlatform _browserPlatform = () {
   final String navigatorPlatform = html.window.navigator.platform?.toLowerCase() ?? '';
   if (navigatorPlatform.startsWith('mac')) {
     return platform.TargetPlatform.macOS;
@@ -41,4 +44,4 @@ platform.TargetPlatform _browserPlatform() {
     return platform.TargetPlatform.linux;
   }
   return platform.TargetPlatform.android;
-}
+}();


### PR DESCRIPTION
Cache the value of `defaultTargetPlatform`. It is expensive to compute, as it needs to call `window.matchQuery`, which parses and evals a CSS matcher string. Caching is safe as the browser doesn't cache while the app is running.

### Benchmark results

The improvement is ~53x for `defaultTargetPlatform` itself. Impact on a real app depends on the app. In one of the customer apps it saves 1-3ms per frame.

Before:

![default-target-platform-before](https://user-images.githubusercontent.com/211513/106340219-e3df5400-624d-11eb-9ff7-2c6da1d0e391.png)

After:

![default-target-platform-after](https://user-images.githubusercontent.com/211513/106340224-e8a40800-624d-11eb-8896-bb18359d13a4.png)


Fixes https://github.com/flutter/flutter/issues/75036
