### PR TITLE
Add ability to specify tolerance level for golden files

### DIFF
--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -700,7 +700,7 @@ class FakeProcessManager extends Fake implements ProcessManager {
 
   @override
   Future<ProcessResult> run(
-    List<dynamic> command, {
+    List<Object> command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -700,7 +700,7 @@ class FakeProcessManager extends Fake implements ProcessManager {
 
   @override
   Future<ProcessResult> run(
-    List<Object> command, {
+    List<dynamic> command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool includeParentEnvironment = true,

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -116,7 +116,8 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
       final String error = await generateFailureOutput(result, golden, basedir);
       throw FlutterError(error);
     }
-    return result.passed;
+
+    return result.passed || result.diffPercentage >= _tolerance;
   }
 
   @override
@@ -263,7 +264,7 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
         'maskedDiff' : await _createImage(maskedDiffRgba, width, height),
         'isolatedDiff' : await _createImage(isolatedDiffRgba, width, height),
       },
-      diffPercentage: diffPercent,
+      diffPercentage: diffPercent / 100,
     );
   }
   return ComparisonResult(passed: true);

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -89,14 +89,6 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
   /// platform to test behaviors with arbitrary path styles.
   final path.Context _path;
 
-  double _tolerance = 0.0;
-
-  @override
-  void setPrecisionTolerance(double precisionTolerance) {
-    super.setPrecisionTolerance(precisionTolerance);
-    _tolerance = precisionTolerance;
-  }
-
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     final File goldenFile = _getGoldenFile(golden);
@@ -112,12 +104,12 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
     );
 
     // Users can specify a tolerance level for pixel diff.
-    if (!result.passed && result.diffPercentage > _tolerance) {
+    if (!result.passed && result.diffPercentage > precisionTolerance) {
       final String error = await generateFailureOutput(result, golden, basedir);
       throw FlutterError(error);
     }
 
-    return result.passed || result.diffPercentage >= _tolerance;
+    return result.passed || result.diffPercentage <= precisionTolerance;
   }
 
   @override

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -36,16 +36,19 @@ Future<ui.Image> captureImage(Element element) {
 /// test is running on a VM using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, this.precisionTolerance);
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, this.precisionTolerance) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// The allowable difference when comparing image pixels.
+  final double precisionTolerance;
 
   @override
   Future<String?> matchAsync(dynamic item) async {
@@ -66,6 +69,7 @@ class MatchesGoldenFile extends AsyncMatcher {
       throw 'must provide a Finder, Image, or Future<Image>';
     }
 
+    goldenFileComparator.setPrecisionTolerance(precisionTolerance);
     final Uri testNameUri = goldenFileComparator.getTestUri(key, version);
 
     final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -48,6 +48,9 @@ class MatchesGoldenFile extends AsyncMatcher {
   final int? version;
 
   /// The allowable difference when comparing image pixels.
+  ///
+  /// Must be between 0.0 and 1.0. For example, a tolerance of 0.01 would allow
+  /// for golden file images under test to have a 1% difference.
   final double precisionTolerance;
 
   @override
@@ -69,7 +72,7 @@ class MatchesGoldenFile extends AsyncMatcher {
       throw 'must provide a Finder, Image, or Future<Image>';
     }
 
-    goldenFileComparator.setPrecisionTolerance(precisionTolerance);
+    goldenFileComparator.precisionTolerance = precisionTolerance;
     final Uri testNameUri = goldenFileComparator.getTestUri(key, version);
 
     final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;

--- a/packages/flutter_test/lib/src/_matchers_web.dart
+++ b/packages/flutter_test/lib/src/_matchers_web.dart
@@ -23,16 +23,22 @@ Future<ui.Image> captureImage(Element element) {
 /// test is running in a web browser using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, this.precisionTolerance);
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, this.precisionTolerance) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// The allowable difference when comparing image pixels.
+  ///
+  /// Must be between 0.0 and 1.0. For example, a tolerance of 0.01 would allow
+  /// for golden file images under test to have a 1% difference.
+  final double precisionTolerance;
 
   @override
   Future<String?> matchAsync(dynamic item) async {
@@ -62,6 +68,7 @@ class MatchesGoldenFile extends AsyncMatcher {
         return null;
       }
       try {
+        webGoldenComparator.precisionTolerance = precisionTolerance;
         final bool success = await webGoldenComparator.compare(size.width, size.height, key);
         return success ? null : 'does not match';
       } on TestFailure catch (ex) {

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -4,7 +4,6 @@
 
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import '_goldens_io.dart' if (dart.library.html) '_goldens_web.dart' as _goldens;
 
@@ -75,13 +74,19 @@ abstract class GoldenFileComparator {
 
   /// Can be used to set an acceptable tolerance level, establishing an
   /// allowable difference between pixels.
-  @mustCallSuper
-  void setPrecisionTolerance(double precisionTolerance) {
+  ///
+  /// Must be between 0.0 and 1.0. For example, a tolerance of 0.01 would allow
+  /// for golden file images under test to have a 1% difference.
+  double get precisionTolerance => _precisionTolerance;
+  double _precisionTolerance = 0.0;
+  /// Sets an allowable percentage of difference between golden file images.
+  set precisionTolerance(double value) {
     assert(
       precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
       'The precision tolerance for testing golden files must be between 0.0 and'
       '1.0 inclusive, expressing the allowable percentage in pixel difference.'
     );
+    _precisionTolerance = value;
   }
 
   /// Returns a new golden file [Uri] to incorporate any [version] number with
@@ -137,7 +142,7 @@ abstract class GoldenFileComparator {
 ///  * [flutter_test] for more information about how to configure tests at the
 ///    directory-level.
 GoldenFileComparator get goldenFileComparator => _goldenFileComparator;
-GoldenFileComparator _goldenFileComparator = const TrivialComparator._();
+GoldenFileComparator _goldenFileComparator = TrivialComparator._();
 set goldenFileComparator(GoldenFileComparator value) {
   _goldenFileComparator = value;
 }
@@ -213,6 +218,20 @@ abstract class WebGoldenComparator {
         .join() + '.' + version.toString() + extension
     );
   }
+
+  /// Can be used to set an acceptable tolerance level, establishing an
+  /// allowable difference between pixels.
+  double get precisionTolerance => _precisionTolerance;
+  double _precisionTolerance = 0.0;
+  /// Sets an allowable percentage of difference between golden file images.
+  set precisionTolerance(double value) {
+    assert(
+    precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
+    'The precision tolerance for testing golden files must be between 0.0 and'
+      '1.0 inclusive, expressing the allowable percentage in pixel difference.'
+    );
+    _precisionTolerance = value;
+  }
 }
 
 /// Compares pixels against those of a golden image file.
@@ -244,7 +263,7 @@ abstract class WebGoldenComparator {
 ///  * [goldenFileComparator], the comparator used when tests are not running on
 ///    a web browser.
 WebGoldenComparator get webGoldenComparator => _webGoldenComparator;
-WebGoldenComparator _webGoldenComparator = const _TrivialWebGoldenComparator._();
+WebGoldenComparator _webGoldenComparator = _TrivialWebGoldenComparator._();
 set webGoldenComparator(WebGoldenComparator value) {
   _webGoldenComparator = value;
 }
@@ -280,8 +299,8 @@ bool autoUpdateGoldenFiles = false;
 ///
 /// This class can't be constructed. It represents the default value of
 /// [goldenFileComparator].
-class TrivialComparator implements GoldenFileComparator {
-  const TrivialComparator._();
+class TrivialComparator extends GoldenFileComparator {
+  TrivialComparator._();
 
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) {
@@ -300,17 +319,11 @@ class TrivialComparator implements GoldenFileComparator {
   }
 
   @override
-  void setPrecisionTolerance(double precisionTolerance) {
-    assert(
-      precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
-      'The precision tolerance for testing golden files must be between 0.0 and'
-      '1.0 inclusive, expressing the allowable percentage in pixel difference.'
-    );
-  }
+  final double precisionTolerance = 0.0;
 }
 
-class _TrivialWebGoldenComparator implements WebGoldenComparator {
-  const _TrivialWebGoldenComparator._();
+class _TrivialWebGoldenComparator extends WebGoldenComparator {
+   _TrivialWebGoldenComparator._();
 
   @override
   Future<bool> compare(double width, double height, Uri golden) {
@@ -327,6 +340,9 @@ class _TrivialWebGoldenComparator implements WebGoldenComparator {
   Uri getTestUri(Uri key, int? version) {
     return key;
   }
+
+  @override
+  final double precisionTolerance = 0.0;
 }
 
 /// The result of a pixel comparison test.
@@ -358,6 +374,9 @@ class ComparisonResult {
 
   /// The percent difference between pixels found when a comparison fails.
   ///
-  /// Cannot be null, defaults to 0.0 if the comparison has passed.
+  /// Cannot be null. Must be between 0.0 and 1.0 inclusive, with 1.0
+  /// representing a 100% difference between images.
+  ///
+  /// Defaults to 0.0 if the comparison has passed.
   final double diffPercentage;
 }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -4,6 +4,7 @@
 
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import '_goldens_io.dart' if (dart.library.html) '_goldens_web.dart' as _goldens;
 
@@ -71,6 +72,13 @@ abstract class GoldenFileComparator {
   /// The method by which [golden] is located and by which its bytes are written
   /// is left up to the implementation class.
   Future<void> update(Uri golden, Uint8List imageBytes);
+
+  /// Can be used to set an acceptable tolerance level, establishing an
+  /// allowable difference between pixels.
+  @mustCallSuper
+  void setPrecisionTolerance(double precisionTolerance) {
+    assert(precisionTolerance > 0.0 && precisionTolerance < 1.0);
+  }
 
   /// Returns a new golden file [Uri] to incorporate any [version] number with
   /// the [key].
@@ -288,6 +296,11 @@ class TrivialComparator implements GoldenFileComparator {
   Uri getTestUri(Uri key, int? version) {
     return key;
   }
+
+  @override
+  void setPrecisionTolerance(double precisionTolerance) {
+    assert(precisionTolerance > 0.0 && precisionTolerance < 1.0);
+  }
 }
 
 class _TrivialWebGoldenComparator implements WebGoldenComparator {
@@ -321,6 +334,7 @@ class ComparisonResult {
     required this.passed,
     this.error,
     this.diffs,
+    this.diffPercentage = 0.0,
   });
 
   /// Indicates whether or not a pixel comparison test has failed.
@@ -335,4 +349,9 @@ class ComparisonResult {
   /// values in the execution of the pixel test.
   // TODO(jonahwilliams): fix type signature when image is updated to support web.
   final Map<String, Object>? diffs;
+
+  /// The percent difference between pixels found when a comparison fails.
+  ///
+  /// Cannot be null, defaults to 0.0 if the comparison has passed.
+  final double diffPercentage;
 }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -130,8 +130,7 @@ abstract class GoldenFileComparator {
 ///
 /// Callers may choose to override the default comparator by setting this to a
 /// custom comparator during test set-up (or using directory-level test
-/// configuration). For example, some projects may wish to install a comparator
-/// with tolerance levels for allowable differences.
+/// configuration).
 ///
 /// See also:
 ///
@@ -236,8 +235,7 @@ abstract class WebGoldenComparator {
 ///
 /// Callers may choose to override the default comparator by setting this to a
 /// custom comparator during test set-up (or using directory-level test
-/// configuration). For example, some projects may wish to install a comparator
-/// with tolerance levels for allowable differences.
+/// configuration).
 ///
 /// See also:
 ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -82,7 +82,7 @@ abstract class GoldenFileComparator {
   /// Sets an allowable percentage of difference between golden file images.
   set precisionTolerance(double value) {
     assert(
-      precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
+      value >= 0.0 && value <= 1.0,
       'The precision tolerance for testing golden files must be between 0.0 and'
       '1.0 inclusive, expressing the allowable percentage in pixel difference.'
     );
@@ -226,8 +226,8 @@ abstract class WebGoldenComparator {
   /// Sets an allowable percentage of difference between golden file images.
   set precisionTolerance(double value) {
     assert(
-    precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
-    'The precision tolerance for testing golden files must be between 0.0 and'
+      value >= 0.0 && value <= 1.0,
+      'The precision tolerance for testing golden files must be between 0.0 and'
       '1.0 inclusive, expressing the allowable percentage in pixel difference.'
     );
     _precisionTolerance = value;

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -77,7 +77,11 @@ abstract class GoldenFileComparator {
   /// allowable difference between pixels.
   @mustCallSuper
   void setPrecisionTolerance(double precisionTolerance) {
-    assert(precisionTolerance > 0.0 && precisionTolerance < 1.0);
+    assert(
+      precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
+      'The precision tolerance for testing golden files must be between 0.0 and'
+      '1.0 inclusive, expressing the allowable percentage in pixel difference.'
+    );
   }
 
   /// Returns a new golden file [Uri] to incorporate any [version] number with
@@ -299,7 +303,11 @@ class TrivialComparator implements GoldenFileComparator {
 
   @override
   void setPrecisionTolerance(double precisionTolerance) {
-    assert(precisionTolerance > 0.0 && precisionTolerance < 1.0);
+    assert(
+      precisionTolerance >= 0.0 && precisionTolerance <= 1.0,
+      'The precision tolerance for testing golden files must be between 0.0 and'
+      '1.0 inclusive, expressing the allowable percentage in pixel difference.'
+    );
   }
 }
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -364,11 +364,11 @@ Matcher coversSameAreaAs(Path expectedPath, { required Rect areaToCompare, int s
 ///    verify that two different code paths create identical images.
 ///  * [flutter_test] for a discussion of test configurations, whereby callers
 ///    may swap out the backend for this matcher.
-AsyncMatcher matchesGoldenFile(Object key, {int? version}) {
+AsyncMatcher matchesGoldenFile(Object key, {int? version, double precisionTolerance = 0.0}) {
   if (key is Uri) {
-    return MatchesGoldenFile(key, version);
+    return MatchesGoldenFile(key, version, precisionTolerance);
   } else if (key is String) {
-    return MatchesGoldenFile.forStringPath(key, version);
+    return MatchesGoldenFile.forStringPath(key, version, precisionTolerance);
   }
   throw ArgumentError('Unexpected type for golden file: ${key.runtimeType}');
 }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -301,7 +301,8 @@ Matcher coversSameAreaAs(Path expectedPath, { required Rect areaToCompare, int s
   => _CoversSameAreaAs(expectedPath, areaToCompare: areaToCompare, sampleSize: sampleSize);
 
 /// Asserts that a [Finder], [Future<ui.Image>], or [ui.Image] matches the
-/// golden image file identified by [key], with an optional [version] number.
+/// golden image file identified by [key], with optional [version] number and
+/// [precisionTolerance] level.
 ///
 /// For the case of a [Finder], the [Finder] must match exactly one widget and
 /// the rendered image of the first [RepaintBoundary] ancestor of the widget is
@@ -312,6 +313,11 @@ Matcher coversSameAreaAs(Path expectedPath, { required Rect areaToCompare, int s
 ///
 /// The [version] is a number that can be used to differentiate historical
 /// golden files. This parameter is optional.
+///
+/// The [precisionTolerance] represents the allowable percent difference in
+/// pixel comparison. The value must be between 0.0 and 1.0 inclusive, and
+/// defaults to 0.0. This allows the user to set an allowable amount of
+/// difference between images.
 ///
 /// This is an asynchronous matcher, meaning that callers should use
 /// [expectLater] when using this matcher and await the future returned by

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -280,7 +280,7 @@ void main() {
         test('asserting tolerance too low', () async {
           await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
           try {
-            await doComparison(tolerance: -1.0);
+            await doComparison(tolerance: -1.5);
             fail('TestFailure expected but not thrown.');
           } catch (error) {
             expect(error.toString(), contains('The precision tolerance for testing'));

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -134,7 +134,7 @@ void main() {
     group('compare', () {
       Future<bool> doComparison({ String? golden, double tolerance = 0.0 }) {
         final Uri uri = fs.file(fix(golden ?? 'golden.png')).uri;
-        comparator.setPrecisionTolerance(tolerance);
+        comparator.precisionTolerance = tolerance;
         return comparator.compare(
           Uint8List.fromList(_kExpectedPngBytes),
           uri,

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -694,6 +694,9 @@ class _FakeComparator implements GoldenFileComparator {
   Uri getTestUri(Uri key, int? version) {
     return key;
   }
+
+  @override
+  void setPrecisionTolerance(double precisionTolerance) { }
 }
 
 class _FakeSemanticsNode extends SemanticsNode {

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -696,7 +696,7 @@ class _FakeComparator implements GoldenFileComparator {
   }
 
   @override
-  void setPrecisionTolerance(double precisionTolerance) { }
+  double precisionTolerance = 0.0;
 }
 
 class _FakeSemanticsNode extends SemanticsNode {


### PR DESCRIPTION
This adds the ability to specify a tolerance level for golden file comparison.
A good example of this use would be golden files that fail due to very small imperceptible changes, like from Skia rolls.
Here is one such case:
![image](https://user-images.githubusercontent.com/16964204/108751344-b3669f00-7507-11eb-9490-ccd4aaf0a16e.png)

This image fails due to a realllly small diff.

Fixes #76337
Related to #71437

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
