### PR TITLE
Return an empty FlutterViews list when the service disappears

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -779,7 +779,10 @@ extension FlutterVmService on vm_service.VmService {
         kListViewsMethod,
       );
       if (response == null) {
-        return null;
+        // The service may have disappeared mid-request.
+        // Return an empty list now, and let the shutdown logic elsewhere deal
+        // with cleaning up.
+        return <FlutterView>[];
       }
       final List<Object> rawViews = response.json['views'] as List<Object>;
       final List<FlutterView> views = <FlutterView>[

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -356,7 +356,7 @@ void main() {
     expect(skSLs, isNull);
 
     final List<FlutterView> views = await fakeVmServiceHost.vmService.getFlutterViews();
-    expect(views, isNull);
+    expect(views, isEmpty);
 
     final vm_service.Response screenshot = await fakeVmServiceHost.vmService.screenshot();
     expect(screenshot, isNull);


### PR DESCRIPTION
`getFlutterViews` is assumed to be non-null in a few places.  Return an empty list instead so it doesn't crash before the shutdown logic can take over.

Fixes https://github.com/flutter/flutter/issues/75289.
See https://github.com/flutter/flutter/pull/74424.