### PR TITLE
Delete lock files to prevent inconsistency of package upgrades 

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -47,6 +47,7 @@ class CleanCommand extends FlutterCommand {
 
     deleteFile(flutterProject.dartTool);
     deleteFile(flutterProject.packagesFile);
+    deleteFile(flutterProject.pubspecLock);
 
     deleteFile(flutterProject.android.ephemeralDirectory);
 
@@ -56,6 +57,7 @@ class CleanCommand extends FlutterCommand {
     deleteFile(flutterProject.ios.deprecatedCompiledDartFramework);
     deleteFile(flutterProject.ios.deprecatedProjectFlutterFramework);
     deleteFile(flutterProject.ios.flutterPodspec);
+    deleteFile(flutterProject.ios.podfileLock);
 
     deleteFile(flutterProject.linux.ephemeralDirectory);
     deleteFile(flutterProject.macos.ephemeralDirectory);

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -47,7 +47,7 @@ class CleanCommand extends FlutterCommand {
 
     deleteFile(flutterProject.dartTool);
     deleteFile(flutterProject.packagesFile);
-    deleteFile(flutterProject.pubspecLock);
+    deleteFile(flutterProject.pubspecLockFile);
 
     deleteFile(flutterProject.android.ephemeralDirectory);
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -161,6 +161,9 @@ class FlutterProject {
   /// The `pubspec.yaml` file of this project.
   File get pubspecFile => directory.childFile('pubspec.yaml');
 
+  // The `pubspec.lock` file of this project.
+  File get pubspecLock => directory.childFile('pubspec.lock');
+
   /// The `.packages` file of this project.
   File get packagesFile => directory.childFile('.packages');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -162,7 +162,7 @@ class FlutterProject {
   File get pubspecFile => directory.childFile('pubspec.yaml');
 
   // The `pubspec.lock` file of this project.
-  File get pubspecLock => directory.childFile('pubspec.lock');
+  File get pubspecLockFile => directory.childFile('pubspec.lock');
 
   /// The `.packages` file of this project.
   File get packagesFile => directory.childFile('.packages');

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -75,6 +75,7 @@ void main() {
         expect(buildDirectory.existsSync(), isFalse);
         expect(projectUnderTest.dartTool.existsSync(), isFalse);
         expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.pubspecLockFile.existsSync(), isFalse);
 
         expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
@@ -82,6 +83,7 @@ void main() {
         expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);
         expect(projectUnderTest.ios.deprecatedProjectFlutterFramework.existsSync(), isFalse);
         expect(projectUnderTest.ios.flutterPodspec.existsSync(), isFalse);
+        expect(projectUnderTest.ios.podfileLock.existsSync(), isFalse);
 
         expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);


### PR DESCRIPTION
Delete lock files to prevent inconsistency of package upgrades  when using git sources, but also for consistency of the clean command itself.

When one runs a clean command i think the expectation is to have no hard ties to the previous build, wether stranded, non-working or wrongly-generated. Keeping the .lock files induces possible issues like the one shown below, and confusion, because you just cleaned before building and it still fails, and is still referencing that old version.

![Screenshot 2021-02-05 at 08 45 52](https://user-images.githubusercontent.com/3778474/107004537-b7b45d80-678e-11eb-9f56-baf62d64f547.png)

This PR adds a reference on project of the .lock file:
```dart
// The `pubspec.lock` file of this project.
File get pubspecLockFile => directory.childFile('pubspec.lock');
```

and adds it's deletion to the flutter clean command, along the deletion of the ios pod lock file (reference already existed).

```dart
deleteFile(flutterProject.pubspecLockFile);
···
deleteFile(flutterProject.ios.podfileLock);
```
issue:
https://github.com/flutter/flutter/issues/75483

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
