### PR TITLE
Remove dead tool_coverage code

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -117,7 +117,6 @@ Future<void> main(List<String> args) async {
       'build_tests': _runBuildTests,
       'framework_coverage': _runFrameworkCoverage,
       'framework_tests': _runFrameworkTests,
-      'tool_coverage': _runToolCoverage,
       'tool_tests': _runToolTests,
       'tool_general_tests': _runGeneralToolTests,
       'tool_command_tests': _runCommandsToolTests,
@@ -287,30 +286,6 @@ Future<void> _runSmokeTests() async {
   final String versionError = await verifyVersion(File(path.join(flutterRoot, 'version')));
   if (versionError != null)
     exitWithError(<String>[versionError]);
-}
-
-Future<void> _runToolCoverage() async {
-  await _pubRunTest(
-    toolRoot,
-    testPaths: <String>[
-      path.join('test', 'general.shard'),
-      path.join('test', 'commands.shard', 'hermetic'),
-    ],
-    coverage: 'coverage',
-  );
-  await runCommand(pub,
-    <String>[
-      'run',
-      'coverage:format_coverage',
-      '--lcov',
-      '--in=coverage',
-      '--out=coverage/lcov.info',
-      '--packages=.packages',
-      '--report-on=lib/'
-    ],
-    workingDirectory: toolRoot,
-    outputMode: OutputMode.capture,
-  );
 }
 
 Future<void> _runGeneralToolTests() async {


### PR DESCRIPTION
The `tool_coverage` shard was removed from Cirrus in https://github.com/flutter/flutter/pull/66503, and migration to LUCI was deemed unnecessary in that PR.

Remove the shard code that's not being run anywhere.