### PR TITLE
Move iOS framework thinning into the tool as assemble target

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -417,7 +417,6 @@ abstract class IosAssetBundle extends Target {
       environment.buildDir.childFile('flutter_assets.d'),
     );
 
-
     // Copy the plist from either the project or module.
     // TODO(jonahwilliams): add plist to inputs
     final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
@@ -532,6 +531,87 @@ Future<RunResult> createStubAppFramework(File outputFile, String sdkRoot,
       // Best effort. Sometimes we can't delete things from system temp.
     } on Exception catch (e) {
       throwToolExit('Failed to create App.framework stub at ${outputFile.path}: $e');
+    }
+  }
+}
+
+/// Destructively thins the specified executable file to include only the specified architectures.
+///
+/// This target is not fingerprinted and will always run.
+class ThinIosApplicationFrameworks extends Target {
+  const ThinIosApplicationFrameworks();
+
+  @override
+  String get name => 'thin_ios_application_frameworks';
+
+  @override
+  List<Target> get dependencies => const <Target>[];
+
+  @override
+  List<Source> get inputs => const <Source>[];
+
+  @override
+  List<Source> get outputs => const <Source>[];
+
+  @override
+  Future<void> build(Environment environment) async {
+    if (environment.defines[kIosArchs] == null) {
+      throw MissingDefineException(kIosArchs, 'thin_ios_application_frameworks');
+    }
+    final Directory frameworkDirectory = environment.outputDir;
+
+    final File appFramework = frameworkDirectory.childDirectory('App.framework').childFile('App');
+    final File flutterFramework = frameworkDirectory.childDirectory('Flutter.framework').childFile('Flutter');
+    await _thinBinary(appFramework, environment);
+    await _thinBinary(flutterFramework, environment);
+  }
+
+  Future<void> _thinBinary(File binary, Environment environment) async {
+    final String binaryPath = binary.path;
+    if (!binary.existsSync()) {
+      throw Exception('Binary $binaryPath does not exist, cannot thin');
+    }
+    final String archs = environment.defines[kIosArchs];
+    final List<String> archList = archs.split(' ').toList();
+    final ProcessResult infoResult = environment.processManager.runSync(<String>[
+      'lipo',
+      '-info',
+      binaryPath,
+    ]);
+    final String lipoInfo = infoResult.stdout as String;
+
+    final ProcessResult verifyResult = environment.processManager.runSync(<String>[
+      'lipo',
+      binaryPath,
+      '-verify_arch',
+      ...archList
+    ]);
+
+    if (verifyResult.exitCode != 0) {
+      throw Exception('Binary $binaryPath does not contain $archs. Running lipo -info:\n$lipoInfo');
+    }
+
+    // Skip this step for non-fat executables.
+    if (lipoInfo.startsWith('Non-fat file:')) {
+      environment.logger.printTrace('Skipping lipo for non-fat file $binaryPath');
+      return;
+    }
+
+    // Thin in-place.
+    final ProcessResult extractResult = environment.processManager.runSync(<String>[
+      'lipo',
+      '-output',
+      binaryPath,
+      for (final String arch in archList)
+        ...<String>[
+          '-extract',
+          arch,
+        ],
+      ...<String>[binaryPath],
+    ]);
+
+    if (extractResult.exitCode != 0) {
+      throw Exception('Failed to extract $archs for $binaryPath.\n${extractResult.stderr}\nRunning lipo -info:\n$lipoInfo');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -66,6 +66,7 @@ const List<Target> _kDefaultTargets = <Target>[
   DebugIosApplicationBundle(),
   ProfileIosApplicationBundle(),
   ReleaseIosApplicationBundle(),
+  ThinIosApplicationFrameworks(),
   // Windows targets
   UnpackWindows(),
   DebugBundleWindowsAssets(),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -45,7 +45,7 @@ void main() {
   FileSystem fileSystem;
   FakeProcessManager processManager;
   Artifacts artifacts;
-  Logger logger;
+  BufferLogger logger;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -298,6 +298,276 @@ void main() {
       );
 
       await const DebugUnpackIOS().build(environment);
+    });
+  });
+
+  group('thin frameworks', () {
+    testWithoutContext('fails when frameworks missing', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks');
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64',
+        },
+      );
+      expect(
+        const ThinIosApplicationFrameworks().build(environment),
+        throwsA(isA<Exception>().having(
+          (Exception exception) => exception.toString(),
+          'description',
+          contains('App.framework/App does not exist, cannot thin'),
+        )));
+    });
+
+    testWithoutContext('fails when requested archs missing from framework', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks')..createSync(recursive: true);
+      final File appBinary = outputDir.childDirectory('App.framework').childFile('App')..createSync(recursive: true);
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64 armv7',
+        },
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          appBinary.path,
+        ], stdout: 'Architectures in the fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          appBinary.path,
+          '-verify_arch',
+          'arm64',
+          'armv7',
+        ], exitCode: 1),
+      );
+
+      expect(
+          const ThinIosApplicationFrameworks().build(environment),
+          throwsA(isA<Exception>().having(
+                (Exception exception) => exception.toString(),
+            'description',
+            contains('does not contain arm64 armv7. Running lipo -info:\nArchitectures in the fat file:'),
+          )));
+    });
+
+    testWithoutContext('fails when lipo extract fails', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks')..createSync(recursive: true);
+      final File appBinary = outputDir.childDirectory('App.framework').childFile('App')..createSync(recursive: true);
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64 armv7',
+        },
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          appBinary.path,
+        ], stdout: 'Architectures in the fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          appBinary.path,
+          '-verify_arch',
+          'arm64',
+          'armv7',
+        ]),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-output',
+          appBinary.path,
+          '-extract',
+          'arm64',
+          '-extract',
+          'armv7',
+          appBinary.path,
+        ], exitCode: 1,
+        stderr: 'lipo error'),
+      );
+
+      expect(
+        const ThinIosApplicationFrameworks().build(environment),
+        throwsA(isA<Exception>().having(
+              (Exception exception) => exception.toString(),
+          'description',
+          contains('Failed to extract arm64 armv7 for Runner.app/Frameworks/App.framework/App.\nlipo error\nRunning lipo -info:\nArchitectures in the fat file:'),
+        )));
+    });
+
+    testWithoutContext('skips thin frameworks', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks')..createSync(recursive: true);
+      final File appBinary = outputDir.childDirectory('App.framework').childFile('App')..createSync(recursive: true);
+      final File flutterBinary = outputDir.childDirectory('Flutter.framework').childFile('Flutter')..createSync(recursive: true);
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64',
+        },
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          appBinary.path,
+        ], stdout: 'Non-fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          appBinary.path,
+          '-verify_arch',
+          'arm64',
+        ]),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          flutterBinary.path,
+        ], stdout: 'Non-fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          flutterBinary.path,
+          '-verify_arch',
+          'arm64',
+        ]),
+      );
+      await const ThinIosApplicationFrameworks().build(environment);
+
+      expect(logger.traceText, contains('Skipping lipo for non-fat file Runner.app/Frameworks/App.framework/App'));
+      expect(logger.traceText, contains('Skipping lipo for non-fat file Runner.app/Frameworks/Flutter.framework/Flutter'));
+
+      expect(processManager.hasRemainingExpectations, isFalse);
+    });
+
+    testWithoutContext('thins fat frameworks', () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks')..createSync(recursive: true);
+      final File appBinary = outputDir.childDirectory('App.framework').childFile('App')..createSync(recursive: true);
+      final File flutterBinary = outputDir.childDirectory('Flutter.framework').childFile('Flutter')..createSync(recursive: true);
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64 armv7',
+        },
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          appBinary.path,
+        ], stdout: 'Architectures in the fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          appBinary.path,
+          '-verify_arch',
+          'arm64',
+          'armv7',
+        ]),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-output',
+          appBinary.path,
+          '-extract',
+          'arm64',
+          '-extract',
+          'armv7',
+          appBinary.path,
+        ]),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-info',
+          flutterBinary.path,
+        ], stdout: 'Architectures in the fat file:'),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          flutterBinary.path,
+          '-verify_arch',
+          'arm64',
+          'armv7',
+        ]),
+      );
+
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          'lipo',
+          '-output',
+          flutterBinary.path,
+          '-extract',
+          'arm64',
+          '-extract',
+          'armv7',
+          flutterBinary.path,
+        ]),
+      );
+
+      await const ThinIosApplicationFrameworks().build(environment);
+      expect(processManager.hasRemainingExpectations, isFalse);
     });
   });
 }

--- a/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
@@ -195,6 +195,8 @@ void main() {
             'VERBOSE_SCRIPT_LOGGING': '1',
             'FLUTTER_BUILD_MODE': 'release',
             'ACTION': 'install',
+            'ARCHS': 'arm64 armv7',
+            'FLUTTER_ROOT': flutterRoot,
             // Skip bitcode stripping since we just checked that above.
           },
         );


### PR DESCRIPTION
The `xcode_backend` script removed extraneous architectures from the app in debug and profile ("thinned") to reduce install app size.

1. Move framework thinning into the tool as an assemble target.
2. Change the logic to only thin Flutter-owned `App.framework` and `Flutter.framework` instead of all frameworks in the app.  CocoaPods handles thinning plugins, and Xcode handles the rest, so don't duplicate the work.
3. Remove the logic that creates a framework per requested architecture and then merges them at the end.  Instead, first validate all the frameworks have the requested architectures via `lipo -verify_arch`, then extract all the requested architectures at the same time in-place to the same binary location.

Added unit tests, but this is also already covered by existing tests like
https://github.com/flutter/flutter/blob/d603ee11004f0379d2b51fede1ba34f572ac83da/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart#L307
