### PR TITLE
Improve lifecycle docs

### DIFF
--- a/packages/flutter/lib/src/foundation/node.dart
+++ b/packages/flutter/lib/src/foundation/node.dart
@@ -87,6 +87,9 @@ class AbstractNode {
   /// Subclasses with children should override this method to first call their
   /// inherited [attach] method, and then [attach] all their children to the
   /// same [owner].
+  ///
+  /// If you override this, make sure your method starts with a call to
+  /// `super.attach(owner)`.
   @mustCallSuper
   void attach(covariant Object owner) {
     assert(owner != null);
@@ -101,6 +104,9 @@ class AbstractNode {
   ///
   /// Subclasses with children should override this method to first call their
   /// inherited [detach] method, and then [detach] all their children.
+  ///
+  /// If you override this, make sure to end your method with a call to
+  /// `super.detach()`.
   @mustCallSuper
   void detach() {
     assert(_owner != null);

--- a/packages/flutter/lib/src/foundation/node.dart
+++ b/packages/flutter/lib/src/foundation/node.dart
@@ -88,8 +88,8 @@ class AbstractNode {
   /// inherited [attach] method, and then [attach] all their children to the
   /// same [owner].
   ///
-  /// If you override this, make sure your method starts with a call to
-  /// `super.attach(owner)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.attach(owner)`.
   @mustCallSuper
   void attach(covariant Object owner) {
     assert(owner != null);
@@ -105,8 +105,8 @@ class AbstractNode {
   /// Subclasses with children should override this method to first call their
   /// inherited [detach] method, and then [detach] all their children.
   ///
-  /// If you override this, make sure to end your method with a call to
-  /// `super.detach()`.
+  /// Implementations of this method should end with a call to the inherited
+  /// method, as in `super.detach()`.
   @mustCallSuper
   void detach() {
     assert(_owner != null);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2583,8 +2583,8 @@ abstract class RenderBox extends RenderObject {
   /// object you can determine the [PointerDownEvent]'s position in local coordinates.
   /// (This is useful because [PointerEvent.position] is in global coordinates.)
   ///
-  /// If you override this, consider calling [debugHandleEvent] as follows, so
-  /// that you can support [debugPaintPointersEnabled]:
+  /// Implementations of this method should call [debugHandleEvent] as follows,
+  /// so that they support [debugPaintPointersEnabled]:
   ///
   /// ```dart
   /// @override

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -242,8 +242,8 @@ abstract class ViewportOffset extends ChangeNotifier {
   /// the [State] base class calls [debugFillDescription] to collect useful
   /// information from subclasses to incorporate into its return value.
   ///
-  /// If you override this, make sure to start your method with a call to
-  /// `super.debugFillDescription(description)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.debugFillDescription(description)`.
   @mustCallSuper
   void debugFillDescription(List<String> description) {
     if (hasPixels) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -976,7 +976,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// be used there.
   ///
   /// If you override this, make sure your method starts with a call to
-  /// super.initState().
+  /// `super.initState()`.
   @protected
   @mustCallSuper
   void initState() {
@@ -1000,7 +1000,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// {@macro flutter.widgets.State.initState}
   ///
   /// If you override this, make sure your method starts with a call to
-  /// super.didUpdateWidget(oldWidget).
+  /// `super.didUpdateWidget(oldWidget)`.
   @mustCallSuper
   @protected
   void didUpdateWidget(covariant T oldWidget) { }
@@ -1144,7 +1144,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// ancestor with a pointer to a descendant's [RenderObject]).
   ///
   /// If you override this, make sure to end your method with a call to
-  /// super.deactivate().
+  /// `super.deactivate()`.
   ///
   /// See also:
   ///
@@ -1168,7 +1168,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// {@macro flutter.widgets.State.initState}
   ///
   /// If you override this, make sure to end your method with a call to
-  /// super.dispose().
+  /// `super.dispose()`.
   ///
   /// See also:
   ///
@@ -3402,6 +3402,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// [update], [visitChildren], [RenderObjectElement.insertRenderObjectChild],
   /// [RenderObjectElement.moveRenderObjectChild], and
   /// [RenderObjectElement.removeRenderObjectChild].
+  ///
+  /// If you override this, make sure your method starts with a call to
+  /// `super.mount(parent, newSlot)`.
   @mustCallSuper
   void mount(Element? parent, dynamic newSlot) {
     assert(_lifecycleState == _ElementLifecycle.initial);
@@ -3721,6 +3724,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// lifecycle state). Instead, the framework calls [mount] in that situation.
   ///
   /// See the lifecycle documentation for [Element] for additional information.
+  ///
+  /// If you override this, make sure your method starts with a call to
+  /// `super.activate()`.
   @mustCallSuper
   void activate() {
     assert(_lifecycleState == _ElementLifecycle.inactive);
@@ -3752,6 +3758,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// This is (indirectly) called by [deactivateChild].
   ///
   /// See the lifecycle documentation for [Element] for additional information.
+  ///
+  /// If you override this, make sure to end your method with a call to
+  /// `super.deactivate()`.
   @mustCallSuper
   void deactivate() {
     assert(_lifecycleState == _ElementLifecycle.active);
@@ -3790,6 +3799,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// the tree again.
   ///
   /// See the lifecycle documentation for [Element] for additional information.
+  ///
+  /// If you override this, make sure to end your method with a call to
+  /// `super.unmount()`.
   @mustCallSuper
   void unmount() {
     assert(_lifecycleState == _ElementLifecycle.inactive);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -975,8 +975,8 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// following this method, and [BuildContext.dependOnInheritedWidgetOfExactType] can
   /// be used there.
   ///
-  /// If you override this, make sure your method starts with a call to
-  /// `super.initState()`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.initState()`.
   @protected
   @mustCallSuper
   void initState() {
@@ -999,8 +999,8 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   ///
   /// {@macro flutter.widgets.State.initState}
   ///
-  /// If you override this, make sure your method starts with a call to
-  /// `super.didUpdateWidget(oldWidget)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.didUpdateWidget(oldWidget)`.
   @mustCallSuper
   @protected
   void didUpdateWidget(covariant T oldWidget) { }
@@ -1143,8 +1143,8 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// this object and other elements in the tree (e.g. if you have provided an
   /// ancestor with a pointer to a descendant's [RenderObject]).
   ///
-  /// If you override this, make sure to end your method with a call to
-  /// `super.deactivate()`.
+  /// Implementations of this method should end with a call to the inherited
+  /// method, as in `super.deactivate()`.
   ///
   /// See also:
   ///
@@ -1167,8 +1167,8 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   ///
   /// {@macro flutter.widgets.State.initState}
   ///
-  /// If you override this, make sure to end your method with a call to
-  /// `super.dispose()`.
+  /// Implementations of this method should end with a call to the inherited
+  /// method, as in `super.dispose()`.
   ///
   /// See also:
   ///
@@ -3403,8 +3403,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// [RenderObjectElement.moveRenderObjectChild], and
   /// [RenderObjectElement.removeRenderObjectChild].
   ///
-  /// If you override this, make sure your method starts with a call to
-  /// `super.mount(parent, newSlot)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.mount(parent, newSlot)`.
   @mustCallSuper
   void mount(Element? parent, dynamic newSlot) {
     assert(_lifecycleState == _ElementLifecycle.initial);
@@ -3725,8 +3725,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// See the lifecycle documentation for [Element] for additional information.
   ///
-  /// If you override this, make sure your method starts with a call to
-  /// `super.activate()`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.activate()`.
   @mustCallSuper
   void activate() {
     assert(_lifecycleState == _ElementLifecycle.inactive);
@@ -3759,8 +3759,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// See the lifecycle documentation for [Element] for additional information.
   ///
-  /// If you override this, make sure to end your method with a call to
-  /// `super.deactivate()`.
+  /// Implementations of this method should end with a call to the inherited
+  /// method, as in `super.deactivate()`.
   @mustCallSuper
   void deactivate() {
     assert(_lifecycleState == _ElementLifecycle.active);
@@ -3800,8 +3800,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// See the lifecycle documentation for [Element] for additional information.
   ///
-  /// If you override this, make sure to end your method with a call to
-  /// `super.unmount()`.
+  /// Implementations of this method should end with a call to the inherited
+  /// method, as in `super.unmount()`.
   @mustCallSuper
   void unmount() {
     assert(_lifecycleState == _ElementLifecycle.inactive);

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -152,8 +152,8 @@ abstract class Notification {
   /// the [Notification] base class calls [debugFillDescription] to collect
   /// useful information from subclasses to incorporate into its return value.
   ///
-  /// If you override this, make sure to start your method with a call to
-  /// `super.debugFillDescription(description)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.debugFillDescription(description)`.
   @protected
   @mustCallSuper
   void debugFillDescription(List<String> description) { }

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -255,8 +255,8 @@ class ScrollController extends ChangeNotifier {
   /// the [ScrollController] base class calls [debugFillDescription] to collect
   /// useful information from subclasses to incorporate into its return value.
   ///
-  /// If you override this, make sure to start your method with a call to
-  /// `super.debugFillDescription(description)`.
+  /// Implementations of this method should start with a call to the inherited
+  /// method, as in `super.debugFillDescription(description)`.
   @mustCallSuper
   void debugFillDescription(List<String> description) {
     if (debugLabel != null)


### PR DESCRIPTION
This PR aims at improving the docs for lifecycle methods in `AbstractNode`, `Element`, and `State`.

For these methods, it is usually crucial that the paradigm of calling the inherited method first or last is followed. The reason for that is that there might be some preliminary setup or disposal of resources that has to happen first/last. 

Not following it is an easy source of error when adding mixins or not looking up all ancestor overrides. I assume this is also why at this time the notes are already present in `State` - I simply added them to `AbstractNode` and `Element` as well.  
I noticed that some people writing `RenderObject` subclasses are not following it, so establishing a paradigm via the docs should be beneficial.

---

There is no issue for this because this is just my **attempt** at improving the docs - maybe my assumptions are wrong after all.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
