### PR TITLE
Replace context FakeUsage with TestUsage

### DIFF
--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -126,7 +126,7 @@ void testUsingContext(
           OperatingSystemUtils: () => FakeOperatingSystemUtils(),
           PersistentToolState: () => buildPersistentToolState(globals.fs),
           SimControl: () => MockSimControl(),
-          Usage: () => FakeUsage(),
+          Usage: () => TestUsage(),
           XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter(),
           FileSystem: () => LocalFileSystemBlockingSetCurrentDirectory(),
           PlistParser: () => FakePlistParser(),
@@ -331,48 +331,6 @@ class FakeOperatingSystemUtils implements OperatingSystemUtils {
 }
 
 class MockIOSSimulatorUtils extends Mock implements IOSSimulatorUtils {}
-
-class FakeUsage implements Usage {
-  @override
-  bool get suppressAnalytics => false;
-
-  @override
-  set suppressAnalytics(bool value) { }
-
-  @override
-  bool get enabled => true;
-
-  @override
-  set enabled(bool value) { }
-
-  @override
-  String get clientId => '00000000-0000-4000-0000-000000000000';
-
-  @override
-  void sendCommand(String command, { Map<String, String> parameters }) { }
-
-  @override
-  void sendEvent(String category, String parameter, {
-    String label,
-    int value,
-    Map<String, String> parameters,
-  }) { }
-
-  @override
-  void sendTiming(String category, String variableName, Duration duration, { String label }) { }
-
-  @override
-  void sendException(dynamic exception) { }
-
-  @override
-  Stream<Map<String, dynamic>> get onSend => null;
-
-  @override
-  Future<void> ensureAnalyticsSent() => Future<void>.value();
-
-  @override
-  void printWelcome() { }
-}
 
 class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   @override


### PR DESCRIPTION
`context` is overriding `Usage` with another `Usage` subclass.  Adopt `TestUsage` introduced in #74829.
