### PR TITLE
[flutter_tools] remove mock process manager from gradle tests

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -65,7 +65,7 @@ class ApplicationPackageFactory {
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
         if (_androidSdk?.licensesAvailable == true && _androidSdk?.latestVersion == null) {
-          await checkGradleDependencies(_logger);
+          await checkGradleDependencies(_logger, _processUtils);
         }
         if (applicationBinary == null) {
           return await AndroidApk.fromAndroidProject(

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -81,6 +81,8 @@ Future<T> runInContext<T>(
     fallbacks: <Type, Generator>{
       AndroidBuilder: () => AndroidGradleBuilder(
         logger: globals.logger,
+        processManager: globals.processManager,
+        fileSystem: globals.fs,
       ),
       AndroidLicenseValidator: () => AndroidLicenseValidator(
         operatingSystemUtils: globals.os,

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -436,9 +436,11 @@ void main() {
 
   group('Config files', () {
     Directory tempDir;
+    FileSystem fileSystem;
 
     setUp(() {
-      tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_settings_aar_test.');
+      fileSystem = MemoryFileSystem.test();
+      tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_settings_aar_test.');
     });
 
     testUsingContext('create settings_aar.gradle when current settings.gradle loads plugins', () {
@@ -468,25 +470,24 @@ include ':app'
 
       tempDir.childFile('settings.gradle').writeAsStringSync(currentSettingsGradle);
 
-      final String toolGradlePath = globals.fs.path.join(
-          globals.fs.path.absolute(Cache.flutterRoot),
+      final String toolGradlePath = fileSystem.path.join(
+          fileSystem.path.absolute(Cache.flutterRoot),
           'packages',
           'flutter_tools',
           'gradle');
-      globals.fs.directory(toolGradlePath).createSync(recursive: true);
-      globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings.gradle.legacy_versions'))
+      fileSystem.directory(toolGradlePath).createSync(recursive: true);
+      fileSystem.file(fileSystem.path.join(toolGradlePath, 'settings.gradle.legacy_versions'))
           .writeAsStringSync(currentSettingsGradle);
 
-      globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
+      fileSystem.file(fileSystem.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
           .writeAsStringSync(settingsAarFile);
 
       createSettingsAarGradle(tempDir, testLogger);
 
       expect(testLogger.statusText, contains('created successfully'));
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
-
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem.test(),
+      FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -501,25 +502,24 @@ include ':app'
 
       tempDir.childFile('settings.gradle').writeAsStringSync(currentSettingsGradle);
 
-      final String toolGradlePath = globals.fs.path.join(
-          globals.fs.path.absolute(Cache.flutterRoot),
+      final String toolGradlePath = fileSystem.path.join(
+          fileSystem.path.absolute(Cache.flutterRoot),
           'packages',
           'flutter_tools',
           'gradle');
-      globals.fs.directory(toolGradlePath).createSync(recursive: true);
-      globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings.gradle.legacy_versions'))
+      fileSystem.directory(toolGradlePath).createSync(recursive: true);
+      fileSystem.file(fileSystem.path.join(toolGradlePath, 'settings.gradle.legacy_versions'))
           .writeAsStringSync(currentSettingsGradle);
 
-      globals.fs.file(globals.fs.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
+      fileSystem.file(fileSystem.path.join(toolGradlePath, 'settings_aar.gradle.tmpl'))
           .writeAsStringSync(settingsAarFile);
 
       createSettingsAarGradle(tempDir, testLogger);
 
       expect(testLogger.statusText, contains('created successfully'));
       expect(tempDir.childFile('settings_aar.gradle').existsSync(), isTrue);
-
     }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem.test(),
+      FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -860,7 +860,7 @@ flutter:
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.directory).thenReturn(fs.directory('irrelevant'));
-      builder = AndroidGradleBuilder(logger: logger);
+      builder = AndroidGradleBuilder(logger: logger, processManager: fakeProcessManager, fileSystem: fs);
     });
 
     testUsingContext('calls gradle', () async {


### PR DESCRIPTION
Update the AndroidGradleBuilder to inject the ProcessManager/FileSystem. Update all of the android_gradle_builder tests to use the fake process manager.

Note that there is still injection and use of FlutterProject that requires the use of TestUsingContext.