### PR TITLE
[win] Suppress Powershell download/extraction visualization progress bar.

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -56,6 +56,7 @@ $dartSdkZip = "$cachePath\$dartZipName"
 
 Try {
     Import-Module BitsTransfer
+    $ProgressPreference = 'SilentlyContinue'
     Start-BitsTransfer -Source $dartSdkUrl -Destination $dartSdkZip -ErrorAction Stop
 }
 Catch {
@@ -70,6 +71,7 @@ Catch {
     $ProgressPreference = $OriginalProgressPreference
 }
 
+Write-Host "Expanding downloaded archive..."
 If (Get-Command 7z -errorAction SilentlyContinue) {
     # The built-in unzippers are painfully slow. Use 7-Zip, if available.
     & 7z x $dartSdkZip "-o$cachePath" -bd | Out-Null
@@ -78,6 +80,7 @@ If (Get-Command 7z -errorAction SilentlyContinue) {
     & 7za x $dartSdkZip "-o$cachePath" -bd | Out-Null
 } ElseIf (Get-Command Microsoft.PowerShell.Archive\Expand-Archive -errorAction SilentlyContinue) {
     # Use PowerShell's built-in unzipper, if available (requires PowerShell 5+).
+    $global:ProgressPreference='SilentlyContinue'
     Microsoft.PowerShell.Archive\Expand-Archive $dartSdkZip -DestinationPath $cachePath
 } Else {
     # As last resort: fall back to the Windows GUI.


### PR DESCRIPTION
This is to avoid Windows Command Prompt window from changing the fonts and colors as it transitions into Powershell with its drawing progress bar.
Instead simple console text will be printed:
```
C:\src\f\flutter>bin\flutter doctor
Checking Dart SDK version...
Downloading Dart SDK from Flutter engine 2c144c3eeb4b25fd78b90dd3e2a24c36f4201021...
Expanding downloaded archive...
Building flutter tool...
...
```

Fixes https://github.com/flutter/flutter/issues/74864
