### PR TITLE
Added the ability to bring up the date picker dialogs in calendar or text input only mode.

### DIFF
--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -144,22 +144,38 @@ class DateUtils {
   }
 }
 
-/// Mode of the date picker dialog.
+/// Mode of date entry method for the date picker dialog.
 ///
-/// Either a calendar or text input. In [calendar] mode, a calendar view is
-/// displayed and the user taps the day they wish to select. In [input] mode a
-/// [TextField] is displayed and the user types in the date they wish to select.
+/// In [calendar] mode, a calendar grid is displayed and the user taps the
+/// day they wish to select. In [input] mode a TextField] is displayed and
+/// the user types in the date they wish to select.
+///
+/// [calendarOnly] and [inputOnly] are variants of the above that don't
+/// allow the user to change to the mode.
 ///
 /// See also:
 ///
 ///  * [showDatePicker] and [showDateRangePicker], which use this to control
 ///    the initial entry mode of their dialogs.
 enum DatePickerEntryMode {
-  /// Tapping on a calendar.
+  /// User picks a date from calendar grid. Can switch to [input] by activating
+  /// a mode button in the dialog.
   calendar,
 
-  /// Text input.
+  /// User can input the date by typing it into a text field.
+  ///
+  /// Can switch to [calendar] by activating a mode button in the dialog.
   input,
+
+  /// User can only pick a date from calendar grid.
+  ///
+  /// There is no user interface to switch to another mode.
+  calendarOnly,
+
+  /// User can only input the date by typing it into a text field.
+  ///
+  /// There is no user interface to switch to another mode.
+  inputOnly,
 }
 
 /// Initial display of a calendar date picker.

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -132,7 +132,7 @@ void main() {
       });
     });
 
-    testWidgets('Can toggle to input entry mode', (WidgetTester tester) async {
+    testWidgets('Can switch from calendar to input entry mode', (WidgetTester tester) async {
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         expect(find.byType(TextField), findsNothing);
         await tester.tap(find.byIcon(Icons.edit));
@@ -141,7 +141,33 @@ void main() {
       });
     });
 
-    testWidgets('Toggle to input mode keeps selected date', (WidgetTester tester) async {
+    testWidgets('Can switch from input to calendar entry mode', (WidgetTester tester) async {
+      initialEntryMode = DatePickerEntryMode.input;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(find.byType(TextField), findsOneWidget);
+        await tester.tap(find.byIcon(Icons.calendar_today));
+        await tester.pumpAndSettle();
+        expect(find.byType(TextField), findsNothing);
+      });
+    });
+
+    testWidgets('Can not switch out of calendarOnly mode', (WidgetTester tester) async {
+      initialEntryMode = DatePickerEntryMode.calendarOnly;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(find.byType(TextField), findsNothing);
+        expect(find.byIcon(Icons.edit), findsNothing);
+      });
+    });
+
+    testWidgets('Can not switch out of inputOnly mode', (WidgetTester tester) async {
+      initialEntryMode = DatePickerEntryMode.inputOnly;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(find.byType(TextField), findsOneWidget);
+        expect(find.byIcon(Icons.calendar_today), findsNothing);
+      });
+    });
+
+    testWidgets('Switching to input mode keeps selected date', (WidgetTester tester) async {
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         await tester.tap(find.text('12'));
         await tester.tap(find.byIcon(Icons.edit));

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -231,7 +231,7 @@ void main() {
     });
   });
 
-  testWidgets('Can toggle to input entry mode', (WidgetTester tester) async {
+  testWidgets('Can switch from calendar to input entry mode', (WidgetTester tester) async {
     await preparePicker(tester, (Future<DateTimeRange?> range) async {
       expect(find.byType(TextField), findsNothing);
       await tester.tap(find.byIcon(Icons.edit));
@@ -240,7 +240,33 @@ void main() {
     });
   });
 
-  testWidgets('Toggle to input mode keeps selected date', (WidgetTester tester) async {
+  testWidgets('Can switch from input to calendar entry mode', (WidgetTester tester) async {
+    initialEntryMode = DatePickerEntryMode.input;
+    await preparePicker(tester, (Future<DateTimeRange?> range) async {
+      expect(find.byType(TextField), findsNWidgets(2));
+      await tester.tap(find.byIcon(Icons.calendar_today));
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsNothing);
+    });
+  });
+
+  testWidgets('Can not switch out of calendarOnly mode', (WidgetTester tester) async {
+    initialEntryMode = DatePickerEntryMode.calendarOnly;
+    await preparePicker(tester, (Future<DateTimeRange?> range) async {
+      expect(find.byType(TextField), findsNothing);
+      expect(find.byIcon(Icons.edit), findsNothing);
+    });
+  });
+
+  testWidgets('Can not switch out of inputOnly mode', (WidgetTester tester) async {
+    initialEntryMode = DatePickerEntryMode.inputOnly;
+    await preparePicker(tester, (Future<DateTimeRange?> range) async {
+      expect(find.byType(TextField), findsNWidgets(2));
+      expect(find.byIcon(Icons.calendar_today), findsNothing);
+    });
+  });
+
+  testWidgets('Switching to input mode keeps selected date', (WidgetTester tester) async {
     await preparePicker(tester, (Future<DateTimeRange?> range) async {
       await tester.tap(find.text('12').first);
       await tester.tap(find.text('14').first);


### PR DESCRIPTION
We have had a request to remove the entry mode switching buttons from the date picker dialogs. This PR adds two new values to the `DatePickerEntryMode` enum: `calendarOnly` and `inputOnly`.  These function exactly like the non-'only' counterparts, but remove the button in the dialog header that allows the user to switch calendar and input entry modes. This doesn't change the defaults, it just provides an option for apps that need to restrict the dialogs to only one mode of entry. This applies to the dialogs displayed by `showDatePicker` as well as `showDateRangePicker`.

| calendar  | calendarOnly |
| ------------- | ------------- |
| <img width="310" alt="calendar" src="https://user-images.githubusercontent.com/19588/108429910-7479d600-71f5-11eb-8f85-44f11c8b5d3b.png">  | <img width="310" alt="calendarOnly" src="https://user-images.githubusercontent.com/19588/108429926-7774c680-71f5-11eb-8a3b-8dacd273111b.png">  |

| input  | inputOnly |
| ------------- | ------------- |
| <img width="310" alt="input" src="https://user-images.githubusercontent.com/19588/108429921-76dc3000-71f5-11eb-85d4-5ad6be8925e9.png">  | <img width="310" alt="inputOnly" src="https://user-images.githubusercontent.com/19588/108429927-780d5d00-71f5-11eb-9ead-8451b2d7fcf5.png"> |

This looks like more changes than would be necessary, but that is only due to the fact that I refactored how the toggle button was implemented in the header to make it easier for us to add more action buttons there in the future.

Fixes #72513

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
