### PR TITLE
Fix analyzer warning, remove import

### DIFF
--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -17,7 +17,6 @@ import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';


### PR DESCRIPTION
```
Analyzing 3 directories...                                      

   info • Unused import: 'package:process/process.dart' • packages/flutter_tools/test/general.shard/macos/xcode_test.dart:20:8 • unused_import

1 issue found. (ran in 127.0s)
```