### PR TITLE
MockPub -> FakePub

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -23,6 +23,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -65,7 +66,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -78,7 +79,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -93,7 +94,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -108,7 +109,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
     BuildSystem: () => MockBuildSystem(),
   });
@@ -119,7 +120,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -129,7 +130,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -145,7 +146,7 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
     BuildSystem: () => MockBuildSystem(),
   });
@@ -208,7 +209,6 @@ class UrlLauncherPlugin {}
 }
 
 class MockBuildSystem extends Mock implements BuildSystem {}
-class MockPub extends Mock implements Pub {}
 
 class TestWebBuildCommand extends FlutterCommand {
   TestWebBuildCommand({ bool verboseHelp = false }) :

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -27,6 +27,7 @@ import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../src/common.dart';
+import '../src/fakes.dart';
 import '../src/testbed.dart';
 
 void main() {
@@ -58,7 +59,7 @@ void main() {
           urlTunneller: null,
         ) as ResidentWebRunner;
       }, overrides: <Type, Generator>{
-        Pub: () => MockPub(),
+        Pub: () => FakePub(),
       }
     );
   });
@@ -201,5 +202,4 @@ class MockChromeConnection extends Mock implements ChromeConnection {}
 class MockChromeTab extends Mock implements ChromeTab {}
 class MockWipConnection extends Mock implements WipConnection {}
 class MockBuildSystem extends Mock implements BuildSystem {}
-class MockPub extends Mock implements Pub {}
 class MockChromiumLauncher extends Mock implements ChromiumLauncher {}

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -37,6 +37,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fakes.dart';
 import '../src/testbed.dart';
 
 const List<VmServiceExpectation> kAttachLogExpectations = <VmServiceExpectation>[
@@ -188,7 +189,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -215,7 +216,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
   testUsingContext('profile does not supportsServiceProtocol', () {
@@ -246,7 +247,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -275,7 +276,7 @@ void main() {
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -295,7 +296,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -330,7 +331,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -354,7 +355,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -374,7 +375,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -412,7 +413,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -480,7 +481,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -506,7 +507,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -586,7 +587,7 @@ void main() {
     Usage: () => MockFlutterUsage(),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -670,7 +671,7 @@ void main() {
     Usage: () => MockFlutterUsage(),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -712,7 +713,7 @@ void main() {
     Usage: () => MockFlutterUsage(),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -724,7 +725,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -760,7 +761,7 @@ void main() {
     Usage: () => MockFlutterUsage(),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -793,7 +794,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -833,7 +834,7 @@ void main() {
     Usage: () => MockFlutterUsage(),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -861,7 +862,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -889,7 +890,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -902,7 +903,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -929,7 +930,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -956,7 +957,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -983,7 +984,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1010,7 +1011,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1038,7 +1039,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1079,7 +1080,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1120,7 +1121,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1161,7 +1162,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1202,7 +1203,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1243,7 +1244,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1286,7 +1287,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1329,7 +1330,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1361,7 +1362,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1387,7 +1388,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1412,7 +1413,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1487,7 +1488,7 @@ void main() {
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1534,7 +1535,7 @@ void main() {
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1551,7 +1552,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1568,7 +1569,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1585,7 +1586,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1600,7 +1601,7 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
@@ -1627,7 +1628,7 @@ void main() {
     )),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => MockPub(),
+    Pub: () => FakePub(),
     Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 }
@@ -1660,4 +1661,3 @@ class MockWipConnection extends Mock implements WipConnection {}
 class MockWipDebugger extends Mock implements WipDebugger {}
 class MockWebServerDevice extends Mock implements WebServerDevice {}
 class MockDevice extends Mock implements Device {}
-class MockPub extends Mock implements Pub {}

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -25,6 +25,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import 'utils.dart';
 
 void main() {
@@ -670,20 +671,6 @@ class FakeSignals implements Signals {
 
   @override
   Stream<Object> get errors => delegate.errors;
-}
-
-class FakePub extends Fake implements Pub {
-  @override
-  Future<void> get({
-    PubContext context,
-    String directory,
-    bool skipIfAbsent = false,
-    bool upgrade = false,
-    bool offline = false,
-    bool generateSyntheticPackage = false,
-    String flutterRootOverride,
-    bool checkUpToDate = false,
-  }) async { }
 }
 
 class FakeClock extends Fake implements SystemClock {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -14,8 +14,10 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
+import 'package:test/fake.dart';
 
 /// A fake implementation of the [DeviceLogReader].
 class FakeDeviceLogReader extends DeviceLogReader {
@@ -426,4 +428,18 @@ class FakeBotDetector implements BotDetector {
   Future<bool> get isRunningOnBot async => _isRunningOnBot;
 
   final bool _isRunningOnBot;
+}
+
+class FakePub extends Fake implements Pub {
+  @override
+  Future<void> get({
+    PubContext context,
+    String directory,
+    bool skipIfAbsent = false,
+    bool upgrade = false,
+    bool offline = false,
+    bool generateSyntheticPackage = false,
+    String flutterRootOverride,
+    bool checkUpToDate = false,
+  }) async { }
 }


### PR DESCRIPTION
Move `FakePub` from flutter_command_test to fakes.dart, use it instead of `MockPub` in a few spots.

Part of #71511