### PR TITLE
Migrate the TestTextInput text entry methods to async

### DIFF
--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -334,7 +334,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     // Try the test again with a nonempty EditableText.
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: 'X',
       selection: TextSelection.collapsed(offset: 1),
     ));
@@ -497,7 +497,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     const String testValue = 'A B C';
-    tester.testTextInput.updateEditingValue(
+    await tester.testTextInput.updateTextAndSelection(
         const TextEditingValue(
           text: testValue
         )
@@ -864,7 +864,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     const String testValue = 'ABC';
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: testValue,
       selection: TextSelection.collapsed(offset: testValue.length),
     ));
@@ -874,7 +874,7 @@ void main() {
     // Enter a character into the obscured field and verify that the character
     // is temporarily shown to the user and then changed to a bullet.
     const String newChar = 'X';
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: testValue + newChar,
       selection: TextSelection.collapsed(offset: testValue.length + 1),
     ));
@@ -904,7 +904,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     const String testValue = 'ABC';
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: testValue,
       selection: TextSelection.collapsed(offset: testValue.length),
     ));
@@ -914,7 +914,7 @@ void main() {
     // Enter a character into the obscured field and verify that the character
     // isn't shown to the user.
     const String newChar = 'X';
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: testValue + newChar,
       selection: TextSelection.collapsed(offset: testValue.length + 1),
     ));
@@ -4108,7 +4108,7 @@ void main() {
 
     await tester.showKeyboard(find.byType(TextField));
     const String testValue = '123';
-    tester.testTextInput.updateEditingValue(const TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
       text: testValue,
       selection: TextSelection.collapsed(offset: 3),
       composing: TextRange(start: 0, end: testValue.length),
@@ -4236,7 +4236,7 @@ void main() {
 
       const String testValue = 'abcdefghi';
       await tester.showKeyboard(find.byType(TextField));
-      tester.testTextInput.updateEditingValue(const TextEditingValue(
+      await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
         text: testValue,
         selection: TextSelection.collapsed(offset: 3),
         composing: TextRange(start: 0, end: testValue.length),
@@ -8492,7 +8492,7 @@ void main() {
     expect(controller.selection, const TextSelection.collapsed(offset: 0));
 
     if (kIsWeb) {
-      tester.testTextInput.updateEditingValue(const TextEditingValue(
+      await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
         selection: TextSelection(baseOffset: 2, extentOffset: 7),
       ));
       // Wait for all the `setState` calls to be flushed.

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -166,7 +166,7 @@ void main() {
     expect(find.byType(EditableText), findsNothing);
 
     // Entering text brings it back on screen.
-    tester.testTextInput.enterText('Hello');
+    await tester.testTextInput.updateText('Hello');
     await tester.pumpAndSettle();
     expect(scrollController.offset, greaterThan(0.0));
     expect(find.byType(EditableText), findsOneWidget);
@@ -216,7 +216,7 @@ void main() {
     expect(find.byType(EditableText), findsNothing);
 
     // Entering text brings it not back on screen.
-    tester.testTextInput.enterText('Hello');
+    await tester.testTextInput.updateText('Hello');
     await tester.pumpAndSettle();
     expect(scrollController.offset, 0.0);
     expect(find.byType(EditableText), findsNothing);
@@ -261,7 +261,7 @@ void main() {
     await tester.showKeyboard(find.byType(EditableText));
     await tester.pumpAndSettle();
     expect(textController.text, '');
-    tester.testTextInput.enterText('H');
+    await tester.testTextInput.updateText('H');
     final int frames = await tester.pumpAndSettle();
 
     // The text input should not trigger any animations, which would indicate
@@ -309,7 +309,7 @@ void main() {
 
     // Enter text at end, which is off-screen.
     final String textToEnter = '${controller.text} HELLO';
-    tester.testTextInput.updateEditingValue(TextEditingValue(
+    await tester.testTextInput.updateTextAndSelection(TextEditingValue(
       text: textToEnter,
       selection: TextSelection.collapsed(offset: textToEnter.length),
     ));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1396,7 +1396,7 @@ void main() {
     if (kIsWeb) {
       // On the web, the input connection exists, but text updates should be
       // ignored.
-      tester.testTextInput.updateEditingValue(const TextEditingValue(
+      await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
         text: 'Foo bar',
         selection: TextSelection(baseOffset: 0, extentOffset: 3),
         composing: TextRange(start: 3, end: 4),
@@ -1443,7 +1443,7 @@ void main() {
 
     expect(tester.testTextInput.hasAnyClients, kIsWeb ? isTrue : isFalse);
     if (kIsWeb) {
-      tester.testTextInput.updateEditingValue(const TextEditingValue(
+      await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
         text: 'Foo bar',
         selection: TextSelection(baseOffset: 0, extentOffset: 3),
       ));

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -4439,7 +4439,7 @@ void main() {
     );
 
     if (kIsWeb) {
-      tester.testTextInput.updateEditingValue(const TextEditingValue(
+      await tester.testTextInput.updateTextAndSelection(const TextEditingValue(
         selection: TextSelection(baseOffset: 2, extentOffset: 7),
       ));
       // Wait for all the `setState` calls to be flushed.

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -197,7 +197,7 @@ mixin CommandHandlerFactory {
             'disabled. You can enable it using `FlutterDriver.setTextEntryEmulation`.';
     }
     final EnterText enterTextCommand = command as EnterText;
-    _testTextInput.enterText(enterTextCommand.text);
+    await _testTextInput.updateText(enterTextCommand.text);
     return Result.empty;
   }
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -124,6 +124,20 @@ class TestTextInput {
   }
   bool _isVisible = false;
 
+  /// Simulates the user hiding the onscreen keyboard.
+  void hide() {
+    assert(isRegistered);
+    _isVisible = false;
+  }
+
+  /// Simulates the user typing the given text.
+  void enterText(String text) {
+    assert(isRegistered);
+    updateEditingValue(TextEditingValue(
+      text: text,
+    ));
+  }
+
   /// Simulates the user changing the [TextEditingValue] to the given value.
   void updateEditingValue(TextEditingValue value) {
     assert(isRegistered);
@@ -141,37 +155,6 @@ class TestTextInput {
       ),
       (ByteData? data) { /* response from framework is discarded */ },
     );
-  }
-
-  /// Simulates the user closing the text input connection.
-  ///
-  /// For example:
-  /// - User pressed the home button and sent the application to background.
-  /// - User closed the virtual keyboard.
-  void closeConnection() {
-    assert(isRegistered);
-    // Not using the `expect` function because in the case of a FlutterDriver
-    // test this code does not run in a package:test test zone.
-    if (_client == 0)
-      throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
-    _binaryMessenger.handlePlatformMessage(
-      SystemChannels.textInput.name,
-      SystemChannels.textInput.codec.encodeMethodCall(
-        MethodCall(
-          'TextInputClient.onConnectionClosed',
-           <dynamic>[_client,]
-        ),
-      ),
-      (ByteData? data) { /* response from framework is discarded */ },
-    );
-  }
-
-  /// Simulates the user typing the given text.
-  void enterText(String text) {
-    assert(isRegistered);
-    updateEditingValue(TextEditingValue(
-      text: text,
-    ));
   }
 
   /// Simulates the user pressing one of the [TextInputAction] buttons.
@@ -217,9 +200,26 @@ class TestTextInput {
     });
   }
 
-  /// Simulates the user hiding the onscreen keyboard.
-  void hide() {
+  /// Simulates the user closing the text input connection.
+  ///
+  /// For example:
+  /// - User pressed the home button and sent the application to background.
+  /// - User closed the virtual keyboard.
+  void closeConnection() {
     assert(isRegistered);
-    _isVisible = false;
+    // Not using the `expect` function because in the case of a FlutterDriver
+    // test this code does not run in a package:test test zone.
+    if (_client == 0)
+      throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
+    _binaryMessenger.handlePlatformMessage(
+      SystemChannels.textInput.name,
+      SystemChannels.textInput.codec.encodeMethodCall(
+        MethodCall(
+          'TextInputClient.onConnectionClosed',
+           <dynamic>[_client,]
+        ),
+      ),
+      (ByteData? data) { /* response from framework is discarded */ },
+    );
   }
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -1035,11 +1035,20 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// or `find.byType(TextFormField)`, or `find.byType(EditableText)`.
   ///
   /// To just give [finder] the focus without entering any text,
-  /// see [showKeyboard].
+  /// consider [showKeyboard].
+  ///
+  /// This method does not imply a [pump], but it is recommended to
+  /// call [pump] after calling this method if the UI needs to reflect
+  /// the entered text.
+  ///
+  /// See also:
+  ///
+  ///  * [TestTextInput.updateText], which is similar but targets
+  ///    the active text field rather than a specified one.
   Future<void> enterText(Finder finder, String text) async {
     return TestAsyncUtils.guard<void>(() async {
       await showKeyboard(finder);
-      testTextInput.enterText(text);
+      await testTextInput.updateText(text);
       await idle();
     });
   }


### PR DESCRIPTION
We are migrating the message channel logic to a pure async model, and these methods are currently sync and will not be able to maintain their behavior going forward.

This PR deprecates them and introduces updated methods that are async instead.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
