### PR TITLE
Mark flutter_immediately_exit_test as unflaky

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_immediately_exit_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_immediately_exit_test.dart
@@ -42,6 +42,5 @@ void main() {
         );
       }
     });
-  }, skip: true, // Flaky: https://github.com/flutter/flutter/issues/74052
-  );
+  });
 }


### PR DESCRIPTION
Let's see if https://github.com/flutter/devtools/pull/2600 fixed this flake.

Fixes https://github.com/flutter/flutter/issues/74052