### PR TITLE
Revert "Migrate driver tests in example/ to NNBD"

### DIFF
--- a/examples/hello_world/test_driver/smoke_web_engine_test.dart
+++ b/examples/hello_world/test_driver/smoke_web_engine_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
 import 'dart:async';
 
 import 'package:flutter_driver/flutter_driver.dart';
@@ -14,7 +15,7 @@ void main() {
   group('Hello World App', () {
     final SerializableFinder titleFinder = find.byValueKey('title');
 
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     // Connect to the Flutter driver before running any tests.
     setUpAll(() async {

--- a/examples/platform_channel/test_driver/button_tap_test.dart
+++ b/examples/platform_channel/test_driver/button_tap_test.dart
@@ -2,19 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(goderbauer): migrate this file to null-safety when flutter_driver is null-safe.
+// @dart = 2.9
+
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('button tap test', () {
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
     });
 
     tearDownAll(() async {
-      driver.close();
+      if (driver != null)
+        driver.close();
     });
 
     test('tap on the button, verify result', () async {
@@ -26,7 +30,7 @@ void main() {
       await driver.waitFor(button);
       await driver.tap(button);
 
-      String? batteryLevel;
+      String batteryLevel;
       while (batteryLevel == null || batteryLevel.contains('unknown')) {
         batteryLevel = await driver.getText(batteryLevelLabel);
       }

--- a/examples/platform_channel_swift/test_driver/button_tap_test.dart
+++ b/examples/platform_channel_swift/test_driver/button_tap_test.dart
@@ -2,19 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(goderbauer): migrate this file to null-safety when flutter_driver is null-safe.
+// @dart = 2.9
+
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('button tap test', () {
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
     });
 
     tearDownAll(() async {
-      driver.close();
+      if (driver != null)
+        driver.close();
     });
 
     test('tap on the button, verify result', () async {
@@ -26,7 +30,7 @@ void main() {
       await driver.waitFor(button);
       await driver.tap(button);
 
-      String? batteryLevel;
+      String batteryLevel;
       while (batteryLevel == null || batteryLevel.contains('unknown')) {
         batteryLevel = await driver.getText(batteryLevelLabel);
       }


### PR DESCRIPTION
Reverts flutter/flutter#75022

`platform_channel_sample_test` tests are failing
`platform_channel_sample_test_swift`
`platform_channel_sample_test_ios`

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8856475614555404576/+/steps/run_platform_channel_sample_test/0/stdout
```
[platform_channel_sample_test] [STDOUT] stdout: [ +625 ms] 00:00 [32m+0[0m[31m -1[0m: button tap test (setUpAll) [1m[31m[E][0m[0m
[platform_channel_sample_test] [STDOUT] stdout: [   +1 ms]   DriverError: Failed to fulfill GetHealth due to remote error
[platform_channel_sample_test] [STDOUT] stdout: [        ]   Original error: type '() => Null' is not a subtype of type '(() => FutureOr<Map<String, dynamic>>)?' of 'onTimeout'
[platform_channel_sample_test] [STDOUT] stdout: [        ]   Original stack trace:
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #0      Future.timeout (dart:async/future_impl.dart)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #1      _warnIfSlow (package:flutter_driver/src/driver/vmservice_driver.dart:633:6)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #2      VMServiceFlutterDriver.sendCommand (package:flutter_driver/src/driver/vmservice_driver.dart:315:25)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #3      FlutterDriver.checkHealth (package:flutter_driver/src/driver/driver.dart:187:34)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #4      VMServiceFlutterDriver.connect (package:flutter_driver/src/driver/vmservice_driver.dart:232:40)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test] [STDOUT] stdout: [        ]   #5      StackZoneSpecification._registerUnaryCallback.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart)
[platform_channel_sample_test] [STDOUT] stdout: [        ]   <asynchronous suspension>
```