### PR TITLE
Remove mocks from visual_studio_test

### DIFF
--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -323,31 +323,6 @@ class MockResidentCompiler extends _BasicMock implements ResidentCompiler {
   void addFileSystemRoot(String root) { }
 }
 
-/// A fake implementation of [ProcessResult].
-class FakeProcessResult implements ProcessResult {
-  FakeProcessResult({
-    this.exitCode = 0,
-    this.pid = 1,
-    this.stderr,
-    this.stdout,
-  });
-
-  @override
-  final int exitCode;
-
-  @override
-  final int pid;
-
-  @override
-  final dynamic stderr;
-
-  @override
-  final dynamic stdout;
-
-  @override
-  String toString() => stdout?.toString() ?? stderr?.toString() ?? runtimeType.toString();
-}
-
 class MockStdIn extends Mock implements IOSink {
   final StringBuffer stdInWrites = StringBuffer();
 


### PR DESCRIPTION
- Replace `MockProcessManager` with `FakeProcessManager`.
- Combine `isInstalled returns false when vswhere is missing` and `cmakePath returns null when vswhere is missing` into one test with two expectations.
- Remove dead `FakeProcessResult`.

Part of #71511