### PR TITLE
[flutter_tools] remove error handling specific process resolution bypass

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -246,6 +246,7 @@ abstract class ProcessUtils {
     String workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String> environment,
+    bool skipProcessResolution = false,
   });
 
   /// This runs the command and streams stdout/stderr from the child process to
@@ -471,12 +472,14 @@ class _DefaultProcessUtils implements ProcessUtils {
     String workingDirectory,
     bool allowReentrantFlutter = false,
     Map<String, String> environment,
+    bool skipProcessResolution = false,
   }) {
     _traceCommand(cmd, workingDirectory: workingDirectory);
     return _processManager.start(
       cmd,
       workingDirectory: workingDirectory,
       environment: _environment(allowReentrantFlutter, environment),
+      skipProcessResolution: skipProcessResolution,
     );
   }
 
@@ -688,6 +691,7 @@ abstract class ProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
+    bool skipProcessResolution = false,
   });
 
   /// Starts a process and runs it non-interactively to completion.
@@ -740,6 +744,7 @@ abstract class ProcessManager {
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
+    bool skipProcessResolution = false,
   });
 
   /// Starts a process and runs it to completion. This is a synchronous
@@ -757,6 +762,7 @@ abstract class ProcessManager {
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
+    bool skipProcessResolution = false,
   });
 
   /// Returns `true` if the [executable] exists and if it can be executed.
@@ -808,12 +814,14 @@ class LocalProcessManager implements ProcessManager {
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
+    bool skipProcessResolution = false,
   }) {
     return Process.run(
       sanitizeExecutablePath(_getExecutable(
         command,
         workingDirectory,
         runInShell,
+        skipProcessResolution,
       ), platform: _platform),
       _getArguments(command),
       environment: environment,
@@ -833,12 +841,14 @@ class LocalProcessManager implements ProcessManager {
     bool runInShell = false,
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
+    bool skipProcessResolution = false,
   }) {
     return Process.runSync(
       sanitizeExecutablePath(_getExecutable(
         command,
         workingDirectory,
         runInShell,
+        skipProcessResolution,
       ), platform: _platform),
       _getArguments(command),
       environment: environment,
@@ -858,12 +868,14 @@ class LocalProcessManager implements ProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
+    bool skipProcessResolution = false,
   }) {
     return Process.start(
       sanitizeExecutablePath(_getExecutable(
         command,
         workingDirectory,
         runInShell,
+        skipProcessResolution,
       ), platform: _platform),
       _getArguments(command),
       workingDirectory: workingDirectory,
@@ -878,9 +890,10 @@ class LocalProcessManager implements ProcessManager {
     List<String> command,
     String workingDirectory,
     bool runInShell,
+    bool skipProcessResolution,
   ) {
     final String commandName = command.first.toString();
-    if (runInShell) {
+    if (runInShell || skipProcessResolution) {
       return commandName;
     }
     final String executable = getExecutablePath(commandName, workingDirectory, platform: _platform, fileSystem: _fileSystem);

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -10,7 +10,6 @@ import 'package:package_config/package_config.dart';
 import '../base/bot_detector.dart';
 import '../base/common.dart';
 import '../base/context.dart';
-import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/io.dart' as io;
 import '../base/logger.dart';
@@ -333,13 +332,12 @@ class _DefaultPub implements Pub {
     bool generateSyntheticPackage = false,
   }) async {
     // Fully resolved pub or pub.bat is calculated based on current platform.
-    final io.Process process = await ErrorHandlingProcessManager.skipCommandLookup(() async {
-      return _processUtils.start(
-        _pubCommand(arguments),
-        workingDirectory: directory,
-        environment: await _createPubEnvironment(PubContext.interactive),
-      );
-    });
+    final io.Process process = await _processUtils.start(
+      _pubCommand(arguments),
+      workingDirectory: directory,
+      environment: await _createPubEnvironment(PubContext.interactive),
+      skipProcessResolution: true,
+    );
 
     // Pipe the Flutter tool stdin to the pub stdin.
     unawaited(process.stdin.addStream(stdio.stdin)

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2643,6 +2643,7 @@ class LoggingProcessManager extends LocalProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
+    bool skipProcessResolution = false,
   }) {
     commands.add(command);
     return super.start(
@@ -2652,6 +2653,7 @@ class LoggingProcessManager extends LocalProcessManager {
       includeParentEnvironment: includeParentEnvironment,
       runInShell: runInShell,
       mode: mode,
+      skipProcessResolution: skipProcessResolution,
     );
   }
 }

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -676,17 +676,15 @@ void main() {
       platform: windowsPlatform,
     );
 
-    // Throws an argument error because package:process fails to locate the executable.
+    // Throws an argument error because ProcessManager fails to locate the executable.
     expect(() => processManager.runSync(<String>['foo']), throwsArgumentError);
     expect(() => processManager.run(<String>['foo']), throwsArgumentError);
     expect(() => processManager.start(<String>['foo']), throwsArgumentError);
 
     // Throws process exception because the executable does not exist.
-    await ErrorHandlingProcessManager.skipCommandLookup<void>(() async {
-      expect(() => processManager.runSync(<String>['foo']), throwsA(isA<ProcessException>()));
-      expect(() => processManager.run(<String>['foo']), throwsA(isA<ProcessException>()));
-      expect(() => processManager.start(<String>['foo']), throwsA(isA<ProcessException>()));
-    });
+    expect(() => processManager.runSync(<String>['foo'], skipProcessResolution: true), throwsA(isA<ProcessException>()));
+    expect(() => processManager.run(<String>['foo'], skipProcessResolution: true), throwsA(isA<ProcessException>()));
+    expect(() => processManager.start(<String>['foo'], skipProcessResolution: true), throwsA(isA<ProcessException>()));
   });
 
   group('ProcessManager on windows throws tool exit', () {

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -707,6 +707,7 @@ class MockProcessManager implements ProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
+    bool skipProcessResolution = false,
   }) {
     lastPubEnvironment = environment['PUB_ENVIRONMENT'];
     lastPubCache = environment['PUB_CACHE'];

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -248,6 +248,7 @@ abstract class FakeProcessManager implements ProcessManager {
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
     ProcessStartMode mode = ProcessStartMode.normal, // ignored
+    bool skipProcessResolution = false, // ignored
   }) {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, systemEncoding);
     if (process._completer != null) {
@@ -268,6 +269,7 @@ abstract class FakeProcessManager implements ProcessManager {
     bool runInShell = false, // ignored
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
+    bool skipProcessResolution = false, // ignored
   }) async {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     await process.exitCode;
@@ -288,6 +290,7 @@ abstract class FakeProcessManager implements ProcessManager {
     bool runInShell = false, // ignored
     Encoding stdoutEncoding = systemEncoding, // actual encoder is ignored
     Encoding stderrEncoding = systemEncoding, // actual encoder is ignored
+    bool skipProcessResolution = false, // ignored
   }) {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     return ProcessResult(

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -116,6 +116,7 @@ class MockProcessManager extends Mock implements ProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
+    bool skipProcessResolution = false,
   }) {
     final List<String> commands = command.cast<String>();
     if (!runSucceeds) {


### PR DESCRIPTION
Now that the process manager is in flutter_tools, we do not need a specific workaround to add a named parameter to the ProcessManager APIs.

Add `bool skipProcessResolution  = false` which causes the local process manager to only apply escaping without running process resolution logic.