### PR TITLE
Reland "Migrate some benchmarks to NNBD (#75023)"

### DIFF
--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -15,13 +15,11 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key key
+    Key? key,
   }) : super(key: key);
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
-
-  static PlatformViewAppState of(BuildContext context) => context.findAncestorStateOfType<PlatformViewAppState>();
 }
 
 class PlatformViewAppState extends State<PlatformViewApp> {
@@ -42,7 +40,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key key }) : super(key: key);
+  const PlatformViewLayout({ Key? key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -72,12 +70,12 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key key}) : super(key: key);
+  const DummyPlatformView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     const String viewType = 'benchmarks/platform_views_layout/DummyPlatformView';
-    Widget nativeView;
+    late Widget nativeView;
     if (Platform.isIOS) {
       nativeView = const UiKitView(
         viewType: viewType,
@@ -98,7 +96,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key key}) : super(key: key);
+  const RotationContainer({Key? key}) : super(key: key);
 
   @override
   _RotationContainerState createState() => _RotationContainerState();
@@ -106,7 +104,7 @@ class RotationContainer extends StatefulWidget {
 
 class _RotationContainerState extends State<RotationContainer>
   with SingleTickerProviderStateMixin {
-  AnimationController _rotationController;
+  late AnimationController _rotationController;
 
   @override
   void initState() {

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('scrolling performance test', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -16,8 +16,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
-        driver.close();
+      driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
@@ -12,10 +12,9 @@ class AndroidPlatformView extends StatelessWidget {
   /// Creates a platform view for Android, which is rendered as a
   /// native view.
   const AndroidPlatformView({
-    Key key,
-    @required this.viewType,
-  })  : assert(viewType != null),
-        super(key: key);
+    Key? key,
+    required this.viewType,
+  }) : super(key: key);
 
   /// The unique identifier for the view type to be embedded by this widget.
   ///

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -19,13 +19,11 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key key
+    Key? key
   }) : super(key: key);
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
-
-  static PlatformViewAppState of(BuildContext context) => context.findAncestorStateOfType<PlatformViewAppState>();
 }
 
 class PlatformViewAppState extends State<PlatformViewApp> {
@@ -46,7 +44,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key key }) : super(key: key);
+  const PlatformViewLayout({ Key? key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -76,12 +74,12 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key key}) : super(key: key);
+  const DummyPlatformView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     const String viewType = 'benchmarks/platform_views_layout_hybrid_composition/DummyPlatformView';
-    Widget nativeView;
+    late Widget nativeView;
     if (Platform.isIOS) {
       nativeView = const UiKitView(
         viewType: viewType,
@@ -103,7 +101,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key key}) : super(key: key);
+  const RotationContainer({Key? key}) : super(key: key);
 
   @override
   _RotationContainerState createState() => _RotationContainerState();
@@ -111,7 +109,7 @@ class RotationContainer extends StatefulWidget {
 
 class _RotationContainerState extends State<RotationContainer>
   with SingleTickerProviderStateMixin {
-  AnimationController _rotationController;
+  late AnimationController _rotationController;
 
   @override
   void initState() {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/test_driver/scroll_perf_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('scrolling performance test', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -16,8 +16,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null)
-        driver.close();
+      driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {


### PR DESCRIPTION
Test failures were NNBD bugs in the flutter_driver code, that have been fixed here: https://github.com/flutter/flutter/pull/75343