### PR TITLE
Skip assemble version check in tool backend scripts

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -83,6 +83,7 @@ BuildApp() {
       ${flutter_engine_flag}                                                  \
       ${local_engine_flag}                                                    \
       assemble                                                                \
+      --no-version-check                                                      \
       ${performance_measurement_option}                                       \
       -dTargetPlatform=darwin-x64                                             \
       -dTargetFile="${target_path}"                                           \

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -66,6 +66,7 @@ or
       if (flutterEngine != null) '--local-engine-src-path=$flutterEngine',
       if (localEngine != null) '--local-engine=$localEngine',
       'assemble',
+      '--no-version-check',
       '--output=build',
       '-dTargetPlatform=$targetPlatform',
       '-dTrackWidgetCreation=$trackWidgetCreation',

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -171,6 +171,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     ${flutter_engine_flag}                                                \
     ${local_engine_flag}                                                  \
     assemble                                                              \
+    --no-version-check                                                    \
     --output="${BUILT_PRODUCTS_DIR}/"                                     \
     ${performance_measurement_option}                                     \
     -dTargetPlatform=ios                                                  \

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -1002,6 +1002,7 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "--quiet"
             }
             args "assemble"
+            args "--no-version-check"
             args "--depfile", "${intermediateDir}/flutter_build.d"
             args "--output", "${intermediateDir}"
             if (performanceMeasurementFile != null) {


### PR DESCRIPTION
Skip the Flutter version freshness and associated `git` commands when calling `flutter assemble` since the user will have seen the warning from the outer `flutter` call, or it will be buried in some build logs they will never read.

In my manual tests the version check isn't expensive, but it's not needed.

It's hard to test these scripts, but our existing integration tests will at least validate building for these platforms hasn't regressed