### PR TITLE
Add exception to FakeCommand

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -184,19 +184,17 @@ void main() {
     });
 
     testUsingContext('fetchLatestVersion throws toolExit if HEAD is detached', () async {
-      processManager.addCommands(<FakeCommand>[
-        const FakeCommand(command: <String>[
+      processManager.addCommands(const <FakeCommand>[
+        FakeCommand(command: <String>[
           'git', 'fetch', '--tags'
         ]),
         FakeCommand(
-          command: const <String>['git', 'rev-parse', '--verify', '@{u}'],
-          onRun: () {
-            throw const ProcessException(
-              'git',
-              <String>['rev-parse', '--verify', '@{u}'],
-              'fatal: HEAD does not point to a branch',
-            );
-          }
+          command: <String>['git', 'rev-parse', '--verify', '@{u}'],
+          exception: ProcessException(
+            'git',
+            <String>['rev-parse', '--verify', '@{u}'],
+            'fatal: HEAD does not point to a branch',
+          ),
         ),
       ]);
 
@@ -211,19 +209,17 @@ void main() {
     });
 
     testUsingContext('fetchRemoteRevision throws toolExit if no upstream configured', () async {
-      processManager.addCommands(<FakeCommand>[
-        const FakeCommand(command: <String>[
+      processManager.addCommands(const <FakeCommand>[
+        FakeCommand(command: <String>[
           'git', 'fetch', '--tags'
         ]),
         FakeCommand(
-          command: const <String>['git', 'rev-parse', '--verify', '@{u}'],
-          onRun: () {
-            throw const ProcessException(
-              'git',
-              <String>['rev-parse', '--verify', '@{u}'],
-              'fatal: no upstream configured for branch',
-            );
-          },
+          command: <String>['git', 'rev-parse', '--verify', '@{u}'],
+          exception: ProcessException(
+            'git',
+            <String>['rev-parse', '--verify', '@{u}'],
+            'fatal: no upstream configured for branch',
+          ),
         ),
       ]);
 
@@ -242,18 +238,16 @@ void main() {
     testUsingContext('git exception during attemptReset throwsToolExit', () async {
       const String revision = 'abc123';
       const String errorMessage = 'fatal: Could not parse object ´$revision´';
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: const <String>['git', 'reset', '--hard', revision],
-          onRun: () {
-            throw const ProcessException(
-              'git',
-              <String>['reset', '--hard', revision],
-              errorMessage,
-            );
-          },
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>['git', 'reset', '--hard', revision],
+          exception: ProcessException(
+            'git',
+            <String>['reset', '--hard', revision],
+            errorMessage,
+          ),
         ),
-      ]);
+      );
 
       await expectLater(
             () async => await realCommandRunner.attemptReset(revision),

--- a/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
@@ -46,14 +46,12 @@ void main() {
   });
 
   testUsingContext('AndroidStudioValidator gives doctor error on java crash', () async {
-    fakeProcessManager.addCommand(FakeCommand(
-      command: const <String>[
+    fakeProcessManager.addCommand(const FakeCommand(
+      command: <String>[
         '/opt/android-studio-with-cheese-5.0/jre/bin/java',
         '-version',
       ],
-      onRun: () {
-        throw const ProcessException('java', <String>['-version']);
-      },
+      exception: ProcessException('java', <String>['-version']),
     ));
     const String installPath = '/opt/android-studio-with-cheese-5.0';
     const String studioHome = '$home/.AndroidStudioWithCheese5.0';

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -228,18 +228,16 @@ void main() {
           ],
           stdout: 'devtools 0.9.6',
         ),
-        FakeCommand(
-            command: const <String>[
-              'pub',
-              'global',
-              'run',
-              'devtools',
-              '--no-launch-browser',
-              '--vm-uri=http://127.0.0.1:1234/abcdefg',
-            ],
-            onRun: () {
-              throw const ProcessException('pub', <String>[]);
-            }
+        const FakeCommand(
+          command: <String>[
+            'pub',
+            'global',
+            'run',
+            'devtools',
+            '--no-launch-browser',
+            '--vm-uri=http://127.0.0.1:1234/abcdefg',
+          ],
+          exception: ProcessException('pub', <String>[]),
         )
       ]),
     );
@@ -273,18 +271,16 @@ void main() {
           ],
           stdout: 'devtools 0.9.6',
         ),
-        FakeCommand(
-            command: const <String>[
-              'pub',
-              'global',
-              'run',
-              'devtools',
-              '--no-launch-browser',
-              '--vm-uri=http://127.0.0.1:1234/abcdefg',
-            ],
-            onRun: () {
-              throw const ProcessException('pub', <String>[]);
-            }
+        const FakeCommand(
+          command: <String>[
+            'pub',
+            'global',
+            'run',
+            'devtools',
+            '--no-launch-browser',
+            '--vm-uri=http://127.0.0.1:1234/abcdefg',
+          ],
+          exception: ProcessException('pub', <String>[]),
         )
       ]),
     );

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -137,9 +137,7 @@ void main() {
         ], environment: const <String, String>{
           'PATH': '/usr/bin:null',
           ...kDyLdLibEntry,
-        }, onRun: () {
-          throw const ProcessException('ios-deploy', <String>[]);
-        })
+        }, exception: const ProcessException('ios-deploy', <String>[])),
       ]);
       final IOSDevice device = setUpIOSDevice(processManager: processManager, artifacts: artifacts);
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
@@ -244,9 +242,7 @@ void main() {
       ], environment: const <String, String>{
         'PATH': '/usr/bin:null',
         ...kDyLdLibEntry,
-      }, onRun: () {
-        throw const ProcessException('ios-deploy', <String>[]);
-      })
+      }, exception: const ProcessException('ios-deploy', <String>[])),
     ]);
     final IOSDevice device = setUpIOSDevice(processManager: processManager, artifacts: artifacts);
     final bool wasAppInstalled = await device.installApp(iosApp);
@@ -267,9 +263,7 @@ void main() {
       ], environment: const <String, String>{
         'PATH': '/usr/bin:null',
         ...kDyLdLibEntry,
-      }, onRun: () {
-        throw const ProcessException('ios-deploy', <String>[]);
-      })
+      }, exception: const ProcessException('ios-deploy', <String>[])),
     ]);
     final IOSDevice device = setUpIOSDevice(processManager: processManager, artifacts: artifacts);
     final bool wasAppUninstalled = await device.uninstallApp(iosApp);

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -798,17 +798,15 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
     });
 
     testWithoutContext('.install() handles exceptions', () async {
-      fakeProcessManager.addCommand(FakeCommand(
-        command: const <String>[
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
           'xcrun',
           'simctl',
           'install',
           deviceId,
           appId,
         ],
-        onRun: () {
-          throw const ProcessException('xcrun', <String>[]);
-        },
+        exception: ProcessException('xcrun', <String>[]),
       ));
 
       expect(
@@ -818,17 +816,15 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
     });
 
     testWithoutContext('.uninstall() handles exceptions', () async {
-      fakeProcessManager.addCommand(FakeCommand(
-        command: const <String>[
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
           'xcrun',
           'simctl',
           'uninstall',
           deviceId,
           appId,
         ],
-        onRun: () {
-          throw const ProcessException('xcrun', <String>[]);
-        },
+        exception: ProcessException('xcrun', <String>[]),
       ));
 
       expect(
@@ -838,17 +834,15 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
     });
 
     testWithoutContext('.launch() handles exceptions', () async {
-      fakeProcessManager.addCommand(FakeCommand(
-        command: const <String>[
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <String>[
           'xcrun',
           'simctl',
           'launch',
           deviceId,
           appId,
         ],
-        onRun: () {
-          throw const ProcessException('xcrun', <String>[]);
-        },
+        exception: ProcessException('xcrun', <String>[]),
       ));
 
       expect(

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -49,18 +49,6 @@ void main() {
       );
     });
 
-    // Work around https://github.com/flutter/flutter/issues/56415.
-    testWithoutContext('xcodebuild versionText returns null when xcodebuild is not installed', () {
-      when(processManager.runSync(<String>['which', 'sysctl']))
-          .thenReturn(ProcessResult(0, 0, '', ''));
-      when(processManager.runSync(<String>['sysctl', 'hw.optional.arm64']))
-          .thenReturn(ProcessResult(0, 1, '', ''));
-      when(processManager.runSync(<String>['xcrun', 'xcodebuild', '-version']))
-        .thenThrow(const ProcessException(xcodebuild, <String>['-version']));
-
-      expect(xcodeProjectInterpreter.versionText, isNull);
-    });
-
     testWithoutContext('xcodebuild build settings flakes', () async {
       const Duration delay = Duration(seconds: 1);
       processManager.processFactory = mocks.flakyProcessFactory(
@@ -140,6 +128,19 @@ void main() {
 
     expect(xcodeProjectInterpreter.versionText, isNull);
     expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+  });
+
+  testWithoutContext('xcodebuild versionText returns null when xcodebuild is not installed', () {
+    fakeProcessManager.addCommands(const <FakeCommand>[
+      kWhichSysctlCommand,
+      kARMCheckCommand,
+      FakeCommand(
+        command: <String>['xcrun', 'xcodebuild', '-version'],
+        exception: ProcessException(xcodebuild, <String>['-version']),
+      ),
+    ]);
+
+    expect(xcodeProjectInterpreter.versionText, isNull);
   });
 
   testWithoutContext('xcodebuild versionText returns formatted version text', () {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
+import 'package:flutter_tools/src/base/io.dart' show ProcessException;
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -26,89 +26,6 @@ void main() {
 
   setUp(() {
     logger = BufferLogger.test();
-  });
-
-  // Group exists to work around https://github.com/flutter/flutter/issues/56415.
-  // Do not add more `MockProcessManager` tests.
-  group('MockProcessManager', () {
-    ProcessManager processManager;
-
-    setUp(() {
-      processManager = MockProcessManager();
-    });
-
-    group('Xcode', () {
-      Xcode xcode;
-      MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
-
-      setUp(() {
-        mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-        xcode = Xcode.test(
-          processManager: processManager,
-          xcodeProjectInterpreter: mockXcodeProjectInterpreter,
-        );
-      });
-
-      testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
-        when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-          .thenThrow(const ProcessException('/usr/bin/xcode-select', <String>['--print-path']));
-        expect(xcode.xcodeSelectPath, isNull);
-        when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-          .thenThrow(ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'));
-
-        expect(xcode.xcodeSelectPath, isNull);
-      });
-
-      testWithoutContext('eulaSigned is false when clang is not installed', () {
-        when(mockXcodeProjectInterpreter.xcrunCommand()).thenReturn(<String>['xcrun']);
-
-        when(processManager.runSync(<String>['which', 'sysctl']))
-            .thenReturn(ProcessResult(1, 0, '', ''));
-        when(processManager.runSync(<String>['sysctl', 'hw.optional.arm64']))
-            .thenReturn(ProcessResult(123, 1, '', ''));
-        when(processManager.runSync(<String>['xcrun', 'clang']))
-          .thenThrow(const ProcessException('xcrun', <String>['clang']));
-
-        expect(xcode.eulaSigned, isFalse);
-      });
-    });
-
-    group('xcdevice', () {
-      XCDevice xcdevice;
-      Xcode xcode;
-
-      setUp(() {
-        xcode = Xcode.test(
-          processManager: FakeProcessManager.any(),
-          xcodeProjectInterpreter: XcodeProjectInterpreter.test(
-            processManager: FakeProcessManager.any(),
-          ),
-        );
-        xcdevice = XCDevice(
-          processManager: processManager,
-          logger: logger,
-          xcode: xcode,
-          platform: null,
-          artifacts: Artifacts.test(),
-          cache: Cache.test(),
-          iproxy: IProxy.test(logger: logger, processManager: processManager),
-        );
-      });
-
-      testWithoutContext('available devices xcdevice fails', () async {
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
-
-        expect(await xcdevice.getAvailableIOSDevices(), isEmpty);
-      });
-
-      testWithoutContext('diagnostics xcdevice fails', () async {
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
-
-        expect(await xcdevice.getDiagnostics(), isEmpty);
-      });
-    });
   });
 
   group('FakeProcessManager', () {
@@ -196,6 +113,24 @@ void main() {
           ));
 
           expect(xcode.xcodeSelectPath, xcodePath);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['/usr/bin/xcode-select', '--print-path'],
+            exception: ProcessException('/usr/bin/xcode-select', <String>['--print-path']),
+          ));
+
+          expect(xcode.xcodeSelectPath, isNull);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+
+          fakeProcessManager.addCommand(FakeCommand(
+            command: const <String>['/usr/bin/xcode-select', '--print-path'],
+            exception: ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'),
+          ));
+
+          expect(xcode.xcodeSelectPath, isNull);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         });
 
@@ -340,6 +275,18 @@ void main() {
 
           expect(xcode.eulaSigned, isFalse);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('eulaSigned is false when clang is not installed', () {
+          when(mockXcodeProjectInterpreter.xcrunCommand()).thenReturn(<String>['xcrun']);
+          fakeProcessManager.addCommand(
+            const FakeCommand(
+              command: <String>['xcrun', 'clang'],
+              exception: ProcessException('xcrun', <String>['clang']),
+            ),
+          );
+
+          expect(xcode.eulaSigned, isFalse);
         });
 
         testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
@@ -608,6 +555,15 @@ void main() {
           Artifacts: () => Artifacts.test(),
         });
 
+        testWithoutContext('available devices xcdevice fails', () async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            exception: ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']),
+          ));
+
+          expect(await xcdevice.getAvailableIOSDevices(), isEmpty);
+        });
+
         testWithoutContext('uses timeout', () async {
           fakeProcessManager.addCommand(const FakeCommand(
             command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '20'],
@@ -736,6 +692,15 @@ void main() {
           Platform: () => macPlatform,
         });
 
+        testWithoutContext('diagnostics xcdevice fails', () async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            exception: ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']),
+          ));
+
+          expect(await xcdevice.getDiagnostics(), isEmpty);
+        });
+
         testUsingContext('returns error message', () async {
           const String devicesOutput = '''
 [
@@ -842,5 +807,4 @@ void main() {
   });
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -30,6 +30,7 @@ class FakeCommand {
     this.stderr = '',
     this.completer,
     this.stdin,
+    this.exception,
   }) : assert(command != null),
        assert(duration != null),
        assert(exitCode != null);
@@ -93,6 +94,9 @@ class FakeCommand {
   /// An optional stdin sink that will be exposed through the resulting
   /// [FakeProcess].
   final IOSink stdin;
+
+  /// If provided, this exception will be thrown when the fake command is run.
+  final dynamic exception;
 
   void _matches(
     List<String> command,
@@ -226,6 +230,9 @@ abstract class FakeProcessManager implements ProcessManager {
   ) {
     _pid += 1;
     final FakeCommand fakeCommand = findCommand(command, workingDirectory, environment, encoding);
+    if (fakeCommand.exception != null) {
+      throw fakeCommand.exception;
+    }
     if (fakeCommand.onRun != null) {
       fakeCommand.onRun();
     }


### PR DESCRIPTION
Throwing exceptions in `FakeCommand`'s `onRun` block didn't work for `runSync` processes.  Add an exception parameter to `FakeCommand`, and adopt in places where that was the only thing being done in `onRun`.
Fixes https://github.com/flutter/flutter/issues/56415

Part of #71511