### PR TITLE
Add sharding options to test command line

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -275,16 +275,16 @@ class TestCommand extends FlutterCommand {
       ];
     }
 
-    final int shardIndex = int.tryParse(stringArg('shard-index'));
-    if (shardIndex == null || shardIndex < 0 || !shardIndex.isFinite) {
+    final int shardIndex = int.tryParse(stringArg('shard-index') ?? '');
+    if (shardIndex != null && (shardIndex < 0 || !shardIndex.isFinite)) {
       throwToolExit(
-          'Could not parse --shard-index argument. It must be an integer greater than -1.');
+          'Could not parse --shard-index=$shardIndex argument. It must be an integer greater than -1.');
     }
 
-    final int totalShards = int.tryParse(stringArg('total-shards'));
-    if (totalShards == null || totalShards <= 0 || !totalShards.isFinite) {
+    final int totalShards = int.tryParse(stringArg('total-shards') ?? '');
+    if (totalShards != null && (totalShards <= 0 || !totalShards.isFinite)) {
       throwToolExit(
-          'Could not parse --total-shards argument. It must be an integer greater than zero.');
+          'Could not parse --total-shards=$totalShards argument. It must be an integer greater than zero.');
     }
 
     if (totalShards != null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -140,13 +140,13 @@ class TestCommand extends FlutterCommand {
               'which indicates that a seed should be selected randomly. '
               'By default, tests run in the order they are declared.',
       )
-      ..addOption('--total-shards',
-        help: 'Tests can also be sharded with the --total-shards and --shard-index'
+      ..addOption('total-shards',
+        help: 'Tests can be sharded with the --total-shards and --shard-index'
               'arguments, allowing you to split up your test suites and run'
               'them separately.'
       )
-      ..addOption('--shard-index',
-          help: 'Tests can also be sharded with the --total-shards and --shard-index'
+      ..addOption('shard-index',
+          help: 'Tests can be sharded with the --total-shards and --shard-index'
               'arguments, allowing you to split up your test suites and run'
               'them separately.'
       )

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -290,7 +290,7 @@ class TestCommand extends FlutterCommand {
     if (totalShards != null) {
       if (shardIndex == null) {
         throwToolExit(
-            'If you set --total-hards you need to add --shard-index.');
+            'If you set --total-shards you need to add --shard-index.');
       }
     } else if (shardIndex != null) {
       if (totalShards == null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -141,13 +141,13 @@ class TestCommand extends FlutterCommand {
               'By default, tests run in the order they are declared.',
       )
       ..addOption('total-shards',
-        help: 'Tests can be sharded with the --total-shards and --shard-index'
-              'arguments, allowing you to split up your test suites and run'
+        help: 'Tests can be sharded with the "--total-shards" and "--shard-index" '
+              'arguments, allowing you to split up your test suites and run '
               'them separately.'
       )
       ..addOption('shard-index',
-          help: 'Tests can be sharded with the --total-shards and --shard-index'
-              'arguments, allowing you to split up your test suites and run'
+          help: 'Tests can be sharded with the "--total-shards" and "--shard-index" '
+              'arguments, allowing you to split up your test suites and run '
               'them separately.'
       )
       ..addFlag('enable-vmservice',

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -278,13 +278,13 @@ class TestCommand extends FlutterCommand {
     final int shardIndex = int.tryParse(stringArg('shard-index'));
     if (shardIndex == null || shardIndex < 0 || !shardIndex.isFinite) {
       throwToolExit(
-          'Could not parse -j/--shard-index argument. It must be an integer greater than -1.');
+          'Could not parse --shard-index argument. It must be an integer greater than -1.');
     }
 
     final int totalShards = int.tryParse(stringArg('total-shards'));
     if (totalShards == null || totalShards <= 0 || !totalShards.isFinite) {
       throwToolExit(
-          'Could not parse -j/--total-shards argument. It must be an integer greater than zero.');
+          'Could not parse --total-shards argument. It must be an integer greater than zero.');
     }
 
     if (totalShards != null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -287,15 +287,13 @@ class TestCommand extends FlutterCommand {
           'Could not parse --total-shards=$totalShards argument. It must be an integer greater than zero.');
     }
 
-    if (totalShards != null) {
-      if (shardIndex == null) {
-        throwToolExit(
-            'If you set --total-hards you need to add --shard-index.');
-      }
-    } else if (shardIndex != null) {
-      if (totalShards == null) {
-        throwToolExit('If you set --shard-index you need to add --total-hard.');
-      }
+    if (totalShards != null && shardIndex == null) {
+      throwToolExit(
+          'If you set --total-shards you need to also set --shard-index.');
+    }
+    if (shardIndex != null && totalShards == null) {
+      throwToolExit(
+          'If you set --shard-index you need to also set --total-shards.');
     }
 
     final bool machine = boolArg('machine');

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -140,6 +140,16 @@ class TestCommand extends FlutterCommand {
               'which indicates that a seed should be selected randomly. '
               'By default, tests run in the order they are declared.',
       )
+      ..addOption('--total-shards',
+        help: 'Tests can also be sharded with the --total-shards and --shard-index'
+              'arguments, allowing you to split up your test suites and run'
+              'them separately.'
+      )
+      ..addOption('--shard-index',
+          help: 'Tests can also be sharded with the --total-shards and --shard-index'
+              'arguments, allowing you to split up your test suites and run'
+              'them separately.'
+      )
       ..addFlag('enable-vmservice',
         defaultsTo: false,
         hide: !verboseHelp,
@@ -265,6 +275,29 @@ class TestCommand extends FlutterCommand {
       ];
     }
 
+    final int shardIndex = int.tryParse(stringArg('shard-index'));
+    if (shardIndex == null || shardIndex < 0 || !shardIndex.isFinite) {
+      throwToolExit(
+          'Could not parse -j/--shard-index argument. It must be an integer greater than -1.');
+    }
+
+    final int totalShards = int.tryParse(stringArg('total-shards'));
+    if (totalShards == null || totalShards <= 0 || !totalShards.isFinite) {
+      throwToolExit(
+          'Could not parse -j/--total-shards argument. It must be an integer greater than zero.');
+    }
+
+    if (totalShards != null) {
+      if (shardIndex == null) {
+        throwToolExit(
+            'If you set --total-hards you need to add --shard-index.');
+      }
+    } else if (shardIndex != null) {
+      if (totalShards == null) {
+        throwToolExit('If you set --shard-index you need to add --total-hard.');
+      }
+    }
+
     final bool machine = boolArg('machine');
     CoverageCollector collector;
     if (boolArg('coverage') || boolArg('merge-coverage')) {
@@ -314,6 +347,8 @@ class TestCommand extends FlutterCommand {
       reporter: stringArg('reporter'),
       timeout: stringArg('timeout'),
       runSkipped: boolArg('run-skipped'),
+      shardIndex: shardIndex,
+      totalShards: totalShards,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -51,6 +51,8 @@ abstract class FlutterTestRunner {
     String reporter,
     String timeout,
     bool runSkipped = false,
+    int shardIndex,
+    int totalShards,
   });
 }
 
@@ -83,6 +85,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     String reporter,
     String timeout,
     bool runSkipped = false,
+    int shardIndex,
+    int totalShards,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -112,6 +116,10 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['--exclude-tags', excludeTags],
       if (runSkipped)
         '--run-skipped',
+      if (totalShards != null)
+        '--total-hards=$randomSeed',
+      if (shardIndex != null)
+        '--shard-index=$randomSeed',
     ];
     if (web) {
       final String tempBuildDir = globals.fs.systemTempDirectory

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -117,7 +117,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       if (runSkipped)
         '--run-skipped',
       if (totalShards != null)
-        '--total-hards=$totalShards',
+        '--total-shards=$totalShards',
       if (shardIndex != null)
         '--shard-index=$shardIndex',
     ];

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -117,9 +117,9 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       if (runSkipped)
         '--run-skipped',
       if (totalShards != null)
-        '--total-hards=$randomSeed',
+        '--total-hards=$totalShards',
       if (shardIndex != null)
-        '--shard-index=$randomSeed',
+        '--shard-index=$shardIndex',
     ];
     if (web) {
       final String tempBuildDir = globals.fs.systemTempDirectory

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -59,27 +59,50 @@ void main() {
     Cache: () => FakeCache(),
   });
 
-  testUsingContext('Pipes shard-index and total-shards to package:test',
-      () async {
-    final FakePackageTest fakePackageTest = FakePackageTest();
+  group('shard-index and total-shards', () {
+    testUsingContext('with the params they are Piped to package:test',
+        () async {
+      final FakePackageTest fakePackageTest = FakePackageTest();
 
-    final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
-    final CommandRunner<void> commandRunner =
-        createTestCommandRunner(testCommand);
+      final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+      final CommandRunner<void> commandRunner =
+          createTestCommandRunner(testCommand);
 
-    await commandRunner.run(const <String>[
-      'test',
-      '--total-shards=1',
-      '--shard-index=2',
-      '--no-pub',
-    ]);
+      await commandRunner.run(const <String>[
+        'test',
+        '--total-shards=1',
+        '--shard-index=2',
+        '--no-pub',
+      ]);
 
-    expect(fakePackageTest.lastArgs, contains('--total-shards=1'));
-    expect(fakePackageTest.lastArgs, contains('--shard-index=2'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fs,
-    ProcessManager: () => FakeProcessManager.any(),
-    Cache: () => FakeCache(),
+      expect(fakePackageTest.lastArgs, contains('--total-shards=1'));
+      expect(fakePackageTest.lastArgs, contains('--shard-index=2'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+      Cache: () => FakeCache(),
+    });
+
+    testUsingContext('without the params they not Piped to package:test',
+        () async {
+      final FakePackageTest fakePackageTest = FakePackageTest();
+
+      final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+      final CommandRunner<void> commandRunner =
+          createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+      ]);
+
+      expect(fakePackageTest.lastArgs, isNot(contains('--total-shards=1')));
+      expect(fakePackageTest.lastArgs, isNot(contains('--shard-index=2')));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+      Cache: () => FakeCache(),
+    });
   });
 
   testUsingContext('Supports coverage and machine', () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -60,32 +60,27 @@ void main() {
   });
 
   testUsingContext('Pipes shard-index and total-shards to package:test',
-          () async {
-        final FakePackageTest fakePackageTest = FakePackageTest();
+      () async {
+    final FakePackageTest fakePackageTest = FakePackageTest();
 
-        final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
-        final CommandRunner<void> commandRunner =
+    final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+    final CommandRunner<void> commandRunner =
         createTestCommandRunner(testCommand);
 
-        await commandRunner.run(const <String>[
-          'test',
-          '--total-shards=1',
-          '--shard-index=2',
-          '--no-pub',
-        ]);
-        expect(
-          fakePackageTest.lastArgs,
-          contains('--total-shards=1'),
-        );
-        expect(
-          fakePackageTest.lastArgs,
-          contains('--shard-index=2'),
-        );
-      }, overrides: <Type, Generator>{
-        FileSystem: () => fs,
-        ProcessManager: () => FakeProcessManager.any(),
-        Cache: () => FakeCache(),
-      });
+    await commandRunner.run(const <String>[
+      'test',
+      '--total-shards=1',
+      '--shard-index=2',
+      '--no-pub',
+    ]);
+
+    expect(fakePackageTest.lastArgs, contains('--total-shards=1'));
+    expect(fakePackageTest.lastArgs, contains('--shard-index=2'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fs,
+    ProcessManager: () => FakeProcessManager.any(),
+    Cache: () => FakeCache(),
+  });
 
   testUsingContext('Supports coverage and machine', () async {
     final FakePackageTest fakePackageTest = FakePackageTest();

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -59,6 +59,34 @@ void main() {
     Cache: () => FakeCache(),
   });
 
+  testUsingContext('Pipes shard-index and total-shards to package:test',
+          () async {
+        final FakePackageTest fakePackageTest = FakePackageTest();
+
+        final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+        final CommandRunner<void> commandRunner =
+        createTestCommandRunner(testCommand);
+
+        await commandRunner.run(const <String>[
+          'test',
+          '--total-shards=1',
+          '--shard-index=2',
+          '--no-pub',
+        ]);
+        expect(
+          fakePackageTest.lastArgs,
+          contains('--total-shards=1'),
+        );
+        expect(
+          fakePackageTest.lastArgs,
+          contains('--shard-index=2'),
+        );
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        Cache: () => FakeCache(),
+      });
+
   testUsingContext('Supports coverage and machine', () async {
     final FakePackageTest fakePackageTest = FakePackageTest();
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -216,6 +216,8 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     String reporter,
     String timeout,
     bool runSkipped = false,
+    int shardIndex,
+    int totalShards,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     return exitCode;

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -96,8 +96,8 @@ void main() {
         '--no-pub',
       ]);
 
-      expect(fakePackageTest.lastArgs, isNot(contains('--total-shards=1')));
-      expect(fakePackageTest.lastArgs, isNot(contains('--shard-index=2')));
+      expect(fakePackageTest.lastArgs, isNot(contains('--total-shards')));
+      expect(fakePackageTest.lastArgs, isNot(contains('--shard-index')));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
The idea is to be able to run tests in parallel and this feature is already on the test package, but flutter CLI does not recognize them.

- It will add two parameters:
```
--total-shards 3 
--shard-index 0
````
   - I added some validations:
      - `--total-shards`: should be positive and if set then `--shard-index` must exist also
      - `--shard-index`: should be more than -1 and if set then `--shard-index` must exist also
- Update docs on -h adding this two options:
```
    --total-shards                    Tests can be sharded with the "--total-shards" and "--shard-index" arguments, allowing you to split up your test suites and run them separately.
    --shard-index                     Tests can be sharded with the "--total-shards" and "--shard-index" arguments, allowing you to split up your test suites and run them separately.
```

This PR will fix https://github.com/flutter/flutter/issues/71225

# Current

```bash
$ flutter test  --total-shards 3 --shard-index 0  path/to/test.dart
Could not find an option named "total-shards".
```

# Expected

```bash
$ flutter test  --total-shards 3 --shard-index 0  path/to/test.dart
... tests run fine
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
