### PR TITLE
Adopt subshard naming convention in build_tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -435,7 +435,10 @@ Future<void> _runBuildTests() async {
       ],
   ]..shuffle(math.Random(0));
 
-  await _selectIndexedSubshard(tests, kBuildTestShardCount);
+  if (!await _runShardRunnerIndexOfTotalSubshard(tests)) {
+    // TODO(jmagman): Remove fallback once LUCI configs are migrated to d+_d+ subshard format.
+    await _selectIndexedSubshard(tests, kBuildTestShardCount);
+  }
 }
 
 Future<void> _runExampleProjectBuildTests(FileSystemEntity exampleDirectory) async {


### PR DESCRIPTION
Adopt new subshard naming convention introduced in https://github.com/flutter/flutter/pull/75033 in `build_tests`. The total number of subshards is encoded in the subshard name itself (`2_8` means "2 of 8") so now there doesn't have to be coordination between constants in the framework and infra, like [`kBuildTestShardCount`](https://github.com/flutter/flutter/blob/8712f63dd8efd9a41fbbb04a4a99e0d37b46f140/dev/bots/test.dart#L63).

The fallback will be removed once the infra `build_tests` builders adopt the new name in https://github.com/flutter/infra/pull/341.