### PR TITLE
Revert "Migrate some benchmarks to NNBD"

### DIFF
--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -15,11 +15,13 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key? key,
+    Key key
   }) : super(key: key);
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
+
+  static PlatformViewAppState of(BuildContext context) => context.findAncestorStateOfType<PlatformViewAppState>();
 }
 
 class PlatformViewAppState extends State<PlatformViewApp> {
@@ -40,7 +42,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key? key }) : super(key: key);
+  const PlatformViewLayout({ Key key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -70,12 +72,12 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key? key}) : super(key: key);
+  const DummyPlatformView({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     const String viewType = 'benchmarks/platform_views_layout/DummyPlatformView';
-    late Widget nativeView;
+    Widget nativeView;
     if (Platform.isIOS) {
       nativeView = const UiKitView(
         viewType: viewType,
@@ -96,7 +98,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key? key}) : super(key: key);
+  const RotationContainer({Key key}) : super(key: key);
 
   @override
   _RotationContainerState createState() => _RotationContainerState();
@@ -104,7 +106,7 @@ class RotationContainer extends StatefulWidget {
 
 class _RotationContainerState extends State<RotationContainer>
   with SingleTickerProviderStateMixin {
-  late AnimationController _rotationController;
+  AnimationController _rotationController;
 
   @override
   void initState() {

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('scrolling performance test', () {
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -16,7 +16,8 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver.close();
+      if (driver != null)
+        driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
@@ -12,9 +12,10 @@ class AndroidPlatformView extends StatelessWidget {
   /// Creates a platform view for Android, which is rendered as a
   /// native view.
   const AndroidPlatformView({
-    Key? key,
-    required this.viewType,
-  }) : super(key: key);
+    Key key,
+    @required this.viewType,
+  })  : assert(viewType != null),
+        super(key: key);
 
   /// The unique identifier for the view type to be embedded by this widget.
   ///

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -19,11 +19,13 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key? key
+    Key key
   }) : super(key: key);
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
+
+  static PlatformViewAppState of(BuildContext context) => context.findAncestorStateOfType<PlatformViewAppState>();
 }
 
 class PlatformViewAppState extends State<PlatformViewApp> {
@@ -44,7 +46,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key? key }) : super(key: key);
+  const PlatformViewLayout({ Key key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -74,12 +76,12 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key? key}) : super(key: key);
+  const DummyPlatformView({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     const String viewType = 'benchmarks/platform_views_layout_hybrid_composition/DummyPlatformView';
-    late Widget nativeView;
+    Widget nativeView;
     if (Platform.isIOS) {
       nativeView = const UiKitView(
         viewType: viewType,
@@ -101,7 +103,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key? key}) : super(key: key);
+  const RotationContainer({Key key}) : super(key: key);
 
   @override
   _RotationContainerState createState() => _RotationContainerState();
@@ -109,7 +111,7 @@ class RotationContainer extends StatefulWidget {
 
 class _RotationContainerState extends State<RotationContainer>
   with SingleTickerProviderStateMixin {
-  late AnimationController _rotationController;
+  AnimationController _rotationController;
 
   @override
   void initState() {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/test_driver/scroll_perf_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('scrolling performance test', () {
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -16,7 +16,8 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver.close();
+      if (driver != null)
+        driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {


### PR DESCRIPTION
Reverts flutter/flutter#75023

These failures from the device lab seem related to the PR:

https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20android_view_scroll_perf__timeline_summary/458/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20platform_views_scroll_perf__timeline_summary/461/overview

```
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [   +3 ms]   DriverError: Failed to fulfill GetHealth due to remote error
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   Original error: type '() => Null' is not a subtype of type '(() => FutureOr<Map<String, dynamic>>)?' of 'onTimeout'
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   Original stack trace:
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #0      Future.timeout (dart:async/future_impl.dart)
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #1      _warnIfSlow (package:flutter_driver/src/driver/vmservice_driver.dart:633:6)
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #2      VMServiceFlutterDriver.sendCommand (package:flutter_driver/src/driver/vmservice_driver.dart:315:25)
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #3      FlutterDriver.checkHealth (package:flutter_driver/src/driver/driver.dart:187:34)
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #4      VMServiceFlutterDriver.connect (package:flutter_driver/src/driver/vmservice_driver.dart:232:40)
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   <asynchronous suspension>
[android_view_scroll_perf__timeline_summary] [STDOUT] stdout: [        ]   #5      StackZoneSpecification._registerUnaryCallback.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart)
```