### PR TITLE
Add gallery integration iOS UI integration test

### DIFF
--- a/dev/devicelab/bin/tasks/native_ui_tests_ios32.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_ios32.dart
@@ -1,0 +1,95 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/host_agent.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+
+  await task(() async {
+    final String projectDirectory = '${flutterDirectory.path}/dev/integration_tests/flutter_gallery';
+
+    await inDirectory(projectDirectory, () async {
+      section('Build clean');
+
+      await flutter('clean');
+
+      section('Build gallery app');
+
+      await flutter(
+        'build',
+        options: <String>[
+          'ios',
+          '-v',
+          '--release',
+          '--config-only',
+        ],
+      );
+    });
+
+    section('Run platform unit tests');
+
+    final Device device = await devices.workingDevice;
+    final Map<String, String> environment = Platform.environment;
+    // If not running on CI, inject the Flutter team code signing properties.
+    final String developmentTeam = environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] ?? 'S8QB4VV633';
+    final String codeSignStyle = environment['FLUTTER_XCODE_CODE_SIGN_STYLE'];
+    final String provisioningProfile = environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'];
+
+    final String resultBundleTemp = Directory.systemTemp.createTempSync('native_ui_tests_ios32_xcresult.').path;
+    final String resultBundlePath = path.join(resultBundleTemp, 'result');
+    final int testResultExit = await exec(
+      'xcodebuild',
+      <String>[
+        '-workspace',
+        'Runner.xcworkspace',
+        '-scheme',
+        'Runner',
+        '-configuration',
+        'Release',
+        '-destination',
+        'id=${device.deviceId}',
+        '-resultBundlePath',
+        resultBundlePath,
+        'test',
+        'COMPILER_INDEX_STORE_ENABLE=NO',
+        'DEVELOPMENT_TEAM=$developmentTeam',
+        if (codeSignStyle != null)
+          'CODE_SIGN_STYLE=$codeSignStyle',
+        if (provisioningProfile != null)
+          'PROVISIONING_PROFILE_SPECIFIER=$provisioningProfile',
+      ],
+      workingDirectory: path.join(projectDirectory, 'ios'),
+      canFail: true,
+    );
+
+    if (testResultExit != 0) {
+      // Zip the test results to the artifacts directory for upload.
+      final String zipPath = path.join(hostAgent.dumpDirectory.path,
+          'native_ui_tests_ios32-${DateTime.now().toLocal().toIso8601String()}.zip');
+      await exec(
+        'zip',
+        <String>[
+          '-r',
+          '-9',
+          zipPath,
+          'result.xcresult',
+        ],
+        workingDirectory: resultBundleTemp,
+        canFail: true, // Best effort to get the logs.
+      );
+
+      return TaskResult.failure('Platform unit tests failed');
+    }
+
+    return TaskResult.success(null);
+  });
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -91,6 +91,13 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
 
+  native_ui_tests_ios32:
+    description: >
+      Run native XCUITests on 32-bit iOS (iPhone 4S).
+    stage: devicelab_ios
+    required_agent_capabilities: ["mac/ios32"]
+    flaky: true
+
   platform_interaction_test_ios:
     description: >
       Checks platform interaction on iPhone 6.

--- a/dev/integration_tests/flutter_gallery/ios/GalleryUITests/GalleryUITests.m
+++ b/dev/integration_tests/flutter_gallery/ios/GalleryUITests/GalleryUITests.m
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+
+@interface GalleryUITests : XCTestCase
+@end
+
+@implementation GalleryUITests
+
+- (void)setUp {
+    self.continueAfterFailure = NO;
+}
+
+- (void)testLaunch {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app launch];
+
+    // Basic smoke test that the app launched and any element was loaded.
+    XCTAssertTrue([app.otherElements.firstMatch waitForExistenceWithTimeout:60.0]);
+}
+
+@end

--- a/dev/integration_tests/flutter_gallery/ios/GalleryUITests/Info.plist
+++ b/dev/integration_tests/flutter_gallery/ios/GalleryUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/project.pbxproj
@@ -15,7 +15,18 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		AA1F617779EAA28FB12EC66E /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C77CA0BBC4B57129484236F4 /* libPods-Runner.a */; };
+		F7C2268825DCA70C00389C82 /* GalleryUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C2268725DCA70C00389C82 /* GalleryUITests.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F7C2268A25DCA70C00389C82 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
@@ -49,6 +60,9 @@
 		C77CA0BBC4B57129484236F4 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC01738FBE39EADD5AC4BF42 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		ECF490DDAB8ABCEEFB1780BE /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F7C2268525DCA70C00389C82 /* GalleryUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GalleryUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7C2268725DCA70C00389C82 /* GalleryUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GalleryUITests.m; sourceTree = "<group>"; };
+		F7C2268925DCA70C00389C82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +71,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA1F617779EAA28FB12EC66E /* libPods-Runner.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F7C2268225DCA70C00389C82 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,6 +100,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				F7C2268625DCA70C00389C82 /* GalleryUITests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				CF3B75C9A7D2FA2A4C99F110 /* Frameworks */,
 				E54E8B7296D73DD9B2385312 /* Pods */,
@@ -89,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Flutter Gallery.app */,
+				F7C2268525DCA70C00389C82 /* GalleryUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -135,6 +158,15 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		F7C2268625DCA70C00389C82 /* GalleryUITests */ = {
+			isa = PBXGroup;
+			children = (
+				F7C2268725DCA70C00389C82 /* GalleryUITests.m */,
+				F7C2268925DCA70C00389C82 /* Info.plist */,
+			);
+			path = GalleryUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -159,6 +191,24 @@
 			productReference = 97C146EE1CF9000F007C117D /* Flutter Gallery.app */;
 			productType = "com.apple.product-type.application";
 		};
+		F7C2268425DCA70C00389C82 /* GalleryUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F7C2268F25DCA70C00389C82 /* Build configuration list for PBXNativeTarget "GalleryUITests" */;
+			buildPhases = (
+				F7C2268125DCA70C00389C82 /* Sources */,
+				F7C2268225DCA70C00389C82 /* Frameworks */,
+				F7C2268325DCA70C00389C82 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F7C2268B25DCA70C00389C82 /* PBXTargetDependency */,
+			);
+			name = GalleryUITests;
+			productName = GalleryUITests;
+			productReference = F7C2268525DCA70C00389C82 /* GalleryUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -170,6 +220,11 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+					};
+					F7C2268425DCA70C00389C82 = {
+						CreatedOnToolsVersion = 12.4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 97C146ED1CF9000F007C117D;
 					};
 				};
 			};
@@ -187,6 +242,7 @@
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				F7C2268425DCA70C00389C82 /* GalleryUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -200,6 +256,13 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F7C2268325DCA70C00389C82 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -265,7 +328,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F7C2268125DCA70C00389C82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7C2268825DCA70C00389C82 /* GalleryUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F7C2268B25DCA70C00389C82 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = F7C2268A25DCA70C00389C82 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
@@ -479,6 +558,45 @@
 			};
 			name = Release;
 		};
+		F7C2268C25DCA70C00389C82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = GalleryUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flutterio.GalleryUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Runner;
+			};
+			name = Debug;
+		};
+		F7C2268D25DCA70C00389C82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = GalleryUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flutterio.GalleryUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Runner;
+			};
+			name = Release;
+		};
+		F7C2268E25DCA70C00389C82 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = GalleryUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flutterio.GalleryUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Runner;
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -498,6 +616,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				244B5B83218289A200D656CE /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F7C2268F25DCA70C00389C82 /* Build configuration list for PBXNativeTarget "GalleryUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F7C2268C25DCA70C00389C82 /* Debug */,
+				F7C2268D25DCA70C00389C82 /* Release */,
+				F7C2268E25DCA70C00389C82 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/flutter_gallery/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -37,6 +37,16 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F7C2268425DCA70C00389C82"
+               BuildableName = "GalleryUITests.xctest"
+               BlueprintName = "GalleryUITests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
Add new Gallery XCUITest and run it in Release mode on 32-bit iOS devices.  This shows the app builds and launches without `flutter drive` and relying on the flaky VM service connections on these devices.  Once this test is passing in staging, `flutter_gallery_sksl_warmup__transition_perf_e2e_ios32`, `flutter_gallery__transition_perf_e2e_ios32`, and `flutter_gallery_ios32__start_up` benchmarks will be retired.

See internal doc go/flutter-ios32-customers for proposal.
See also https://github.com/flutter/flutter/issues/75831

Infra task config added at https://github.com/flutter/infra/pull/364.