### PR TITLE
Avoid duplicating Pods-Runner xcconfig #includes

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -274,9 +274,10 @@ class CocoaPods {
     final File file = xcodeProject.xcodeConfigFor(mode);
     if (file.existsSync()) {
       final String content = file.readAsStringSync();
-      final String include = '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
-          .toLowerCase()}.xcconfig"';
-      if (!content.contains(include)) {
+      final String includeFile = 'Pods/Target Support Files/Pods-Runner/Pods-Runner.${mode
+          .toLowerCase()}.xcconfig';
+      final String include = '#include? "$includeFile"';
+      if (!content.contains(includeFile)) {
         file.writeAsStringSync('$include\n$content', flush: true);
       }
     }


### PR DESCRIPTION
Before https://github.com/flutter/flutter/pull/73112 the generated file was
```
#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
```
after that change it's now
```
#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
```

But it was always adding the `#include?` line if it didn't exist. So on legacy projects it generates:
```
#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
```

Just keep the old style since it's not really hurting anything.  See my justification for not writing a migrator in https://github.com/flutter/flutter/pull/73112.

I don't think fixing this mistake is worth a migration either.  Having the two includes is stupid, but it's not hurting anything either (as opposed to a botched migration).

Fixes https://github.com/flutter/flutter/issues/75817