### PR TITLE
Consolidate ascii spinner stop in devtools activation

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -153,18 +153,17 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
         'devtools'
       ]);
       if (_devToolsActivateProcess.exitCode != 0) {
-        status.cancel();
         _logger.printError('Error running `pub global activate '
             'devtools`:\n${_devToolsActivateProcess.stderr}');
         return false;
       }
-      status.stop();
       _persistentToolState.lastDevToolsActivationTime = DateTime.now();
       return true;
     } on Exception catch (e, _) {
-      status.stop();
       _logger.printError('Error running `pub global activate devtools`: $e');
       return false;
+    } finally {
+      status.stop();
     }
   }
 


### PR DESCRIPTION
`status.stop()` in `catch` was throwing because the timer was already stopped and nulled out.  Consolidate the status `stop` calls into one `finally` block.

Introduced in #73366
Fixes https://github.com/flutter/flutter/issues/75677