### PR TITLE
Do not show embedding warning for plugins when example app is missing

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -217,6 +217,9 @@ class FlutterProject {
   /// True if this project is a Flutter module project.
   bool get isModule => manifest.isModule;
 
+  /// True if this project is a Flutter plugin project.
+  bool get isPlugin => manifest.isPlugin;
+
   /// True if the Flutter project is using the AndroidX support library.
   bool get usesAndroidX => manifest.usesAndroidX;
 
@@ -285,7 +288,7 @@ class FlutterProject {
     bool windowsPlatform = false,
     bool webPlatform = false,
   }) async {
-    if (!directory.existsSync() || hasExampleApp) {
+    if (!directory.existsSync() || hasExampleApp || isPlugin) {
       return;
     }
     await refreshPluginsList(this, iosPlatform: iosPlatform, macOSPlatform: macOSPlatform);

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -185,6 +185,13 @@ void main() {
         await project.regeneratePlatformSpecificTooling();
         expect(testLogger.statusText, contains('https://flutter.dev/go/android-project-migration'));
       });
+      _testInMemory('Android plugin without example app does not show a warning', () async {
+        final FlutterProject project = await aPluginProject();
+        project.example.directory.deleteSync();
+
+        await project.regeneratePlatformSpecificTooling();
+        expect(testLogger.statusText, isNot(contains('https://flutter.dev/go/android-project-migration')));
+      });
       _testInMemory('updates local properties for Android', () async {
         final FlutterProject project = await someProject();
         await project.regeneratePlatformSpecificTooling();
@@ -306,6 +313,7 @@ void main() {
     group('example', () {
       _testInMemory('exists for plugin in legacy format', () async {
         final FlutterProject project = await aPluginProject();
+        expect(project.isPlugin, isTrue);
         expect(project.hasExampleApp, isTrue);
       });
       _testInMemory('exists for plugin in multi-platform format', () async {
@@ -314,6 +322,7 @@ void main() {
       });
       _testInMemory('does not exist for non-plugin', () async {
         final FlutterProject project = await someProject();
+        expect(project.isPlugin, isFalse);
         expect(project.hasExampleApp, isFalse);
       });
     });


### PR DESCRIPTION
`The plugin "plugin1" requires your app to be migrated to the Android embedding v2` warning is not expected to be shown for plugins, but right now it is shown in plugin projects when the user removes the example app.

Instead of using the existence of the example directory, explicitly check if the project is a plugin to tell whether to go down the app plugin injection path.

See also #16861.

Fixes https://github.com/flutter/flutter/issues/66561