### PR TITLE
[flutter_tools] Fail fast when test dependencies are missing

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -219,8 +219,7 @@ class TestCommand extends FlutterCommand {
     final BuildInfo buildInfo = await getBuildInfo(forcedBuildMode: BuildMode.debug);
 
     if (buildInfo.packageConfig['test_api'] == null) {
-      globals.printError(
-        '\n'
+      throwToolExit(
         'Error: cannot run without a dependency on either "package:flutter_test" or "package:test". '
         'Ensure the following lines are present in your pubspec.yaml:'
         '\n\n'


### PR DESCRIPTION
Currently we only log an error when some dependencies are missing from the pubspec, when running `flutter test`. This results in obscure compilation errors when loading test files should these dependencies be missing.

This PR makes it such that the tool fails immediately when this situation is encountered.