### PR TITLE
[fuchsia] - update getting local host address logic

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
@@ -68,12 +68,9 @@ class FuchsiaDevFinder {
 
   /// Returns the address of the named device.
   ///
-  /// If local is true, then gives the address by which the device reaches the
-  /// host.
-  ///
   /// The string [deviceName] should be the name of the device from the
   /// 'list' command, e.g. 'scare-cable-skip-joy'.
-  Future<String> resolve(String deviceName, {bool local = false}) async {
+  Future<String> resolve(String deviceName) async {
     if (_fuchsiaArtifacts.devFinder == null ||
         !_fuchsiaArtifacts.devFinder.existsSync()) {
       throwToolExit('Fuchsia device-finder tool not found.');
@@ -81,7 +78,6 @@ class FuchsiaDevFinder {
     final List<String> command = <String>[
       _fuchsiaArtifacts.devFinder.path,
       'resolve',
-      if (local) '-local',
       '-device-limit', '1',
       deviceName,
     ];

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -211,7 +211,6 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
     final String name = words[1];
     final String resolvedHost = await _fuchsiaSdk.fuchsiaDevFinder.resolve(
       name,
-      local: false,
     );
     if (resolvedHost == null) {
       _logger.printError('Failed to resolve host for Fuchsia device `$name`');
@@ -297,14 +296,7 @@ class FuchsiaDevice extends Device {
     }
     // Stop the app if it's currently running.
     await stopApp(package);
-    final String host = await fuchsiaSdk.fuchsiaDevFinder.resolve(
-      name,
-      local: true,
-    );
-    if (host == null) {
-      globals.printError('Failed to resolve host for Fuchsia device');
-      return LaunchResult.failed();
-    }
+    final String host = await hostAddress;
     // Find out who the device thinks we are.
     final int port = await globals.os.findFreePort();
     if (port == 0) {


### PR DESCRIPTION
Update device-discovery logic to get the host address by sshing into target. This will make using ffx easier.

*List which issues are fixed by this PR. You must list at least one issue.*


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
