### PR TITLE
Build more integration tests during pre-submit

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -345,7 +345,6 @@ Future<void> _runWebToolTests() async {
 Future<void> _runBuildTests() async {
   final List<FileSystemEntity> exampleDirectories = Directory(path.join(flutterRoot, 'examples')).listSync()
     ..add(Directory(path.join(flutterRoot, 'packages', 'integration_test', 'example')))
-    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'abstract_method_smoke_test')))
     ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing')))
     ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'android_views')))
     ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'channels')))

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -345,8 +345,15 @@ Future<void> _runWebToolTests() async {
 Future<void> _runBuildTests() async {
   final List<FileSystemEntity> exampleDirectories = Directory(path.join(flutterRoot, 'examples')).listSync()
     ..add(Directory(path.join(flutterRoot, 'packages', 'integration_test', 'example')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'abstract_method_smoke_test')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'android_views')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'channels')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'hybrid_android_views')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'flutter_gallery')))
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'ios_platform_view_tests')))
     ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'non_nullable')))
-    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'flutter_gallery')));
+    ..add(Directory(path.join(flutterRoot, 'dev', 'integration_tests', 'ui')));
 
   // The tests are randomly distributed into subshards so as to get a uniform
   // distribution of costs, but the seed is fixed so that issues are reproducible.

--- a/dev/integration_tests/ui/macos/Flutter/Flutter-Debug.xcconfig
+++ b/dev/integration_tests/ui/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"

--- a/dev/integration_tests/ui/macos/Flutter/Flutter-Release.xcconfig
+++ b/dev/integration_tests/ui/macos/Flutter/Flutter-Release.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"

--- a/examples/image_list/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/image_list/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Add the missing files that should be checked in to `dev/integration_tests/ui/macos` to make it build.  Also add `examples/image_list/android/gradle/wrapper/gradle-wrapper.properties` which should be checked in.

[Linux](https://ci.chromium.org/p/flutter/builders/try/Linux%20build_tests/11407?) went from 17 to 19 minutes, [Mac](https://ci.chromium.org/p/flutter/builders/try/Mac%20build_tests/8020?) went from 17 to 27, and [Windows](https://ci.chromium.org/p/flutter/builders/try/Windows%20build_tests/9044?) seems the same.  I'll add a [fourth subshard](https://github.com/flutter/infra/blob/bb5fafafa21daedef60bf9d9e80e67ec2f5be096/config/framework_config.star#L504) for Mac, based on those numbers.

Fixes https://github.com/flutter/flutter/issues/76419