### PR TITLE
[flutter_tools] remove process manager mocks from error_handling_io tests

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -25,7 +25,6 @@ class MockFileSystem extends Mock implements FileSystem {}
 class MockPathContext extends Mock implements path.Context {}
 class MockDirectory extends Mock implements Directory {}
 class MockRandomAccessFile extends Mock implements RandomAccessFile {}
-class MockProcessManager extends Mock implements ProcessManager {}
 
 final Platform windowsPlatform = FakePlatform(
   operatingSystem: 'windows',
@@ -695,18 +694,19 @@ void main() {
     const int kUserPermissionDenied = 5;
 
     test('when the device is full', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kDeviceFull)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kDeviceFull)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kDeviceFull)),
+      ]);
+
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: windowsPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, kDeviceFull);
 
       const String expectedMessage = 'The target device is full';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
+
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -716,18 +716,18 @@ void main() {
     });
 
     test('when the file is being used by another program', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserMappedSectionOpened)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserMappedSectionOpened)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserMappedSectionOpened)),
+      ]);
+
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: windowsPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, kUserMappedSectionOpened);
 
       const String expectedMessage = 'The file is being used by another program';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -737,18 +737,18 @@ void main() {
     });
 
     test('when permissions are denied', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserPermissionDenied)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserPermissionDenied)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', kUserPermissionDenied)),
+      ]);
+
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: windowsPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, kUserPermissionDenied);
 
       const String expectedMessage = 'The flutter tool cannot access the file';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -763,18 +763,18 @@ void main() {
     const int eacces = 13;
 
     test('when writing to a full device', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+      ]);
+
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: linuxPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, enospc);
 
       const String expectedMessage = 'The target device is full';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -784,18 +784,18 @@ void main() {
     });
 
     test('when permissions are denied', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+      ]);
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: linuxPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, eacces);
 
       const String expectedMessage = 'The flutter tool cannot access the file';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
+
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -810,18 +810,18 @@ void main() {
     const int eacces = 13;
 
     test('when writing to a full device', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', enospc)),
+      ]);
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: macOSPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, enospc);
 
       const String expectedMessage = 'The target device is full';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
+
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -831,18 +831,18 @@ void main() {
     });
 
     test('when permissions are denied', () {
-      final MockProcessManager mockProcessManager = MockProcessManager();
+      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', eacces)),
+      ]);
       final ProcessManager processManager = ErrorHandlingProcessManager(
-        delegate: mockProcessManager,
+        delegate: fakeProcessManager,
         platform: linuxPlatform,
       );
-      setupProcessManagerMocks(mockProcessManager, eacces);
 
       const String expectedMessage = 'The flutter tool cannot access the file';
-      expect(() => processManager.canRun('foo'),
-             throwsToolExit(message: expectedMessage));
-      expect(() => processManager.killPid(1),
-             throwsToolExit(message: expectedMessage));
+
       expect(() async => await processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => await processManager.run(<String>['foo']),
@@ -987,39 +987,4 @@ void main() {
       Usage: () => TestUsage(),
     });
   });
-}
-
-void setupProcessManagerMocks(
-  MockProcessManager processManager,
-  int errorCode,
-) {
-  when(processManager.canRun(any, workingDirectory: anyNamed('workingDirectory')))
-    .thenThrow(ProcessException('', <String>[], '', errorCode));
-  when(processManager.killPid(any, any))
-    .thenThrow(ProcessException('', <String>[], '', errorCode));
-  when(processManager.runSync(
-    any,
-    environment: anyNamed('environment'),
-    includeParentEnvironment: anyNamed('includeParentEnvironment'),
-    runInShell: anyNamed('runInShell'),
-    workingDirectory: anyNamed('workingDirectory'),
-    stdoutEncoding: anyNamed('stdoutEncoding'),
-    stderrEncoding: anyNamed('stderrEncoding'),
-  )).thenThrow(ProcessException('', <String>[], '', errorCode));
-  when(processManager.run(
-    any,
-    environment: anyNamed('environment'),
-    includeParentEnvironment: anyNamed('includeParentEnvironment'),
-    runInShell: anyNamed('runInShell'),
-    workingDirectory: anyNamed('workingDirectory'),
-    stdoutEncoding: anyNamed('stdoutEncoding'),
-    stderrEncoding: anyNamed('stderrEncoding'),
-  )).thenThrow(ProcessException('', <String>[], '', errorCode));
-  when(processManager.start(
-    any,
-    environment: anyNamed('environment'),
-    includeParentEnvironment: anyNamed('includeParentEnvironment'),
-    runInShell: anyNamed('runInShell'),
-    workingDirectory: anyNamed('workingDirectory'),
-  )).thenThrow(ProcessException('', <String>[], '', errorCode));
 }


### PR DESCRIPTION
Removes mocks/tests of killPid and canRun, since those do not throw the same kinds of errors as running a process. 

Work towards https://github.com/flutter/flutter/issues/71511