### PR TITLE
ios_platform_view tests pass when device rotated

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -77,10 +77,11 @@ class PlatformViewPage extends StatelessWidget {
       ),
       body: Column(
         children: <Widget>[
-          Container(
-            child: const UiKitView(viewType: 'platform_view'),
-            width: 300,
-            height: 300,
+          Expanded(
+            child: Container(
+              child: const UiKitView(viewType: 'platform_view'),
+              width: 300,
+            ),
           ),
           ElevatedButton(
             key: button,


### PR DESCRIPTION
![Screen Shot 2021-02-08 at 2 06 52 PM](https://user-images.githubusercontent.com/682784/107290324-302f4e80-6a1b-11eb-86de-777bc3b8f1b6.png)
becomes
![flutter_01](https://user-images.githubusercontent.com/682784/107290427-5ce36600-6a1b-11eb-853c-7d1f13b07170.png)


Fixes https://github.com/flutter/flutter/issues/75648