### PR TITLE
Custom textstyle for aboutdialog action button

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -51,6 +51,7 @@ import 'theme.dart';
 /// ```dart
 ///  Widget build(BuildContext context) {
 ///    final TextStyle textStyle = Theme.of(context).textTheme.bodyText2!;
+///    final TextStyle aboutButtonTextStyle = Theme.of(context).textTheme.botton!;
 ///    final List<Widget> aboutBoxChildren = <Widget>[
 ///      SizedBox(height: 24),
 ///      RichText(

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -105,7 +105,7 @@ import 'theme.dart';
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '\u{a9} 2014 The Flutter Authors',
 ///              children: aboutBoxChildren,
-///              buttonTextStyle: aboutButtonTextStyle, 
+///              buttonTextStyle: aboutButtonTextStyle,
 ///            );
 ///          },
 ///        ),
@@ -244,7 +244,7 @@ class AboutListTile extends StatelessWidget {
 ///
 /// The [context], [useRootNavigator] and [routeSettings] arguments are passed to
 /// [showDialog], the documentation for which discusses how it is used.
-/// 
+///
 /// The [buttonTextStyle] argument is passed to override the default style of the
 /// action buttons in the [AboutDialog].
 void showAboutDialog({

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -89,6 +89,7 @@ import 'theme.dart';
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '\u{a9} 2014 The Flutter Authors',
 ///              aboutBoxChildren: aboutBoxChildren,
+///              buttonTextStyle: aboutButtonTextStyle,
 ///            ),
 ///          ),
 ///        ),
@@ -104,6 +105,7 @@ import 'theme.dart';
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '\u{a9} 2014 The Flutter Authors',
 ///              children: aboutBoxChildren,
+///              buttonTextStyle: aboutButtonTextStyle, 
 ///            );
 ///          },
 ///        ),
@@ -128,6 +130,7 @@ class AboutListTile extends StatelessWidget {
     this.applicationLegalese,
     this.aboutBoxChildren,
     this.dense,
+    this.buttonTextStyle,
   }) : super(key: key);
 
   /// The icon to show for this drawer item.
@@ -193,6 +196,13 @@ class AboutListTile extends StatelessWidget {
   /// Dense list tiles default to a smaller height.
   final bool? dense;
 
+  /// [TextStyle] of the text in the action buttons of [AboutDialog].
+  ///
+  /// Defines the style of the VIEW LICENSES and CLOSE action buttons.
+  ///
+  /// Defaults to [TextTheme.button].
+  final TextStyle? buttonTextStyle;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
@@ -211,6 +221,7 @@ class AboutListTile extends StatelessWidget {
           applicationIcon: applicationIcon,
           applicationLegalese: applicationLegalese,
           children: aboutBoxChildren,
+          buttonTextStyle: buttonTextStyle,
         );
       },
     );
@@ -233,6 +244,9 @@ class AboutListTile extends StatelessWidget {
 ///
 /// The [context], [useRootNavigator] and [routeSettings] arguments are passed to
 /// [showDialog], the documentation for which discusses how it is used.
+/// 
+/// The [buttonTextStyle] argument is passed to override the default style of the
+/// action buttons in the [AboutDialog].
 void showAboutDialog({
   required BuildContext context,
   String? applicationName,
@@ -242,6 +256,7 @@ void showAboutDialog({
   List<Widget>? children,
   bool useRootNavigator = true,
   RouteSettings? routeSettings,
+  TextStyle? buttonTextStyle,
 }) {
   assert(context != null);
   assert(useRootNavigator != null);
@@ -255,6 +270,7 @@ void showAboutDialog({
         applicationIcon: applicationIcon,
         applicationLegalese: applicationLegalese,
         children: children,
+        buttonTextStyle: buttonTextStyle,
       );
     },
     routeSettings: routeSettings,
@@ -332,6 +348,7 @@ class AboutDialog extends StatelessWidget {
     this.applicationIcon,
     this.applicationLegalese,
     this.children,
+    this.buttonTextStyle,
   }) : super(key: key);
 
   /// The name of the application.
@@ -370,6 +387,13 @@ class AboutDialog extends StatelessWidget {
   /// Defaults to nothing.
   final List<Widget>? children;
 
+  /// [TextStyle] of the text in the action buttons of [AboutDialog].
+  ///
+  /// Defines the style of the VIEW LICENSES and CLOSE action buttons.
+  ///
+  /// Defaults to [TextTheme.button].
+  final TextStyle? buttonTextStyle;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -403,7 +427,10 @@ class AboutDialog extends StatelessWidget {
       ),
       actions: <Widget>[
         TextButton(
-          child: Text(MaterialLocalizations.of(context).viewLicensesButtonLabel),
+          child: Text(
+            MaterialLocalizations.of(context).viewLicensesButtonLabel,
+            style: buttonTextStyle,
+          ),
           onPressed: () {
             showLicensePage(
               context: context,
@@ -415,7 +442,10 @@ class AboutDialog extends StatelessWidget {
           },
         ),
         TextButton(
-          child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+          child: Text(
+            MaterialLocalizations.of(context).closeButtonLabel,
+            style: buttonTextStyle,
+          ),
           onPressed: () {
             Navigator.pop(context);
           },

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -51,7 +51,7 @@ import 'theme.dart';
 /// ```dart
 ///  Widget build(BuildContext context) {
 ///    final TextStyle textStyle = Theme.of(context).textTheme.bodyText2!;
-///    final TextStyle aboutButtonTextStyle = Theme.of(context).textTheme.botton!;
+///    final TextStyle aboutButtonTextStyle = TextStyle(fontSize: 14);
 ///    final List<Widget> aboutBoxChildren = <Widget>[
 ///      SizedBox(height: 24),
 ///      RichText(

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -709,6 +709,202 @@ void main() {
     expect(materialDones[0].color, scaffoldColor);
     expect(materialDones[1].color, cardColor);
   });
+
+  testWidgets('showAboutDialog overrides text style for action buttons in AboutDialog', (WidgetTester tester) async {
+    const TextStyle themeButtonTextStyle = TextStyle(
+      fontSize: 16,
+      color: Colors.red,
+    );
+
+    const TextStyle actionButtonTextStyle = TextStyle(
+      fontSize: 20,
+      color: Colors.blue,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primaryTextTheme: const TextTheme(
+            button: themeButtonTextStyle,
+          ),
+        ),
+        home: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    showAboutDialog(
+                      context: context,
+                      buttonTextStyle: actionButtonTextStyle,
+                    );
+                  },
+                  child: const Text('Show About Dialog'),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    expect(find.text('VIEW LICENSES'), findsOneWidget);
+    expect(find.text('CLOSE'), findsOneWidget);
+
+    final Text viewLicensesButtonText = tester.widget(find.text('VIEW LICENSES'));
+    final Text closeButtonText = tester.widget(find.text('CLOSE'));
+
+    expect(viewLicensesButtonText.style, isNot(themeButtonTextStyle));
+    expect(closeButtonText.style, isNot(themeButtonTextStyle));
+    expect(viewLicensesButtonText.style, actionButtonTextStyle);
+    expect(closeButtonText.style, actionButtonTextStyle);
+  });
+
+  testWidgets('AboutListTile overrides text style for action buttons in AboutDialog', (WidgetTester tester) async {
+    const TextStyle themeButtonTextStyle = TextStyle(
+      fontSize: 16,
+      color: Colors.red,
+    );
+
+    const TextStyle actionButtonTextStyle = TextStyle(
+      fontSize: 20,
+      color: Colors.blue,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primaryTextTheme: const TextTheme(
+            button: themeButtonTextStyle,
+          ),
+        ),
+        title: 'Test App',
+        home: Scaffold(
+          body: Navigator(
+            onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<dynamic>(
+                builder: (BuildContext context) {
+                  return const AboutListTile(
+                    buttonTextStyle: actionButtonTextStyle,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    expect(find.text('VIEW LICENSES'), findsOneWidget);
+    expect(find.text('CLOSE'), findsOneWidget);
+
+    final Text viewLicensesButtonText = tester.widget(find.text('VIEW LICENSES'));
+    final Text closeButtonText = tester.widget(find.text('CLOSE'));
+
+    expect(viewLicensesButtonText.style, isNot(themeButtonTextStyle));
+    expect(closeButtonText.style, isNot(themeButtonTextStyle));
+    expect(viewLicensesButtonText.style, actionButtonTextStyle);
+    expect(closeButtonText.style, actionButtonTextStyle);
+  });
+
+  testWidgets('showAboutDialog uses theme text style for action buttons in AboutDialog when none passed', (WidgetTester tester) async {
+    const TextStyle themeButtonTextStyle = TextStyle(
+      fontSize: 16,
+      color: Colors.red,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primaryTextTheme: const TextTheme(
+            button: themeButtonTextStyle,
+          ),
+        ),
+        home: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    showAboutDialog(
+                      context: context,
+                      buttonTextStyle: themeButtonTextStyle,
+                    );
+                  },
+                  child: const Text('Show About Dialog'),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    expect(find.text('VIEW LICENSES'), findsOneWidget);
+    expect(find.text('CLOSE'), findsOneWidget);
+
+    final Text viewLicensesButtonText = tester.widget(find.text('VIEW LICENSES'));
+    final Text closeButtonText = tester.widget(find.text('CLOSE'));
+
+    expect(viewLicensesButtonText.style, themeButtonTextStyle);
+    expect(closeButtonText.style, themeButtonTextStyle);
+  });
+
+  testWidgets('AboutListTile uses theme text style for action buttons in AboutDialog when none passed', (WidgetTester tester) async {
+    const TextStyle themeButtonTextStyle = TextStyle(
+      fontSize: 16,
+      color: Colors.red,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          primaryTextTheme: const TextTheme(
+            button: themeButtonTextStyle,
+          ),
+        ),
+        title: 'Test App',
+        home: Scaffold(
+          body: Navigator(
+            onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<dynamic>(
+                builder: (BuildContext context) {
+                  return const AboutListTile(
+                    buttonTextStyle: themeButtonTextStyle,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    expect(find.text('VIEW LICENSES'), findsOneWidget);
+    expect(find.text('CLOSE'), findsOneWidget);
+
+    final Text viewLicensesButtonText = tester.widget(find.text('VIEW LICENSES'));
+    final Text closeButtonText = tester.widget(find.text('CLOSE'));
+
+    expect(viewLicensesButtonText.style, themeButtonTextStyle);
+    expect(closeButtonText.style, themeButtonTextStyle);
+  });
 }
 
 class FakeLicenseEntry extends LicenseEntry {


### PR DESCRIPTION
Added an additional argument to showAboutDialog, AboutListTile and AboutDialog that will allow developers to override the default style of the action buttons of the AboutDialog.

Closes #76535 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
