### PR TITLE
Add mac_ios luci tests.

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -793,6 +793,222 @@
          "flaky": false
       },
       {
+         "name": "Mac_ios backdrop_filter_perf_ios__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_ios_backdrop_filter_perf_ios__timeline_summary",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios basic_material_app_ios__compile",
+         "repo": "flutter",
+         "task_name": "mac_ios_basic_material_app_ios__compile",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios channels_integration_test_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_channels_integration_test_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios complex_layout_ios__compile",
+         "repo": "flutter",
+         "task_name": "mac_ios_complex_layout_ios__compile",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios complex_layout_ios__start_up",
+         "repo": "flutter",
+         "task_name": "mac_ios_complex_layout_ios__start_up",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios complex_layout_scroll_perf_ios__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_ios_complex_layout_scroll_perf_ios__timeline_summary",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios external_ui_integration_test_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_external_ui_integration_test_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flavors_test_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_flavors_test_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flutter_gallery__transition_perf_e2e_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_flutter_gallery__transition_perf_e2e_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flutter_gallery_ios__compile",
+         "repo": "flutter",
+         "task_name": "mac_ios_flutter_gallery_ios__compile",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flutter_gallery_ios__start_up",
+         "repo": "flutter",
+         "task_name": "mac_ios_flutter_gallery_ios__start_up",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flutter_gallery_ios__transition_perf",
+         "repo": "flutter",
+         "task_name": "mac_ios_flutter_gallery_ios__transition_perf",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios flutter_view_ios__start_up",
+         "repo": "flutter",
+         "task_name": "mac_ios_flutter_view_ios__start_up",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios hello_world_ios__compile",
+         "repo": "flutter",
+         "task_name": "mac_ios_hello_world_ios__compile",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios hot_mode_dev_cycle_macos_target__benchmark",
+         "repo": "flutter",
+         "task_name": "mac_ios_hot_mode_dev_cycle_macos_target__benchmark",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios integration_ui_ios_driver",
+         "repo": "flutter",
+         "task_name": "mac_ios_integration_ui_ios_driver",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios integration_ui_ios_keyboard_resize",
+         "repo": "flutter",
+         "task_name": "mac_ios_integration_ui_ios_keyboard_resize",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios integration_ui_ios_screenshot",
+         "repo": "flutter",
+         "task_name": "mac_ios_integration_ui_ios_screenshot",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios integration_ui_ios_textfield",
+         "repo": "flutter",
+         "task_name": "mac_ios_integration_ui_ios_textfield",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios ios_app_with_extensions_test",
+         "repo": "flutter",
+         "task_name": "mac_ios_ios_app_with_extensions_test",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios ios_content_validation_test",
+         "repo": "flutter",
+         "task_name": "mac_ios_ios_content_validation_test",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios ios_defines_test",
+         "repo": "flutter",
+         "task_name": "mac_ios_ios_defines_test",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios ios_platform_view_tests",
+         "repo": "flutter",
+         "task_name": "mac_ios_ios_platform_view_tests",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios large_image_changer_perf_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_large_image_changer_perf_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios macos_chrome_dev_mode",
+         "repo": "flutter",
+         "task_name": "mac_ios_macos_chrome_dev_mode",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios microbenchmarks_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_microbenchmarks_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios new_gallery_ios__transition_perf",
+         "repo": "flutter",
+         "task_name": "mac_ios_new_gallery_ios__transition_perf",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios platform_channel_sample_test_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_platform_channel_sample_test_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios platform_channel_sample_test_swift",
+         "repo": "flutter",
+         "task_name": "mac_ios_platform_channel_sample_test_swift",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios platform_interaction_test_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_platform_interaction_test_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios platform_view_ios__start_up",
+         "repo": "flutter",
+         "task_name": "mac_ios_platform_view_ios__start_up",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios platform_views_scroll_perf_ios__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_ios_platform_views_scroll_perf_ios__timeline_summary",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios post_backdrop_filter_perf_ios__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_ios_post_backdrop_filter_perf_ios__timeline_summary",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios simple_animation_perf_ios",
+         "repo": "flutter",
+         "task_name": "mac_ios_simple_animation_perf_ios",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark",
+         "repo": "flutter",
+         "task_name": "mac_ios_smoke_catalina_hot_mode_dev_cycle_ios__benchmark",
+         "flaky": true
+      },
+      {
+         "name": "Mac_ios tiles_scroll_perf_ios__timeline_summary",
+         "repo": "flutter",
+         "task_name": "mac_ios_tiles_scroll_perf_ios__timeline_summary",
+         "flaky": true
+      },
+      {
          "name": "Windows build_aar_module_test",
          "repo": "flutter",
          "task_name": "win_build_aar_module_test",


### PR DESCRIPTION
Mac/iOS luci tasks are ready to replace Cocoon Agent ones. This PR starts running all the luci tasks using the production pool test beds.

Bug: https://github.com/flutter/flutter/issues/73392

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
