### PR TITLE
Install prebuilt iOS app only once

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -332,10 +332,6 @@ class IOSDevice extends Device {
         return LaunchResult.failed();
       }
       packageId = buildResult.xcodeBuildExecution?.buildSettings['PRODUCT_BUNDLE_IDENTIFIER'];
-    } else {
-      if (!await installApp(package)) {
-        return LaunchResult.failed();
-      }
     }
 
     packageId ??= package.id;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -27,21 +27,6 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
 
-const FakeCommand kDeployCommand = FakeCommand(
-  command: <String>[
-    'Artifact.iosDeploy.TargetPlatform.ios',
-    '--id',
-    '123',
-    '--bundle',
-    '/',
-    '--no-wifi',
-  ],
-  environment: <String, String>{
-    'PATH': '/usr/bin:null',
-    'DYLD_LIBRARY_PATH': '/path/to/libraries',
-  }
-);
-
 // The command used to actually launch the app with args in release/profile.
 const FakeCommand kLaunchReleaseCommand = FakeCommand(
   command: <String>[
@@ -123,7 +108,6 @@ void main() {
   testWithoutContext('IOSDevice.startApp attaches in debug mode via log reading on iOS 13+', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
       kAttachDebuggerCommand,
     ]);
     final IOSDevice device = setUpIOSDevice(
@@ -160,7 +144,6 @@ void main() {
   testWithoutContext('IOSDevice.startApp launches in debug mode via log reading on <iOS 13', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
       kLaunchDebugCommand,
     ]);
     final IOSDevice device = setUpIOSDevice(
@@ -198,7 +181,6 @@ void main() {
   testWithoutContext('IOSDevice.startApp succeeds in release mode', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
       kLaunchReleaseCommand,
     ]);
     final IOSDevice device = setUpIOSDevice(
@@ -226,7 +208,6 @@ void main() {
   testWithoutContext('IOSDevice.startApp forwards all supported debugging options', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kDeployCommand,
       FakeCommand(
         command: <String>[
           'script',


### PR DESCRIPTION
Running with a prebuilt iOS binary copies over the app twice, once to install

https://github.com/flutter/flutter/blob/74bd7b6f6db6433783a36f94d9e43173745187f4/packages/flutter_tools/lib/src/ios/devices.dart#L336

and then again to launch.
https://github.com/flutter/flutter/blob/74bd7b6f6db6433783a36f94d9e43173745187f4/packages/flutter_tools/lib/src/ios/devices.dart#L388

Instead, only copy and install the app once.

Confirms this change also installs only once on the code path where `prepareDebuggerForLaunch` isn't called, when iOS version is < 13.
https://github.com/flutter/flutter/blob/74bd7b6f6db6433783a36f94d9e43173745187f4/packages/flutter_tools/lib/src/ios/devices.dart#L407-L414

Fixes https://github.com/flutter/flutter/issues/75386