### PR TITLE
[Api docs] Added Vertical Divider dartpad demo

### DIFF
--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -234,7 +234,7 @@ class Divider extends StatelessWidget {
 ///
 /// This sample shows how to display a [VerticalDivider] between an purple and orange box
 /// inside a [Row]. The [VerticalDivider] is 20 logical pixels in width and contains a
-/// horizontally centered black line that is 1 logical pixels thick. The black
+/// horizontally centered black line that is 1 logical pixels thick. The grey
 /// line is indented by 20 logical pixels.
 ///
 /// ```dart

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -236,7 +236,7 @@ class Divider extends StatelessWidget {
 /// inside a [Row]. The [VerticalDivider] is 20 logical pixels in width and contains a
 /// horizontally centered black line that is 1 logical pixels thick. The black
 /// line is indented by 20 logical pixels.
-/// 
+///
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return Container(

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -242,7 +242,7 @@ class Divider extends StatelessWidget {
 ///   return Container(
 ///     padding: const EdgeInsets.all(10),
 ///     child: Row(
-///       children: [
+///       children: <Widget>[
 ///         Expanded(
 ///           child: Container(
 ///             decoration: BoxDecoration(

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -230,6 +230,48 @@ class Divider extends StatelessWidget {
 /// The box's total width is controlled by [width]. The appropriate
 /// padding is automatically computed from the width.
 ///
+/// {@tool dartpad --template=stateless_widget_scaffold}
+///
+/// This sample shows how to display a [VerticalDivider] between an purple and orange box
+/// inside a [Row]. The [VerticalDivider] is 20 logical pixels in width and contains a
+/// horizontally centered black line that is 1 logical pixels thick. The black
+/// line is indented by 20 logical pixels.
+/// 
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Container(
+///     padding: const EdgeInsets.all(10),
+///     child: Row(
+///       children: [
+///         Expanded(
+///           child: Container(
+///             decoration: BoxDecoration(
+///               borderRadius: BorderRadius.circular(10),
+///               color: Colors.deepPurpleAccent,
+///             ),
+///           ),
+///         ),
+///         const VerticalDivider(
+///           color: Colors.grey,
+///           thickness: 1,
+///           indent: 20,
+///           endIndent: 0,
+///           width: 20,
+///         ),
+///         Expanded(
+///           child: Container(
+///             decoration: BoxDecoration(
+///               borderRadius: BorderRadius.circular(10),
+///               color: Colors.deepOrangeAccent,
+///             ),
+///           ),
+///         ),
+///       ],
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
 /// See also:
 ///
 ///  * [ListView.separated], which can be used to generate vertical dividers.


### PR DESCRIPTION
VerticalDivider has no demo in api docs.

This PR adds one.

![Screenshot_1612276623](https://user-images.githubusercontent.com/57143358/106615525-88d19800-6592-11eb-8c5c-0876cfb507a0.png)


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
