### PR TITLE
Avoid iOS local networking dialog in integration tests

### DIFF
--- a/dev/devicelab/bin/tasks/build_mode_test.dart
+++ b/dev/devicelab/bin/tasks/build_mode_test.dart
@@ -18,7 +18,7 @@ Future<String> runFlutterAndQuit(List<String> args, Device device) async {
   print('run: starting...');
   final Process run = await startProcess(
     path.join(flutterDirectory.path, 'bin', 'flutter'),
-    <String>['run', '--suppress-analytics', ...args],
+    <String>['run', '--suppress-analytics', '--no-publish-port', ...args],
     isBot: false, // we just want to test the output, not have any debugging info
   );
   final List<String> stdout = <String>[];

--- a/dev/devicelab/bin/tasks/flutter_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_run_test.dart
@@ -39,7 +39,7 @@ Future<TaskResult> createFlutterRunTask() async {
   final Device device = await devices.workingDevice;
   await device.unlock();
   final List<String> options = <String>[
-    '-t', runTestSource.absolute.path, '-d', device.deviceId, '-v',
+    '-t', runTestSource.absolute.path, '-d', device.deviceId, '-v', '--no-publish-port',
   ];
   await inDirectory<void>(flutterGalleryDir, () async {
     final Process run = await startProcess(

--- a/dev/devicelab/bin/tasks/routing_test.dart
+++ b/dev/devicelab/bin/tasks/routing_test.dart
@@ -36,7 +36,7 @@ void main() {
       final Process run = await startProcess(
         path.join(flutterDirectory.path, 'bin', 'flutter'),
         // --fast-start does not support routes.
-        <String>['run', '--verbose', '--disable-service-auth-codes', '--no-fast-start', '-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
+        <String>['run', '--verbose', '--disable-service-auth-codes', '--no-fast-start', '--no-publish-port', '-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
       );
       run.stdout
         .transform<String>(utf8.decoder)

--- a/dev/devicelab/bin/tasks/service_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/service_extensions_test.dart
@@ -26,7 +26,7 @@ void main() {
       print('run: starting...');
       final Process run = await startProcess(
         path.join(flutterDirectory.path, 'bin', 'flutter'),
-        <String>['run', '--verbose', '--no-fast-start', '--disable-service-auth-codes', '-d', device.deviceId, 'lib/main.dart'],
+        <String>['run', '--verbose', '--no-fast-start', '--no-publish-port', '--disable-service-auth-codes', '-d', device.deviceId, 'lib/main.dart'],
       );
       run.stdout
           .transform<String>(utf8.decoder)

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -33,7 +33,7 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
     rm(benchmarkFile);
     final List<String> options = <String>[
-      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--verbose',
+      '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--no-publish-port', '--verbose',
     ];
     int hotReloadCount = 0;
     Map<String, dynamic> smallReloadData;

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -30,6 +30,7 @@ TaskFunction createMicrobenchmarkTask() {
             '-v',
             // --release doesn't work on iOS due to code signing issues
             '--profile',
+            '--no-publish-port',
             '-d',
             device.deviceId,
           ];

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -484,6 +484,7 @@ class StartupTest {
       for (int i = 0; i < iterations; i += 1) {
         final int result = await flutter('run', options: <String>[
           '--no-android-gradle-daemon',
+          '--no-publish-port',
           '--verbose',
           '--profile',
           '--trace-startup',
@@ -783,6 +784,7 @@ class PerfTestWithSkSL extends PerfTest {
         '--verbose',
         '--verbose-system-logs',
         '--purge-persistent-cache',
+        '--no-publish-port',
         '--profile',
         if (cacheSkSL) '--cache-sksl',
         '-d', _device.deviceId,
@@ -1286,6 +1288,7 @@ class DevToolsMemoryTest {
         'run',
         '--verbose',
         '--profile',
+        '--no-publish-port',
         '-d', _device.deviceId,
         driverTest,
       ],
@@ -1401,6 +1404,7 @@ class ReportedDurationTest {
       print('launching $project$test on device...');
       await flutter('run', options: <String>[
         '--verbose',
+        '--no-publish-port',
         '--no-fast-start',
         '--${_reportedDurationTestToString(flavor)}',
         '--no-resident',


### PR DESCRIPTION
Use the `flutter run --no-publish-port` flag introduced in #67452 to avoid the local network popup in integration tests.

![](https://user-images.githubusercontent.com/54371434/106346551-d4bbce80-626c-11eb-89fc-78163f11042a.png)

Fixes https://github.com/flutter/flutter/issues/75048