### PR TITLE
Remove mac/ios agents and remove flaky flag from mac/ios on LUCI.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -36,13 +36,6 @@
 tasks:
   # Tests of compiling in a variety of modes
 
-  complex_layout_ios__compile:
-    description: >
-      Collects various performance metrics of compiling the Complex
-      Layout sample app for iOS from Mac.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
   complex_layout_win__compile:
     description: >
       Collects various performance metrics of compiling the Complex
@@ -50,26 +43,12 @@ tasks:
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
 
-  basic_material_app_ios__compile:
-    description: >
-      Collects various performance metrics of compiling the default
-      app for iOS from Mac.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
   basic_material_app_win__compile:
     description: >
       Collects various performance metrics of compiling the default
       app for Android from Windows.
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
-
-  flutter_gallery_ios__compile:
-    description: >
-      Collects various performance metrics of compiling the Flutter
-      Gallery for iOS from Mac.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
 
   flutter_gallery_win__compile:
     description: >
@@ -100,22 +79,9 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  ios_content_validation_test:
-    description: >
-      Builds an obfuscated app and verifies contents and structure
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-    on_luci: true
-
   tiles_scroll_perf_ios__timeline_summary:
     description: >
       Measures the runtime performance of the tiles tab in the Complex Layout sample app on iPhone 6.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
-  platform_views_scroll_perf_ios__timeline_summary:
-    description: >
-      Measures the runtime performance of platform views in the Complex Layout sample app on iPhone 6.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
@@ -124,24 +90,6 @@ tasks:
       Measures the startup time of the Flutter Gallery app on 32-bit iOS (iPhone 4S).
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
-
-  flavors_test_ios:
-    description: >
-      Checks that flavored builds work on iPhone 6.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
-  external_ui_integration_test_ios:
-    description: >
-      Checks that external UIs work on iPhone 6.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
-  channels_integration_test_ios:
-    description: >
-      Checks that platform channels work on iPhone 6.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
 
   platform_interaction_test_ios:
     description: >
@@ -167,34 +115,15 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  backdrop_filter_perf_ios__timeline_summary:
-    description: >
-      Measures the runtime performance of backdrop filter blurs on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
   post_backdrop_filter_perf_ios__timeline_summary:
     description: >
       Measures the runtime performance of animations after a backdrop filter is removed on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  complex_layout_scroll_perf_ios__timeline_summary:
-    description: >
-      Measures the runtime performance of the Complex Layout sample app on
-      iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
   flutter_gallery_ios__start_up:
     description: >
       Measures the startup time of the Flutter Gallery app on iPhone 6.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios"]
-
-  complex_layout_ios__start_up:
-    description: >
-      Measures the startup time of the Complex Layout sample app on iPhone 6.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -796,49 +796,49 @@
       "name": "Mac_ios backdrop_filter_perf_ios__timeline_summary",
       "repo": "flutter",
       "task_name": "mac_ios_backdrop_filter_perf_ios__timeline_summary",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios basic_material_app_ios__compile",
       "repo": "flutter",
       "task_name": "mac_ios_basic_material_app_ios__compile",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios channels_integration_test_ios",
       "repo": "flutter",
       "task_name": "mac_ios_channels_integration_test_ios",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios complex_layout_ios__compile",
       "repo": "flutter",
       "task_name": "mac_ios_complex_layout_ios__compile",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios complex_layout_ios__start_up",
       "repo": "flutter",
       "task_name": "mac_ios_complex_layout_ios__start_up",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios complex_layout_scroll_perf_ios__timeline_summary",
       "repo": "flutter",
       "task_name": "mac_ios_complex_layout_scroll_perf_ios__timeline_summary",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios external_ui_integration_test_ios",
       "repo": "flutter",
       "task_name": "mac_ios_external_ui_integration_test_ios",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios flavors_test_ios",
       "repo": "flutter",
       "task_name": "mac_ios_flavors_test_ios",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios flutter_gallery__transition_perf_e2e_ios",
@@ -850,7 +850,7 @@
       "name": "Mac_ios flutter_gallery_ios__compile",
       "repo": "flutter",
       "task_name": "mac_ios_flutter_gallery_ios__compile",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios flutter_gallery_ios__start_up",
@@ -916,7 +916,7 @@
       "name": "Mac_ios ios_content_validation_test",
       "repo": "flutter",
       "task_name": "mac_ios_ios_content_validation_test",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios ios_defines_test",
@@ -982,7 +982,7 @@
       "name": "Mac_ios platform_views_scroll_perf_ios__timeline_summary",
       "repo": "flutter",
       "task_name": "mac_ios_platform_views_scroll_perf_ios__timeline_summary",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios post_backdrop_filter_perf_ios__timeline_summary",


### PR DESCRIPTION
Mac/ios LUCI test beds and tests are now stable. We are removing the flaky flag to make them block the tree on failures and we are also removing the mac/ios agent configurations.

Bug: https://github.com/flutter/flutter/issues/73392


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
