### PR TITLE
Add RenderEditable keys listener back in attach()

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1639,6 +1639,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     _offset.addListener(markNeedsPaint);
     _showHideCursor();
     _showCursor.addListener(_showHideCursor);
+    if (_listenerAttached)
+      RawKeyboard.instance.addListener(_handleKeyEvent);
   }
 
   @override

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -955,6 +955,67 @@ void main() {
     expect(delegate.textEditingValue.text, '');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
+  test('arrow keys work after detaching the widget and attaching it again', () async {
+    final TextSelectionDelegate delegate = FakeEditableTextState()
+      ..textEditingValue = const TextEditingValue(
+          text: 'W Szczebrzeszynie chrząszcz brzmi w trzcinie',
+          selection: TextSelection.collapsed(offset: 0),
+        );
+    final ViewportOffset viewportOffset = ViewportOffset.zero();
+    final RenderEditable editable = RenderEditable(
+      backgroundCursorColor: Colors.grey,
+      selectionColor: Colors.black,
+      textDirection: TextDirection.ltr,
+      cursorColor: Colors.red,
+      offset: viewportOffset,
+      textSelectionDelegate: delegate,
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+        renderObject.selection = selection;
+      },
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      text: const TextSpan(
+        text: 'W Szczebrzeszynie chrząszcz brzmi w trzcinie',
+        style: TextStyle(
+          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+        ),
+      ),
+      selection: const TextSelection.collapsed(
+        offset: 0,
+      ),
+    );
+
+    final PipelineOwner pipelineOwner = PipelineOwner();
+    editable.attach(pipelineOwner);
+    editable.hasFocus = true;
+    editable.detach();
+    layout(editable);
+    editable.hasFocus = true;
+    editable.selectPositionAt(from: Offset.zero, cause: SelectionChangedCause.tap);
+    editable.selection = const TextSelection.collapsed(offset: 0);
+    pumpFrame();
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.arrowRight, platform: 'android');
+    expect(editable.selection?.isCollapsed, true);
+    expect(editable.selection?.baseOffset, 4);
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowLeft, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.arrowLeft, platform: 'android');
+    expect(editable.selection?.isCollapsed, true);
+    expect(editable.selection?.baseOffset, 3);
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    expect(delegate.textEditingValue.text, 'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
   test('arrow keys with selection text', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final ViewportOffset viewportOffset = ViewportOffset.zero();


### PR DESCRIPTION
## Description
RenderEditable currently shows an issue when it's detached and re-attached to the root tree, resulting in navigation and shortcut keys stopping to work (while text input still works).
This appears to be because the detach() function calls RawKeyboard.instance.removeListener(_handleKeyEvent) and on re-attaching, RawKeyboard.instance.addListener(_handleKeyEvent) isn't called - and as a result even though setFocus() is called, the key event handler is missing forever.
This PR adds the key event listener in attach() if _listenerAttached is true, meaning the widget was previously attached and handling keys.

## Related Issues
https://github.com/flutter/flutter/issues/75562

## Tests
I added the following tests:
```
packages/flutter/test/rendering/editable_test.dart:
test('arrow keys and delete handle surrogate pairs correctly'
```

Relevant tests passing:
```
% ../../bin/flutter test test/rendering/editable_test.dart
00:03 +53: All tests passed!                                                                                                                
% ../../bin/flutter test test/rendering/editable_gesture_test.dart 
00:03 +1: All tests passed!                                                                                                                 
% ../../bin/flutter test test/widgets/editable_text_test.dart 
00:12 +161: All tests passed!                                                                                                               
% ../../bin/flutter test test/widgets/editable_text_cursor_test.dart 
00:07 +24: All tests passed!                                                                                                                
% ../../bin/flutter test test/widgets/editable_text_show_on_screen_test.dart 
00:04 +9: All tests passed!                                                                                                                 
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
