### PR TITLE
[flutter_tools] remove package HTTP and add pub.dev head check tests

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -75,7 +75,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
         if (!useOverrideUrl) {
           rethrow;
         }
-        // The user supplied a custom pub URL that was invalid, the pretend to be offline
+        // The user supplied a custom pub URL that was invalid, pretend to be offline
         // and inform them that the URL was invalid.
         offline = true;
         _logger.printError(

--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -18,8 +18,8 @@ import 'resident_runner.dart';
 
 /// An implementation of the devtools launcher that uses the server package.
 ///
-/// This is implemented in isolated to prevent the flutter_tool from needing
-/// a devtools dep in google3.
+/// This is implemented in `isolated/` to prevent the flutter_tool from needing
+/// a devtools dependency in google3.
 class DevtoolsServerLauncher extends DevtoolsLauncher {
   DevtoolsServerLauncher({
     @required Platform platform,

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -40,7 +40,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -67,7 +67,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -88,7 +88,7 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-        FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(
+        FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(
           headers: <String, List<String>>{
             'x-goog-hash': <String>[],
           }
@@ -100,7 +100,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -119,7 +119,7 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-        FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(
+        FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(
           body: <int>[0],
           headers: <String, List<String>>{
             'x-goog-hash': <String>[
@@ -135,7 +135,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -154,7 +154,7 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-         FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(
+         FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(
            body: <int>[0],
            headers: <String, List<String>>{
              'x-goog-hash': <String>[
@@ -163,7 +163,7 @@ void main() {
             ],
           }
         )),
-       FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(
+       FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(
            headers: <String, List<String>>{
              'x-goog-hash': <String>[
               'foo-bar-baz',
@@ -178,7 +178,7 @@ void main() {
 
     await expectLater(() async => await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit(message: 'k7iFrf4SQT9WfcQ==')); // validate that the hash mismatch message is included.
   });
@@ -197,8 +197,8 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-        FakeRequest(Uri.parse('http:///test.zip'), responseError: const HttpException('')),
-        FakeRequest(Uri.parse('http:///test.zip')),
+        FakeRequest(Uri.parse('http://test.zip'), responseError: const HttpException('')),
+        FakeRequest(Uri.parse('http://test.zip')),
       ]),
       tempStorage: fileSystem.currentDirectory.childDirectory('temp')
         ..createSync(),
@@ -206,7 +206,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
 
@@ -224,8 +224,8 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-        FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(statusCode: HttpStatus.preconditionFailed)),
-        FakeRequest(Uri.parse('http:///test.zip'), response: const FakeResponse(statusCode: HttpStatus.preconditionFailed)),
+        FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(statusCode: HttpStatus.preconditionFailed)),
+        FakeRequest(Uri.parse('http://test.zip'), response: const FakeResponse(statusCode: HttpStatus.preconditionFailed)),
       ]),
       tempStorage: fileSystem.currentDirectory.childDirectory('temp')
         ..createSync(),
@@ -233,7 +233,7 @@ void main() {
 
     await expectLater(() async => await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsToolExit());
 
@@ -281,7 +281,7 @@ void main() {
       operatingSystemUtils: operatingSystemUtils,
       platform: testPlatform,
       httpClient: FakeHttpClient.list(<FakeRequest>[
-        FakeRequest(Uri.parse('http:///test.zip'), responseError: ArgumentError()),
+        FakeRequest(Uri.parse('http://test.zip'), responseError: ArgumentError()),
       ]),
       tempStorage: fileSystem.currentDirectory.childDirectory('temp')
         ..createSync(),
@@ -289,7 +289,7 @@ void main() {
 
     await expectLater(() async => await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsA(isA<ArgumentError>()));
 
@@ -314,7 +314,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -338,7 +338,7 @@ void main() {
 
     await artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(logger.statusText, contains('test message'));
@@ -362,7 +362,7 @@ void main() {
 
     expect(artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsA(isA<ToolExit>()));
     expect(fileSystem.file('te,[/test'), isNot(exists));
@@ -386,7 +386,7 @@ void main() {
 
     expect(artifactUpdater.downloadZipArchive(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     ), throwsA(isA<ToolExit>()));
     expect(fileSystem.file('te,[/test'), isNot(exists));
@@ -409,7 +409,7 @@ void main() {
 
     await artifactUpdater.downloadZippedTarball(
       'test message',
-      Uri.parse('http:///test.zip'),
+      Uri.parse('http://test.zip'),
       fileSystem.currentDirectory.childDirectory('out'),
     );
     expect(fileSystem.file('out/test'), exists);

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -259,6 +259,7 @@ void main() {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[createDevFSRequest],
     );
+    setHttpAddress(Uri.parse('http://localhost'), fakeVmServiceHost.vmService);
 
     final DevFS devFS = DevFS(
       fakeVmServiceHost.vmService,

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -77,6 +77,23 @@ void main() {
     expect(address, isNull);
   });
 
+  testWithoutContext('DevtoolsLauncher handles an invalid PUB_HOSTED_URL', () async {
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: FakePlatform(environment: <String, String>{
+        'PUB_HOSTED_URL': r'not_an_http_url'
+      }),
+      persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.list(<FakeRequest>[]),
+      processManager: FakeProcessManager.list(<FakeCommand>[]),
+    );
+
+    final DevToolsServerAddress address = await launcher.serve();
+    expect(address, isNull);
+    expect(logger.errorText, contains('PUB_HOSTED_URL was set to an invalid URL: "not_an_http_url".'));
+  });
+
   testWithoutContext('DevtoolsLauncher launches DevTools through pub and saves the URI', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_http_client.dart';
 
 void main() {
   BufferLogger logger;
@@ -34,6 +35,48 @@ void main() {
     );
   });
 
+   testWithoutContext('DevtoolsLauncher does not launch devtools if unable to reach pub.dev', () async {
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: platform,
+      persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.list(<FakeRequest>[
+        FakeRequest(
+          Uri.https('pub.dev', ''),
+          method: HttpMethod.head,
+          response: const FakeResponse(statusCode: HttpStatus.internalServerError),
+        ),
+      ]),
+      processManager: FakeProcessManager.list(<FakeCommand>[]),
+    );
+
+    final DevToolsServerAddress address = await launcher.serve();
+    expect(address, isNull);
+  });
+
+  testWithoutContext('DevtoolsLauncher pings PUB_HOSTED_URL instead of pub.dev for online check', () async {
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: FakePlatform(environment: <String, String>{
+        'PUB_HOSTED_URL': 'https://pub2.dev'
+      }),
+      persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.list(<FakeRequest>[
+        FakeRequest(
+          Uri.https('pub2.dev', ''),
+          method: HttpMethod.head,
+          response: const FakeResponse(statusCode: HttpStatus.internalServerError),
+        ),
+      ]),
+      processManager: FakeProcessManager.list(<FakeCommand>[]),
+    );
+
+    final DevToolsServerAddress address = await launcher.serve();
+    expect(address, isNull);
+  });
+
   testWithoutContext('DevtoolsLauncher launches DevTools through pub and saves the URI', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
@@ -41,6 +84,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -85,6 +129,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -129,6 +174,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -178,6 +224,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -209,6 +256,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
@@ -253,6 +301,7 @@ void main() {
       logger: logger,
       platform: platform,
       persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.any(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[

--- a/packages/flutter_tools/test/general.shard/testbed_test.dart
+++ b/packages/flutter_tools/test/general.shard/testbed_test.dart
@@ -66,7 +66,7 @@ void main() {
       final Testbed testbed = Testbed();
       await testbed.run(() async {
         final HttpClient client = HttpClient();
-        final HttpClientRequest request = await client.getUrl(null);
+        final HttpClientRequest request = await client.getUrl(Uri.parse('http://foo.dev'));
         final HttpClientResponse response = await request.close();
 
         expect(response.statusCode, HttpStatus.ok);

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -263,6 +263,12 @@ class FakeHttpClient implements HttpClient {
   int _requestCount = 0;
 
   _FakeHttpClientRequest _findRequest(HttpMethod method, Uri uri) {
+    // Ensure the fake client throws similar errors to the real client.
+    if (uri.host.isEmpty) {
+      throw ArgumentError('No host specified in URI $uri');
+    } else if (uri.scheme != 'http' && uri.scheme != 'https') {
+      throw ArgumentError("Unsupported scheme '${uri.scheme}' in URI $uri");
+    }
     final String methodString = _toMethodString(method);
     if (_any) {
       return _FakeHttpClientRequest(


### PR DESCRIPTION
We've seen a resurgence of crashes from package:http. Remove the usage and add tests using the FakeHttpClient.