### PR TITLE
Audit and update deprecation warnings

### DIFF
--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -69,7 +69,7 @@ const _DayPickerGridDelegate _kDayPickerGridDelegate = _DayPickerGridDelegate();
 ///
 @Deprecated(
   'Use CalendarDatePicker instead. '
-  'This feature was deprecated after v1.15.3.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class DayPicker extends StatelessWidget {
   /// Creates a day picker.
@@ -77,7 +77,7 @@ class DayPicker extends StatelessWidget {
   /// Rarely used directly. Instead, typically used as part of a [MonthPicker].
   @Deprecated(
     'Use CalendarDatePicker instead. '
-    'This feature was deprecated after v1.15.3.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   DayPicker({
     Key? key,
@@ -355,7 +355,7 @@ class DayPicker extends StatelessWidget {
 ///
 @Deprecated(
   'Use CalendarDatePicker instead. '
-  'This feature was deprecated after v1.15.3.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class MonthPicker extends StatefulWidget {
   /// Creates a month picker.
@@ -364,7 +364,7 @@ class MonthPicker extends StatefulWidget {
   /// by [showDatePicker].
   @Deprecated(
     'Use CalendarDatePicker instead. '
-    'This feature was deprecated after v1.15.3.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   MonthPicker({
     Key? key,

--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -75,6 +75,10 @@ class DayPicker extends StatelessWidget {
   /// Creates a day picker.
   ///
   /// Rarely used directly. Instead, typically used as part of a [MonthPicker].
+  @Deprecated(
+    'Use CalendarDatePicker instead. '
+    'This feature was deprecated after v1.15.3.'
+  )
   DayPicker({
     Key? key,
     required this.selectedDate,
@@ -358,6 +362,10 @@ class MonthPicker extends StatefulWidget {
   ///
   /// Rarely used directly. Instead, typically used as part of the dialog shown
   /// by [showDatePicker].
+  @Deprecated(
+    'Use CalendarDatePicker instead. '
+    'This feature was deprecated after v1.15.3.'
+  )
   MonthPicker({
     Key? key,
     required this.selectedDate,

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -31,6 +31,10 @@ class FlatButton extends MaterialButton {
   /// Create a simple text button.
   ///
   /// The [autofocus] and [clipBehavior] arguments must not be null.
+  @Deprecated(
+    'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+    'This feature was deprecated after v1.25.0-8.1.pre.'
+  )
   const FlatButton({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -25,7 +25,7 @@ import 'theme_data.dart';
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
 @Deprecated(
   'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class FlatButton extends MaterialButton {
   /// Create a simple text button.
@@ -33,7 +33,7 @@ class FlatButton extends MaterialButton {
   /// The [autofocus] and [clipBehavior] arguments must not be null.
   @Deprecated(
     'Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-    'This feature was deprecated after v1.25.0-8.1.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   const FlatButton({
     Key? key,

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -36,7 +36,7 @@ const Duration _kElevationDuration = Duration(milliseconds: 75);
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
 @Deprecated(
   'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class OutlineButton extends MaterialButton {
   /// Create an outline button.
@@ -45,7 +45,7 @@ class OutlineButton extends MaterialButton {
   /// and the [autofocus] and [clipBehavior] arguments must not be null.
   @Deprecated(
     'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-    'This feature was deprecated after v1.25.0-8.1.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   const OutlineButton({
     Key? key,

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -43,6 +43,10 @@ class OutlineButton extends MaterialButton {
   ///
   /// The [highlightElevation] argument must be null or a positive value
   /// and the [autofocus] and [clipBehavior] arguments must not be null.
+  @Deprecated(
+    'Use OutlinedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+    'This feature was deprecated after v1.25.0-8.1.pre.'
+  )
   const OutlineButton({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -26,7 +26,7 @@ import 'theme_data.dart';
 /// [flutter.dev/go/material-button-migration-guide](https://flutter.dev/go/material-button-migration-guide).
 @Deprecated(
   'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-  'This feature was deprecated after v1.25.0-8.1.pre.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class RaisedButton extends MaterialButton {
   /// Create a filled button.
@@ -37,7 +37,7 @@ class RaisedButton extends MaterialButton {
   /// specified.
   @Deprecated(
     'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
-    'This feature was deprecated after v1.25.0-8.1.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   const RaisedButton({
     Key? key,

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -35,6 +35,10 @@ class RaisedButton extends MaterialButton {
   /// Additionally,  [elevation], [hoverElevation], [focusElevation],
   /// [highlightElevation], and [disabledElevation] must be non-negative, if
   /// specified.
+  @Deprecated(
+    'Use ElevatedButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). '
+    'This feature was deprecated after v1.25.0-8.1.pre.'
+  )
   const RaisedButton({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1486,7 +1486,13 @@ abstract class BaseSliderTrackShape {
 ///  * [RoundedRectSliderTrackShape], for a similar track with rounded edges.
 class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackShape {
   /// Creates a slider track that draws 2 rectangles.
-  const RectangularSliderTrackShape({ this.disabledThumbGapWidth = 2.0 });
+  const RectangularSliderTrackShape({
+    @Deprecated(
+      'It no longer has any effect because the thumb does not shrink when the slider is disabled now. '
+      'This feature was deprecated after v1.5.7.'
+    )
+    this.disabledThumbGapWidth = 2.0
+  });
 
   /// Horizontal spacing, or gap, between the disabled thumb and the track.
   ///

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1489,7 +1489,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   const RectangularSliderTrackShape({
     @Deprecated(
       'It no longer has any effect because the thumb does not shrink when the slider is disabled now. '
-      'This feature was deprecated after v1.5.7.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     this.disabledThumbGapWidth = 2.0
   });
@@ -1502,7 +1502,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   /// thumb radius.
   @Deprecated(
     'It no longer has any effect because the thumb does not shrink when the slider is disabled now. '
-    'This feature was deprecated after v1.5.7.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   final double disabledThumbGapWidth;
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -559,8 +559,20 @@ class ThemeData with Diagnosticable {
     required this.buttonColor,
     required this.toggleButtonsTheme,
     required this.secondaryHeaderColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     required this.textSelectionColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.cursorColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     required this.cursorColor,
+    @Deprecated(
+      'Use TextSelectionThemeData.selectionHandleColor instead. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     required this.textSelectionHandleColor,
     required this.backgroundColor,
     required this.dialogBackgroundColor,
@@ -610,6 +622,10 @@ class ThemeData with Diagnosticable {
     required this.radioTheme,
     required this.switchTheme,
     required this.fixTextFieldOutlineLabel,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v1.23.0-4.0.pre.'
+    )
     required this.useTextSelectionTheme,
   }) : assert(visualDensity != null),
        assert(primaryColor != null),

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -240,17 +240,17 @@ class ThemeData with Diagnosticable {
     Color? secondaryHeaderColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? textSelectionColor,
     @Deprecated(
       'Use TextSelectionThemeData.cursorColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? cursorColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionHandleColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? textSelectionHandleColor,
     Color? backgroundColor,
@@ -561,17 +561,17 @@ class ThemeData with Diagnosticable {
     required this.secondaryHeaderColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     required this.textSelectionColor,
     @Deprecated(
       'Use TextSelectionThemeData.cursorColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     required this.cursorColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionHandleColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     required this.textSelectionHandleColor,
     required this.backgroundColor,
@@ -948,21 +948,21 @@ class ThemeData with Diagnosticable {
   /// The color of text selections in text fields, such as [TextField].
   @Deprecated(
     'Use TextSelectionThemeData.selectionColor instead. '
-    'This feature was deprecated after v1.23.0-4.0.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   final Color textSelectionColor;
 
   /// The color of cursors in Material-style text fields, such as [TextField].
   @Deprecated(
     'Use TextSelectionThemeData.cursorColor instead. '
-    'This feature was deprecated after v1.23.0-4.0.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   final Color cursorColor;
 
   /// The color of the handles used to adjust what part of the text is currently selected.
   @Deprecated(
     'Use TextSelectionThemeData.selectionHandleColor instead. '
-    'This feature was deprecated after v1.23.0-4.0.pre.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   final Color textSelectionHandleColor;
 
@@ -1257,17 +1257,17 @@ class ThemeData with Diagnosticable {
     Color? secondaryHeaderColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? textSelectionColor,
     @Deprecated(
       'Use TextSelectionThemeData.cursorColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? cursorColor,
     @Deprecated(
       'Use TextSelectionThemeData.selectionHandleColor instead. '
-      'This feature was deprecated after v1.23.0-4.0.pre.'
+      'This feature was deprecated after v1.26.0-18.0.pre.'
     )
     Color? textSelectionHandleColor,
     Color? backgroundColor,

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -152,13 +152,13 @@ class TapSemanticEvent extends SemanticsEvent {
 ///
 @Deprecated(
   'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '
-  'This feature was deprecated after v1.12.16.'
+  'This feature was deprecated after v1.26.0-18.0.pre.'
 )
 class UpdateLiveRegionEvent extends SemanticsEvent {
   /// Creates a new [UpdateLiveRegionEvent].
   @Deprecated(
     'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '
-    'This feature was deprecated after v1.12.16.'
+    'This feature was deprecated after v1.26.0-18.0.pre.'
   )
   const UpdateLiveRegionEvent() : super('updateLiveRegion');
 

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -156,6 +156,10 @@ class TapSemanticEvent extends SemanticsEvent {
 )
 class UpdateLiveRegionEvent extends SemanticsEvent {
   /// Creates a new [UpdateLiveRegionEvent].
+  @Deprecated(
+    'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '
+    'This feature was deprecated after v1.12.16.'
+  )
   const UpdateLiveRegionEvent() : super('updateLiveRegion');
 
   @override


### PR DESCRIPTION
While working on deprecations and dart fixes recently, I found that not all uses of deprecated API were receiving warnings. This is because the annotation must be applied to every use - constructors, parameters and field members.

I did a quick audit and found that some deprecated API is not fully  warned, added where needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
