### PR TITLE
[flutter_tools] remove Artifacts dependency from globals in gradle, remove MockArtifacts from test

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -83,6 +83,7 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         processManager: globals.processManager,
         fileSystem: globals.fs,
+        artifacts: globals.artifacts,
       ),
       AndroidLicenseValidator: () => AndroidLicenseValidator(
         operatingSystemUtils: globals.os,

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -33,11 +33,9 @@ void main() {
     TestUsage testUsage;
     MockAndroidSdk mockAndroidSdk;
     MockAndroidStudio mockAndroidStudio;
-    MockLocalEngineArtifacts mockArtifacts;
     FakePlatform android;
     FileSystem fileSystem;
     Cache cache;
-    AndroidGradleBuilder builder;
     FakeProcessManager processManager;
 
     setUp(() {
@@ -47,14 +45,7 @@ void main() {
       fileSystem = MemoryFileSystem.test();
       mockAndroidSdk = MockAndroidSdk();
       mockAndroidStudio = MockAndroidStudio();
-      mockArtifacts = MockLocalEngineArtifacts();
       android = fakePlatform('android');
-      builder = AndroidGradleBuilder(
-        logger: logger,
-        processManager: processManager,
-        fileSystem: fileSystem,
-      );
-
       when(mockAndroidSdk.directory).thenReturn(fileSystem.directory('irrelevant'));
 
       final Directory rootDirectory = fileSystem.currentDirectory;
@@ -85,6 +76,12 @@ void main() {
     });
 
     testUsingContext('Can immediately tool exit on recognized exit code/stderr', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
          '/android/gradlew',
@@ -170,6 +167,12 @@ void main() {
     });
 
     testUsingContext('Can retry build on recognized exit code/stderr', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -270,6 +273,12 @@ void main() {
     });
 
     testUsingContext('Converts recognized ProcessExceptions into tools exits', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -355,6 +364,12 @@ void main() {
     });
 
     testUsingContext('rethrows unrecognized ProcessException', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(FakeCommand(
         command: const <String>[
           '/android/gradlew',
@@ -412,6 +427,12 @@ void main() {
     });
 
     testUsingContext('logs success event after a successful retry', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -508,6 +529,12 @@ void main() {
     });
 
     testUsingContext('performs code size analysis and sends analytics', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
        processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -599,6 +626,12 @@ void main() {
     });
 
     testUsingContext('Can retry gradle build with plugins built as AARs', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -708,6 +741,12 @@ void main() {
     });
 
     testUsingContext('indicates that an APK has been built successfully', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -769,6 +808,12 @@ void main() {
     });
 
     testUsingContext("doesn't indicate how to consume an AAR when printHowToConsumeAar is false", () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
            '/.android/gradlew',
@@ -797,13 +842,10 @@ void main() {
       );
 
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
         .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
         .createSync(recursive: true);
-
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
       await builder.buildGradleAar(
@@ -833,6 +875,12 @@ void main() {
     });
 
     testUsingContext('gradle exit code and stderr is forwarded to tool exit', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/.android/gradlew',
@@ -862,13 +910,10 @@ void main() {
       );
 
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
           .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
       await expectLater(() async =>
@@ -890,6 +935,12 @@ void main() {
     });
 
     testUsingContext('build apk uses selected local engine with arm32 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_arm'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -906,14 +957,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: TargetPlatform.android_arm,
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm'));
 
       fileSystem.file('out/android_arm/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -933,14 +976,11 @@ void main() {
       fileSystem.file('out/android_arm/flutter_embedding_release.maven-metadata.xml').createSync(recursive: true);
 
       fileSystem.file('android/gradlew').createSync(recursive: true);
-
       fileSystem.directory('android')
         .childFile('gradle.properties')
         .createSync(recursive: true);
-
       fileSystem.file('android/build.gradle')
         .createSync(recursive: true);
-
       fileSystem.directory('android')
         .childDirectory('app')
         .childFile('build.gradle')
@@ -962,17 +1002,10 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-
-
-      // expect(actualGradlewCall, contains('/android/gradlew'));
-      // expect(actualGradlewCall, contains('-Plocal-engine-out=out/android_arm'));
-      // expect(actualGradlewCall, contains('-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0'));
-      // expect(actualGradlewCall, contains('-Plocal-engine-build-mode=release'));
-
+      expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -980,6 +1013,12 @@ void main() {
     });
 
     testUsingContext('build apk uses selected local engine with arm64 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_arm64'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -996,14 +1035,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm64'));
 
       fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1023,14 +1054,11 @@ void main() {
       fileSystem.file('out/android_arm64/flutter_embedding_release.maven-metadata.xml').createSync(recursive: true);
 
       fileSystem.file('android/gradlew').createSync(recursive: true);
-
       fileSystem.directory('android')
           .childFile('gradle.properties')
           .createSync(recursive: true);
-
       fileSystem.file('android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('android')
           .childDirectory('app')
           .childFile('build.gradle')
@@ -1056,7 +1084,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1064,6 +1091,12 @@ void main() {
     });
 
     testUsingContext('build apk uses selected local engine with x86 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_x86'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -1080,14 +1113,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x86'));
 
       fileSystem.file('out/android_x86/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1107,14 +1132,11 @@ void main() {
       fileSystem.file('out/android_x86/flutter_embedding_release.maven-metadata.xml').createSync(recursive: true);
 
       fileSystem.file('android/gradlew').createSync(recursive: true);
-
       fileSystem.directory('android')
           .childFile('gradle.properties')
           .createSync(recursive: true);
-
       fileSystem.file('android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('android')
           .childDirectory('app')
           .childFile('build.gradle')
@@ -1140,7 +1162,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1148,6 +1169,12 @@ void main() {
     });
 
     testUsingContext('build apk uses selected local engine with x64 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_x64'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/android/gradlew',
@@ -1164,14 +1191,6 @@ void main() {
         ],
         exitCode: 1,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x64'));
 
       fileSystem.file('out/android_x64/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1191,14 +1210,11 @@ void main() {
       fileSystem.file('out/android_x64/flutter_embedding_release.maven-metadata.xml').createSync(recursive: true);
 
       fileSystem.file('android/gradlew').createSync(recursive: true);
-
       fileSystem.directory('android')
           .childFile('gradle.properties')
           .createSync(recursive: true);
-
       fileSystem.file('android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('android')
           .childDirectory('app')
           .childFile('build.gradle')
@@ -1224,7 +1240,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1232,6 +1247,12 @@ void main() {
     });
 
     testUsingContext('honors --no-android-gradle-daemon setting', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+      );
       processManager.addCommand(
         const FakeCommand(command: <String>[
           '/android/gradlew',
@@ -1250,10 +1271,8 @@ void main() {
       fileSystem.directory('android')
           .childFile('gradle.properties')
           .createSync(recursive: true);
-
       fileSystem.file('android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('android')
           .childDirectory('app')
           .childFile('build.gradle')
@@ -1280,7 +1299,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => Artifacts.test(),
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1288,6 +1306,12 @@ void main() {
     });
 
     testUsingContext('build aar uses selected local engine with arm32 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_arm'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/.android/gradlew',
@@ -1308,14 +1332,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: TargetPlatform.android_arm,
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm'));
 
       fileSystem.file('out/android_arm/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1345,15 +1361,11 @@ void main() {
 
       fileSystem.directory('.android/gradle')
         .createSync(recursive: true);
-
       fileSystem.directory('.android/gradle/wrapper')
         .createSync(recursive: true);
-
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
         .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
         .createSync(recursive: true);
 
@@ -1376,7 +1388,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1384,6 +1395,12 @@ void main() {
     });
 
     testUsingContext('build aar uses selected local engine with x64 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_arm64'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/.android/gradlew',
@@ -1404,14 +1421,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_arm64'));
 
       fileSystem.file('out/android_arm64/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1441,18 +1450,13 @@ void main() {
 
       fileSystem.directory('.android/gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('.android/gradle/wrapper')
           .createSync(recursive: true);
-
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
           .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
       await builder.buildGradleAar(
@@ -1473,7 +1477,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1481,6 +1484,12 @@ void main() {
     });
 
     testUsingContext('build aar uses selected local engine with x86 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_x86'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
           '/.android/gradlew',
@@ -1501,14 +1510,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x86'));
 
       fileSystem.file('out/android_x86/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1538,18 +1539,13 @@ void main() {
 
       fileSystem.directory('.android/gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('.android/gradle/wrapper')
           .createSync(recursive: true);
-
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
           .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
       await builder.buildGradleAar(
@@ -1570,7 +1566,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1578,6 +1573,12 @@ void main() {
     });
 
     testUsingContext('build aar uses selected local engine on x64 ABI', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(localEngine: 'out/android_x64'),
+      );
       processManager.addCommand(const FakeCommand(
         command: <String>[
          '/.android/gradlew',
@@ -1598,14 +1599,6 @@ void main() {
         ],
         exitCode: 0,
       ));
-
-      when(mockArtifacts.getArtifactPath(
-        Artifact.flutterFramework,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-        environmentType: anyNamed('environmentType'),
-      )).thenReturn('engine');
-      when(mockArtifacts.engineOutPath).thenReturn(fileSystem.path.join('out', 'android_x64'));
 
       fileSystem.file('out/android_x64/flutter_embedding_release.pom')
         ..createSync(recursive: true)
@@ -1635,18 +1628,13 @@ void main() {
 
       fileSystem.directory('.android/gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('.android/gradle/wrapper')
           .createSync(recursive: true);
-
       fileSystem.file('.android/gradlew').createSync(recursive: true);
-
       fileSystem.file('.android/gradle.properties')
           .writeAsStringSync('irrelevant');
-
       fileSystem.file('.android/build.gradle')
           .createSync(recursive: true);
-
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
 
       await builder.buildGradleAar(
@@ -1667,7 +1655,6 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
-      Artifacts: () => mockArtifacts,
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
@@ -1686,4 +1673,3 @@ FakePlatform fakePlatform(String name) {
 
 class MockAndroidSdk extends Mock implements AndroidSdk {}
 class MockAndroidStudio extends Mock implements AndroidStudio {}
-class MockLocalEngineArtifacts extends Mock implements LocalEngineArtifacts {}

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -860,7 +860,12 @@ flutter:
       fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.directory).thenReturn(fs.directory('irrelevant'));
-      builder = AndroidGradleBuilder(logger: logger, processManager: fakeProcessManager, fileSystem: fs);
+      builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: fakeProcessManager,
+        fileSystem: fs,
+        artifacts: Artifacts.test(),
+      );
     });
 
     testUsingContext('calls gradle', () async {


### PR DESCRIPTION
Continued improvements to gradle classes by reducing globals, and to unit tests by removing mocks. The ability to pass through a specific local engine name is required since we determine the platform/architecture of the local engine via the directory name.

https://github.com/flutter/flutter/issues/71511