### PR TITLE
Suggest precache instead of build when engine artifacts are missing

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -43,7 +43,7 @@ def flutter_additional_ios_build_settings(target)
 
   unless Dir.exist?(debug_framework_dir)
     # iOS artifacts have not been downloaded.
-    raise "#{debug_framework_dir} must exist. If you're running pod install manually, make sure flutter build ios is executed first"
+    raise "#{debug_framework_dir} must exist. If you're running pod install manually, make sure \"flutter precache --ios\" is executed first"
   end
 
   release_framework_dir = File.expand_path(File.join(artifacts_dir, 'ios-release', 'Flutter.xcframework'), __FILE__)
@@ -89,6 +89,11 @@ def flutter_additional_macos_build_settings(target)
   artifacts_dir = File.join('..', '..', '..', '..', 'bin', 'cache', 'artifacts', 'engine')
   debug_framework_dir = File.expand_path(File.join(artifacts_dir, 'darwin-x64'), __FILE__)
   release_framework_dir = File.expand_path(File.join(artifacts_dir, 'darwin-x64-release'), __FILE__)
+
+  unless Dir.exist?(debug_framework_dir)
+    # macOS artifacts have not been downloaded.
+    raise "#{debug_framework_dir} must exist. If you're running pod install manually, make sure \"flutter precache --macos\" is executed first"
+  end
 
   target.build_configurations.each do |build_configuration|
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -549,7 +549,7 @@ String _getIosEngineArtifactPath(String engineDirectory,
       .childDirectory(_artifactToFileName(Artifact.flutterXcframework));
 
   if (!xcframeworkDirectory.existsSync()) {
-    throwToolExit('No xcframework found at ${xcframeworkDirectory.path}. Try running "flutter build ios".');
+    throwToolExit('No xcframework found at ${xcframeworkDirectory.path}. Try running "flutter precache --ios".');
   }
   Directory flutterFrameworkSource;
   for (final Directory platformDirectory

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -38,7 +38,7 @@ def install_flutter_engine_pod
     release_framework_dir = File.join(flutter_root, 'bin', 'cache', 'artifacts', 'engine', 'ios-release')
     unless Dir.exist?(release_framework_dir)
       # iOS artifacts have not been downloaded.
-      raise "#{release_framework_dir} must exist. Make sure \"flutter build ios\" has been run at least once"
+      raise "#{release_framework_dir} must exist. Make sure \"flutter precache --ios\" has been run at least once"
     end
     FileUtils.cp_r(File.join(release_framework_dir, framework_name), engine_dir)
   end

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -70,7 +70,7 @@ void main() {
         ),
         throwsToolExit(
             message:
-                'No xcframework found at $xcframeworkPath. Try running "flutter build ios".'),
+                'No xcframework found at $xcframeworkPath.'),
       );
       fileSystem.directory(xcframeworkPath).createSync(recursive: true);
       expect(
@@ -215,7 +215,7 @@ void main() {
         ),
         throwsToolExit(
             message:
-                'No xcframework found at /out/android_debug_unopt/Flutter.xcframework. Try running "flutter build ios".'),
+                'No xcframework found at /out/android_debug_unopt/Flutter.xcframework'),
       );
       fileSystem.directory(xcframeworkPath).createSync(recursive: true);
       expect(


### PR DESCRIPTION
`flutter build ios` is an expensive command to run to download missing engine artifacts.  Instead, suggest the more targeted `precache`.

Add the same warning for macOS.
<img width="1246" alt="Screen Shot 2021-02-03 at 12 11 07 PM" src="https://user-images.githubusercontent.com/682784/106803364-ff18dd80-6618-11eb-857e-e40b846e0d3c.png">


Fixes https://github.com/flutter/flutter/issues/72737