### PR TITLE
Refresh Flutter infra README

### DIFF
--- a/dev/bots/README.md
+++ b/dev/bots/README.md
@@ -10,7 +10,8 @@ Flutter build results are available at:
 * https://ci.chromium.org/p/flutter/
   - Additional testing and processing are done after changes are submitted.
 
-The LUCI infra requires permissions to retrigger or schedule builds. File an
+Flutter infra requires special permissions to retrigger builds on the
+[build dashboard](https://flutter-dashboard.appspot.com/#/build). File an
 [infra ticket](https://github.com/flutter/flutter/wiki/Infra-Ticket-Queue) to
 request permission.
 

--- a/dev/bots/README.md
+++ b/dev/bots/README.md
@@ -2,14 +2,17 @@
 
 This directory exists to support building Flutter on our build infrastructure.
 
-The results of such builds are viewable at:
+Flutter build results are available at:
+* https://flutter-dashboard.appspot.com/#/build
+  - Aggregate dashboard of the the separate CI systems used by Flutter.
 * https://cirrus-ci.com/github/flutter/flutter/master
   - Testing is done on PRs and submitted changes on GitHub.
 * https://ci.chromium.org/p/flutter/
   - Additional testing and processing are done after changes are submitted.
 
-The LUCI infra requires permissions to retrigger or schedule builds. Contact
-@kf6gpe or another Google member of the Flutter team if you need to do that.
+The LUCI infra requires permissions to retrigger or schedule builds. File an
+[infra ticket](https://github.com/flutter/flutter/wiki/Infra-Ticket-Queue) to
+request permission.
 
 The [Cirrus](https://cirrus-ci.org)-based bots run the [`test.dart`](test.dart)
 script for each PR and submission. This does testing for the tools, for the
@@ -23,13 +26,13 @@ We also have post-commit testing with actual devices, in what we call our
 
 ## LUCI (Layered Universal Continuous Integration)
 
-A [set of recipes](https://chromium.googlesource.com/chromium/tools/build.git/+/master/scripts/slave/recipes/flutter)
+A [set of recipes](https://flutter.googlesource.com/recipes/)
 are run on Windows, Linux, and Mac machines. The configuration for how many
-machines and what kind are managed internally by Google. Contact @kf6gpe or
-another Google member of the Flutter team if you suspect changes are needed
-there. Both of these technologies are highly specific to the [LUCI](https://github.com/luci)
-project, which is the successor to Chromium's infra. We're just borrowing some
-of their infrastructures.
+machines and what kind are managed internally by Google. File an
+[infra ticket](https://github.com/flutter/flutter/wiki/Infra-Ticket-Queue)
+if you suspect changes are needed there. Both of these technologies are highly
+specific to the [LUCI](https://github.com/luci) project, which is the successor
+to Chromium's infra and the foundation to Flutter's infrastructure.
 
 ### Prerequisites
 
@@ -71,13 +74,9 @@ search for files named `api.py` or `example.py` under `infra/build`.
 
 ### Editing a recipe
 
-Flutter has one recipe per repository. Currently
-[flutter/flutter](https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/flutter.py)
-and
-[flutter/engine](https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/engine.py):
-
-- recipes/flutter.py
-- recipes/engine.py
+Flutter has several recipes depending on the test. The recipes share common
+actions through `recipe_modules`. Searching the builder config in [flutter/infra](https://github.com/flutter/infra)
+will indicate the recipe used for a test.
 
 Recipes are just Python with some limitations on what can be imported. They are
 [documented](https://github.com/luci/recipes-py/blob/master/doc/user_guide.md)
@@ -96,8 +95,9 @@ The typical cycle for editing a recipe is:
    `GIT_HASH` is the hash to build (which is important for the engine but not
    for the framework).
 5. To submit a CL, you need a local branch first (`git checkout -b [some branch name]`).
-6. Upload the patch (`git commit`, `git cl upload`), and send it to someone in
-   the `OWNERS` file for review.
+6. Upload the patch (`git commit`, `git cl upload`), and open the outputted URL to the CL.
+7. Use "Find owners" to get reviewers for the CL
+
 
 ### The infra config repository
 
@@ -105,20 +105,11 @@ The [flutter/infra](https://github.com/flutter/infra) repository contains
 configuration files for the dashboard, builder groups, scheduling, and
 individual builders. Edits to this may require changes other internal Google
 repositories - e.g., to change the operating system or number of machines. If
-you want to do that, reach out to @kf6gpe or another member of the Google team.
+you want to do that, file an [infra ticket](https://github.com/flutter/flutter/wiki/Infra-Ticket-Queue)
+with your proposed changes.
 
 Each configuration file in that repository has a link in the top comments to a
 schema that describes available properties.
-
-### Future Directions
-
-We would like to host our recipes instead of storing them in
-[build](https://chromium.googlesource.com/chromium/tools/build.git/+/master/scripts/slave/recipes/flutter).
-Support for [cross-repository
-recipes](https://github.com/luci/recipes-py/blob/master/doc/cross_repo.md) is
-in-progress.  If you view the git log of this directory, you'll see we initially
-tried, but it's not quite ready.
-
 
 ### Android Tools
 


### PR DESCRIPTION
This doc is out of date with the migration to LUCI and the addition of the infra ticket queue.

Updated to reference those items instead.