### PR TITLE
[flutter_tools] add unit test for error 32 in cache deletion

### DIFF
--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -440,6 +440,7 @@ void main() {
   });
 
   testWithoutContext('ArtifactUpdater will tool exit if deleting the existing artifacts fails with 32 on windows', () async {
+    const int kSharingViolation = 32;
     final FileExceptionHandler handler = FileExceptionHandler();
     final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
@@ -458,7 +459,7 @@ void main() {
       .childDirectory('out')
       .childDirectory('test')
       ..createSync(recursive: true);
-    handler.addError(errorDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', 32)));
+    handler.addError(errorDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', kSharingViolation)));
 
     await expectLater(() async => await artifactUpdater.downloadZippedTarball(
       'test message',

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -438,6 +438,37 @@ void main() {
     expect(fileSystem.file('a/b/c/d'), isNot(exists));
     expect(logger.errorText, isEmpty);
   });
+
+  testWithoutContext('ArtifactUpdater will tool exit if deleting the existing artifacts fails with 32 on windows', () async {
+    final FileExceptionHandler handler = FileExceptionHandler();
+    final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    final BufferLogger logger = BufferLogger.test();
+    final ArtifactUpdater artifactUpdater = ArtifactUpdater(
+      fileSystem: fileSystem,
+      logger: logger,
+      operatingSystemUtils: operatingSystemUtils,
+      platform: FakePlatform(operatingSystem: 'windows'),
+      httpClient: FakeHttpClient.any(),
+      tempStorage: fileSystem.currentDirectory.childDirectory('temp')
+        ..createSync(),
+    );
+
+    final Directory errorDirectory = fileSystem.currentDirectory
+      .childDirectory('out')
+      .childDirectory('test')
+      ..createSync(recursive: true);
+    handler.addError(errorDirectory, FileSystemOp.delete, const FileSystemException('', '', OSError('', 32)));
+
+    await expectLater(() async => await artifactUpdater.downloadZippedTarball(
+      'test message',
+      Uri.parse('http://test.zip'),
+      fileSystem.currentDirectory.childDirectory('out'),
+    ), throwsToolExit(
+      message: 'Failed to delete /out/test because the local file/directory is in use by another process'
+    ));
+    expect(fileSystem.file('out/test'), isNot(exists));
+  });
 }
 
 class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {


### PR DESCRIPTION
Adds a unit test case for the cherry picked fix for deleting a cache directory that is open by another program