### PR TITLE
Gallery transition tests pass when device rotated

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
@@ -33,13 +33,16 @@ Future<void> runDemos(List<String> demos, WidgetController controller) async {
     print('> $demo');
     await controller.pump(const Duration(milliseconds: 250));
 
+    final Finder demoCategoryItem = find.text(demoCategory);
     if (currentDemoCategory == null) {
-      await controller.tap(find.text(demoCategory));
+      await controller.scrollUntilVisible(demoCategoryItem, 48.0);
+      await controller.tap(demoCategoryItem);
       await controller.pumpAndSettle();
     } else if (currentDemoCategory != demoCategory) {
       await controller.tap(find.byTooltip('Back'));
       await controller.pumpAndSettle();
-      await controller.tap(find.text(demoCategory));
+      await controller.scrollUntilVisible(demoCategoryItem, 48.0);
+      await controller.tap(demoCategoryItem);
       await controller.pumpAndSettle();
       // Scroll back to the top
       await controller.drag(demoList, const Offset(0.0, 10000.0));

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -116,11 +116,14 @@ Future<void> runDemos(List<String> demos, FlutterDriver driver) async {
     final String demoCategory = demo.substring(demo.indexOf('@') + 1);
     print('> $demo');
 
+    final SerializableFinder demoCategoryItem = find.text(demoCategory);
     if (currentDemoCategory == null) {
-      await driver.tap(find.text(demoCategory));
+      await driver.scrollIntoView(demoCategoryItem);
+      await driver.tap(demoCategoryItem);
     } else if (currentDemoCategory != demoCategory) {
       await driver.tap(find.byTooltip('Back'));
-      await driver.tap(find.text(demoCategory));
+      await driver.scrollIntoView(demoCategoryItem);
+      await driver.tap(demoCategoryItem);
       // Scroll back to the top
       await driver.scroll(demoList, 0.0, 10000.0, const Duration(milliseconds: 100));
     }


### PR DESCRIPTION
Scroll the demo category items into view before trying to tap them:
![flutter_01](https://user-images.githubusercontent.com/682784/107296948-39beb380-6a27-11eb-80e0-4e287fa93ae7.png)

Fixes https://github.com/flutter/flutter/issues/75274
Fixes https://github.com/flutter/flutter/issues/75647

