### PR TITLE
CupertinoPageTransition Optimizations

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -801,7 +801,7 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
     ),
   );
 
-  // Colors used to paint a gradient at the start edge of the box it is.
+  // Colors used to paint a gradient at the start edge of the box it is
   // decorating.
   //
   // The first color in the list is used at the start of the gradient, which
@@ -809,7 +809,7 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
   //
   // If this is null, no shadow is drawn.
   //
-  // The list must have at least two colors in it (otherwise it would not a
+  // The list must have at least two colors in it (otherwise it would not be a
   // gradient).
   final List<Color>? _colors;
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -948,7 +948,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
         shadowDirection = 1;
         break;
       case TextDirection.ltr:
-        start = offset.dx - 1;
+        start = offset.dx;
         shadowDirection = -1;
         break;
     }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -910,7 +910,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     // A performance evaluation on xx showed, that drawing the gradient manually
     // as implemented below is more performant than relying on [LinearGradient.createShader]
     // because compiling that shader takes a long time. On an iPhone XR, the
-    // implementation below reduced the worst frame time for a cupertino page transition from xx ms down to
+    // implementation below reduced the worst frame time for a cupertino page transition of a newly installed app from xx ms down to
     // xx ms, mainly because there's no longer a need to compile a shader for the
     // LinearGradient.
     //

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -948,7 +948,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
         shadowDirection = 1;
         break;
       case TextDirection.ltr:
-        start = offset.dx;
+        start = offset.dx - 1;
         shadowDirection = -1;
         break;
     }
@@ -960,6 +960,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
       }
       final Paint paint = Paint()
         ..strokeWidth = 1.0
+        ..isAntiAlias = false
         ..color = Color.lerp(colors[bandColorIndex], colors[bandColorIndex + 1], (dx % bandWidth) / bandWidth)!;
       final double x = start + shadowDirection * dx;
       canvas.drawLine(Offset(x, offset.dy), Offset(x, offset.dy + shadowHeight), paint);

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -929,8 +929,8 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     // The implementation below divides the width of the shadow into multiple
     // bands of equal width, one for each color interval defined by
     // `_decoration._colors`. Band x is filled with a gradient going from
-    // `_decoration._colors[x]` to `_decoration._colors[x + 1]` by drawing 1px
-    // wide lines. The color of a particular line is computed by lerping between
+    // `_decoration._colors[x]` to `_decoration._colors[x + 1]` by drawing a
+    // bunch of 1px wide rects. The rects change their color by lerping between
     // the two colors that define the interval of the band.
 
     // Shadow spans 5% of the page.
@@ -959,11 +959,9 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
         bandColorIndex += 1;
       }
       final Paint paint = Paint()
-        ..strokeWidth = 1.0
-        ..isAntiAlias = false
         ..color = Color.lerp(colors[bandColorIndex], colors[bandColorIndex + 1], (dx % bandWidth) / bandWidth)!;
       final double x = start + shadowDirection * dx;
-      canvas.drawLine(Offset(x, offset.dy), Offset(x, offset.dy + shadowHeight), paint);
+      canvas.drawRect(Rect.fromLTWH(x - 1.0, offset.dy, 1.0, shadowHeight), paint);
     }
   }
 }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -10,7 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import '../../material.dart';
 import 'colors.dart';
 import 'interface_level.dart';
 import 'localizations.dart';
@@ -790,7 +789,7 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
   const _CupertinoEdgeShadowDecoration._(this._colors);
 
   static DecorationTween kTween = DecorationTween(
-    end:  const _CupertinoEdgeShadowDecoration._(
+    end: const _CupertinoEdgeShadowDecoration._(
       // Eyeballed gradient used to mimic a drop shadow on the start side only.
       <Color>[
         Color(0x38000000),
@@ -801,6 +800,11 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
     ),
   );
 
+  // Colors used to paint a gradient at the start edge of the box it's
+  // decorating.
+  //
+  // The first color in the list is used at the start of the gradient, which
+  // is located at the start edge of the decorated box.
   final List<Color> _colors;
 
   // Linearly interpolate between two edge shadow decorations decorations.

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -918,19 +918,20 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     //   colors: _decoration._colors,
     // )
     //
-    // A performance evaluation on xx showed, that drawing the gradient manually
-    // as implemented below is more performant than relying on [LinearGradient.createShader]
-    // because compiling that shader takes a long time. On an iPhone XR, the
-    // implementation below reduced the worst frame time for a cupertino page transition of a newly installed app from xx ms down to
-    // xx ms, mainly because there's no longer a need to compile a shader for the
-    // LinearGradient.
+    // A performance evaluation on Feb 8, 2021 showed, that drawing the gradient
+    // manually as implemented below is more performant than relying on
+    // [LinearGradient.createShad∂er] because compiling that shader takes a long
+    // time. On an iPhone XR, the implementation below reduced the worst frame
+    // time for a cupertino page transition of a newly installed app from ~95ms
+    // down to ~30ms, mainly because there's no longer a need to compile a
+    // shader for the LinearGradient.
     //
     // The implementation below divides the width of the shadow into multiple
-    // bands of equal width, one for each color interval defined by `_decoration._colors`.
-    // Band x is filled with a gradient going from `_decoration._colors[x]` to
-    // `_decoration._colors[x + 1]` by drawing 1px wide lines. The color of a
-    // particular line is computed by lerping between the two colors that define
-    // the interval of the band.
+    // bands of equal width, one for each color interval defined by
+    // `_decoration._colors`. Band x is filled with a gradient going from
+    // `_decoration._colors[x]` to `_decoration._colors[x + 1]` by drawing 1px
+    // wide lines. The color of a particular line is computed by lerping between
+    // the two colors that define the interval of the band.
 
     // Shadow spans 5% of the page.
     final double shadowWidth = 0.05 * configuration.size!.width;

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -897,6 +897,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     this._decoration,
     VoidCallback? onChange,
   ) : assert(_decoration != null),
+      assert(_decoration._colors == null || _decoration._colors!.length > 1),
       super(onChange);
 
   final _CupertinoEdgeShadowDecoration _decoration;
@@ -908,8 +909,6 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
       return;
     }
 
-    assert(colors.length > 1);
-
     // The following code simulates drawing a [LinearGradient] configured as
     // follows:
     //
@@ -920,7 +919,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     //
     // A performance evaluation on Feb 8, 2021 showed, that drawing the gradient
     // manually as implemented below is more performant than relying on
-    // [LinearGradient.createShad∂er] because compiling that shader takes a long
+    // [LinearGradient.createShader] because compiling that shader takes a long
     // time. On an iPhone XR, the implementation below reduced the worst frame
     // time for a cupertino page transition of a newly installed app from ~95ms
     // down to ~30ms, mainly because there's no longer a need to compile a

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -103,14 +103,17 @@ void main() {
     expect(widget1InitialTopLeft.dy == widget2TopLeft.dy, true);
     // Page 2 is coming in from the right.
     expect(widget2TopLeft.dx > widget1InitialTopLeft.dx, true);
-    // The shadow should be drawn to one screen width to the left of where
-    // the page 2 box is. `paints` tests relative to the painter's given canvas
-    // rather than relative to the screen so assert that it's one screen
-    // width to the left of 0 offset box rect and nothing is drawn inside the
-    // box's rect.
-    expect(box, paints..rect(
-      rect: const Rect.fromLTWH(-800.0, 0.0, 800.0, 600.0)
-    ));
+    // As explained in _CupertinoEdgeShadowPainter.paint the shadow is drawn
+    // as a bunch of lines. The lines are covering an area to the left of
+    // where the page 2 box is and a width of 5% of the page 2 box width.
+    // `paints` tests relative to the painter's given canvas
+    // rather than relative to the screen so assert that the shadow starts at
+    // offset.dx = -1.
+    final PaintPattern paintsShadow = paints;
+    for (int i = 1; i <= 0.05 * 800; i += 1) {
+      paintsShadow.line(p1: Offset(-i.toDouble(), 0.0), p2: Offset(-i.toDouble(), 600));
+    }
+    expect(box, paintsShadow);
 
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -104,14 +104,14 @@ void main() {
     // Page 2 is coming in from the right.
     expect(widget2TopLeft.dx > widget1InitialTopLeft.dx, true);
     // As explained in _CupertinoEdgeShadowPainter.paint the shadow is drawn
-    // as a bunch of lines. The lines are covering an area to the left of
+    // as a bunch of rects. The rects are covering an area to the left of
     // where the page 2 box is and a width of 5% of the page 2 box width.
     // `paints` tests relative to the painter's given canvas
     // rather than relative to the screen so assert that the shadow starts at
-    // offset.dx = -1.
+    // offset.dx = 0.
     final PaintPattern paintsShadow = paints;
     for (int i = 0; i < 0.05 * 800; i += 1) {
-      paintsShadow.line(p1: Offset(-i.toDouble(), 0.0), p2: Offset(-i.toDouble(), 600));
+      paintsShadow.rect(rect: Rect.fromLTWH(-i.toDouble() - 1.0 , 0.0, 1.0, 600));
     }
     expect(box, paintsShadow);
 

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -110,7 +110,7 @@ void main() {
     // rather than relative to the screen so assert that the shadow starts at
     // offset.dx = -1.
     final PaintPattern paintsShadow = paints;
-    for (int i = 1; i <= 0.05 * 800; i += 1) {
+    for (int i = 0; i < 0.05 * 800; i += 1) {
       paintsShadow.line(p1: Offset(-i.toDouble(), 0.0), p2: Offset(-i.toDouble(), 600));
     }
     expect(box, paintsShadow);

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -797,9 +797,9 @@ class _TestRecordingCanvasPatternMatcher extends _TestRecordingCanvasMatcher imp
   Description describe(Description description) {
     if (_predicates.isEmpty)
       return description.add('An object or closure and a paint pattern.');
-    description.add('Object or closure painting: ');
+    description.add('Object or closure painting:\n');
     return description.addAll(
-      '', ', ', '',
+      '', '\n', '',
       _predicates.map<String>((_PaintPredicate predicate) => predicate.toString()),
     );
   }


### PR DESCRIPTION
Visual comparison: https://docs.google.com/presentation/d/120sZ247kVG7FNBpOjhCNfyuMH4R_ISKQmpt7sN0mJHA/edit?resourcekey=0-wGkzc8vVceTjc-lvFsliQA#slide=id.p

Cupertino Transition before this change: [timeline_linear_gradient.json.zip](https://github.com/flutter/flutter/files/5947576/timeline_linear_gradient.json.zip)

Cupertino Transition after this change: [timeline_manually_drawn2.json.zip](https://github.com/flutter/flutter/files/5947606/timeline_manually_drawn2.json.zip), [timeline_manual_drawn1.json.zip](https://github.com/flutter/flutter/files/5947633/timeline_manual_drawn1.json.zip)

Fixes: https://github.com/flutter/flutter/issues/75789