### PR TITLE
[flutter_tools] add package:http to forbidden imports test

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -7,7 +7,6 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
-import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart' as intl;
 import 'package:intl/intl_standalone.dart' as intl_standalone;
 
@@ -136,7 +135,6 @@ Future<int> _handleToolError(
     globals.flutterUsage.sendException(error);
     await asyncGuard(() async {
       final CrashReportSender crashReportSender = CrashReportSender(
-        client: http.Client(),
         usage: globals.flutterUsage,
         platform: globals.platform,
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -97,12 +97,12 @@ class CrashReporter {
 /// wish to use your own server for collecting crash reports from Flutter Tools.
 class CrashReportSender {
   CrashReportSender({
-    @required http.Client client,
+    http.Client client,
     @required Usage usage,
     @required Platform platform,
     @required Logger logger,
     @required OperatingSystemUtils operatingSystemUtils,
-  }) : _client = client,
+  }) : _client = client ?? http.Client(),
       _usage = usage,
       _platform = platform,
       _logger = logger,


### PR DESCRIPTION
Generally we'd prefer to use dart:io client directly. Only opt out is for the multipart file request.
