### PR TITLE
[flutter_tools] Merge some test options into DebuggingOptions

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
@@ -142,15 +143,17 @@ Future<void> run(List<String> args) async {
     exitCode = await const FlutterTestRunner().runTests(
       const TestWrapper(),
       tests.keys.toList(),
+      debuggingOptions: DebuggingOptions.enabled(
+        BuildInfo(
+          BuildMode.debug,
+          '',
+          treeShakeIcons: false,
+          packagesPath: globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String)),
+        ),
+      ),
       watcher: collector,
       ipv6: false,
       enableObservatory: collector != null,
-      buildInfo: BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        packagesPath: globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String),
-      )),
       precompiledDillFiles: tests,
       concurrency: math.max(1, globals.platform.numberOfProcessors - 2),
       icudtlPath: globals.fs.path.absolute(argResults[_kOptionIcudtl] as String),

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -13,6 +13,7 @@ import '../build_info.dart';
 import '../bundle.dart';
 import '../cache.dart';
 import '../devfs.dart';
+import '../device.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart';
@@ -265,30 +266,32 @@ class TestCommand extends FlutterCommand {
       watcher = collector;
     }
 
-    final bool disableServiceAuthCodes = boolArg('disable-service-auth-codes');
+    final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
+      buildInfo,
+      startPaused: startPaused,
+      disableServiceAuthCodes: boolArg('disable-service-auth-codes'),
+      disableDds: disableDds,
+      nullAssertions: boolArg(FlutterOptions.kNullAssertions),
+    );
 
     final int result = await testRunner.runTests(
       testWrapper,
       files,
+      debuggingOptions: debuggingOptions,
       names: names,
       plainNames: plainNames,
       tags: tags,
       excludeTags: excludeTags,
       watcher: watcher,
       enableObservatory: collector != null || startPaused || boolArg('enable-vmservice'),
-      startPaused: startPaused,
-      disableServiceAuthCodes: disableServiceAuthCodes,
-      disableDds: disableDds,
       ipv6: boolArg('ipv6'),
       machine: machine,
-      buildInfo: buildInfo,
       updateGoldens: boolArg('update-goldens'),
       concurrency: jobs,
       buildTestAssets: buildTestAssets,
       flutterProject: flutterProject,
       web: stringArg('platform') == 'chrome',
       randomSeed: stringArg('test-randomize-ordering-seed'),
-      nullAssertions: boolArg(FlutterOptions.kNullAssertions),
       reporter: stringArg('reporter'),
       timeout: stringArg('timeout'),
     );

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -10,7 +10,7 @@ import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
-import '../build_info.dart';
+import '../device.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../web/chrome.dart';
@@ -29,14 +29,12 @@ abstract class FlutterTestRunner {
   Future<int> runTests(
     TestWrapper testWrapper,
     List<String> testFiles, {
+    @required DebuggingOptions debuggingOptions,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
     String tags,
     String excludeTags,
     bool enableObservatory = false,
-    bool startPaused = false,
-    bool disableServiceAuthCodes = false,
-    bool disableDds = false,
     bool ipv6 = false,
     bool machine = false,
     String precompiledDillPath,
@@ -50,11 +48,8 @@ abstract class FlutterTestRunner {
     Directory coverageDirectory,
     bool web = false,
     String randomSeed,
-    bool nullAssertions = false,
-    @required BuildInfo buildInfo,
     String reporter,
     String timeout,
-    List<String> additionalArguments,
   });
 }
 
@@ -65,14 +60,12 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
   Future<int> runTests(
     TestWrapper testWrapper,
     List<String> testFiles, {
+    @required DebuggingOptions debuggingOptions,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
     String tags,
     String excludeTags,
     bool enableObservatory = false,
-    bool startPaused = false,
-    bool disableServiceAuthCodes = false,
-    bool disableDds = false,
     bool ipv6 = false,
     bool machine = false,
     String precompiledDillPath,
@@ -86,11 +79,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     Directory coverageDirectory,
     bool web = false,
     String randomSeed,
-    bool nullAssertions = false,
-    @required BuildInfo buildInfo,
     String reporter,
     String timeout,
-    List<String> additionalArguments,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -99,7 +89,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     final List<String> testArgs = <String>[
       if (!globals.terminal.supportsColor)
         '--no-color',
-      if (startPaused)
+      if (debuggingOptions.startPaused)
         '--pause-after-load',
       if (machine)
         ...<String>['-r', 'json']
@@ -136,7 +126,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         projectDirectory: flutterProject.directory,
         testOutputDir: tempBuildDir,
         testFiles: testFiles,
-        buildInfo: buildInfo,
+        buildInfo: debuggingOptions.buildInfo,
       );
       if (result == null) {
         throwToolExit('Failed to compile tests');
@@ -155,9 +145,9 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
             updateGoldens: updateGoldens,
             shellPath: shellPath,
             flutterProject: flutterProject,
-            pauseAfterLoad: startPaused,
-            nullAssertions: nullAssertions,
-            buildInfo: buildInfo,
+            pauseAfterLoad: debuggingOptions.startPaused,
+            nullAssertions: debuggingOptions.nullAssertions,
+            buildInfo: debuggingOptions.buildInfo,
             webMemoryFS: result,
             logger: globals.logger,
             fileSystem: globals.fs,
@@ -187,12 +177,10 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     final loader.FlutterPlatform platform = loader.installHook(
       testWrapper: testWrapper,
       shellPath: shellPath,
+      debuggingOptions: debuggingOptions,
       watcher: watcher,
       enableObservatory: enableObservatory,
       machine: machine,
-      startPaused: startPaused,
-      disableServiceAuthCodes: disableServiceAuthCodes,
-      disableDds: disableDds,
       serverType: serverType,
       precompiledDillPath: precompiledDillPath,
       precompiledDillFiles: precompiledDillFiles,
@@ -201,9 +189,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       projectRootDirectory: globals.fs.currentDirectory.uri,
       flutterProject: flutterProject,
       icudtlPath: icudtlPath,
-      nullAssertions: nullAssertions,
-      buildInfo: buildInfo,
-      additionalArguments: additionalArguments,
     );
 
     try {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -13,10 +13,12 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/test.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/runner.dart';
 import 'package:flutter_tools/src/test/test_wrapper.dart';
 import 'package:flutter_tools/src/test/watcher.dart';
+import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
@@ -163,15 +165,13 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   Future<int> runTests(
     TestWrapper testWrapper,
     List<String> testFiles, {
+    @required DebuggingOptions debuggingOptions,
     Directory workDir,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
     String tags,
     String excludeTags,
     bool enableObservatory = false,
-    bool startPaused = false,
-    bool disableDds = false,
-    bool disableServiceAuthCodes = false,
     bool ipv6 = false,
     bool machine = false,
     String precompiledDillPath,
@@ -188,16 +188,12 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     bool web = false,
     String randomSeed,
     @override List<String> extraFrontEndOptions,
-    bool nullAssertions = false,
-    BuildInfo buildInfo,
     String reporter,
     String timeout,
-    List<String> additionalArguments,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     return exitCode;
   }
-
 }
 
 class FakePackageTest implements TestWrapper {

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/test/flutter_platform.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
@@ -35,9 +36,11 @@ void main() {
     testUsingContext('ensureConfiguration throws an error if an '
       'explicitObservatoryPort is specified and more than one test file', () async {
       final FlutterPlatform flutterPlatform = FlutterPlatform(
-        buildInfo: BuildInfo.debug,
         shellPath: '/',
-        explicitObservatoryPort: 1234,
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          hostVmServicePort: 1234,
+        ),
       );
       flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
 
@@ -50,7 +53,7 @@ void main() {
     testUsingContext('ensureConfiguration throws an error if a precompiled '
       'entrypoint is specified and more that one test file', () {
       final FlutterPlatform flutterPlatform = FlutterPlatform(
-        buildInfo: BuildInfo.debug,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
         shellPath: '/',
         precompiledDillPath: 'example.dill',
       );
@@ -173,35 +176,41 @@ void main() {
 
     testUsingContext('installHook creates a FlutterPlatform', () {
       expect(() => installHook(
-        buildInfo: BuildInfo.debug,
         shellPath: 'abc',
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          startPaused: true,
+        ),
         enableObservatory: false,
-        startPaused: true,
       ), throwsAssertionError);
 
       expect(() => installHook(
-        buildInfo: BuildInfo.debug,
         shellPath: 'abc',
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          startPaused: true,
+          hostVmServicePort: 123,
+        ),
         enableObservatory: false,
-        startPaused: false,
-        observatoryPort: 123,
       ), throwsAssertionError);
 
       FlutterPlatform capturedPlatform;
       final Map<String, String> expectedPrecompiledDillFiles = <String, String>{'Key': 'Value'};
       final FlutterPlatform flutterPlatform = installHook(
         shellPath: 'abc',
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          startPaused: true,
+          disableServiceAuthCodes: true,
+          hostVmServicePort: 200,
+        ),
         enableObservatory: true,
         machine: true,
-        startPaused: true,
-        disableServiceAuthCodes: true,
         port: 100,
         precompiledDillPath: 'def',
         precompiledDillFiles: expectedPrecompiledDillFiles,
-        buildInfo: BuildInfo.debug,
         updateGoldens: true,
         buildTestAssets: true,
-        observatoryPort: 200,
         serverType: InternetAddressType.IPv6,
         icudtlPath: 'ghi',
         platformPluginRegistration: (FlutterPlatform platform) {
@@ -210,16 +219,16 @@ void main() {
 
       expect(identical(capturedPlatform, flutterPlatform), equals(true));
       expect(flutterPlatform.shellPath, equals('abc'));
+      expect(flutterPlatform.debuggingOptions.buildInfo, equals(BuildInfo.debug));
+      expect(flutterPlatform.debuggingOptions.startPaused, equals(true));
+      expect(flutterPlatform.debuggingOptions.disableServiceAuthCodes, equals(true));
+      expect(flutterPlatform.debuggingOptions.hostVmServicePort, equals(200));
       expect(flutterPlatform.enableObservatory, equals(true));
       expect(flutterPlatform.machine, equals(true));
-      expect(flutterPlatform.startPaused, equals(true));
-      expect(flutterPlatform.disableServiceAuthCodes, equals(true));
       expect(flutterPlatform.port, equals(100));
       expect(flutterPlatform.host, InternetAddress.loopbackIPv6);
-      expect(flutterPlatform.explicitObservatoryPort, equals(200));
       expect(flutterPlatform.precompiledDillPath, equals('def'));
       expect(flutterPlatform.precompiledDillFiles, expectedPrecompiledDillFiles);
-      expect(flutterPlatform.buildInfo, equals(BuildInfo.debug));
       expect(flutterPlatform.updateGoldens, equals(true));
       expect(flutterPlatform.buildTestAssets, equals(true));
       expect(flutterPlatform.icudtlPath, equals('ghi'));
@@ -278,18 +287,20 @@ class MockHttpServer extends Mock implements HttpServer {}
 //
 // Uses a mock HttpServer. We don't want to bind random ports in our CI hosts.
 class TestFlutterPlatform extends FlutterPlatform {
-  TestFlutterPlatform([List<String> additionalArguments]) : super(
-    buildInfo: const BuildInfo(BuildMode.debug, '', treeShakeIcons: false, packagesPath: '.dart_tool/package_config.json'),
+  TestFlutterPlatform([List<String> dartEntrypointArgs = const <String>[]]) : super(
     shellPath: '/',
+    debuggingOptions: DebuggingOptions.enabled(
+      const BuildInfo(BuildMode.debug, '', treeShakeIcons: false, packagesPath: '.dart_tool/package_config.json'),
+      startPaused: false,
+      disableDds: true,
+      dartEntrypointArgs: dartEntrypointArgs,
+    ),
     precompiledDillPath: 'example.dill',
     host: InternetAddress.loopbackIPv6,
     port: 0,
     updateGoldens: false,
-    startPaused: false,
     enableObservatory: false,
     buildTestAssets: false,
-    disableDds: true,
-    additionalArguments: additionalArguments,
   );
 
   @override
@@ -302,19 +313,20 @@ class TestFlutterPlatform extends FlutterPlatform {
 // Uses a mock HttpServer. We don't want to bind random ports in our CI hosts.
 class TestObservatoryFlutterPlatform extends FlutterPlatform {
   TestObservatoryFlutterPlatform() : super(
-    buildInfo: const BuildInfo(BuildMode.debug, '', treeShakeIcons: false, packagesPath: '.dart_tool/package_config.json'),
     shellPath: '/',
+    debuggingOptions: DebuggingOptions.enabled(
+      const BuildInfo(BuildMode.debug, '', treeShakeIcons: false, packagesPath: '.dart_tool/package_config.json'),
+      startPaused: false,
+      disableDds: false,
+      disableServiceAuthCodes: false,
+      hostVmServicePort: 1234,
+    ),
     precompiledDillPath: 'example.dill',
     host: InternetAddress.loopbackIPv6,
     port: 0,
     updateGoldens: false,
-    startPaused: false,
     enableObservatory: true,
-    explicitObservatoryPort: 1234,
     buildTestAssets: false,
-    disableServiceAuthCodes: false,
-    disableDds: false,
-    additionalArguments: null,
   );
 
   final Completer<Uri> _ddsServiceUriCompleter = Completer<Uri>();


### PR DESCRIPTION
This will make it easier when we want to start a `Device` as part `FlutterPlatform` in #66264, since `Device.startApp` takes `debuggingOptions` as a parameter.

Also remove `_packageConfig` in `FlutterPlatform` as a mutable instance variable, as that didn't seem necessary.

This change will affect Google3, but I will send out a G3Fix to move the parameters accordingly.