### PR TITLE
Fix for issue #75518 - ListTile.divideTiles throws error if empty list is passed when null-safety enabled

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -984,7 +984,8 @@ class ListTile extends StatelessWidget {
 
     final Iterator<Widget> iterator = tiles.iterator;
     final bool isNotEmpty = iterator.moveNext();
-    if (!isNotEmpty) return;
+    if (!isNotEmpty)
+      return;
 
     final Decoration decoration = BoxDecoration(
       border: Border(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -982,10 +982,11 @@ class ListTile extends StatelessWidget {
     assert(tiles != null);
     assert(color != null || context != null);
 
+    if (tiles.isEmpty)
+      return;
+
     final Iterator<Widget> iterator = tiles.iterator;
     final bool isNotEmpty = iterator.moveNext();
-    if (!isNotEmpty)
-      return;
 
     final Decoration decoration = BoxDecoration(
       border: Border(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -984,6 +984,7 @@ class ListTile extends StatelessWidget {
 
     final Iterator<Widget> iterator = tiles.iterator;
     final bool isNotEmpty = iterator.moveNext();
+    if (!isNotEmpty) return;
 
     final Decoration decoration = BoxDecoration(
       border: Border(

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -252,6 +252,11 @@ void main() {
     expect(find.text('third'), findsOneWidget);
   });
 
+  testWidgets('ListTile.divideTiles with empty list', (WidgetTester tester) async {
+    final Iterable<Widget> output = ListTile.divideTiles(tiles: <Widget>[], color: Colors.grey);
+    expect(output, isEmpty);
+  });
+
   testWidgets('ListTileTheme', (WidgetTester tester) async {
     final Key titleKey = UniqueKey();
     final Key subtitleKey = UniqueKey();


### PR DESCRIPTION
This PR fixes the issue reported in #75518.

In the original code, when the parameter `tiles` of `ListTile.divideTiles` is an empty list, the line that calls `Widget tile = iterator.current;` is going to throw an exception because `current` is null.

To fix that, I added a return early on when the list is empty, avoiding this issue.

The test I added simply uses the divideTiles with an empty list of widgets, the result should be empty as well and not throwing an exception.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

