### PR TITLE
Re-land "Migrate driver tests in example/ to NNBD (#75022)"

### DIFF
--- a/examples/hello_world/test_driver/smoke_web_engine_test.dart
+++ b/examples/hello_world/test_driver/smoke_web_engine_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
 import 'dart:async';
 
 import 'package:flutter_driver/flutter_driver.dart';
@@ -15,7 +14,7 @@ void main() {
   group('Hello World App', () {
     final SerializableFinder titleFinder = find.byValueKey('title');
 
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     // Connect to the Flutter driver before running any tests.
     setUpAll(() async {

--- a/examples/platform_channel/test_driver/button_tap_test.dart
+++ b/examples/platform_channel/test_driver/button_tap_test.dart
@@ -2,23 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(goderbauer): migrate this file to null-safety when flutter_driver is null-safe.
-// @dart = 2.9
-
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('button tap test', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
     });
 
     tearDownAll(() async {
-      if (driver != null)
-        driver.close();
+      driver.close();
     });
 
     test('tap on the button, verify result', () async {
@@ -30,7 +26,7 @@ void main() {
       await driver.waitFor(button);
       await driver.tap(button);
 
-      String batteryLevel;
+      String? batteryLevel;
       while (batteryLevel == null || batteryLevel.contains('unknown')) {
         batteryLevel = await driver.getText(batteryLevelLabel);
       }

--- a/examples/platform_channel_swift/test_driver/button_tap_test.dart
+++ b/examples/platform_channel_swift/test_driver/button_tap_test.dart
@@ -2,23 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(goderbauer): migrate this file to null-safety when flutter_driver is null-safe.
-// @dart = 2.9
-
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('button tap test', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
     });
 
     tearDownAll(() async {
-      if (driver != null)
-        driver.close();
+      driver.close();
     });
 
     test('tap on the button, verify result', () async {
@@ -30,7 +26,7 @@ void main() {
       await driver.waitFor(button);
       await driver.tap(button);
 
-      String batteryLevel;
+      String? batteryLevel;
       while (batteryLevel == null || batteryLevel.contains('unknown')) {
         batteryLevel = await driver.getText(batteryLevelLabel);
       }


### PR DESCRIPTION
Reverts flutter/flutter#75161

The underlying issue was in flutter_driver, which has been fixed in https://github.com/flutter/flutter/pull/75175.