### PR TITLE
[flutter_tools] Don't stringify null values in EventPrinter

### DIFF
--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -22,7 +22,7 @@ class EventPrinter extends TestWatcher {
   @override
   void handleStartedDevice(Uri observatoryUri) {
     _sendEvent('test.startedProcess',
-        <String, dynamic>{'observatoryUri': observatoryUri.toString()});
+        <String, dynamic>{'observatoryUri': observatoryUri?.toString()});
     _parent?.handleStartedDevice(observatoryUri);
   }
 

--- a/packages/flutter_tools/test/general.shard/test/event_printer_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/event_printer_test.dart
@@ -11,15 +11,48 @@ import 'package:mockito/mockito.dart';
 import '../../src/common.dart';
 
 void main() {
-  testWithoutContext('EventPrinter handles a null parent', () {
-    final EventPrinter eventPrinter = EventPrinter(out: StringBuffer());
-    final _Device device = _Device();
+  group(EventPrinter, () {
     final Uri observatoryUri = Uri.parse('http://localhost:1234');
+    EventPrinter eventPrinter;
+    StringBuffer output;
 
-    expect(() => eventPrinter.handleFinishedTest(device), returnsNormally);
-    expect(() => eventPrinter.handleStartedDevice(observatoryUri), returnsNormally);
-    expect(() => eventPrinter.handleTestCrashed(device), returnsNormally);
-    expect(() => eventPrinter.handleTestTimedOut(device), returnsNormally);
+    setUp(() {
+      output = StringBuffer();
+      eventPrinter = EventPrinter(out: output);
+    });
+
+    testWithoutContext('handles a null parent', () {
+      final _Device device = _Device();
+
+      expect(() => eventPrinter.handleFinishedTest(device), returnsNormally);
+      expect(() => eventPrinter.handleStartedDevice(observatoryUri), returnsNormally);
+      expect(() => eventPrinter.handleTestCrashed(device), returnsNormally);
+      expect(() => eventPrinter.handleTestTimedOut(device), returnsNormally);
+    });
+
+    group('handleStartedDevice', () {
+      testWithoutContext('with non-null observatory', () {
+        eventPrinter.handleStartedDevice(observatoryUri);
+
+        expect(
+          output.toString(),
+          '\n'
+          '[{"event":"test.startedProcess","params":{"observatoryUri":"http://localhost:1234"}}]'
+          '\n',
+        );
+      });
+
+      testWithoutContext('with null observatory', () {
+        eventPrinter.handleStartedDevice(null);
+
+        expect(
+          output.toString(),
+          '\n'
+          '[{"event":"test.startedProcess","params":{"observatoryUri":null}}]'
+          '\n',
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
#74176 added a watcher event for the observatory even when it is null, but this nullable value is subsequently serialized into a string which makes it difficult for tools to interpret.

Fixes #76533 
