### PR TITLE
Remove mockito from windows_device_test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -384,7 +384,7 @@ void main() {
         )));
       }, overrides: <Type, Generator>{
         Artifacts: () => artifacts,
-        Cache: () => mockCache,
+        Cache: () => Cache.test(),
         DeviceManager: () => mockDeviceManager,
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -553,4 +553,3 @@ Future<BuildApkCommand> runBuildApkCommand(
 
 class MockAndroidSdk extends Mock implements AndroidSdk {}
 class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcess extends Mock implements Process {}

--- a/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
@@ -349,4 +349,3 @@ Matcher not(Matcher target){
 
 class MockAndroidSdk extends Mock implements AndroidSdk {}
 class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcess extends Mock implements Process {}

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/windows/application_package.dart';
 import 'package:flutter_tools/src/windows/windows_device.dart';
 import 'package:flutter_tools/src/windows/windows_workflow.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -116,17 +116,11 @@ void main() {
 
   testWithoutContext('executablePathForDevice uses the correct package executable', () async {
     final WindowsDevice windowsDevice = setUpWindowsDevice();
-    final MockWindowsApp mockApp = MockWindowsApp();
-    const String debugPath = 'debug/executable';
-    const String profilePath = 'profile/executable';
-    const String releasePath = 'release/executable';
-    when(mockApp.executable(BuildMode.debug)).thenReturn(debugPath);
-    when(mockApp.executable(BuildMode.profile)).thenReturn(profilePath);
-    when(mockApp.executable(BuildMode.release)).thenReturn(releasePath);
+    final FakeWindowsApp fakeApp = FakeWindowsApp();
 
-    expect(windowsDevice.executablePathForDevice(mockApp, BuildMode.debug), debugPath);
-    expect(windowsDevice.executablePathForDevice(mockApp, BuildMode.profile), profilePath);
-    expect(windowsDevice.executablePathForDevice(mockApp, BuildMode.release), releasePath);
+    expect(windowsDevice.executablePathForDevice(fakeApp, BuildMode.debug), 'debug/executable');
+    expect(windowsDevice.executablePathForDevice(fakeApp, BuildMode.profile), 'profile/executable');
+    expect(windowsDevice.executablePathForDevice(fakeApp, BuildMode.release), 'release/executable');
   });
 }
 
@@ -151,4 +145,7 @@ WindowsDevice setUpWindowsDevice({
   );
 }
 
-class MockWindowsApp extends Mock implements WindowsApp {}
+class FakeWindowsApp extends Fake implements WindowsApp {
+  @override
+  String executable(BuildMode buildMode) => '${buildMode.name}/executable';
+}


### PR DESCRIPTION
Replace `MockWindowsApp` with `FakeWindowsApp`.  
Other minor cleanup in other tests.

Part of #71511