### PR TITLE
fix(flutter_driver): Properly declare socket as nullable

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -561,7 +561,7 @@ String _getWebSocketUrl(String url) {
 Future<vms.VmService> _waitAndConnect(String url, Map<String, dynamic>? headers) async {
   final String webSocketUrl = _getWebSocketUrl(url);
   int attempts = 0;
-  late WebSocket socket;
+  WebSocket? socket;
   while (true) {
     try {
       socket = await WebSocket.connect(webSocketUrl, headers: headers);
@@ -575,7 +575,7 @@ Future<vms.VmService> _waitAndConnect(String url, Map<String, dynamic>? headers)
         controller.stream,
         socket.add,
         log: null,
-        disposeHandler: () => socket.close(),
+        disposeHandler: () => socket!.close(),
         streamClosed: streamClosedCompleter.future
       );
       // This call is to ensure we are able to establish a connection instead of
@@ -583,7 +583,7 @@ Future<vms.VmService> _waitAndConnect(String url, Map<String, dynamic>? headers)
       await service.getVersion();
       return service;
     } catch (e) {
-      await socket.close();
+      await socket?.close();
       if (attempts > 5) {
         _log('It is taking an unusually long time to connect to the VM...');
       }

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -52,6 +52,19 @@ void main() {
       restoreVmServiceConnectFunction();
     });
 
+    test('Retries while Dart VM service is not available', () async {
+      // This test case will test the real implementation of `_waitAndConnect`.
+      restoreVmServiceConnectFunction();
+
+      // The actual behavior is to retry indefinitely until the Dart VM service
+      // becomes available. `.timeout` is used here to exit the infinite loop,
+      // expecting that no other types of error are thrown during the process.
+      expect(
+        vmServiceConnectFunction('http://foo.bar', <String, dynamic>{})
+            .timeout(const Duration(seconds: 1)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
 
     test('throws after retries if no isolate', () async {
       fakeVM.numberOfTriesBeforeResolvingIsolate = 10000;


### PR DESCRIPTION
This aligns with the original behavior before null-safety migration.

If `WebSocket.connect` throws, calling `socket.close` in the catch block below will cause a `LateInitializationError`.

This PR fixes an internal test breakage.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
