### PR TITLE
Revert "TextField and last input character should visible on the screen when the cursor is not shown (#74722)"

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2708,22 +2708,21 @@ class _FloatingCursorPainter extends RenderEditablePainter {
     caretRect = caretRect.shift(renderEditable._paintOffset);
     final Rect integralRect = caretRect.shift(renderEditable._snapToPhysicalPixel(caretRect.topLeft));
 
-    if (shouldPaint) {
-      final Radius? radius = cursorRadius;
-      caretPaint.color = caretColor;
-      if (radius == null) {
-        canvas.drawRect(integralRect, caretPaint);
-      } else {
-        final RRect caretRRect = RRect.fromRectAndRadius(integralRect, radius);
-        canvas.drawRRect(caretRRect, caretPaint);
-      }
+    final Radius? radius = cursorRadius;
+    caretPaint.color = caretColor;
+    if (radius == null) {
+      canvas.drawRect(integralRect, caretPaint);
+    } else {
+      final RRect caretRRect = RRect.fromRectAndRadius(integralRect, radius);
+      canvas.drawRRect(caretRRect, caretPaint);
     }
     caretPaintCallback(integralRect);
   }
 
   @override
   void paint(Canvas canvas, Size size, RenderEditable renderEditable) {
-    // Compute the caret location even when `shouldPaint` is false.
+    if (!shouldPaint)
+      return;
 
     assert(renderEditable != null);
     final TextSelection? selection = renderEditable.selection;
@@ -2748,7 +2747,7 @@ class _FloatingCursorPainter extends RenderEditablePainter {
 
     final Color? floatingCursorColor = this.caretColor?.withOpacity(0.75);
     // Floating Cursor.
-    if (floatingCursorRect == null || floatingCursorColor == null || !shouldPaint)
+    if (floatingCursorRect == null || floatingCursorColor == null)
       return;
 
     canvas.drawRRect(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8573,51 +8573,6 @@ void main() {
     expect(scrollController.offset, 48.0);
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/74566
-  testWidgets('TextField and last input character are visible on the screen when the cursor is not shown', (WidgetTester tester) async {
-    final ScrollController scrollController = ScrollController();
-    final ScrollController textFieldScrollController = ScrollController();
-
-    await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(),
-      home: Scaffold(
-        body: Center(
-          child: ListView(
-            controller: scrollController,
-            children: <Widget>[
-              Container(height: 579), // Push field almost off screen.
-              TextField(
-                scrollController: textFieldScrollController,
-                showCursor: false,
-              ),
-              Container(height: 1000),
-            ],
-          ),
-        ),
-      ),
-    ));
-
-    // Tap the TextField to bring it into view.
-    expect(scrollController.offset, 0.0);
-    await tester.tapAt(tester.getTopLeft(find.byType(TextField)));
-    await tester.pumpAndSettle();
-
-    // The ListView has scrolled to keep the TextField visible.
-    expect(scrollController.offset, 48.0);
-    expect(textFieldScrollController.offset, 0.0);
-
-    // After entering some long text, the last input character remains on the screen.
-    final String testValue = 'I love Flutter!' * 10;
-    tester.testTextInput.updateEditingValue(TextEditingValue(
-      text: testValue,
-      selection: TextSelection.collapsed(offset: testValue.length),
-    ));
-    await tester.pump();
-    await tester.pumpAndSettle(); // Text scroll animation.
-
-    expect(textFieldScrollController.offset, 1602.0);
-  });
-
   group('height', () {
     testWidgets('By default, TextField is at least kMinInteractiveDimension high', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
** This is not a straightforward revert: ** https://github.com/flutter/flutter/pull/72828 changed a lot of what was in #74722 to resolve merge conflicts. The commit for resolving the merge conflicts: https://github.com/flutter/flutter/pull/72828/commits/c217f997c43d6d951303bb7cfdb7028e7e67d16a

This reverts commit cd771404e9da3606405c29e1c380684e449665c4 to unblock the roll.
