### PR TITLE
Check for a closed output stream in the devicelab ADB log reader

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -581,7 +581,9 @@ class AndroidDevice extends Device {
           .transform<String>(const LineSplitter())
           .listen((String line) {
             print('adb logcat: $line');
-            stream.sink.add(line);
+            if (!stream.isClosed) {
+              stream.sink.add(line);
+            }
           }, onDone: () { stdoutDone.complete(); });
         process.stderr
           .transform<String>(utf8.decoder)


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/76225