### PR TITLE
[flutter_tools] do not use context logger in gradle

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -65,7 +65,7 @@ class ApplicationPackageFactory {
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
         if (_androidSdk?.licensesAvailable == true && _androidSdk?.latestVersion == null) {
-          await checkGradleDependencies();
+          await checkGradleDependencies(_logger);
         }
         if (applicationBinary == null) {
           return await AndroidApk.fromAndroidProject(

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -413,7 +413,6 @@ class WindowsStdoutLogger extends StdoutLogger {
 
   @override
   void writeToStdOut(String message) {
-    // TODO(jcollins-g): wrong abstraction layer for this, move to [Stdio].
     final String windowsMessage = _terminal.supportsEmoji
       ? message
       : message.replaceAll('🔥', '')
@@ -421,7 +420,8 @@ class WindowsStdoutLogger extends StdoutLogger {
                .replaceAll('✗', 'X')
                .replaceAll('✓', '√')
                .replaceAll('🔨', '')
-               .replaceAll('💪', '');
+               .replaceAll('💪', '')
+               .replaceAll('✏️', '');
     _stdio.stdoutWrite(windowsMessage);
   }
 }

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -84,7 +84,7 @@ abstract class Terminal {
   /// Create a new test [Terminal].
   ///
   /// If not specified, [supportsColor] defaults to `false`.
-  factory Terminal.test({bool supportsColor}) = _TestTerminal;
+  factory Terminal.test({bool supportsColor, bool supportsEmoji}) = _TestTerminal;
 
   /// Whether the current terminal supports color escape codes.
   bool get supportsColor;
@@ -317,7 +317,7 @@ class AnsiTerminal implements Terminal {
 }
 
 class _TestTerminal implements Terminal {
-  _TestTerminal({this.supportsColor = false});
+  _TestTerminal({this.supportsColor = false, this.supportsEmoji = false});
 
   @override
   bool usesTerminalUi;
@@ -351,7 +351,7 @@ class _TestTerminal implements Terminal {
   final bool supportsColor;
 
   @override
-  bool get supportsEmoji => false;
+  final bool supportsEmoji;
 
   @override
   bool get stdinHasTerminal => false;

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -79,7 +79,9 @@ Future<T> runInContext<T>(
     body: runnerWrapper,
     overrides: overrides,
     fallbacks: <Type, Generator>{
-      AndroidBuilder: () => AndroidGradleBuilder(),
+      AndroidBuilder: () => AndroidGradleBuilder(
+        logger: globals.logger,
+      ),
       AndroidLicenseValidator: () => AndroidLicenseValidator(
         operatingSystemUtils: globals.os,
         platform: globals.platform,

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -29,6 +30,7 @@ import '../../src/mocks.dart';
 
 void main() {
   group('gradle build', () {
+    BufferLogger logger;
     TestUsage testUsage;
     MockAndroidSdk mockAndroidSdk;
     MockAndroidStudio mockAndroidStudio;
@@ -41,6 +43,7 @@ void main() {
     AndroidGradleBuilder builder;
 
     setUp(() {
+      logger = BufferLogger.test();
       testUsage = TestUsage();
       fileSystem = MemoryFileSystem.test();
       fileSystemUtils = MockFileSystemUtils();
@@ -49,7 +52,9 @@ void main() {
       mockArtifacts = MockLocalEngineArtifacts();
       mockProcessManager = MockProcessManager();
       android = fakePlatform('android');
-      builder = AndroidGradleBuilder();
+      builder = AndroidGradleBuilder(
+        logger: logger,
+      );
 
       when(mockAndroidSdk.directory).thenReturn('irrelevant');
 
@@ -660,7 +665,7 @@ void main() {
       );
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Built build/app/outputs/flutter-apk/app-release.apk (0.0MB)'),
       );
 
@@ -708,11 +713,11 @@ void main() {
       );
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Built build/outputs/repo'),
       );
       expect(
-        testLogger.statusText.contains('Consuming the Module'),
+        logger.statusText.contains('Consuming the Module'),
         isFalse,
       );
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -462,7 +462,7 @@ include ':app'
       globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
           .writeAsStringSync(settingsAarFile);
 
-      createSettingsAarGradle(tempDir);
+      createSettingsAarGradle(tempDir, testLogger);
 
       expect(testLogger.statusText, contains('created successfully'));
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
@@ -495,7 +495,7 @@ include ':app'
       globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
           .writeAsStringSync(settingsAarFile);
 
-      createSettingsAarGradle(tempDir);
+      createSettingsAarGradle(tempDir, testLogger);
 
       expect(testLogger.statusText, contains('created successfully'));
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
@@ -834,13 +834,15 @@ flutter:
     FakeProcessManager fakeProcessManager;
     MockAndroidSdk mockAndroidSdk;
     AndroidGradleBuilder builder;
+    BufferLogger logger;
 
     setUp(() {
+      logger = BufferLogger.test();
       fs = MemoryFileSystem.test();
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.directory).thenReturn('irrelevant');
-      builder = AndroidGradleBuilder();
+      builder = AndroidGradleBuilder(logger: logger);
     });
 
     testUsingContext('calls gradle', () async {

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -87,6 +87,32 @@ void main() {
     ), isA<AppRunLogger>());
   });
 
+  testWithoutContext('WindowsStdoutLogger rewrites emojis when terminal does not support emoji', () {
+    final FakeStdio stdio = FakeStdio();
+    final WindowsStdoutLogger logger = WindowsStdoutLogger(
+      outputPreferences: OutputPreferences.test(),
+      stdio: stdio,
+      terminal: Terminal.test(supportsColor: false, supportsEmoji: false),
+    );
+
+    logger.printStatus('🔥🖼️✗✓🔨💪✏️');
+
+    expect(stdio.writtenToStdout, <String>['X√\n']);
+  });
+
+  testWithoutContext('WindowsStdoutLogger does not rewrite emojis when terminal does support emoji', () {
+    final FakeStdio stdio = FakeStdio();
+    final WindowsStdoutLogger logger = WindowsStdoutLogger(
+      outputPreferences: OutputPreferences.test(),
+      stdio: stdio,
+      terminal: Terminal.test(supportsColor: true, supportsEmoji: true),
+    );
+
+    logger.printStatus('🔥🖼️✗✓🔨💪✏️');
+
+    expect(stdio.writtenToStdout, <String>['🔥🖼️✗✓🔨💪✏️\n']);
+  });
+
   testWithoutContext('DelegatingLogger delegates', () {
     final FakeLogger fakeLogger = FakeLogger();
     final DelegatingLogger delegatingLogger = DelegatingLogger(fakeLogger);


### PR DESCRIPTION
Part 2 of 999 to clean up gradle.dart . move the logger into the class definition and remove context usage. Also removes sha analytics event that has not been useful (its always pretty fast 🤷🏻‍♂️ ).