### PR TITLE
Mark mac_android_smoke_catalina_start_up test as unflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -273,12 +273,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac-catalina/ios"]
 
-  smoke_catalina_start_up:
-    description: >
-      A smoke test that runs on macOS Catalina, which is a clone of the Gallery startup latency test.
-    stage: devicelab
-    required_agent_capabilities: ["mac-catalina/android"]
-
   # macOS target platform tests
   hot_mode_dev_cycle_macos_target__benchmark:
     description: >

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -682,7 +682,7 @@
          "name": "Mac_android smoke_catalina_start_up",
          "repo": "flutter",
          "task_name": "mac_android_smoke_catalina_start_up",
-         "flaky": true
+         "flaky": false
       },
       {
          "name": "Mac_android textfield_perf__timeline_summary",


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/75798.
Test has been stable for couple of days, and this marks the test as unflaky.

https://github.com/flutter/flutter/issues/73907