### PR TITLE
MockProcessManager -> FakeProcessManager in os_test

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -12,8 +12,6 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -23,11 +21,9 @@ const String kPath1 = '/bar/bin/$kExecutable';
 const String kPath2 = '/another/bin/$kExecutable';
 
 void main() {
-  MockProcessManager mockProcessManager;
   FakeProcessManager fakeProcessManager;
 
   setUp(() {
-    mockProcessManager = MockProcessManager();
     fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
   });
 
@@ -90,13 +86,21 @@ void main() {
 
   group('which on Windows', () {
     testWithoutContext('throws tool exit if where throws an argument error', () async {
-      when(mockProcessManager.runSync(<String>['where', kExecutable]))
-          .thenThrow(ArgumentError('Cannot find executable for where'));
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: const <String>[
+            'where',
+            kExecutable,
+          ],
+          exception: ArgumentError('Cannot find executable for where'),
+        ),
+      );
+
       final OperatingSystemUtils utils = OperatingSystemUtils(
         fileSystem: MemoryFileSystem.test(),
         logger: BufferLogger.test(),
         platform: FakePlatform(operatingSystem: 'windows'),
-        processManager: mockProcessManager,
+        processManager: fakeProcessManager,
       );
 
       expect(() => utils.which(kExecutable), throwsA(isA<ToolExit>()));
@@ -416,58 +420,87 @@ void main() {
     );
   });
 
-  testWithoutContext('If unzip throws an ArgumentError, display an install message', () {
-    final FileSystem fileSystem = MemoryFileSystem.test();
-    when(mockProcessManager.runSync(
-      <String>['unzip', '-o', '-q', 'foo.zip', '-d', fileSystem.currentDirectory.path],
-    )).thenThrow(ArgumentError());
+  group('display an install message when unzip throws an ArgumentError', () {
+    testWithoutContext('Linux', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            'unzip', '-o', '-q', 'foo.zip', '-d', fileSystem.currentDirectory.path,
+          ],
+          exception: ArgumentError(),
+        ),
+      );
 
-    final OperatingSystemUtils linuxOsUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'linux'),
-      processManager: mockProcessManager,
-    );
+      final OperatingSystemUtils linuxOsUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'linux'),
+        processManager: fakeProcessManager,
+      );
 
-    expect(
-      () => linuxOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
-      throwsToolExit(
-        message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
-        'Consider running "sudo apt-get install unzip".'),
-    );
+      expect(
+        () => linuxOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+        throwsToolExit(
+          message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+          'Consider running "sudo apt-get install unzip".'),
+      );
+    });
 
-    final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'macos'),
-      processManager: mockProcessManager,
-    );
+    testWithoutContext('macOS', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            'unzip', '-o', '-q', 'foo.zip', '-d', fileSystem.currentDirectory.path,
+          ],
+          exception: ArgumentError(),
+        ),
+      );
 
-    expect(
-      () => macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
-      throwsToolExit
-      (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
-        'Consider running "brew install unzip".'),
-    );
+      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'macos'),
+        processManager: fakeProcessManager,
+      );
 
-    final OperatingSystemUtils unknownOsUtils = OperatingSystemUtils(
-      fileSystem: fileSystem,
-      logger: BufferLogger.test(),
-      platform: FakePlatform(operatingSystem: 'fuchsia'),
-      processManager: mockProcessManager,
-    );
+      expect(
+            () => macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+        throwsToolExit
+          (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+            'Consider running "brew install unzip".'),
+      );
+    });
 
-    expect(
-      () => unknownOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
-      throwsToolExit
-      (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
-        'Please install unzip.'),
-    );
+    testWithoutContext('unknown OS', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            'unzip', '-o', '-q', 'foo.zip', '-d', fileSystem.currentDirectory.path,
+          ],
+          exception: ArgumentError(),
+        ),
+      );
+
+      final OperatingSystemUtils unknownOsUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'fuchsia'),
+        processManager: fakeProcessManager,
+      );
+
+      expect(
+            () => unknownOsUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory),
+        throwsToolExit
+          (message: 'Missing "unzip" tool. Unable to extract foo.zip.\n'
+            'Please install unzip.'),
+      );
+    });
   });
 
   testWithoutContext('stream compression level', () {
     expect(OperatingSystemUtils.gzipLevel1.level, equals(1));
   });
 }
-
-class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
- Replace `MockProcessManager` with `FakeProcessManager`.
- Split larger `ArgumentError` test into one per OS.

Part of #71511