### PR TITLE
Move FakeBotDetector to fakes

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -21,7 +21,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
-import '../../src/mocks.dart' show MockProcessManager, AlwaysTrueBotDetector, AlwaysFalseBotDetector;
+import '../../src/mocks.dart' show MockProcessManager;
 import '../../src/testbed.dart';
 
 void main() {
@@ -456,7 +456,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysFalseBotDetector(),
+      BotDetector: () => const FakeBotDetector(false),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -478,7 +478,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -579,7 +579,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -599,7 +599,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -619,7 +619,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -639,7 +639,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -659,7 +659,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -679,7 +679,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -700,7 +700,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,
@@ -720,7 +720,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       Stdio: () => mockStdio,
-      BotDetector: () => const AlwaysTrueBotDetector(),
+      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -21,7 +20,6 @@ import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:mockito/mockito.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -344,7 +342,3 @@ IOSDevice setUpIOSDevice({
 
 class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
 class MockDeviceLogReader extends Mock implements DeviceLogReader {}
-class MockVmService extends Mock implements VmService {}
-class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
-class MockIOSDeployDebugger extends Mock implements IOSDeployDebugger {}
-class MockIOSDeploy extends Mock implements IOSDeploy {}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -38,7 +38,6 @@ import 'package:mockito/mockito.dart';
 
 import 'common.dart';
 import 'fakes.dart';
-import 'mocks.dart';
 import 'throwing_pub.dart';
 
 export 'package:flutter_tools/src/base/context.dart' show Generator;
@@ -175,7 +174,7 @@ void testUsingContext(
       // If a test needs a BotDetector that does not always return true, it
       // can provide the AlwaysFalseBotDetector in the overrides, or its own
       // BotDetector implementation in the overrides.
-      BotDetector: overrides[BotDetector] ?? () => const AlwaysTrueBotDetector(),
+      BotDetector: overrides[BotDetector] ?? () => const FakeBotDetector(true),
     });
   }, testOn: testOn, skip: skip, timeout: timeout);
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:io' as io show IOSink, ProcessSignal, Stdout, StdoutException;
 
+import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -415,4 +416,14 @@ class FakePlistParser implements PlistParser {
   String getValueFromFile(String plistFilePath, String key) {
     return _underlyingValues[key] as String;
   }
+}
+
+class FakeBotDetector implements BotDetector {
+  const FakeBotDetector(bool isRunningOnBot)
+      : _isRunningOnBot = isRunningOnBot;
+
+  @override
+  Future<bool> get isRunningOnBot async => _isRunningOnBot;
+
+  final bool _isRunningOnBot;
 }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -10,7 +10,6 @@ import 'dart:io' as io show IOSink;
 
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart' show AndroidSdk;
-import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
@@ -176,7 +175,7 @@ Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr 
   final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(<List<int>>[
     utf8.encode(stderr),
   ]);
-  final Process process = MockBasicProcess();
+  final Process process = _MockBasicProcess();
 
   when(process.stdout).thenAnswer((_) => stdoutStream);
   when(process.stderr).thenAnswer((_) => stderrStream);
@@ -184,7 +183,7 @@ Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr 
   return process;
 }
 
-class MockBasicProcess extends Mock implements Process {}
+class _MockBasicProcess extends Mock implements Process {}
 
 /// A process that exits successfully with no output and ignores all input.
 class MockProcess extends Mock implements Process {
@@ -253,7 +252,7 @@ class MockIOSDevice extends Mock implements IOSDevice {
 }
 
 /// Common functionality for tracking mock interaction.
-class BasicMock {
+class _BasicMock {
   final List<String> messages = <String>[];
 
   void expectMessages(List<String> expectedMessages) {
@@ -271,7 +270,7 @@ class BasicMock {
   }
 }
 
-class MockResidentCompiler extends BasicMock implements ResidentCompiler {
+class MockResidentCompiler extends _BasicMock implements ResidentCompiler {
   @override
   void accept() { }
 
@@ -370,18 +369,3 @@ class MockStdIn extends Mock implements IOSink {
 }
 
 class MockStream extends Mock implements Stream<List<int>> {}
-
-class AlwaysTrueBotDetector implements BotDetector {
-  const AlwaysTrueBotDetector();
-
-  @override
-  Future<bool> get isRunningOnBot async => true;
-}
-
-
-class AlwaysFalseBotDetector implements BotDetector {
-  const AlwaysFalseBotDetector();
-
-  @override
-  Future<bool> get isRunningOnBot async => false;
-}


### PR DESCRIPTION
Replace `AlwaysTrueBotDetector` and `AlwaysFalseBotDetector` with `FakeBotDetector`, move from `mocks.dart` to `fakes.dart`.