### PR TITLE
[flutter_tools] stop using throttled print for service extensions

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -111,11 +111,13 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
           return _forceRepaint();
         },
       );
-      registerSignalServiceExtension(
+      registerServiceExtension(
         name: 'debugDumpLayerTree',
-        callback: () {
-          debugDumpLayerTree();
-          return debugPrintDone;
+        callback: (Map<String, String> parameters) async {
+          final String data = RendererBinding.instance?.renderView.debugLayer?.toStringDeep() ?? 'Layer tree unavailable.';
+          return <String, Object>{
+            'data': data,
+          };
         },
       );
       return true;
@@ -123,27 +125,35 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
     if (!kReleaseMode) {
       // these service extensions work in debug or profile mode
-      registerSignalServiceExtension(
+      registerServiceExtension(
         name: 'debugDumpRenderTree',
-        callback: () {
-          debugDumpRenderTree();
-          return debugPrintDone;
-        },
+        callback: (Map<String, String> parameters) async {
+          final String data = RendererBinding.instance?.renderView.toStringDeep() ?? 'Render tree unavailable.';
+          return <String, Object>{
+            'data': data,
+          };
+        }
       );
 
-      registerSignalServiceExtension(
+      registerServiceExtension(
         name: 'debugDumpSemanticsTreeInTraversalOrder',
-        callback: () {
-          debugDumpSemanticsTree(DebugSemanticsDumpOrder.traversalOrder);
-          return debugPrintDone;
+        callback: (Map<String, String> parameters) async {
+          final String data = RendererBinding.instance?.renderView.debugSemantics
+            ?.toStringDeep(childOrder: DebugSemanticsDumpOrder.traversalOrder) ?? 'Semantics not collected.';
+          return <String, Object>{
+            'data': data,
+          };
         },
       );
 
-      registerSignalServiceExtension(
+      registerServiceExtension(
         name: 'debugDumpSemanticsTreeInInverseHitTestOrder',
-        callback: () {
-          debugDumpSemanticsTree(DebugSemanticsDumpOrder.inverseHitTest);
-          return debugPrintDone;
+        callback: (Map<String, String> parameters) async {
+          final String data = RendererBinding.instance?.renderView.debugSemantics
+            ?.toStringDeep(childOrder: DebugSemanticsDumpOrder.inverseHitTest) ?? 'Semantics not collected.';
+          return <String, Object>{
+            'data': data,
+          };
         },
       );
     }
@@ -491,26 +501,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     instance?.renderView.visitChildren(visitor);
     return endOfFrame;
   }
-}
-
-/// Prints a textual representation of the entire render tree.
-void debugDumpRenderTree() {
-  debugPrint(RendererBinding.instance?.renderView.toStringDeep() ?? 'Render tree unavailable.');
-}
-
-/// Prints a textual representation of the entire layer tree.
-void debugDumpLayerTree() {
-  debugPrint(RendererBinding.instance?.renderView.debugLayer?.toStringDeep() ?? 'Layer tree unavailable.');
-}
-
-/// Prints a textual representation of the entire semantics tree.
-/// This will only work if there is a semantics client attached.
-/// Otherwise, a notice that no semantics are available will be printed.
-///
-/// The order in which the children of a [SemanticsNode] will be printed is
-/// controlled by the [childOrder] parameter.
-void debugDumpSemanticsTree(DebugSemanticsDumpOrder childOrder) {
-  debugPrint(RendererBinding.instance?.renderView.debugSemantics?.toStringDeep(childOrder: childOrder) ?? 'Semantics not collected.');
 }
 
 /// A concrete binding for applications that use the Rendering framework

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -503,6 +503,26 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   }
 }
 
+/// Prints a textual representation of the entire render tree.
+void debugDumpRenderTree() {
+  debugPrint(RendererBinding.instance?.renderView.toStringDeep() ?? 'Render tree unavailable.');
+}
+
+/// Prints a textual representation of the entire layer tree.
+void debugDumpLayerTree() {
+  debugPrint(RendererBinding.instance?.renderView.debugLayer?.toStringDeep() ?? 'Layer tree unavailable.');
+}
+
+/// Prints a textual representation of the entire semantics tree.
+/// This will only work if there is a semantics client attached.
+/// Otherwise, a notice that no semantics are available will be printed.
+///
+/// The order in which the children of a [SemanticsNode] will be printed is
+/// controlled by the [childOrder] parameter.
+void debugDumpSemanticsTree(DebugSemanticsDumpOrder childOrder) {
+  debugPrint(RendererBinding.instance?.renderView.debugSemantics?.toStringDeep(childOrder: childOrder) ?? 'Semantics not collected.');
+}
+
 /// A concrete binding for applications that use the Rendering framework
 /// directly. This is the glue that binds the framework to the Flutter engine.
 ///

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -11,7 +11,6 @@ import 'package:flutter/semantics.dart';
 
 import 'package:vector_math/vector_math_64.dart';
 
-import 'binding.dart';
 import 'box.dart';
 import 'layer.dart';
 import 'layout_helper.dart';

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -391,7 +391,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
       registerServiceExtension(
         name: 'debugDumpApp',
         callback: (Map<String, String> parameters) async {
-          final String data = debugDumpApp();
+          final String data = _debugDumpAppString();
           return <String, Object>{
             'data': data,
           };
@@ -1030,10 +1030,9 @@ void runApp(Widget app) {
     ..scheduleWarmUpFrame();
 }
 
-/// Return a string representation of the currently running app.
-String debugDumpApp() {
+String _debugDumpAppString() {
   assert(WidgetsBinding.instance != null);
-  final String mode = kDebugMode ? 'DEBUG MODE' : 'PROFILE MODE';
+  const String mode = kDebugMode ? 'DEBUG MODE' : 'PROFILE MODE';
   final StringBuffer buffer = StringBuffer();
   buffer.writeln('${WidgetsBinding.instance.runtimeType} - $mode');
   if (WidgetsBinding.instance!.renderViewElement != null) {
@@ -1042,6 +1041,12 @@ String debugDumpApp() {
     buffer.writeln('<no tree currently mounted>');
   }
   return buffer.toString();
+}
+
+/// Print a string representation of the currently running app.
+void debugDumpApp() {
+  final String value = _debugDumpAppString();
+  debugPrint(value);
 }
 
 /// A bridge from a [RenderObject] to an [Element] tree.

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -387,7 +387,6 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
     super.initServiceExtensions();
 
     if (!kReleaseMode) {
-
       registerServiceExtension(
         name: 'debugDumpApp',
         callback: (Map<String, String> parameters) async {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -387,11 +387,14 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
     super.initServiceExtensions();
 
     if (!kReleaseMode) {
-      registerSignalServiceExtension(
+
+      registerServiceExtension(
         name: 'debugDumpApp',
-        callback: () {
-          debugDumpApp();
-          return debugPrintDone;
+        callback: (Map<String, String> parameters) async {
+          final String data = debugDumpApp();
+          return <String, Object>{
+            'data': data,
+          };
         },
       );
 
@@ -1027,20 +1030,18 @@ void runApp(Widget app) {
     ..scheduleWarmUpFrame();
 }
 
-/// Print a string representation of the currently running app.
-void debugDumpApp() {
+/// Return a string representation of the currently running app.
+String debugDumpApp() {
   assert(WidgetsBinding.instance != null);
-  String mode = 'RELEASE MODE';
-  assert(() {
-    mode = 'CHECKED MODE';
-    return true;
-  }());
-  debugPrint('${WidgetsBinding.instance.runtimeType} - $mode');
+  final String mode = kDebugMode ? 'DEBUG MODE' : 'PROFILE MODE';
+  final StringBuffer buffer = StringBuffer();
+  buffer.writeln('${WidgetsBinding.instance.runtimeType} - $mode');
   if (WidgetsBinding.instance!.renderViewElement != null) {
-    debugPrint(WidgetsBinding.instance!.renderViewElement!.toStringDeep());
+    buffer.writeln(WidgetsBinding.instance!.renderViewElement!.toStringDeep());
   } else {
-    debugPrint('<no tree currently mounted>');
+    buffer.writeln('<no tree currently mounted>');
   }
+  return buffer.toString();
 }
 
 /// A bridge from a [RenderObject] to an [Element] tree.

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1033,7 +1033,7 @@ void runApp(Widget app) {
 /// Return a string representation of the currently running app.
 String debugDumpApp() {
   assert(WidgetsBinding.instance != null);
-  final String mode = kDebugMode ? 'DEBUG MODE' : 'PROFILE MODE';
+  const String mode = kDebugMode ? 'DEBUG MODE' : 'PROFILE MODE';
   final StringBuffer buffer = StringBuffer();
   buffer.writeln('${WidgetsBinding.instance.runtimeType} - $mode');
   if (WidgetsBinding.instance!.renderViewElement != null) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -28,7 +28,7 @@ export 'package:flutter/foundation.dart' show FlutterError, ErrorSummary, ErrorD
 export 'package:flutter/foundation.dart' show VoidCallback, ValueChanged, ValueGetter, ValueSetter;
 export 'package:flutter/foundation.dart' show DiagnosticsNode, DiagnosticLevel;
 export 'package:flutter/foundation.dart' show Key, LocalKey, ValueKey;
-export 'package:flutter/rendering.dart' show RenderObject, RenderBox;
+export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpRenderTree, debugDumpLayerTree;
 
 // Examples can assume:
 // late BuildContext context;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -28,7 +28,7 @@ export 'package:flutter/foundation.dart' show FlutterError, ErrorSummary, ErrorD
 export 'package:flutter/foundation.dart' show VoidCallback, ValueChanged, ValueGetter, ValueSetter;
 export 'package:flutter/foundation.dart' show DiagnosticsNode, DiagnosticLevel;
 export 'package:flutter/foundation.dart' show Key, LocalKey, ValueKey;
-export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpRenderTree, debugDumpLayerTree;
+export 'package:flutter/rendering.dart' show RenderObject, RenderBox;
 
 // Examples can assume:
 // late BuildContext context;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -226,22 +226,19 @@ void main() {
   });
 
   test('Service extensions - debugDumpApp', () async {
-    Map<String, dynamic> result;
+    final Map<String, dynamic> result = await binding.testExtension('debugDumpApp', <String, String>{});
 
-    result = await binding.testExtension('debugDumpApp', <String, String>{});
-    expect(result, <String, String>{});
-    expect(console, <String>['TestServiceExtensionsBinding - CHECKED MODE', '<no tree currently mounted>']);
-    console.clear();
+    expect(result, <String, dynamic>{
+      'data': matches('TestServiceExtensionsBinding - DEBUG MODE\n<no tree currently mounted>'),
+    });
   });
 
   test('Service extensions - debugDumpRenderTree', () async {
-    Map<String, dynamic> result;
-
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpRenderTree', <String, String>{});
-    expect(result, <String, String>{});
-    expect(console, <Matcher>[
-      matches(
+    final Map<String, dynamic> result = await binding.testExtension('debugDumpRenderTree', <String, String>{});
+
+    expect(result, <String, dynamic>{
+      'data': matches(
         r'^'
         r'RenderView#[0-9a-f]{5}\n'
         r'   debug mode enabled - [a-zA-Z]+\n'
@@ -250,18 +247,15 @@ void main() {
         r'   configuration: Size\(800\.0, 600\.0\) at 3\.0x \(in logical pixels\)\n'
         r'$'
       ),
-    ]);
-    console.clear();
+    });
   });
 
   test('Service extensions - debugDumpLayerTree', () async {
-    Map<String, dynamic> result;
-
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpLayerTree', <String, String>{});
-    expect(result, <String, String>{});
-    expect(console, <Matcher>[
-      matches(
+    final Map<String, dynamic> result = await binding.testExtension('debugDumpLayerTree', <String, String>{});
+
+    expect(result, <String, dynamic>{
+      'data': matches(
         r'^'
         r'TransformLayer#[0-9a-f]{5}\n'
         r'   owner: RenderView#[0-9a-f]{5}\n'
@@ -275,28 +269,25 @@ void main() {
         r'     \[3] 0\.0,0\.0,0\.0,1\.0\n'
         r'$'
       ),
-    ]);
-    console.clear();
+    });
   });
 
   test('Service extensions - debugDumpSemanticsTreeInTraversalOrder', () async {
-    Map<String, dynamic> result;
-
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpSemanticsTreeInTraversalOrder', <String, String>{});
-    expect(result, <String, String>{});
-    expect(console, <String>['Semantics not collected.']);
-    console.clear();
+    final Map<String, dynamic> result = await binding.testExtension('debugDumpSemanticsTreeInTraversalOrder', <String, String>{});
+
+    expect(result, <String, String>{
+      'data': 'Semantics not collected.'
+    });
   });
 
   test('Service extensions - debugDumpSemanticsTreeInInverseHitTestOrder', () async {
-    Map<String, dynamic> result;
-
     await binding.doFrame();
-    result = await binding.testExtension('debugDumpSemanticsTreeInInverseHitTestOrder', <String, String>{});
-    expect(result, <String, String>{});
-    expect(console, <String>['Semantics not collected.']);
-    console.clear();
+    final Map<String, dynamic> result = await binding.testExtension('debugDumpSemanticsTreeInInverseHitTestOrder', <String, String>{});
+
+    expect(result, <String, String>{
+      'data': 'Semantics not collected.'
+    });
   });
 
   test('Service extensions - debugPaint', () async {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -400,45 +400,50 @@ class FlutterDevice {
   Future<void> debugDumpApp() async {
     final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
-      await vmService.flutterDebugDumpApp(
+      final String data = await vmService.flutterDebugDumpApp(
         isolateId: view.uiIsolate.id,
       );
+      globals.printStatus(data);
     }
   }
 
   Future<void> debugDumpRenderTree() async {
     final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
-      await vmService.flutterDebugDumpRenderTree(
+      final String data = await vmService.flutterDebugDumpRenderTree(
         isolateId: view.uiIsolate.id,
       );
+      globals.printStatus(data);
     }
   }
 
   Future<void> debugDumpLayerTree() async {
     final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
-      await vmService.flutterDebugDumpLayerTree(
+      final String data = await vmService.flutterDebugDumpLayerTree(
         isolateId: view.uiIsolate.id,
       );
+      globals.printStatus(data);
     }
   }
 
   Future<void> debugDumpSemanticsTreeInTraversalOrder() async {
     final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
-      await vmService.flutterDebugDumpSemanticsTreeInTraversalOrder(
+      final String data = await vmService.flutterDebugDumpSemanticsTreeInTraversalOrder(
         isolateId: view.uiIsolate.id,
       );
+      globals.printStatus(data);
     }
   }
 
   Future<void> debugDumpSemanticsTreeInInverseHitTestOrder() async {
     final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
-      await vmService.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
+      final String data = await vmService.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
         isolateId: view.uiIsolate.id,
       );
+      globals.printStatus(data);
     }
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -515,49 +515,55 @@ extension FlutterVmService on vm_service.VmService {
     await onRunnable;
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpApp({
+  Future<String> flutterDebugDumpApp({
     @required String isolateId,
-  }) {
-    return invokeFlutterExtensionRpcRaw(
+  }) async {
+    final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpApp',
       isolateId: isolateId,
     );
+    return response['data']?.toString();
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpRenderTree({
+  Future<String> flutterDebugDumpRenderTree({
     @required String isolateId,
-  }) {
-    return invokeFlutterExtensionRpcRaw(
+  }) async {
+    final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpRenderTree',
       isolateId: isolateId,
+      args: <String, Object>{}
     );
+    return response['data']?.toString();
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpLayerTree({
+  Future<String> flutterDebugDumpLayerTree({
     @required String isolateId,
-  }) {
-    return invokeFlutterExtensionRpcRaw(
+  }) async {
+    final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpLayerTree',
       isolateId: isolateId,
     );
+    return response['data']?.toString();
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInTraversalOrder({
+  Future<String> flutterDebugDumpSemanticsTreeInTraversalOrder({
     @required String isolateId,
-  }) {
-    return invokeFlutterExtensionRpcRaw(
+  }) async {
+    final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpSemanticsTreeInTraversalOrder',
       isolateId: isolateId,
     );
+    return response['data']?.toString();
   }
 
-  Future<Map<String, dynamic>> flutterDebugDumpSemanticsTreeInInverseHitTestOrder({
+  Future<String> flutterDebugDumpSemanticsTreeInInverseHitTestOrder({
     @required String isolateId,
-  }) {
-    return invokeFlutterExtensionRpcRaw(
+  }) async {
+     final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder',
       isolateId: isolateId,
     );
+    return response['data']?.toString();
   }
 
   Future<Map<String, dynamic>> _flutterToggle(String name, {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -559,7 +559,7 @@ extension FlutterVmService on vm_service.VmService {
   Future<String> flutterDebugDumpSemanticsTreeInInverseHitTestOrder({
     @required String isolateId,
   }) async {
-     final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
+    final Map<String, Object> response = await invokeFlutterExtensionRpcRaw(
       'ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder',
       isolateId: isolateId,
     );


### PR DESCRIPTION
Currently the service extensions that print a debug view of the widget, render object, semantics, or layer tree can lock a device for several seconds. This is due to the printing being driven entirely by the device side, and the printing being throttled to prevent logs from being dropped by the host system. 

This has inspired a good deal of frustration, as users that accidentally press these keys find their devices locked up and terminal filled with irrelevant information.

See:

Fixes https://github.com/flutter/flutter/issues/33184
Fixes https://github.com/flutter/flutter/issues/49143

https://stackoverflow.com/questions/56726247/how-to-disable-widget-tree-printing-in-flutter-cli-pressing-t-key-accidently

Remove the lockup by push all of the data over the vm service to the tool for printing. Makes `t`, `S`, `w` immediately print the entire buffer.