### PR TITLE
Do not fail if 9xth_percentile_memory_usage is not recorded

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -714,8 +714,8 @@ class PerfTest {
           if (measureMemory && !isAndroid) ...<String>[
             // See https://github.com/flutter/flutter/issues/68888
             if (data['average_memory_usage'] != null) 'average_memory_usage',
-            '90th_percentile_memory_usage',
-            '99th_percentile_memory_usage',
+            if (data['90th_percentile_memory_usage'] != null) '90th_percentile_memory_usage',
+            if (data['99th_percentile_memory_usage'] != null) '99th_percentile_memory_usage',
           ],
         ],
       );


### PR DESCRIPTION
## Description

Same as https://github.com/flutter/flutter/pull/69268 and https://github.com/flutter/flutter/pull/69339 but include `90th_percentile_memory_usage` and `99th_percentile_memory_usage`.

## Related Issues

https://github.com/flutter/flutter/issues/68888
Fixes https://github.com/flutter/flutter/issues/76148