### PR TITLE
Run flutter_driver, integration_test, flutter_localizations, and fuchsia_remote_debug_protocol in framework_tests presubmit

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -37,7 +37,18 @@
          "repo":"flutter",
          "task_name":"linux_framework_tests",
          "enabled":true,
-         "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
+         "run_if":[
+            "dev/",
+            "packages/flutter/",
+            "packages/flutter_driver/",
+            "packages/integration_test/",
+            "packages/flutter_localizations/",
+            "packages/fuchsia_remote_debug_protocol/",
+            "packages/flutter_test/",
+            "packages/flutter_goldens/",
+            "packages/flutter_tools/lib/src/test/",
+            "bin/"
+         ]
       },
       {
          "name":"Linux firebase_abstract_method_smoke_test",
@@ -226,7 +237,18 @@
          "repo":"flutter",
          "task_name":"mac_framework_tests",
          "enabled":true,
-         "run_if":["dev/**", "packages/flutter/**", "packages/flutter_goldens/**", "packages/flutter_goldens_client/**", "packages/flutter_test/**", "packages/flutter_tools/lib/src/test/**", "bin/**"]
+         "run_if":[
+            "dev/**",
+            "packages/flutter/**",
+            "packages/flutter_driver/**",
+            "packages/integration_test/**",
+            "packages/flutter_localizations/**",
+            "packages/fuchsia_remote_debug_protocol/**",
+            "packages/flutter_test/**",
+            "packages/flutter_goldens/**",
+            "packages/flutter_tools/lib/src/test/**",
+            "bin/**"
+         ]
       },
       {
          "name":"Mac gradle_non_android_plugin_test",
@@ -343,7 +365,18 @@
          "repo": "flutter",
          "task_name": "win_framework_tests",
          "enabled":true,
-         "run_if":["dev/", "packages/flutter/", "packages/flutter_test/", "packages/flutter_goldens/", "packages/flutter_tools/lib/src/test/", "bin/"]
+         "run_if":[
+            "dev/",
+            "packages/flutter/",
+            "packages/flutter_driver/",
+            "packages/integration_test/",
+            "packages/flutter_localizations/",
+            "packages/fuchsia_remote_debug_protocol/",
+            "packages/flutter_test/",
+            "packages/flutter_goldens/",
+            "packages/flutter_tools/lib/src/test/",
+            "bin/"
+         ]
       },
       {
          "name": "Windows gradle_non_android_plugin_test",


### PR DESCRIPTION
The `framework_tests` `misc` sub-shard is responsible for running tests in `flutter_driver`, `integration_test`, `flutter_localizations`, and `fuchsia_remote_debug_protocol` packages.
https://github.com/flutter/flutter/blob/f761ae2ce9228eac2cba839e122e801268f43aba/dev/bots/test.dart#L718-L723

However that shard is not being triggered on presubmit when there are changes in these packages.  This caused a post-submit failure when a flutter_driver test was updated, but never run on the PR https://github.com/flutter/flutter/pull/75266

Run `framework_tests` when there are changes in these packages.