### PR TITLE
[flutter_tools] Avoid duplicated calls to l10n generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Andrey Kabylin <andrey@kabylin.ru>
 vimerzhao <vimerzhao@gmail.com>
 Pedro Massango <pedromassango.developer@gmail.com>
 Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
+Perqin Xie <perqinxie@gmail.com>

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -37,15 +37,9 @@ Future<void> generateLocalizationsSyntheticPackage({
     );
   }
 
-  BuildResult result;
-  // If an l10n.yaml file exists but is empty, attempt to build synthetic
-  // package with default settings.
-  if (yamlNode.value == null) {
-    result = await buildSystem.build(
-      const GenerateLocalizationsTarget(),
-      environment,
-    );
-  } else {
+  // If an l10n.yaml file exists and is not empty, attempt to parse settings in
+  // it.
+  if (yamlNode.value != null) {
     final YamlMap yamlMap = yamlNode as YamlMap;
     final Object value = yamlMap['synthetic-package'];
     if (value is! bool && value != null) {
@@ -63,7 +57,7 @@ Future<void> generateLocalizationsSyntheticPackage({
     }
   }
 
-  result = await buildSystem.build(
+  final BuildResult result = await buildSystem.build(
     const GenerateLocalizationsTarget(),
     environment,
   );

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -18,7 +18,7 @@ import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 
 void main() {
-  testWithoutContext('calls buildSystem.build with blank l10n.yaml file', () {
+  testWithoutContext('calls buildSystem.build with blank l10n.yaml file', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
@@ -44,7 +44,7 @@ void main() {
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
-    expect(
+    await expectLater(
       () => generateLocalizationsSyntheticPackage(
         environment: environment,
         buildSystem: buildSystem,
@@ -58,7 +58,7 @@ void main() {
     )).called(1);
   });
 
-  testWithoutContext('calls buildSystem.build with l10n.yaml synthetic-package: true', () {
+  testWithoutContext('calls buildSystem.build with l10n.yaml synthetic-package: true', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
@@ -85,7 +85,7 @@ void main() {
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
-    expect(
+    await expectLater(
       () => generateLocalizationsSyntheticPackage(
         environment: environment,
         buildSystem: buildSystem,
@@ -99,7 +99,7 @@ void main() {
     )).called(1);
   });
 
-  testWithoutContext('calls buildSystem.build with l10n.yaml synthetic-package: null', () {
+  testWithoutContext('calls buildSystem.build with l10n.yaml synthetic-package: null', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
@@ -124,7 +124,7 @@ void main() {
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
-    expect(
+    await expectLater(
       () => generateLocalizationsSyntheticPackage(
         environment: environment,
         buildSystem: buildSystem,
@@ -171,7 +171,7 @@ void main() {
     ));
   });
 
-  testWithoutContext('does not call buildSystem.build with incorrect l10n.yaml format', () {
+  testWithoutContext('does not call buildSystem.build with incorrect l10n.yaml format', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
@@ -196,7 +196,7 @@ void main() {
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
-    expect(
+    await expectLater(
       () => generateLocalizationsSyntheticPackage(
         environment: environment,
         buildSystem: buildSystem,
@@ -210,7 +210,7 @@ void main() {
     ));
   });
 
-  testWithoutContext('does not call buildSystem.build with non-bool "synthetic-package" value', () {
+  testWithoutContext('does not call buildSystem.build with non-bool "synthetic-package" value', () async {
     // Project directory setup for gen_l10n logic
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
 
@@ -235,7 +235,7 @@ void main() {
     );
     final BuildSystem buildSystem = MockBuildSystem();
 
-    expect(
+    await expectLater(
       () => generateLocalizationsSyntheticPackage(
         environment: environment,
         buildSystem: buildSystem,


### PR DESCRIPTION
This issue is concealed by incorrectly written test cases. `verify` should not be called until previous `expect` has finished, because the mock function may be called later after the expectation. This seems to be a common pitfall that should be avoided when testing asynchronous code, but isn't mentioned in Dart/Flutter's documentation.

This PR should close the issue #76065.
Fixes #76065

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. **Instead, I fixed the wrong test cases.**
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
