### PR TITLE
Add mac/android smoke catalina test to dashboard

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -673,6 +673,12 @@
          "flaky": false
       },
       {
+         "name": "Mac_android smoke_catalina_start_up",
+         "repo": "flutter",
+         "task_name": "mac_android_smoke_catalina_start_up",
+         "flaky": true
+      },
+      {
          "name": "Mac_android textfield_perf__timeline_summary",
          "repo": "flutter",
          "task_name": "mac_android_textfield_perf__timeline_summary",


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/infra/pull/353 to enable `Mac_android smoke_catalina_start_up` test to dashboard. 

Will mark it as `flaky: false` once it shows stable.

Related: flutter/flutter#74059