### PR TITLE
[flutter_tools] allow bypassing context for FlutterProject creation, remove fromPath

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -145,6 +145,6 @@ class BuildAarCommand extends BuildSubCommand {
     if (argResults.rest.isEmpty) {
       return FlutterProject.current();
     }
-    return FlutterProject.fromPath(findProjectRoot(argResults.rest.first));
+    return FlutterProject.fromDirectory(globals.fs.directory(findProjectRoot(argResults.rest.first)));
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -70,7 +70,7 @@ class BuildBundleCommand extends BuildSubCommand {
   @override
   Future<Map<CustomDimensions, String>> get usageValues async {
     final String projectDir = globals.fs.file(targetFile).parent.parent.path;
-    final FlutterProject flutterProject = FlutterProject.fromPath(projectDir);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.directory(projectDir));
     if (flutterProject == null) {
       return const <CustomDimensions, String>{};
     }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -310,7 +310,7 @@ class CreateCommand extends CreateBase {
       _printPluginAddPlatformMessage(relativePluginPath);
     } else  {
       // Tell the user the next steps.
-      final FlutterProject project = FlutterProject.fromPath(projectDirPath);
+      final FlutterProject project = FlutterProject.fromDirectory(globals.fs.directory(projectDirPath));
       final FlutterProject app = project.hasExampleApp ? project.example : project;
       final String relativeAppPath = globals.fs.path.normalize(globals.fs.path.relative(app.directory.path));
       final String relativeAppMain = globals.fs.path.join(relativeAppPath, 'lib', 'main.dart');

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -88,7 +88,7 @@ class PackagesGetCommand extends FlutterCommand {
     if (target == null) {
       return usageValues;
     }
-    final FlutterProject rootProject = FlutterProject.fromPath(target);
+    final FlutterProject rootProject = FlutterProject.fromDirectory(globals.fs.directory(target));
     // Do not send plugin analytics if pub has not run before.
     final bool hasPlugins = rootProject.flutterPluginsDependenciesFile.existsSync()
       && rootProject.packagesFile.existsSync()
@@ -160,7 +160,7 @@ class PackagesGetCommand extends FlutterCommand {
        '${ workingDirectory ?? "current working directory" }.'
       );
     }
-    final FlutterProject rootProject = FlutterProject.fromPath(target);
+    final FlutterProject rootProject = FlutterProject.fromDirectory(globals.fs.directory(target));
 
     await _runPubGet(target, rootProject);
     await rootProject.regeneratePlatformSpecificTooling();
@@ -311,7 +311,7 @@ class PackagesInteractiveGetCommand extends FlutterCommand {
       throwToolExit('Expected to find project root in '
           'current working directory.');
     }
-    final FlutterProject flutterProject = FlutterProject.fromPath(target);
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.directory(target));
 
     if (flutterProject.manifest.generateSyntheticPackage) {
       final Environment environment = Environment(

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -98,8 +98,8 @@ class FlutterProject {
     );
     final FlutterManifest exampleManifest = FlutterProject._readManifest(
       FlutterProject._exampleDirectory(directory)
-          .childFile(bundle.defaultManifestPath)
-          .path,
+        .childFile(bundle.defaultManifestPath)
+        .path,
       logger: logger,
       fileSystem: fileSystem,
     );

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -86,9 +86,25 @@ class FlutterProject {
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   static FlutterProject current() => globals.projectFactory.fromDirectory(globals.fs.currentDirectory);
 
-  /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
-  /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
-  static FlutterProject fromPath(String path) => globals.projectFactory.fromDirectory(globals.fs.directory(path));
+  /// Create a [FlutterProject] and bypass the project caching.
+  @visibleForTesting
+  static FlutterProject fromDirectoryTest(Directory directory, [Logger logger]) {
+    final FileSystem fileSystem = directory.fileSystem;
+    logger ??= BufferLogger.test();
+    final FlutterManifest manifest = FlutterProject._readManifest(
+      directory.childFile(bundle.defaultManifestPath).path,
+      logger: logger,
+      fileSystem: fileSystem,
+    );
+    final FlutterManifest exampleManifest = FlutterProject._readManifest(
+      FlutterProject._exampleDirectory(directory)
+          .childFile(bundle.defaultManifestPath)
+          .path,
+      logger: logger,
+      fileSystem: fileSystem,
+    );
+    return FlutterProject(directory, manifest, exampleManifest);
+  }
 
   /// The location of this project.
   final Directory directory;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -465,7 +465,7 @@ set(BINARY_NAME "fizz_bar")
 ''');
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('.packages').createSync();
-    final FlutterProject flutterProject = FlutterProject.current();
+    final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
 
     expect(getCmakeExecutableName(flutterProject.linux), 'fizz_bar');
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -52,9 +52,10 @@ void main() {
 
   testUsingContext('Refuses to build for web when missing index.html', () async {
     fileSystem.file(fileSystem.path.join('web', 'index.html')).deleteSync();
+    final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
 
     expect(buildWeb(
-      FlutterProject.current(),
+      project,
       fileSystem.path.join('lib', 'main.dart'),
       BuildInfo.debug,
       false,

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -117,7 +117,7 @@ void main() {
       bool handlerCalled = false;
       await expectLater(() async {
        await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -216,7 +216,7 @@ void main() {
       int testFnCalled = 0;
       await expectLater(() async {
        await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -302,7 +302,7 @@ void main() {
       bool handlerCalled = false;
       await expectLater(() async {
        await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -388,7 +388,7 @@ void main() {
 
       await expectLater(() async {
        await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -462,7 +462,7 @@ void main() {
         .createSync(recursive: true);
 
       await builder.buildGradleApp(
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         androidBuildInfo: const AndroidBuildInfo(
           BuildInfo(
             BuildMode.release,
@@ -568,7 +568,7 @@ void main() {
         ..writeAsStringSync('{}');
 
       await builder.buildGradleApp(
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         androidBuildInfo: const AndroidBuildInfo(
           BuildInfo(
             BuildMode.release,
@@ -648,7 +648,7 @@ void main() {
       bool builtPluginAsAar = false;
       await expectLater(() async {
        await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -742,7 +742,7 @@ void main() {
         .createSync(recursive: true);
 
       await builder.buildGradleApp(
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         androidBuildInfo: const AndroidBuildInfo(
           BuildInfo(
             BuildMode.release,
@@ -808,7 +808,7 @@ void main() {
 
       await builder.buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         outputDirectory: fileSystem.directory('build/'),
         target: '',
         buildNumber: '1.0',
@@ -874,7 +874,7 @@ void main() {
       await expectLater(() async =>
         await builder.buildGradleAar(
           androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           outputDirectory: fileSystem.directory('build/'),
           target: '',
           buildNumber: '1.0',
@@ -949,7 +949,7 @@ void main() {
 
       await expectLater(() async {
         await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -1039,7 +1039,7 @@ void main() {
 
       await expectLater(() async {
         await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -1123,7 +1123,7 @@ void main() {
 
       await expectLater(() async {
         await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -1207,7 +1207,7 @@ void main() {
 
       await expectLater(() async {
         await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -1262,7 +1262,7 @@ void main() {
 
       await expectLater(() async {
         await builder.buildGradleApp(
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
               BuildMode.release,
@@ -1361,7 +1361,7 @@ void main() {
 
       await builder.buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         outputDirectory: fileSystem.directory('build/'),
         target: '',
         buildNumber: '2.0',
@@ -1458,7 +1458,7 @@ void main() {
       await builder.buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         outputDirectory: fileSystem.directory('build/'),
         target: '',
         buildNumber: '2.0',
@@ -1555,7 +1555,7 @@ void main() {
       await builder.buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         outputDirectory: fileSystem.directory('build/'),
         target: '',
         buildNumber: '2.0',
@@ -1652,7 +1652,7 @@ void main() {
       await builder.buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
         outputDirectory: fileSystem.directory('build/'),
         target: '',
         buildNumber: '2.0',

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -352,7 +352,7 @@ Command: /home/android/gradlew assembleRelease
 
     testUsingContext('handler - no plugins', () async {
       final GradleBuildStatus status = await androidXFailureHandler
-        .handler(line: '', project: FlutterProject.current());
+        .handler(line: '', project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory));
 
       expect(testUsage.events, contains(
         const TestUsageEvent(
@@ -378,7 +378,7 @@ Command: /home/android/gradlew assembleRelease
       final GradleBuildStatus status = await androidXFailureHandler
         .handler(
           line: '',
-          project: FlutterProject.current(),
+          project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
           usesAndroidX: false,
         );
 
@@ -412,7 +412,7 @@ Command: /home/android/gradlew assembleRelease
 
       final GradleBuildStatus status = await androidXFailureHandler.handler(
         line: '',
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
         usesAndroidX: true,
         shouldBuildPluginAsAar: true,
       );
@@ -440,7 +440,7 @@ Command: /home/android/gradlew assembleRelease
 
       final GradleBuildStatus status = await androidXFailureHandler.handler(
         line: '',
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
         usesAndroidX: true,
         shouldBuildPluginAsAar: false,
       );
@@ -509,7 +509,7 @@ Command: /home/android/gradlew assembleRelease
     testUsingContext('handler', () async {
       await licenseNotAcceptedHandler.handler(
         line: 'You have not accepted the license agreements of the following SDK components: [foo, bar]',
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       );
 
       expect(
@@ -581,7 +581,7 @@ assembleFooTest
       ));
 
       await flavorUndefinedHandler.handler(
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       );
 
       expect(
@@ -623,7 +623,7 @@ assembleProfile
       ));
 
       await flavorUndefinedHandler.handler(
-        project: FlutterProject.current(),
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       );
 
       expect(

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -314,7 +314,7 @@ void main() {
     });
 
     testUsingContext('aab not found', () {
-      final FlutterProject project = FlutterProject.current();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
       expect(
         () {
           findBundleFile(project, const BuildInfo(BuildMode.debug, 'foo_bar', treeShakeIcons: false), BufferLogger.test());
@@ -404,7 +404,7 @@ void main() {
   group('gradle build', () {
     testUsingContext('do not crash if there is no Android SDK', () async {
       expect(() {
-        updateLocalProperties(project: FlutterProject.current());
+        updateLocalProperties(project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory));
       }, throwsToolExit(
         message: '$warningMark No Android SDK found. Try setting the ANDROID_SDK_ROOT environment variable.',
       ));
@@ -573,7 +573,7 @@ include ':app'
 
 
       updateLocalProperties(
-        project: FlutterProject.fromPath('path/to/project'),
+        project: FlutterProject.fromDirectoryTest(globals.fs.directory('path/to/project')),
         buildInfo: buildInfo,
         requireAndroidSdk: false,
       );
@@ -961,7 +961,7 @@ plugin2=${plugin2.path}
         ));
 
       await builder.buildPluginsAsAar(
-        FlutterProject.fromPath(androidDirectory.path),
+        FlutterProject.fromDirectoryTest(androidDirectory),
         const AndroidBuildInfo(BuildInfo(
           BuildMode.release,
           '',
@@ -1014,7 +1014,7 @@ plugin1=${plugin1.path}
         .createSync(recursive: true);
 
       await builder.buildPluginsAsAar(
-        FlutterProject.fromPath(androidDirectory.path),
+        FlutterProject.fromDirectoryTest(androidDirectory),
         const AndroidBuildInfo(BuildInfo.release),
         buildDirectory: buildDirectory,
       );

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -41,6 +41,7 @@ void main() {
     FakeProcessManager fakeProcessManager;
     MemoryFileSystem fs;
     Cache cache;
+
     final Map<Type, Generator> overrides = <Type, Generator>{
       AndroidSdk: () => sdk,
       ProcessManager: () => fakeProcessManager,
@@ -57,7 +58,7 @@ void main() {
       );
       Cache.flutterRoot = '../..';
       when(sdk.licensesAvailable).thenReturn(true);
-      final FlutterProject project = FlutterProject.current();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.currentDirectory);
       fs.file(project.android.hostAppGradleRoot.childFile(
         globals.platform.isWindows ? 'gradlew.bat' : 'gradlew',
       ).path).createSync(recursive: true);
@@ -96,7 +97,7 @@ void main() {
 
     testUsingContext('Licenses available, build tools not, apk exists', () async {
       when(sdk.latestVersion).thenReturn(null);
-      final FlutterProject project = FlutterProject.current();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.currentDirectory);
       final File gradle = project.android.hostAppGradleRoot.childFile(
         globals.platform.isWindows ? 'gradlew.bat' : 'gradlew',
       )..createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
@@ -35,7 +35,7 @@ void main() {
     });
     await buildWithAssemble(
       buildMode: BuildMode.debug,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       mainPath: globals.fs.path.join('lib', 'main.dart'),
       outputDir: 'example',
       targetPlatform: TargetPlatform.ios,
@@ -57,7 +57,7 @@ void main() {
 
     expect(() => buildWithAssemble(
       buildMode: BuildMode.debug,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       mainPath: 'lib/main.dart',
       outputDir: 'example',
       targetPlatform: TargetPlatform.linux_x64,

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -175,18 +175,16 @@ void main() {
       verify(mockPortForwarder.dispose()).called(1);
     });
 
-    testUsingContext('default capabilities', () async {
+    testWithoutContext('default capabilities', () async {
       final FuchsiaDevice device = FuchsiaDevice('123');
-      globals.fs.directory('fuchsia').createSync(recursive: true);
-      globals.fs.file('pubspec.yaml').createSync();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(memoryFileSystem.currentDirectory);
+      memoryFileSystem.directory('fuchsia').createSync(recursive: true);
+      memoryFileSystem.file('pubspec.yaml').createSync();
 
       expect(device.supportsHotReload, true);
       expect(device.supportsHotRestart, false);
       expect(device.supportsFlutterExit, false);
-      expect(device.isSupportedForProject(FlutterProject.current()), true);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => memoryFileSystem,
-      ProcessManager: () => FakeProcessManager.any(),
+      expect(device.isSupportedForProject(project), true);
     });
 
     test('is ephemeral', () {
@@ -195,25 +193,21 @@ void main() {
       expect(device.ephemeral, true);
     });
 
-    testUsingContext('supported for project', () async {
+    testWithoutContext('supported for project', () async {
       final FuchsiaDevice device = FuchsiaDevice('123');
-      globals.fs.directory('fuchsia').createSync(recursive: true);
-      globals.fs.file('pubspec.yaml').createSync();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(memoryFileSystem.currentDirectory);
+      memoryFileSystem.directory('fuchsia').createSync(recursive: true);
+      memoryFileSystem.file('pubspec.yaml').createSync();
 
-      expect(device.isSupportedForProject(FlutterProject.current()), true);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => memoryFileSystem,
-      ProcessManager: () => FakeProcessManager.any(),
+      expect(device.isSupportedForProject(project), true);
     });
 
-    testUsingContext('not supported for project', () async {
+    testWithoutContext('not supported for project', () async {
       final FuchsiaDevice device = FuchsiaDevice('123');
-      globals.fs.file('pubspec.yaml').createSync();
+      final FlutterProject project = FlutterProject.fromDirectoryTest(memoryFileSystem.currentDirectory);
+      memoryFileSystem.file('pubspec.yaml').createSync();
 
-      expect(device.isSupportedForProject(FlutterProject.current()), false);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => memoryFileSystem,
-      ProcessManager: () => FakeProcessManager.any(),
+      expect(device.isSupportedForProject(project), false);
     });
 
     testUsingContext('targetPlatform does not throw when sshConfig is missing', () async {
@@ -945,7 +939,7 @@ void main() {
           ..writeAsStringSync('{}');
         globals.fs.file('.packages').createSync();
         globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-        app = BuildableFuchsiaApp(project: FlutterProject.current().fuchsia);
+        app = BuildableFuchsiaApp(project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory).fuchsia);
       }
 
       final DebuggingOptions debuggingOptions = DebuggingOptions.disabled(BuildInfo(mode, null, treeShakeIcons: false));

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -931,7 +931,7 @@ flutter:
   module: {}
 ''');
       globals.fs.file('.packages').createSync();
-      final FlutterProject flutterProject = FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
 
       final IOSSimulator simulator = IOSSimulator(
         'test',
@@ -949,7 +949,7 @@ flutter:
       globals.fs.file('pubspec.yaml').createSync();
       globals.fs.file('.packages').createSync();
       globals.fs.directory('ios').createSync();
-      final FlutterProject flutterProject = FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
 
       final IOSSimulator simulator = IOSSimulator(
         'test',
@@ -965,7 +965,7 @@ flutter:
     testUsingContext('is false with no host app and no module', () async {
       globals.fs.file('pubspec.yaml').createSync();
       globals.fs.file('.packages').createSync();
-      final FlutterProject flutterProject = FlutterProject.current();
+      final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
 
       final IOSSimulator simulator = IOSSimulator(
         'test',

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -668,7 +668,7 @@ Information about project "Runner":
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo.debug;
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -696,7 +696,7 @@ Information about project "Runner":
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_debug_sim_unopt'));
 
       const BuildInfo buildInfo = BuildInfo.debug;
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -723,7 +723,7 @@ Information about project "Runner":
           .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -750,7 +750,7 @@ Information about project "Runner":
           .thenReturn('engine');
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo.debug;
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -778,7 +778,7 @@ Information about project "Runner":
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
       const BuildInfo buildInfo = BuildInfo.debug;
 
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
         buildInfo: buildInfo,
@@ -818,7 +818,7 @@ Information about project "Runner":
       manifestFile.writeAsStringSync(manifestString);
 
       await updateGeneratedXcodeProperties(
-        project: FlutterProject.fromPath('path/to/project'),
+        project: FlutterProject.fromDirectoryTest(fs.directory('path/to/project')),
         buildInfo: buildInfo,
       );
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -194,7 +194,7 @@ void main() {
           'SWIFT_VERSION': '5.0',
         });
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.directory('project'));
       await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Swift iOS podfile template');
@@ -214,7 +214,7 @@ void main() {
     testUsingContext('does not recreate Podfile when already present', () async {
       projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Existing Podfile');
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.directory('project'));
       await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Existing Podfile');
@@ -226,7 +226,7 @@ void main() {
     testUsingContext('does not create Podfile when we cannot interpret Xcode projects', () async {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.directory('project'));
       await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       expect(projectUnderTest.ios.podfile.existsSync(), false);
@@ -245,7 +245,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing release config');
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.directory('project'));
       await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
@@ -273,7 +273,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(legacyReleaseInclude);
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.directory('project'));
       await cocoaPodsUnderTest.setupPodfile(project.ios);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();
@@ -305,7 +305,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing release config');
 
-      final FlutterProject project = FlutterProject.fromPath('project');
+      final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.directory('project'));
       await injectPlugins(project, iosPlatform: true);
 
       final String debugContents = projectUnderTest.ios.xcodeConfigFor('Debug').readAsStringSync();

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -118,7 +118,7 @@ void main() {
           directory.absolute.path,
         );
         expect(
-          FlutterProject.fromTestDirectory(directory).directory.absolute.path,
+          FlutterProject.fromDirectoryTest(directory).directory.absolute.path,
           directory.absolute.path,
         );
         expect(

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -118,6 +118,10 @@ void main() {
           directory.absolute.path,
         );
         expect(
+          FlutterProject.fromTestDirectory(directory).directory.absolute.path,
+          directory.absolute.path,
+        );
+        expect(
           FlutterProject.current().directory.absolute.path,
           globals.fs.currentDirectory.absolute.path,
         );

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -118,10 +118,6 @@ void main() {
           directory.absolute.path,
         );
         expect(
-          FlutterProject.fromPath(directory.path).directory.absolute.path,
-          directory.absolute.path,
-        );
-        expect(
           FlutterProject.current().directory.absolute.path,
           globals.fs.currentDirectory.absolute.path,
         );

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -48,9 +48,10 @@ void main() {
     });
     testbed = Testbed(
       setup: () {
+        final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
         residentWebRunner = residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
           mockFlutterDevice,
-          flutterProject: FlutterProject.current(),
+          flutterProject: project,
           debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
           ipv6: true,
           stayResident: true,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -172,7 +172,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
@@ -203,7 +203,7 @@ void main() {
     ));
     final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
       stayResident: true,
@@ -224,7 +224,7 @@ void main() {
       ..writeAsStringSync('\n');
     final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
@@ -234,7 +234,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(mockChromeDevice);
     final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile),
       ipv6: true,
       stayResident: true,
@@ -341,7 +341,7 @@ void main() {
       .deleteSync();
     final ResidentWebRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: false,
@@ -363,7 +363,7 @@ void main() {
     _setupMocks();
     final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: false,
@@ -487,7 +487,7 @@ void main() {
   testUsingContext('Does not run main with --start-paused', () async {
     final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
       stayResident: true,
@@ -1459,7 +1459,7 @@ void main() {
     fakeStatusLogger.status = mockStatus;
     final ResidentWebRunner runner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
@@ -1506,7 +1506,7 @@ void main() {
     fakeStatusLogger.status = mockStatus;
     final ResidentWebRunner runner = DwdsWebRunnerFactory().createWebRunner(
       mockFlutterDevice,
-      flutterProject: FlutterProject.current(),
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
@@ -1635,7 +1635,7 @@ void main() {
 ResidentRunner setUpResidentRunner(FlutterDevice flutterDevice) {
   return DwdsWebRunnerFactory().createWebRunner(
     flutterDevice,
-    flutterProject: FlutterProject.current(),
+    flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
     debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
     ipv6: true,
     stayResident: true,

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -47,7 +47,7 @@ void main() {
   testUsingContext('TestCompiler reports a dill file when compile is successful', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
-      FlutterProject.current(),
+      FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       residentCompiler,
     );
     when(residentCompiler.recompile(
@@ -72,7 +72,7 @@ void main() {
   testUsingContext('TestCompiler reports null when a compile fails', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
-      FlutterProject.current(),
+      FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       residentCompiler,
     );
     when(residentCompiler.recompile(
@@ -98,7 +98,7 @@ void main() {
   testUsingContext('TestCompiler disposing test compiler shuts down backing compiler', () async {
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
-      FlutterProject.current(),
+      FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       residentCompiler,
     );
     testCompiler.compiler = residentCompiler;


### PR DESCRIPTION
* Adds `FlutterProject.fromDirectoryTest(Directory directory, [Logger logger])`
* Removes `FlutterProject.fromPath`

Context:

Currently FlutterProject creation bounces through the FlutterProject factory for caching purposes, which is itself a global. Bypassing this is awkward, since it requires setting up a FlutterProjectFactory instance in addition to the FlutterProject. Since the caching is entirely unnecessary for unit testing purposes, we can simplify the removal of all globals involving flutter project by creating a specialized testonly constructor that bypasses this entirely.

fromPath should also be removed, because it is fairly redundant with the existing options. In many cases where it is used, the callsite already had access to either the directory or to a filesystem entity + path. In general, we should prefer APIs and operations that use the file system objects instead of string-based path manipulation.