### PR TITLE
Convert usages of Container() to const SizedBox()

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
@@ -33,7 +33,7 @@ class DummyImage extends StatelessWidget {
         // Use Image.memory instead of Image.asset to make sure that we're
         // creating many copies of the image to trigger the memory issue.
         return snapshot.data == null
-            ? Container()
+            ? const SizedBox()
             : Image.memory(snapshot.data.buffer.asUint8List());
       },
     );

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -170,7 +170,7 @@ enum AnimationBehavior {
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return Container(); // ...
+///     return const SizedBox(); // ...
 ///   }
 /// }
 /// ```

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -773,7 +773,7 @@ class _ContextMenuRoute<T> extends PopupRoute<T> {
     // animate the entire page into the scene. In the case of _ContextMenuRoute,
     // two individual pieces of the page are animated into the scene in
     // buildTransitions, and a Container is returned here.
-    return Container();
+    return const SizedBox();
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -464,7 +464,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         return CupertinoActivityIndicator(radius: radius * percentageComplete);
       case RefreshIndicatorMode.inactive:
         // Anything else doesn't show anything.
-        return Container();
+        return const SizedBox();
     }
   }
 
@@ -609,7 +609,7 @@ class _CupertinoSliverRefreshControlState extends State<CupertinoSliverRefreshCo
               widget.refreshIndicatorExtent,
             );
           }
-          return Container();
+          return const SizedBox();
         },
       ),
     );

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -584,7 +584,7 @@ class _TabSwitchingViewState extends State<_TabSwitchingView> {
               child: FocusScope(
                 node: tabFocusNodes[index],
                 child: Builder(builder: (BuildContext context) {
-                  return shouldBuildTab[index] ? widget.tabBuilder(context, index) : Container();
+                  return shouldBuildTab[index] ? widget.tabBuilder(context, index) : const SizedBox();
                 }),
               ),
             ),

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -1622,7 +1622,7 @@ class _DetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (_arguments == null) {
-      return Container();
+      return const SizedBox();
     }
     final double screenHeight = MediaQuery.of(context).size.height;
     final double minHeight = (screenHeight - kToolbarHeight) / screenHeight;

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -973,7 +973,7 @@ class _DayPickerState extends State<_DayPicker> {
     while (day < daysInMonth) {
       day++;
       if (day < 1) {
-        dayItems.add(Container());
+        dayItems.add(const SizedBox());
       } else {
         final DateTime dayToBuild = DateTime(year, month, day);
         final bool isDisabled = dayToBuild.isAfter(widget.lastDate) ||

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1689,8 +1689,8 @@ class _DayHeaders extends StatelessWidget {
     final List<Widget> labels = _getDayHeaders(textStyle, localizations);
 
     // Add leading and trailing containers for edges of the custom grid layout.
-    labels.insert(0, Container());
-    labels.add(Container());
+    labels.insert(0, const SizedBox());
+    labels.add(const SizedBox());
 
     return Container(
       constraints: BoxConstraints(
@@ -2093,7 +2093,7 @@ class _MonthItemState extends State<_MonthItem> {
       if (day > daysInMonth)
         break;
       if (day < 1) {
-        dayItems.add(Container());
+        dayItems.add(const SizedBox());
       } else {
         final DateTime dayToBuild = DateTime(year, month, day);
         final Widget dayItem = _buildDayItem(

--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -250,7 +250,7 @@ class DayPicker extends StatelessWidget {
       if (day > daysInMonth)
         break;
       if (day < 1) {
-        labels.add(Container());
+        labels.add(const SizedBox());
       } else {
         final DateTime dayToBuild = DateTime(year, month, day);
         final bool disabled = dayToBuild.isAfter(lastDate)

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1354,7 +1354,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     // display the hint or nothing at all.
     final Widget innerItemsWidget;
     if (items.isEmpty) {
-      innerItemsWidget = Container();
+      innerItemsWidget = const SizedBox();
     } else {
       innerItemsWidget = IndexedStack(
         index: _selectedIndex ?? hintIndex,

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -265,7 +265,7 @@ class _InkState extends State<Ink> {
       _ink!.decoration = widget.decoration;
       _ink!.configuration = createLocalImageConfiguration(context);
     }
-    return widget.child ?? Container();
+    return widget.child ?? const SizedBox();
   }
 
   @override

--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -71,7 +71,7 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// class MyApp extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return Container();
+///     return const SizedBox();
 ///   }
 /// }
 /// ```

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -304,7 +304,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
 ///                   ),
 ///                 ),
 ///               )
-///             : Container(),
+///             : const SizedBox(),
 ///       ],
 ///     );
 ///   }

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
-import 'container.dart';
 import 'debug.dart';
 import 'framework.dart';
 
@@ -571,7 +570,7 @@ class _LocalizationsState extends State<Localizations> {
   @override
   Widget build(BuildContext context) {
     if (_locale == null)
-      return Container();
+      return const SizedBox();
     return Semantics(
       textDirection: _textDirection,
       child: _LocalizationsScope(

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1623,7 +1623,7 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
 /// final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
 /// void main() {
 ///   runApp(MaterialApp(
-///     home: Container(),
+///     home: const SizedBox(),
 ///     navigatorObservers: [routeObserver],
 ///   ));
 /// }
@@ -1658,7 +1658,7 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
 ///   }
 ///
 ///   @override
-///   Widget build(BuildContext context) => Container();
+///   Widget build(BuildContext context) => const SizedBox();
 ///
 /// }
 /// ```

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -535,7 +535,7 @@ class TextSelectionOverlay {
   Widget _buildHandle(BuildContext context, _TextSelectionHandlePosition position) {
     if ((_selection.isCollapsed && position == _TextSelectionHandlePosition.end) ||
          selectionControls == null)
-      return Container(); // hide the second handle when collapsed
+      return const SizedBox(); // hide the second handle when collapsed
     return Visibility(
       visible: handlesVisible,
       child: _TextSelectionHandleOverlay(
@@ -553,7 +553,7 @@ class TextSelectionOverlay {
 
   Widget _buildToolbar(BuildContext context) {
     if (selectionControls == null)
-      return Container();
+      return const SizedBox();
 
     // Find the horizontal midpoint, just above the selected text.
     final List<TextSelectionPoint> endpoints =


### PR DESCRIPTION
## Description

Looked for instances of bare `Container()` and replaced them with `const SizedBox()` where appropriate.

In general, the visual result is the same, and it's a const object so more efficient.

## Related Issues

## Tests
