### PR TITLE
[fuchsia] - migrate device discovery workflows to use ffx

### DIFF
--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -13,7 +13,7 @@
 # The first and only parameter should be the path to the Fuchsia system image
 # tarball, e.g. `./run_fuchsia_tests.sh generic-x64.tgz`.
 #
-# This script expects `pm`, `device-finder`, and `fuchsia_ctl` to all be in the
+# This script expects `pm`, `ffx`, and `fuchsia_ctl` to all be in the
 # same directory as the script.
 #
 # This script also expects a private key available at:
@@ -44,7 +44,7 @@ fi
 # Wrapper function to pass common args to fuchsia_ctl.
 fuchsia_ctl() {
   $script_dir/fuchsia_ctl -d $device_name \
-      --device-finder-path $script_dir/device-finder "$@"
+      --ffx-path $script_dir/ffx "$@"
 }
 
 reboot() {
@@ -114,6 +114,8 @@ Host *
 EOF
 
 export FUCHSIA_SSH_CONFIG=$script_dir/fuchsia_ssh_config
+
+export FUCHSIA_ANALYTICS_DISABLED="1"
 
 # Run the driver test
 echo "$(date) START:DRIVER_TEST -------------------------------------"

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -322,12 +322,12 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
 
  FuchsiaDevice _workingDevice;
 
- String get _devFinder {
-    final String devFinder = path.join(getArtifactPath(), 'fuchsia', 'tools', 'device-finder');
-    if (!File(devFinder).existsSync()) {
-      throw FileSystemException("Couldn't find device-finder at location $devFinder");
+ String get _ffx {
+    final String ffx = path.join(getArtifactPath(), 'fuchsia', 'tools','x64', 'ffx');
+    if (!File(ffx).existsSync()) {
+      throw FileSystemException("Couldn't find ffx at location $ffx");
     }
-    return devFinder;
+    return ffx;
  }
 
   @override
@@ -373,7 +373,7 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
 
   @override
   Future<List<String>> discoverDevices() async {
-    final List<String> output = (await eval(_devFinder, <String>['list', '-full']))
+    final List<String> output = (await eval(_ffx, <String>['target', 'list', '--format', 's']))
       .trim()
       .split('\n');
 
@@ -391,16 +391,20 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
     final Map<String, HealthCheckResult> results = <String, HealthCheckResult>{};
     for (final String deviceId in await discoverDevices()) {
       try {
+        StringBuffer stderr;
         final int resolveResult = await exec(
-          _devFinder,
+          _ffx,
           <String>[
-            'resolve',
-            '-device-limit',
-            '1',
+            'target',
+            'list',
+            '--format',
+            'a',
             deviceId,
-          ]
+          ],
+          stderr: stderr
         );
-        if (resolveResult == 0) {
+        final String stderrOutput = stderr.toString().trim();
+        if (resolveResult == 0 && ! stderrOutput.contains('No devices found')) {
           results['fuchsia-device-$deviceId'] = HealthCheckResult.success();
         } else {
           results['fuchsia-device-$deviceId'] = HealthCheckResult.failure('Cannot resolve device $deviceId');

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -322,6 +322,7 @@ Future<int> exec(
   List<String> arguments, {
   Map<String, String> environment,
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
+  StringBuffer stderr, // if not null, the stderr will be written here
   String workingDirectory,
 }) async {
   return _execute(
@@ -329,6 +330,7 @@ Future<int> exec(
     arguments,
     environment: environment,
     canFail : canFail,
+    stderr: stderr,
     workingDirectory: workingDirectory,
   );
 }

--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -30,6 +30,7 @@ final ArgParser parser = ArgParser()
   ..addOption('entrypoint', defaultsTo: 'main.dart', help: 'The filename of the main method. Defaults to main.dart')
   ..addOption('device', help: 'The device id to attach to')
   ..addOption('dev-finder', help: 'The location of the device-finder binary')
+  ..addOption('ffx', help: 'The location of the ffx binary')
   ..addFlag('verbose', negatable: true);
 
 // Track the original working directory so that the tool can find the
@@ -48,6 +49,7 @@ Future<void> main(List<String> args) async {
   final File frontendServer = globals.fs.file('$buildDirectory/host_x64/gen/third_party/flutter/frontend_server/frontend_server_tool.snapshot');
   final File sshConfig = globals.fs.file('$buildDirectory/ssh-keys/ssh_config');
   final File devFinder = globals.fs.file(argResults['dev-finder']);
+  final File ffx = globals.fs.file(argResults['ffx']);
   final File platformKernelDill = globals.fs.file('$buildDirectory/flutter_runner_patched_sdk/platform_strong.dill');
   final File flutterPatchedSdk = globals.fs.file('$buildDirectory/flutter_runner_patched_sdk');
   final String packages = '$buildDirectory/dartlang/gen/$path/${name}_dart_library.packages';
@@ -60,6 +62,10 @@ Future<void> main(List<String> args) async {
 
   if (!devFinder.existsSync()) {
     print('Error: device-finder not found at ${devFinder.path}.');
+    return 1;
+  }
+  if (!ffx.existsSync()) {
+    print('Error: ffx not found at ${ffx.path}.');
     return 1;
   }
   if (!frontendServer.existsSync()) {
@@ -107,7 +113,8 @@ Future<void> main(List<String> args) async {
     overrides: <Type, Generator>{
       FeatureFlags: () => const _FuchsiaFeatureFlags(),
       DeviceManager: () => _FuchsiaDeviceManager(),
-      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig, devFinder: devFinder),
+      FuchsiaArtifacts: () => FuchsiaArtifacts(
+        sshConfig: sshConfig, devFinder: devFinder, ffx: ffx),
       Artifacts: () => OverrideArtifacts(
         parent: CachedArtifacts(
           fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
@@ -1,0 +1,101 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+import '../base/common.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import 'fuchsia_sdk.dart';
+
+// Usage: ffx [-c <config>] [-e <env>] [-t <target>] [-T <timeout>] [-v] [<command>] [<args>]
+
+// Fuchsia's developer tool
+
+// Options:
+//   -c, --config      override default configuration
+//   -e, --env         override default environment settings
+//   -t, --target      apply operations across single or multiple targets
+//   -T, --timeout     override default proxy timeout
+//   -v, --verbose     use verbose output
+//   --help            display usage information
+
+// Commands:
+//   config            View and switch default and user configurations
+//   daemon            Interact with/control the ffx daemon
+//   target            Interact with a target device or emulator
+
+/// A simple wrapper for the Fuchsia SDK's 'ffx' tool.
+class FuchsiaFfx {
+  FuchsiaFfx({
+    @required FuchsiaArtifacts fuchsiaArtifacts,
+    @required Logger logger,
+    @required ProcessManager processManager,
+  })  : _fuchsiaArtifacts = fuchsiaArtifacts,
+        _logger = logger,
+        _processUtils =
+            ProcessUtils(logger: logger, processManager: processManager);
+
+  final FuchsiaArtifacts _fuchsiaArtifacts;
+  final Logger _logger;
+  final ProcessUtils _processUtils;
+
+  /// Returns a list of attached devices as a list of strings with entries
+  /// formatted as follows:
+  ///
+  /// abcd::abcd:abc:abcd:abcd%qemu scare-cable-skip-joy
+  Future<List<String>> list({Duration timeout}) async {
+    if (_fuchsiaArtifacts.ffx == null || !_fuchsiaArtifacts.ffx.existsSync()) {
+      throwToolExit('Fuchsia ffx tool not found.');
+    }
+    final List<String> command = <String>[
+      _fuchsiaArtifacts.ffx.path,
+      if (timeout != null)
+        ...<String>['-T', '${timeout.inSeconds}'],
+      'target',
+      'list',
+      '--format',
+      's'
+    ];
+    final RunResult result = await _processUtils.run(command);
+    if (result.exitCode != 0) {
+      _logger.printError('ffx failed: ${result.stderr}');
+      return null;
+    }
+    if (result.stderr.contains('No devices found')) {
+      return null;
+    }
+    return result.stdout.split('\n');
+  }
+
+  /// Returns the address of the named device.
+  ///
+  /// The string [deviceName] should be the name of the device from the
+  /// 'list' command, e.g. 'scare-cable-skip-joy'.
+  Future<String> resolve(String deviceName) async {
+    if (_fuchsiaArtifacts.ffx == null || !_fuchsiaArtifacts.ffx.existsSync()) {
+      throwToolExit('Fuchsia ffx tool not found.');
+    }
+    final List<String> command = <String>[
+      _fuchsiaArtifacts.ffx.path,
+      'target',
+      'list',
+      '--format',
+      'a',
+      deviceName,
+    ];
+    final RunResult result = await _processUtils.run(command);
+    if (result.exitCode != 0) {
+      _logger.printError('ffx failed: ${result.stderr}');
+      return null;
+    }
+    if (result.stderr.contains('No devices found')) {
+      return null;
+    }
+    return result.stdout.trim();
+  }
+}

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -106,7 +106,7 @@ class FuchsiaPM {
   ///
   /// The argument [repoPath] should have previously been an argument to
   /// [newrepo]. The [host] should be the host reported by
-  /// [FuchsiaDevFinder.resolve], and [port] should be an unused port for the
+  /// [FuchsiaDevFinder.resolve] or [FuchsiaFfx.resolve] and [port] should be an unused port for the
   /// http server to bind.
   Future<Process> serve(String repoPath, String host, int port) async {
     if (globals.fuchsiaArtifacts.pm == null) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_workflow.dart
@@ -37,12 +37,14 @@ class FuchsiaWorkflow implements Workflow {
 
   @override
   bool get canListDevices {
-    return _fuchsiaArtifacts.devFinder != null;
+    return _fuchsiaArtifacts.devFinder != null && _fuchsiaArtifacts.ffx != null;
   }
 
   @override
   bool get canLaunchDevices {
-    return _fuchsiaArtifacts.devFinder != null && _fuchsiaArtifacts.sshConfig != null;
+    return _fuchsiaArtifacts.devFinder != null &&
+        _fuchsiaArtifacts.ffx != null &&
+        _fuchsiaArtifacts.sshConfig != null;
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
@@ -1,0 +1,136 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_ffx.dart';
+import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
+import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+  MockFuchsiaArtifacts mockFuchsiaArtifacts;
+  BufferLogger logger;
+  MemoryFileSystem memoryFileSystem;
+  File ffx;
+
+  setUp(() {
+    mockFuchsiaArtifacts = MockFuchsiaArtifacts();
+    memoryFileSystem = MemoryFileSystem.test();
+    logger = BufferLogger.test();
+    ffx = memoryFileSystem.file('ffx');
+
+    when(mockFuchsiaArtifacts.ffx).thenReturn(ffx);
+  });
+
+  group('ffx list', () {
+    testWithoutContext('ffx not found', () {
+      final FuchsiaFfx fuchsiaFfx = FuchsiaFfx(
+        fuchsiaArtifacts: mockFuchsiaArtifacts,
+        logger: logger,
+        processManager: FakeProcessManager.any(),
+      );
+
+      expect(() async => await fuchsiaFfx.list(),
+          throwsToolExit(message: 'Fuchsia ffx tool not found.'));
+    });
+
+    testWithoutContext('no device found', () async {
+      ffx.createSync();
+
+      final ProcessManager processManager =
+          FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          exitCode: 0,
+          stderr: 'No devices found.',
+        ),
+      ]);
+
+      final FuchsiaFfx fuchsiaFfx = FuchsiaFfx(
+        fuchsiaArtifacts: mockFuchsiaArtifacts,
+        logger: logger,
+        processManager: processManager,
+      );
+
+      expect(await fuchsiaFfx.list(), isNull);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('error', () async {
+      ffx.createSync();
+
+      final ProcessManager processManager =
+          FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          exitCode: 1,
+          stderr: 'unexpected error',
+        ),
+      ]);
+
+      final FuchsiaFfx fuchsiaFfx = FuchsiaFfx(
+        fuchsiaArtifacts: mockFuchsiaArtifacts,
+        logger: logger,
+        processManager: processManager,
+      );
+
+      expect(await fuchsiaFfx.list(), isNull);
+      expect(logger.errorText, contains('unexpected error'));
+    });
+
+    testWithoutContext('devices found', () async {
+      ffx.createSync();
+
+      final ProcessManager processManager =
+          FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          exitCode: 0,
+          stdout: 'device1\ndevice2',
+        ),
+      ]);
+
+      final FuchsiaFfx fuchsiaFfx = FuchsiaFfx(
+        fuchsiaArtifacts: mockFuchsiaArtifacts,
+        logger: logger,
+        processManager: processManager,
+      );
+
+      expect(await fuchsiaFfx.list(), <String>['device1', 'device2']);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('timeout', () async {
+      ffx.createSync();
+
+      final ProcessManager processManager =
+          FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: <String>[ffx.path, '-T', '2', 'target', 'list', '--format', 's'],
+          exitCode: 0,
+          stdout: 'device1',
+        ),
+      ]);
+
+      final FuchsiaFfx fuchsiaFfx = FuchsiaFfx(
+        fuchsiaArtifacts: mockFuchsiaArtifacts,
+        logger: logger,
+        processManager: processManager,
+      );
+
+      expect(await fuchsiaFfx.list(timeout: const Duration(seconds: 2)),
+          <String>['device1']);
+    });
+  });
+}
+
+class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_workflow_test.dart
@@ -17,6 +17,7 @@ void main() {
   final FileSystem fileSystem = MemoryFileSystem.test();
   final File devFinder = fileSystem.file('dev_finder');
   final File sshConfig = fileSystem.file('ssh_config');
+  final File ffx = fileSystem.file('ffx');
 
   testWithoutContext('Fuchsia workflow does not apply to host platform if feature is disabled', () {
     final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
@@ -38,10 +39,10 @@ void main() {
     expect(fuchsiaWorkflow.appliesToHostPlatform, false);
   });
 
-  testWithoutContext('Fuchsia workflow can not list and launch devices if there is no ssh config and dev finder', () {
+  testWithoutContext('Fuchsia workflow can not list and launch devices if there is no ssh config, dev finder and ffx', () {
     final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
       featureFlags: TestFeatureFlags(),
-      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: null, sshConfig: null),
+      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: null, sshConfig: null, ffx: null),
       platform: FakePlatform(operatingSystem: 'linux'),
     );
 
@@ -50,10 +51,22 @@ void main() {
     expect(fuchsiaWorkflow.canListEmulators, false);
   });
 
-  testWithoutContext('Fuchsia workflow can not list and launch devices if there is no ssh config and dev finder', () {
+  testWithoutContext('Fuchsia workflow can not list and launch devices if there is no ffx', () {
     final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
       featureFlags: TestFeatureFlags(),
-      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: null),
+      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: null, ffx: null),
+      platform: FakePlatform(operatingSystem: 'linux'),
+    );
+
+    expect(fuchsiaWorkflow.canLaunchDevices, false);
+    expect(fuchsiaWorkflow.canListDevices, false);
+    expect(fuchsiaWorkflow.canListEmulators, false);
+  });
+
+  testWithoutContext('Fuchsia workflow can not list and launch devices if there is no ssh config, dev finder and ffx', () {
+    final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
+      featureFlags: TestFeatureFlags(),
+      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: null, ffx: ffx),
       platform: FakePlatform(operatingSystem: 'linux'),
     );
 
@@ -65,7 +78,7 @@ void main() {
   testWithoutContext('Fuchsia workflow can list and launch devices supported with sufficient SDK artifacts', () {
     final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
       featureFlags: TestFeatureFlags(),
-      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
+      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig, ffx: ffx),
       platform: FakePlatform(operatingSystem: 'linux'),
     );
 
@@ -77,7 +90,7 @@ void main() {
   testWithoutContext('Fuchsia workflow can list and launch devices supported with sufficient SDK artifacts on macOS', () {
     final FuchsiaWorkflow fuchsiaWorkflow = FuchsiaWorkflow(
       featureFlags: TestFeatureFlags(),
-      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig),
+      fuchsiaArtifacts: FuchsiaArtifacts(devFinder: devFinder, sshConfig: sshConfig, ffx: ffx),
       platform: FakePlatform(operatingSystem: 'macOS'),
     );
 


### PR DESCRIPTION
This defaults the use of ffx for device discovery.
It can be disabled using `export FUCHSIA_DISABLED_ffx_discovery=1`.

The reason for the lower case in the env variable is to stay consistent with fuchsia tree.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
