### PR TITLE
Adopt tool_test shard builders

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -373,16 +373,10 @@
          "flaky": false
       },
       {
-         "name": "Linux tool_general_tests",
+         "name": "Linux tool_tests",
          "repo": "flutter",
-         "task_name": "linux_tool_general_tests",
-         "flaky": true
-      },
-      {
-         "name": "Linux tool_command_tests",
-         "repo": "flutter",
-         "task_name": "linux_tool_command_tests",
-         "flaky": true
+         "task_name": "linux_tool_tests",
+         "flaky": false
       },
       {
          "name": "Linux tool_integration_tests",
@@ -769,21 +763,15 @@
          "flaky": false
       },
       {
-         "name": "Mac tool_general_tests",
+         "name": "Mac tool_tests",
          "repo": "flutter",
-         "task_name": "mac_tool_general_tests",
-         "flaky": true
+         "task_name": "mac_tool_tests",
+         "flaky": false
       },
       {
-         "name": "Mac tool_command_tests",
+         "name": "Mac tool_integration_tests",
          "repo": "flutter",
-         "task_name": "mac_tool_command_tests",
-         "flaky": true
-      },
-      {
-         "name": "Mac tool_command_tests",
-         "repo": "flutter",
-         "task_name": "mac_tool_command_tests",
+         "task_name": "mac_tool_integration_tests",
          "flaky": true
       },
       {
@@ -859,16 +847,10 @@
          "flaky": false
       },
       {
-         "name": "Windows tool_general_tests",
+         "name": "Windows tool_tests",
          "repo": "flutter",
-         "task_name": "win_tool_general_tests",
-         "flaky": true
-      },
-      {
-         "name": "Windows tool_command_tests",
-         "repo": "flutter",
-         "task_name": "win_tool_command_tests",
-         "flaky": true
+         "task_name": "win_tool_tests",
+         "flaky": false
       },
       {
          "name": "Windows tool_integration_tests",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -373,10 +373,22 @@
          "flaky": false
       },
       {
-         "name": "Linux tool_tests",
+         "name": "Linux tool_general_tests",
          "repo": "flutter",
-         "task_name": "linux_tool_tests",
-         "flaky": false
+         "task_name": "linux_tool_general_tests",
+         "flaky": true
+      },
+      {
+         "name": "Linux tool_command_tests",
+         "repo": "flutter",
+         "task_name": "linux_tool_command_tests",
+         "flaky": true
+      },
+      {
+         "name": "Linux tool_integration_tests",
+         "repo": "flutter",
+         "task_name": "linux_tool_integration_tests",
+         "flaky": true
       },
       {
          "name": "Linux web_tool_tests",
@@ -757,10 +769,22 @@
          "flaky": false
       },
       {
-         "name": "Mac tool_tests",
+         "name": "Mac tool_general_tests",
          "repo": "flutter",
-         "task_name": "mac_tool_tests",
-         "flaky": false
+         "task_name": "mac_tool_general_tests",
+         "flaky": true
+      },
+      {
+         "name": "Mac tool_command_tests",
+         "repo": "flutter",
+         "task_name": "mac_tool_command_tests",
+         "flaky": true
+      },
+      {
+         "name": "Mac tool_command_tests",
+         "repo": "flutter",
+         "task_name": "mac_tool_command_tests",
+         "flaky": true
       },
       {
          "name": "Windows build_aar_module_test",
@@ -835,10 +859,22 @@
          "flaky": false
       },
       {
-         "name": "Windows tool_tests",
+         "name": "Windows tool_general_tests",
          "repo": "flutter",
-         "task_name": "win_tool_tests",
-         "flaky": false
+         "task_name": "win_tool_general_tests",
+         "flaky": true
+      },
+      {
+         "name": "Windows tool_command_tests",
+         "repo": "flutter",
+         "task_name": "win_tool_command_tests",
+         "flaky": true
+      },
+      {
+         "name": "Windows tool_integration_tests",
+         "repo": "flutter",
+         "task_name": "win_tool_integration_tests",
+         "flaky": true
       },
       {
          "name": "Windows web_tool_tests",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -127,9 +127,23 @@
          "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name":"Linux tool_tests",
+         "name":"Linux tool_general_tests",
          "repo":"flutter",
-         "task_name":"linux_tool_tests",
+         "task_name":"linux_tool_general_tests",
+         "enabled":true,
+         "run_if":["dev/", "packages/flutter_tools/", "bin/"]
+      },
+      {
+         "name":"Linux tool_command_tests",
+         "repo":"flutter",
+         "task_name":"linux_tool_command_tests",
+         "enabled":true,
+         "run_if":["dev/", "packages/flutter_tools/", "bin/"]
+      },
+      {
+         "name":"Linux tool_integration_tests",
+         "repo":"flutter",
+         "task_name":"linux_tool_integration_tests",
          "enabled":true,
          "run_if":["dev/", "packages/flutter_tools/", "bin/"]
       },
@@ -292,9 +306,23 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name":"Mac tool_tests",
+         "name":"Mac tool_general_tests",
          "repo":"flutter",
-         "task_name":"mac_tool_tests",
+         "task_name":"mac_tool_general_tests",
+         "enabled":true,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
+      },
+      {
+         "name":"Mac tool_command_tests",
+         "repo":"flutter",
+         "task_name":"mac_tool_command_tests",
+         "enabled":true,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
+      },
+      {
+         "name":"Mac tool_integration_tests",
+         "repo":"flutter",
+         "task_name":"mac_tool_integration_tests",
          "enabled":true,
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
@@ -381,10 +409,22 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-        "name": "Windows tool_tests",
-        "repo": "flutter",
-        "task_name": "win_tool_tests",
-        "enabled":true
+         "name": "Windows tool_general_tests",
+         "repo": "flutter",
+         "task_name": "win_tool_general_tests",
+         "enabled":true
+      },
+      {
+         "name": "Windows tool_command_tests",
+         "repo": "flutter",
+         "task_name": "win_tool_command_tests",
+         "enabled":true
+      },
+      {
+         "name": "Windows tool_integration_tests",
+         "repo": "flutter",
+         "task_name": "win_tool_integration_tests",
+         "enabled":true
       },
       {
          "name": "Windows web_tool_tests",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -127,16 +127,9 @@
          "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name":"Linux tool_general_tests",
+         "name":"Linux tool_tests",
          "repo":"flutter",
-         "task_name":"linux_tool_general_tests",
-         "enabled":true,
-         "run_if":["dev/", "packages/flutter_tools/", "bin/"]
-      },
-      {
-         "name":"Linux tool_command_tests",
-         "repo":"flutter",
-         "task_name":"linux_tool_command_tests",
+         "task_name":"linux_tool_tests",
          "enabled":true,
          "run_if":["dev/", "packages/flutter_tools/", "bin/"]
       },
@@ -306,16 +299,9 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name":"Mac tool_general_tests",
+         "name":"Mac tool_tests",
          "repo":"flutter",
-         "task_name":"mac_tool_general_tests",
-         "enabled":true,
-         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
-      },
-      {
-         "name":"Mac tool_command_tests",
-         "repo":"flutter",
-         "task_name":"mac_tool_command_tests",
+         "task_name":"mac_tool_tests",
          "enabled":true,
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
@@ -409,22 +395,18 @@
          "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
-         "name": "Windows tool_general_tests",
-         "repo": "flutter",
-         "task_name": "win_tool_general_tests",
-         "enabled":true
-      },
-      {
-         "name": "Windows tool_command_tests",
-         "repo": "flutter",
-         "task_name": "win_tool_command_tests",
-         "enabled":true
+        "name": "Windows tool_tests",
+        "repo": "flutter",
+        "task_name": "win_tool_tests",
+        "enabled":true,
+        "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows tool_integration_tests",
          "repo": "flutter",
          "task_name": "win_tool_integration_tests",
-         "enabled":true
+         "enabled":true,
+         "run_if":["dev/**", "packages/flutter_tools/**", "bin/**"]
       },
       {
          "name": "Windows web_tool_tests",


### PR DESCRIPTION
Adopt `tool_integration_tests` builder from https://github.com/flutter/infra/pull/339 to test https://github.com/flutter/flutter/pull/75033.

Example [tool_integration_tests run](https://ci.chromium.org/p/flutter/builders/try/Linux%20tool_integration_tests/3):
![Screen Shot 2021-02-01 at 3 47 46 PM](https://user-images.githubusercontent.com/682784/106532327-dc65b800-64a4-11eb-93a2-b68c9028e07e.png)

Remove `tool_general_tests ` and `tool_command_tests ` introduced in https://github.com/flutter/flutter/pull/75033 since shards without subshards is evidently not supported (see https://github.com/flutter/infra/pull/340).  Support these subshards in `tool_tests` and simplify the subshard selecting logic in the runner.

Fixes https://github.com/flutter/flutter/issues/75003