### PR TITLE
fuchsia_remote_debug_protocol: never published

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -1,8 +1,7 @@
 name: fuchsia_remote_debug_protocol
-version: 0.0.0
+publish_to: none
 description: Provides an API to test/debug Flutter applications on remote Fuchsia devices and emulators.
 homepage: http://flutter.dev
-author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
Aids in some tracking tools. Prevents accidental publish.