### PR TITLE
Toggleable Refactor

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -38,7 +38,7 @@ import 'toggleable.dart';
 ///  * [Slider], for selecting a value in a range.
 ///  * <https://material.io/design/components/selection-controls.html#checkboxes>
 ///  * <https://material.io/design/components/lists.html#types>
-class Checkbox extends StatelessWidget {
+class Checkbox extends StatefulWidget {
   /// Creates a material design checkbox.
   ///
   /// The checkbox itself does not maintain any state. Instead, when the state of
@@ -286,19 +286,58 @@ class Checkbox extends StatelessWidget {
   /// The width of a checkbox widget.
   static const double width = 18.0;
 
+  @override
+  _CheckboxState createState() => _CheckboxState();
+}
+
+class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, ToggleableStateMixin {
+  final _CheckboxPainter _painter = _CheckboxPainter();
+  bool? _previousValue;
+
+  @override
+  void initState() {
+    super.initState();
+    _previousValue = widget.value;
+  }
+
+  @override
+  void didUpdateWidget(Checkbox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.value != widget.value) {
+      _previousValue = oldWidget.value;
+      animateToValue();
+    }
+  }
+
+  @override
+  void dispose() {
+    _painter.dispose();
+    super.dispose();
+  }
+
+  @override
+  ValueChanged<bool?>? get onChanged => widget.onChanged;
+
+  @override
+  bool get tristate => widget.tristate;
+
+  @override
+  bool? get value => widget.value;
+
   MaterialStateProperty<Color?> get _widgetFillColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return null;
       }
       if (states.contains(MaterialState.selected)) {
-        return activeColor;
+        return widget.activeColor;
       }
       return null;
     });
   }
 
-  MaterialStateProperty<Color> _defaultFillColor(ThemeData themeData) {
+  MaterialStateProperty<Color> get _defaultFillColor {
+    final ThemeData themeData = Theme.of(context);
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return themeData.disabledColor;
@@ -314,10 +353,11 @@ class Checkbox extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context);
-    final MaterialTapTargetSize effectiveMaterialTapTargetSize = materialTapTargetSize
+
+    final MaterialTapTargetSize effectiveMaterialTapTargetSize = widget.materialTapTargetSize
       ?? themeData.checkboxTheme.materialTapTargetSize
       ?? themeData.materialTapTargetSize;
-    final VisualDensity effectiveVisualDensity = visualDensity
+    final VisualDensity effectiveVisualDensity = widget.visualDensity
       ?? themeData.checkboxTheme.visualDensity
       ?? themeData.visualDensity;
     Size size;
@@ -332,77 +372,79 @@ class Checkbox extends StatelessWidget {
     size += effectiveVisualDensity.baseSizeAdjustment;
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
-      return MaterialStateProperty.resolveAs<MouseCursor?>(mouseCursor, states)
+      return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
           ?? themeData.checkboxTheme.mouseCursor?.resolve(states)
           ?? MaterialStateMouseCursor.clickable.resolve(states);
     });
 
+    // Colors need to be resolved in selected and non selected states separately
+    // so that they can be lerped between.
+    final Set<MaterialState> activeStates = states..add(MaterialState.selected);
+    final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
+    final Color effectiveActiveColor = widget.fillColor?.resolve(activeStates)
+        ?? _widgetFillColor.resolve(activeStates)
+        ?? themeData.checkboxTheme.fillColor?.resolve(activeStates)
+        ?? _defaultFillColor.resolve(activeStates);
+    final Color effectiveInactiveColor = widget.fillColor?.resolve(inactiveStates)
+        ?? _widgetFillColor.resolve(inactiveStates)
+        ?? themeData.checkboxTheme.fillColor?.resolve(inactiveStates)
+        ?? _defaultFillColor.resolve(inactiveStates);
+
+    final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
+    final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
+        ?? widget.focusColor
+        ?? themeData.checkboxTheme.overlayColor?.resolve(focusedStates)
+        ?? themeData.focusColor;
+
+    final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
+    final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
+        ?? widget.hoverColor
+        ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
+        ?? themeData.hoverColor;
+
+    final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
+    final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
+        ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+
+    final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
+    final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
+        ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+
+    final Color effectiveCheckColor = widget.checkColor
+        ?? themeData.checkboxTheme.checkColor?.resolve(states)
+        ?? const Color(0xFFFFFFFF);
+
     return Semantics(
-      checked: value == true,
-      child: Toggleable(
-        size: size,
-        value: value,
-        tristate: tristate,
-        onChanged: onChanged,
-        focusNode: focusNode,
-        autofocus: autofocus,
+      checked: widget.value == true,
+      child: buildToggleable(
         mouseCursor: effectiveMouseCursor,
-        painterBuilder: (BuildContext context, ToggleableDetails data) {
-          // Colors need to be resolved in selected and non selected states separately
-          // so that they can be lerped between.
-          final Set<MaterialState> activeStates = data.states..add(MaterialState.selected);
-          final Set<MaterialState> inactiveStates = data.states..remove(MaterialState.selected);
-          final Color effectiveActiveColor = fillColor?.resolve(activeStates)
-              ?? _widgetFillColor.resolve(activeStates)
-              ?? themeData.checkboxTheme.fillColor?.resolve(activeStates)
-              ?? _defaultFillColor(themeData).resolve(activeStates);
-          final Color effectiveInactiveColor = fillColor?.resolve(inactiveStates)
-              ?? _widgetFillColor.resolve(inactiveStates)
-              ?? themeData.checkboxTheme.fillColor?.resolve(inactiveStates)
-              ?? _defaultFillColor(themeData).resolve(inactiveStates);
-
-          final Set<MaterialState> focusedStates = data.states..add(MaterialState.focused);
-          final Color effectiveFocusOverlayColor = overlayColor?.resolve(focusedStates)
-              ?? focusColor
-              ?? themeData.checkboxTheme.overlayColor?.resolve(focusedStates)
-              ?? themeData.focusColor;
-
-          final Set<MaterialState> hoveredStates = data.states..add(MaterialState.hovered);
-          final Color effectiveHoverOverlayColor = overlayColor?.resolve(hoveredStates)
-              ?? hoverColor
-              ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
-              ?? themeData.hoverColor;
-
-          final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
-          final Color effectiveActivePressedOverlayColor = overlayColor?.resolve(activePressedStates)
-              ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
-              ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
-
-          final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
-          final Color effectiveInactivePressedOverlayColor = overlayColor?.resolve(inactivePressedStates)
-              ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
-              ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
-
-          final Color effectiveCheckColor = checkColor
-              ?? themeData.checkboxTheme.checkColor?.resolve(data.states)
-              ?? const Color(0xFFFFFFFF);
-
-          return _CheckboxPainter(
-            data: data,
-            activeColor: effectiveActiveColor,
-            checkColor: effectiveCheckColor,
-            inactiveColor: effectiveInactiveColor,
-            focusColor: effectiveFocusOverlayColor,
-            hoverColor: effectiveHoverOverlayColor,
-            reactionColor: effectiveActivePressedOverlayColor,
-            inactiveReactionColor: effectiveInactivePressedOverlayColor,
-            splashRadius: splashRadius ?? themeData.checkboxTheme.splashRadius ?? kRadialReactionRadius,
-            side: side ?? themeData.checkboxTheme.side,
-            shape: shape ?? themeData.checkboxTheme.shape ?? const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(1.0)),
-            ),
-          );
-        }
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
+        size: size,
+        painter: _painter
+          ..position = position
+          ..reaction = reaction
+          ..reactionFocusFade = reactionFocusFade
+          ..reactionHoverFade = reactionHoverFade
+          ..inactiveReactionColor = effectiveInactivePressedOverlayColor
+          ..reactionColor = effectiveActivePressedOverlayColor
+          ..hoverColor = effectiveHoverOverlayColor
+          ..focusColor = effectiveFocusOverlayColor
+          ..splashRadius = widget.splashRadius ?? themeData.checkboxTheme.splashRadius ?? kRadialReactionRadius
+          ..downPosition = downPosition
+          ..isFocused = states.contains(MaterialState.focused)
+          ..isHovered = states.contains(MaterialState.hovered)
+          ..activeColor = effectiveActiveColor
+          ..inactiveColor = effectiveInactiveColor
+          ..checkColor = effectiveCheckColor
+          ..value = value
+          ..previousValue = _previousValue
+          ..shape = widget.shape ?? themeData.checkboxTheme.shape ?? const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(1.0))
+          )
+          ..side = widget.side ?? themeData.checkboxTheme.side,
       ),
     );
   }
@@ -412,39 +454,54 @@ const double _kEdgeSize = Checkbox.width;
 const double _kStrokeWidth = 2.0;
 
 class _CheckboxPainter extends ToggleablePainter {
-  _CheckboxPainter({
-    required ToggleableDetails data,
-    required Color activeColor,
-    required this.checkColor,
-    required Color inactiveColor,
-    Color? focusColor,
-    Color? hoverColor,
-    Color? reactionColor,
-    Color? inactiveReactionColor,
-    required double splashRadius,
-    required this.shape,
-    required this.side,
-  }) : super(
-         data: data,
-         activeColor: activeColor,
-         inactiveColor: inactiveColor,
-         focusColor: focusColor,
-         hoverColor: hoverColor,
-         reactionColor: reactionColor,
-         inactiveReactionColor: inactiveReactionColor,
-         splashRadius: splashRadius,
-       );
+  Color get checkColor => _checkColor!;
+  Color? _checkColor;
+  set checkColor(Color value) {
+    if (_checkColor == value) {
+      return;
+    }
+    _checkColor = value;
+    notifyListeners();
+  }
 
-  final Color checkColor;
-  final OutlinedBorder shape;
-  final BorderSide? side;
+  bool? get value => _value;
+  bool? _value;
+  set value(bool? value) {
+    if (_value == value) {
+      return;
+    }
+    _value = value;
+    notifyListeners();
+  }
 
-  @override
-  bool shouldRepaint(_CheckboxPainter oldDelegate) {
-    return super.shouldRepaint(oldDelegate)
-        || oldDelegate.checkColor != checkColor
-        || oldDelegate.shape != shape
-        || oldDelegate.side != side;
+  bool? get previousValue => _previousValue;
+  bool? _previousValue;
+  set previousValue(bool? value) {
+    if (_previousValue == value) {
+      return;
+    }
+    _previousValue = value;
+    notifyListeners();
+  }
+
+  OutlinedBorder get shape => _shape!;
+  OutlinedBorder? _shape;
+  set shape(OutlinedBorder value) {
+    if (_shape == value) {
+      return;
+    }
+    _shape = value;
+    notifyListeners();
+  }
+
+  BorderSide? get side => _side;
+  BorderSide? _side;
+  set side(BorderSide? value) {
+    if (_side == value) {
+      return;
+    }
+    _side = value;
+    notifyListeners();
   }
 
   // The square outer bounds of the checkbox at t, with the specified origin.
@@ -519,18 +576,18 @@ class _CheckboxPainter extends ToggleablePainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    paintRadialReaction(canvas, size.center(Offset.zero));
+    paintRadialReaction(canvas: canvas, origin: size.center(Offset.zero));
 
     final Paint strokePaint = _createStrokePaint();
     final Offset origin = size / 2.0 - const Size.square(_kEdgeSize) / 2.0 as Offset;
-    final AnimationStatus status = data.position.status;
+    final AnimationStatus status = position.status;
     final double tNormalized = status == AnimationStatus.forward || status == AnimationStatus.completed
-      ? data.position.value
-      : 1.0 - data.position.value;
+      ? position.value
+      : 1.0 - position.value;
 
     // Four cases: false to null, false to true, null to false, true to false
-    if (data.previousValue == false || data.value == false) {
-      final double t = data.value == false ? 1.0 - tNormalized : tNormalized;
+    if (previousValue == false || value == false) {
+      final double t = value == false ? 1.0 - tNormalized : tNormalized;
       final Rect outer = _outerRectAt(origin, t);
       final Path emptyCheckboxPath = shape.copyWith(side: side).getOuterPath(outer);
       final Paint paint = Paint()..color = _colorAt(t);
@@ -541,7 +598,7 @@ class _CheckboxPainter extends ToggleablePainter {
         canvas.drawPath(emptyCheckboxPath, paint);
 
         final double tShrink = (t - 0.5) * 2.0;
-        if (data.previousValue == null || data.value == null)
+        if (previousValue == null || value == null)
           _drawDash(canvas, origin, tShrink, strokePaint);
         else
           _drawCheck(canvas, origin, tShrink, strokePaint);
@@ -553,13 +610,13 @@ class _CheckboxPainter extends ToggleablePainter {
 
       if (tNormalized <= 0.5) {
         final double tShrink = 1.0 - tNormalized * 2.0;
-        if (data.previousValue == true)
+        if (previousValue == true)
           _drawCheck(canvas, origin, tShrink, strokePaint);
         else
           _drawDash(canvas, origin, tShrink, strokePaint);
       } else {
         final double tExpand = (tNormalized - 0.5) * 2.0;
-        if (data.value == true)
+        if (value == true)
           _drawCheck(canvas, origin, tExpand, strokePaint);
         else
           _drawDash(canvas, origin, tExpand, strokePaint);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -373,8 +373,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
       return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-          ?? themeData.checkboxTheme.mouseCursor?.resolve(states)
-          ?? MaterialStateMouseCursor.clickable.resolve(states);
+        ?? themeData.checkboxTheme.mouseCursor?.resolve(states)
+        ?? MaterialStateMouseCursor.clickable.resolve(states);
     });
 
     // Colors need to be resolved in selected and non selected states separately
@@ -382,39 +382,39 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     final Set<MaterialState> activeStates = states..add(MaterialState.selected);
     final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
     final Color effectiveActiveColor = widget.fillColor?.resolve(activeStates)
-        ?? _widgetFillColor.resolve(activeStates)
-        ?? themeData.checkboxTheme.fillColor?.resolve(activeStates)
-        ?? _defaultFillColor.resolve(activeStates);
+      ?? _widgetFillColor.resolve(activeStates)
+      ?? themeData.checkboxTheme.fillColor?.resolve(activeStates)
+      ?? _defaultFillColor.resolve(activeStates);
     final Color effectiveInactiveColor = widget.fillColor?.resolve(inactiveStates)
-        ?? _widgetFillColor.resolve(inactiveStates)
-        ?? themeData.checkboxTheme.fillColor?.resolve(inactiveStates)
-        ?? _defaultFillColor.resolve(inactiveStates);
+      ?? _widgetFillColor.resolve(inactiveStates)
+      ?? themeData.checkboxTheme.fillColor?.resolve(inactiveStates)
+      ?? _defaultFillColor.resolve(inactiveStates);
 
     final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
-        ?? widget.focusColor
-        ?? themeData.checkboxTheme.overlayColor?.resolve(focusedStates)
-        ?? themeData.focusColor;
+      ?? widget.focusColor
+      ?? themeData.checkboxTheme.overlayColor?.resolve(focusedStates)
+      ?? themeData.focusColor;
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-        ?? widget.hoverColor
-        ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
-        ?? themeData.hoverColor;
+      ?? widget.hoverColor
+      ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
+      ?? themeData.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-        ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
-        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+      ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
+      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-        ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
-        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+      ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
+      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Color effectiveCheckColor = widget.checkColor
-        ?? themeData.checkboxTheme.checkColor?.resolve(states)
-        ?? const Color(0xFFFFFFFF);
+      ?? themeData.checkboxTheme.checkColor?.resolve(states)
+      ?? const Color(0xFFFFFFFF);
 
     return Semantics(
       checked: widget.value == true,

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -353,7 +353,6 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context);
-
     final MaterialTapTargetSize effectiveMaterialTapTargetSize = widget.materialTapTargetSize
       ?? themeData.checkboxTheme.materialTapTargetSize
       ?? themeData.materialTapTargetSize;
@@ -398,19 +397,19 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-      ?? widget.hoverColor
-      ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
-      ?? themeData.hoverColor;
+        ?? widget.hoverColor
+        ?? themeData.checkboxTheme.overlayColor?.resolve(hoveredStates)
+        ?? themeData.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-      ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
-      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+        ?? themeData.checkboxTheme.overlayColor?.resolve(activePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-      ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
-      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+        ?? themeData.checkboxTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Color effectiveCheckColor = widget.checkColor
       ?? themeData.checkboxTheme.checkColor?.resolve(states)

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -386,7 +386,6 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
         break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;
-    final BoxConstraints additionalConstraints = BoxConstraints.tight(size);
     final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, _states)
       ?? themeData.checkboxTheme.mouseCursor?.resolve(_states)
       ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, _states);
@@ -437,11 +436,16 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
       onShowFocusHighlight: _handleFocusHighlightChanged,
       onShowHoverHighlight: _handleHoverChanged,
       mouseCursor: effectiveMouseCursor,
-      child: Builder(
-        builder: (BuildContext context) {
-          return _CheckboxRenderObjectWidget(
-            value: widget.value,
-            tristate: widget.tristate,
+      child: Semantics(
+        checked: widget.value == true,
+        child: Toggleable(
+          size: size,
+          value: widget.value,
+          tristate: widget.tristate,
+          onChanged: widget.onChanged,
+          hasFocus: _focused,
+          hovering: _hovering,
+          painter: _CheckboxPainter(
             activeColor: effectiveActiveColor,
             checkColor: effectiveCheckColor,
             inactiveColor: effectiveInactiveColor,
@@ -450,120 +454,22 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
             reactionColor: effectiveActivePressedOverlayColor,
             inactiveReactionColor: effectiveInactivePressedOverlayColor,
             splashRadius: widget.splashRadius ?? themeData.checkboxTheme.splashRadius ?? kRadialReactionRadius,
-            onChanged: widget.onChanged,
-            additionalConstraints: additionalConstraints,
-            vsync: this,
-            hasFocus: _focused,
-            hovering: _hovering,
             side: widget.side ?? themeData.checkboxTheme.side,
             shape: widget.shape ?? themeData.checkboxTheme.shape ?? const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(Radius.circular(1.0)),
             ),
-          );
-        },
+          ),
+        ),
       ),
     );
-  }
-}
-
-class _CheckboxRenderObjectWidget extends LeafRenderObjectWidget {
-  const _CheckboxRenderObjectWidget({
-    Key? key,
-    required this.value,
-    required this.tristate,
-    required this.activeColor,
-    required this.checkColor,
-    required this.inactiveColor,
-    required this.focusColor,
-    required this.hoverColor,
-    required this.reactionColor,
-    required this.inactiveReactionColor,
-    required this.splashRadius,
-    required this.onChanged,
-    required this.vsync,
-    required this.additionalConstraints,
-    required this.hasFocus,
-    required this.hovering,
-    required this.shape,
-    required this.side,
-  }) : assert(tristate != null),
-       assert(tristate || value != null),
-       assert(activeColor != null),
-       assert(inactiveColor != null),
-       assert(vsync != null),
-       super(key: key);
-
-  final bool? value;
-  final bool tristate;
-  final bool hasFocus;
-  final bool hovering;
-  final Color activeColor;
-  final Color checkColor;
-  final Color inactiveColor;
-  final Color focusColor;
-  final Color hoverColor;
-  final Color reactionColor;
-  final Color inactiveReactionColor;
-  final double splashRadius;
-  final ValueChanged<bool?>? onChanged;
-  final TickerProvider vsync;
-  final BoxConstraints additionalConstraints;
-  final OutlinedBorder shape;
-  final BorderSide? side;
-
-  @override
-  _RenderCheckbox createRenderObject(BuildContext context) => _RenderCheckbox(
-    value: value,
-    tristate: tristate,
-    activeColor: activeColor,
-    checkColor: checkColor,
-    inactiveColor: inactiveColor,
-    focusColor: focusColor,
-    hoverColor: hoverColor,
-    reactionColor: reactionColor,
-    inactiveReactionColor: inactiveReactionColor,
-    splashRadius: splashRadius,
-    onChanged: onChanged,
-    vsync: vsync,
-    additionalConstraints: additionalConstraints,
-    hasFocus: hasFocus,
-    hovering: hovering,
-    shape: shape,
-    side: side,
-  );
-
-  @override
-  void updateRenderObject(BuildContext context, _RenderCheckbox renderObject) {
-    renderObject
-      // The `tristate` must be changed before `value` due to the assertion at
-      // the beginning of `set value`.
-      ..tristate = tristate
-      ..value = value
-      ..activeColor = activeColor
-      ..checkColor = checkColor
-      ..inactiveColor = inactiveColor
-      ..focusColor = focusColor
-      ..hoverColor = hoverColor
-      ..reactionColor = reactionColor
-      ..inactiveReactionColor = inactiveReactionColor
-      ..splashRadius = splashRadius
-      ..onChanged = onChanged
-      ..additionalConstraints = additionalConstraints
-      ..vsync = vsync
-      ..hasFocus = hasFocus
-      ..hovering = hovering
-      ..shape = shape
-      ..side = side;
   }
 }
 
 const double _kEdgeSize = Checkbox.width;
 const double _kStrokeWidth = 2.0;
 
-class _RenderCheckbox extends RenderToggleable {
-  _RenderCheckbox({
-    bool? value,
-    required bool tristate,
+class _CheckboxPainter extends ToogleablePainter {
+  _CheckboxPainter({
     required Color activeColor,
     required this.checkColor,
     required Color inactiveColor,
@@ -572,17 +478,9 @@ class _RenderCheckbox extends RenderToggleable {
     Color? reactionColor,
     Color? inactiveReactionColor,
     required double splashRadius,
-    required BoxConstraints additionalConstraints,
-    ValueChanged<bool?>? onChanged,
-    required bool hasFocus,
-    required bool hovering,
     required this.shape,
     required this.side,
-    required TickerProvider vsync,
-  }) : _oldValue = value,
-       super(
-         value: value,
-         tristate: tristate,
+  }) : super(
          activeColor: activeColor,
          inactiveColor: inactiveColor,
          focusColor: focusColor,
@@ -590,31 +488,11 @@ class _RenderCheckbox extends RenderToggleable {
          reactionColor: reactionColor,
          inactiveReactionColor: inactiveReactionColor,
          splashRadius: splashRadius,
-         onChanged: onChanged,
-         additionalConstraints: additionalConstraints,
-         vsync: vsync,
-         hasFocus: hasFocus,
-         hovering: hovering,
        );
 
-  bool? _oldValue;
-  Color checkColor;
-  OutlinedBorder shape;
-  BorderSide? side;
-
-  @override
-  set value(bool? newValue) {
-    if (newValue == value)
-      return;
-    _oldValue = value;
-    super.value = newValue;
-  }
-
-  @override
-  void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    super.describeSemanticsConfiguration(config);
-    config.isChecked = value == true;
-  }
+  final Color checkColor;
+  final OutlinedBorder shape;
+  final BorderSide? side;
 
   // The square outer bounds of the checkbox at t, with the specified origin.
   // At t == 0.0, the outer rect's size is _kEdgeSize (Checkbox.width)
@@ -644,10 +522,11 @@ class _RenderCheckbox extends RenderToggleable {
 
   void _drawBorder(Canvas canvas, Rect outer, double t, Paint paint) {
     assert(t >= 0.0 && t <= 0.5);
+    OutlinedBorder resolvedShape = shape;
     if (side == null) {
-      shape = shape.copyWith(side: BorderSide(width: 2, color: paint.color));
+      resolvedShape = resolvedShape.copyWith(side: BorderSide(width: 2, color: paint.color));
     }
-    shape.copyWith(side: side).paint(canvas, outer);
+    resolvedShape.copyWith(side: side).paint(canvas, outer);
   }
 
   void _drawCheck(Canvas canvas, Offset origin, double t, Paint paint) {
@@ -686,20 +565,19 @@ class _RenderCheckbox extends RenderToggleable {
   }
 
   @override
-  void paint(PaintingContext context, Offset offset) {
-    final Canvas canvas = context.canvas;
-    paintRadialReaction(canvas, offset, size.center(Offset.zero));
+  void paint(Canvas canvas, Size size, ToggleableDetails details) {
+    paintRadialReaction(canvas, size.center(Offset.zero), details);
 
     final Paint strokePaint = _createStrokePaint();
-    final Offset origin = offset + (size / 2.0 - const Size.square(_kEdgeSize) / 2.0 as Offset);
-    final AnimationStatus status = position.status;
+    final Offset origin = size / 2.0 - const Size.square(_kEdgeSize) / 2.0 as Offset;
+    final AnimationStatus status = details.position.status;
     final double tNormalized = status == AnimationStatus.forward || status == AnimationStatus.completed
-      ? position.value
-      : 1.0 - position.value;
+      ? details.position.value
+      : 1.0 - details.position.value;
 
     // Four cases: false to null, false to true, null to false, true to false
-    if (_oldValue == false || value == false) {
-      final double t = value == false ? 1.0 - tNormalized : tNormalized;
+    if (details.previousValue == false || details.value == false) {
+      final double t = details.value == false ? 1.0 - tNormalized : tNormalized;
       final Rect outer = _outerRectAt(origin, t);
       final Path emptyCheckboxPath = shape.copyWith(side: side).getOuterPath(outer);
       final Paint paint = Paint()..color = _colorAt(t);
@@ -710,7 +588,7 @@ class _RenderCheckbox extends RenderToggleable {
         canvas.drawPath(emptyCheckboxPath, paint);
 
         final double tShrink = (t - 0.5) * 2.0;
-        if (_oldValue == null || value == null)
+        if (details.previousValue == null || details.value == null)
           _drawDash(canvas, origin, tShrink, strokePaint);
         else
           _drawCheck(canvas, origin, tShrink, strokePaint);
@@ -722,13 +600,13 @@ class _RenderCheckbox extends RenderToggleable {
 
       if (tNormalized <= 0.5) {
         final double tShrink = 1.0 - tNormalized * 2.0;
-        if (_oldValue == true)
+        if (details.previousValue == true)
           _drawCheck(canvas, origin, tShrink, strokePaint);
         else
           _drawDash(canvas, origin, tShrink, strokePaint);
       } else {
         final double tExpand = (tNormalized - 0.5) * 2.0;
-        if (value == true)
+        if (details.value == true)
           _drawCheck(canvas, origin, tExpand, strokePaint);
         else
           _drawDash(canvas, origin, tExpand, strokePaint);

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -444,8 +444,8 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
       return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-          ?? themeData.radioTheme.mouseCursor?.resolve(states)
-          ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
+        ?? themeData.radioTheme.mouseCursor?.resolve(states)
+        ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
     });
 
     // Colors need to be resolved in selected and non selected states separately
@@ -453,35 +453,35 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
     final Set<MaterialState> activeStates = states..add(MaterialState.selected);
     final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
     final Color effectiveActiveColor = widget.fillColor?.resolve(activeStates)
-        ?? _widgetFillColor.resolve(activeStates)
-        ?? themeData.radioTheme.fillColor?.resolve(activeStates)
-        ?? _defaultFillColor.resolve(activeStates);
+      ?? _widgetFillColor.resolve(activeStates)
+      ?? themeData.radioTheme.fillColor?.resolve(activeStates)
+      ?? _defaultFillColor.resolve(activeStates);
     final Color effectiveInactiveColor = widget.fillColor?.resolve(inactiveStates)
-        ?? _widgetFillColor.resolve(inactiveStates)
-        ?? themeData.radioTheme.fillColor?.resolve(inactiveStates)
-        ?? _defaultFillColor.resolve(inactiveStates);
+      ?? _widgetFillColor.resolve(inactiveStates)
+      ?? themeData.radioTheme.fillColor?.resolve(inactiveStates)
+      ?? _defaultFillColor.resolve(inactiveStates);
 
     final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
-        ?? widget.focusColor
-        ?? themeData.radioTheme.overlayColor?.resolve(focusedStates)
-        ?? themeData.focusColor;
+      ?? widget.focusColor
+      ?? themeData.radioTheme.overlayColor?.resolve(focusedStates)
+      ?? themeData.focusColor;
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-        ?? widget.hoverColor
-        ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
-        ?? themeData.hoverColor;
+      ?? widget.hoverColor
+      ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
+      ?? themeData.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-        ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
-        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+      ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
+      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-        ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
-        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+      ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
+      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     return Semantics(
       inMutuallyExclusiveGroup: true,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -88,7 +88,7 @@ const double _kInnerRadius = 4.5;
 ///  * [Slider], for selecting a value in a range.
 ///  * [Checkbox] and [Switch], for toggling a particular value on or off.
 ///  * <https://material.io/design/components/selection-controls.html#radio-buttons>
-class Radio<T> extends StatelessWidget {
+class Radio<T> extends StatefulWidget {
   /// Creates a material design radio button.
   ///
   /// The radio button itself does not maintain any state. Instead, when the
@@ -353,19 +353,47 @@ class Radio<T> extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  bool get _enabled => onChanged != null;
+  bool get _selected => value == groupValue;
+
+  @override
+  _RadioState<T> createState() => _RadioState<T>();
+}
+
+class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, ToggleableStateMixin {
+  final _RadioPainter _painter = _RadioPainter();
 
   void _handleChanged(bool? selected) {
     if (selected == null) {
-      onChanged!(null);
+      widget.onChanged!(null);
       return;
     }
     if (selected) {
-      onChanged!(value);
+      widget.onChanged!(widget.value);
     }
   }
 
-  bool get _selected => value == groupValue;
+  @override
+  void didUpdateWidget(Radio<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget._selected != oldWidget._selected) {
+      animateToValue();
+    }
+  }
+
+  @override
+  void dispose() {
+    _painter.dispose();
+    super.dispose();
+  }
+
+  @override
+  ValueChanged<bool?>? get onChanged => widget.onChanged != null ? _handleChanged : null;
+
+  @override
+  bool get tristate => widget.toggleable;
+
+  @override
+  bool? get value => widget._selected;
 
   MaterialStateProperty<Color?> get _widgetFillColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
@@ -373,13 +401,14 @@ class Radio<T> extends StatelessWidget {
         return null;
       }
       if (states.contains(MaterialState.selected)) {
-        return activeColor;
+        return widget.activeColor;
       }
       return null;
     });
   }
 
-  MaterialStateProperty<Color> _defaultFillColor(ThemeData themeData) {
+  MaterialStateProperty<Color> get _defaultFillColor {
+    final ThemeData themeData = Theme.of(context);
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return themeData.disabledColor;
@@ -395,10 +424,11 @@ class Radio<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context);
-    final MaterialTapTargetSize effectiveMaterialTapTargetSize = materialTapTargetSize
+
+    final MaterialTapTargetSize effectiveMaterialTapTargetSize = widget.materialTapTargetSize
       ?? themeData.radioTheme.materialTapTargetSize
       ?? themeData.materialTapTargetSize;
-    final VisualDensity effectiveVisualDensity = visualDensity
+    final VisualDensity effectiveVisualDensity = widget.visualDensity
       ?? themeData.radioTheme.visualDensity
       ?? themeData.visualDensity;
     Size size;
@@ -411,113 +441,94 @@ class Radio<T> extends StatelessWidget {
         break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;
+
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
-      return MaterialStateProperty.resolveAs<MouseCursor?>(mouseCursor, states)
+      return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
           ?? themeData.radioTheme.mouseCursor?.resolve(states)
           ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
     });
 
+    // Colors need to be resolved in selected and non selected states separately
+    // so that they can be lerped between.
+    final Set<MaterialState> activeStates = states..add(MaterialState.selected);
+    final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
+    final Color effectiveActiveColor = widget.fillColor?.resolve(activeStates)
+        ?? _widgetFillColor.resolve(activeStates)
+        ?? themeData.radioTheme.fillColor?.resolve(activeStates)
+        ?? _defaultFillColor.resolve(activeStates);
+    final Color effectiveInactiveColor = widget.fillColor?.resolve(inactiveStates)
+        ?? _widgetFillColor.resolve(inactiveStates)
+        ?? themeData.radioTheme.fillColor?.resolve(inactiveStates)
+        ?? _defaultFillColor.resolve(inactiveStates);
+
+    final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
+    final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
+        ?? widget.focusColor
+        ?? themeData.radioTheme.overlayColor?.resolve(focusedStates)
+        ?? themeData.focusColor;
+
+    final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
+    final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
+        ?? widget.hoverColor
+        ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
+        ?? themeData.hoverColor;
+
+    final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
+    final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
+        ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+
+    final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
+    final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
+        ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+
     return Semantics(
       inMutuallyExclusiveGroup: true,
-      checked: _selected,
-      child: Toggleable(
-        size: size,
-        value: _selected,
-        tristate: toggleable,
-        onChanged: _enabled ? _handleChanged : null,
-        focusNode: focusNode,
-        autofocus: autofocus,
+      checked: widget._selected,
+      child: buildToggleable(
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
         mouseCursor: effectiveMouseCursor,
-        painterBuilder: (BuildContext context, ToggleableDetails data) {
-          // Colors need to be resolved in selected and non selected states separately
-          // so that they can be lerped between.
-          final Set<MaterialState> activeStates = data.states..add(MaterialState.selected);
-          final Set<MaterialState> inactiveStates = data.states..remove(MaterialState.selected);
-          final Color effectiveActiveColor = fillColor?.resolve(activeStates)
-              ?? _widgetFillColor.resolve(activeStates)
-              ?? themeData.radioTheme.fillColor?.resolve(activeStates)
-              ?? _defaultFillColor(themeData).resolve(activeStates);
-          final Color effectiveInactiveColor = fillColor?.resolve(inactiveStates)
-              ?? _widgetFillColor.resolve(inactiveStates)
-              ?? themeData.radioTheme.fillColor?.resolve(inactiveStates)
-              ?? _defaultFillColor(themeData).resolve(inactiveStates);
-
-          final Set<MaterialState> focusedStates = data.states..add(MaterialState.focused);
-          final Color effectiveFocusOverlayColor = overlayColor?.resolve(focusedStates)
-              ?? focusColor
-              ?? themeData.radioTheme.overlayColor?.resolve(focusedStates)
-              ?? themeData.focusColor;
-
-          final Set<MaterialState> hoveredStates = data.states..add(MaterialState.hovered);
-          final Color effectiveHoverOverlayColor = overlayColor?.resolve(hoveredStates)
-              ?? hoverColor
-              ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
-              ?? themeData.hoverColor;
-
-          final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
-          final Color effectiveActivePressedOverlayColor = overlayColor?.resolve(activePressedStates)
-              ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
-              ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
-
-          final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
-          final Color effectiveInactivePressedOverlayColor = overlayColor?.resolve(inactivePressedStates)
-              ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
-              ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
-
-          return _RadioPainter(
-            data: data,
-            activeColor: effectiveActiveColor,
-            inactiveColor: effectiveInactiveColor,
-            focusColor: effectiveFocusOverlayColor,
-            hoverColor: effectiveHoverOverlayColor,
-            reactionColor: effectiveActivePressedOverlayColor,
-            inactiveReactionColor: effectiveInactivePressedOverlayColor,
-            splashRadius: splashRadius ?? themeData.radioTheme.splashRadius ?? kRadialReactionRadius,
-          );
-        },
+        size: size,
+        painter: _painter
+          ..position = position
+          ..reaction = reaction
+          ..reactionFocusFade = reactionFocusFade
+          ..reactionHoverFade = reactionHoverFade
+          ..inactiveReactionColor = effectiveInactivePressedOverlayColor
+          ..reactionColor = effectiveActivePressedOverlayColor
+          ..hoverColor = effectiveHoverOverlayColor
+          ..focusColor = effectiveFocusOverlayColor
+          ..splashRadius = widget.splashRadius ?? themeData.radioTheme.splashRadius ?? kRadialReactionRadius
+          ..downPosition = downPosition
+          ..isFocused = states.contains(MaterialState.focused)
+          ..isHovered = states.contains(MaterialState.hovered)
+          ..activeColor = effectiveActiveColor
+          ..inactiveColor = effectiveInactiveColor
       ),
     );
   }
 }
 
 class _RadioPainter extends ToggleablePainter {
-  _RadioPainter({
-    required ToggleableDetails data,
-    required Color activeColor,
-    required Color inactiveColor,
-    required Color focusColor,
-    required Color hoverColor,
-    required Color reactionColor,
-    required Color inactiveReactionColor,
-    required double splashRadius,
-  }) : super(
-         data: data,
-         activeColor: activeColor,
-         inactiveColor: inactiveColor,
-         focusColor: focusColor,
-         hoverColor: hoverColor,
-         reactionColor: reactionColor,
-         inactiveReactionColor: inactiveReactionColor,
-         splashRadius: splashRadius,
-       );
-
   @override
   void paint(Canvas canvas, Size size) {
-    paintRadialReaction(canvas, size.center(Offset.zero));
+    paintRadialReaction(canvas: canvas, origin: size.center(Offset.zero));
 
     final Offset center = (Offset.zero & size).center;
 
     // Outer circle
     final Paint paint = Paint()
-      ..color = Color.lerp(inactiveColor, activeColor, data.position.value)!
+      ..color = Color.lerp(inactiveColor, activeColor, position.value)!
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2.0;
     canvas.drawCircle(center, _kOuterRadius, paint);
 
     // Inner circle
-    if (!data.position.isDismissed) {
+    if (!position.isDismissed) {
       paint.style = PaintingStyle.fill;
-      canvas.drawCircle(center, _kInnerRadius * data.position.value, paint);
+      canvas.drawCircle(center, _kInnerRadius * position.value, paint);
     }
   }
 }

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -424,7 +424,6 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData themeData = Theme.of(context);
-
     final MaterialTapTargetSize effectiveMaterialTapTargetSize = widget.materialTapTargetSize
       ?? themeData.radioTheme.materialTapTargetSize
       ?? themeData.materialTapTargetSize;
@@ -469,19 +468,19 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-      ?? widget.hoverColor
-      ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
-      ?? themeData.hoverColor;
+        ?? widget.hoverColor
+        ?? themeData.radioTheme.overlayColor?.resolve(hoveredStates)
+        ?? themeData.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-      ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
-      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+        ?? themeData.radioTheme.overlayColor?.resolve(activePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-      ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
-      ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
+        ?? themeData.radioTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? effectiveActiveColor.withAlpha(kRadialReactionAlpha);
 
     return Semantics(
       inMutuallyExclusiveGroup: true,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -420,7 +420,7 @@ class Radio<T> extends StatelessWidget {
     return Semantics(
       inMutuallyExclusiveGroup: true,
       checked: _selected,
-        child: Toggleable(
+      child: Toggleable(
         size: size,
         value: _selected,
         tristate: toggleable,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -706,6 +706,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
     return Semantics(
       toggled: widget.value,
       child: GestureDetector(
+        excludeFromSemantics: true,
         onHorizontalDragStart: _handleDragStart,
         onHorizontalDragUpdate: _handleDragUpdate,
         onHorizontalDragEnd: _handleDragEnd,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -361,8 +361,8 @@ class Switch extends StatelessWidget {
 
   Size _getSwitchSize(ThemeData theme) {
     final MaterialTapTargetSize effectiveMaterialTapTargetSize = materialTapTargetSize
-        ?? theme.switchTheme.materialTapTargetSize
-        ?? theme.materialTapTargetSize;
+      ?? theme.switchTheme.materialTapTargetSize
+      ?? theme.materialTapTargetSize;
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
         return const Size(_kSwitchWidth, _kSwitchHeight);
@@ -665,43 +665,43 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
     final Set<MaterialState> activeStates = states..add(MaterialState.selected);
     final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
     final Color effectiveActiveThumbColor = widget.thumbColor?.resolve(activeStates)
-        ?? _widgetThumbColor.resolve(activeStates)
-        ?? theme.switchTheme.thumbColor?.resolve(activeStates)
-        ?? _defaultThumbColor.resolve(activeStates);
+      ?? _widgetThumbColor.resolve(activeStates)
+      ?? theme.switchTheme.thumbColor?.resolve(activeStates)
+      ?? _defaultThumbColor.resolve(activeStates);
     final Color effectiveInactiveThumbColor = widget.thumbColor?.resolve(inactiveStates)
-        ?? _widgetThumbColor.resolve(inactiveStates)
-        ?? theme.switchTheme.thumbColor?.resolve(inactiveStates)
-        ?? _defaultThumbColor.resolve(inactiveStates);
+      ?? _widgetThumbColor.resolve(inactiveStates)
+      ?? theme.switchTheme.thumbColor?.resolve(inactiveStates)
+      ?? _defaultThumbColor.resolve(inactiveStates);
     final Color effectiveActiveTrackColor = widget.trackColor?.resolve(activeStates)
-        ?? _widgetTrackColor.resolve(activeStates)
-        ?? theme.switchTheme.trackColor?.resolve(activeStates)
-        ?? _defaultTrackColor.resolve(activeStates);
+      ?? _widgetTrackColor.resolve(activeStates)
+      ?? theme.switchTheme.trackColor?.resolve(activeStates)
+      ?? _defaultTrackColor.resolve(activeStates);
     final Color effectiveInactiveTrackColor = widget.trackColor?.resolve(inactiveStates)
-        ?? _widgetTrackColor.resolve(inactiveStates)
-        ?? theme.switchTheme.trackColor?.resolve(inactiveStates)
-        ?? _defaultTrackColor.resolve(inactiveStates);
+      ?? _widgetTrackColor.resolve(inactiveStates)
+      ?? theme.switchTheme.trackColor?.resolve(inactiveStates)
+      ?? _defaultTrackColor.resolve(inactiveStates);
 
     final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
-        ?? widget.focusColor
-        ?? theme.switchTheme.overlayColor?.resolve(focusedStates)
-        ?? theme.focusColor;
+      ?? widget.focusColor
+      ?? theme.switchTheme.overlayColor?.resolve(focusedStates)
+      ?? theme.focusColor;
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-        ?? widget.hoverColor
-        ?? theme.switchTheme.overlayColor?.resolve(hoveredStates)
-        ?? theme.hoverColor;
+      ?? widget.hoverColor
+      ?? theme.switchTheme.overlayColor?.resolve(hoveredStates)
+      ?? theme.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-        ?? theme.switchTheme.overlayColor?.resolve(activePressedStates)
-        ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+      ?? theme.switchTheme.overlayColor?.resolve(activePressedStates)
+      ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-        ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
-        ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+      ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
+      ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     return Semantics(
       toggled: widget.value,
@@ -930,7 +930,7 @@ class _SwitchPainter extends ToggleablePainter {
       size.height / 2.0,
     );
 
-    paintRadialReaction(canvas: canvas, origin: thumbPosition,);
+    paintRadialReaction(canvas: canvas, origin: thumbPosition);
 
     try {
       _isPainting = true;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -694,8 +694,8 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-      ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
-      ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+        ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
       return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -654,12 +654,6 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
 
     final ThemeData theme = Theme.of(context);
 
-    final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
-      return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-        ?? theme.switchTheme.mouseCursor?.resolve(states)
-        ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
-    });
-
     // Colors need to be resolved in selected and non selected states separately
     // so that they can be lerped between.
     final Set<MaterialState> activeStates = states..add(MaterialState.selected);
@@ -689,19 +683,25 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
-      ?? widget.hoverColor
-      ?? theme.switchTheme.overlayColor?.resolve(hoveredStates)
-      ?? theme.hoverColor;
+        ?? widget.hoverColor
+        ?? theme.switchTheme.overlayColor?.resolve(hoveredStates)
+        ?? theme.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-      ?? theme.switchTheme.overlayColor?.resolve(activePressedStates)
-      ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+        ?? theme.switchTheme.overlayColor?.resolve(activePressedStates)
+        ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
       ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
       ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+
+    final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
+      return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
+        ?? theme.switchTheme.mouseCursor?.resolve(states)
+        ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
+    });
 
     return Semantics(
       toggled: widget.value,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -897,6 +897,7 @@ class _SwitchPainter extends ToggleablePainter {
     }
 
     final Color trackColor = Color.lerp(inactiveTrackColor, activeTrackColor, currentValue)!;
+    print('i: $inactiveTrackColor, a: $activeColor, t: $trackColor, v:$currentValue, l: $trackInnerLength');
     final Color lerpedThumbColor = Color.lerp(inactiveColor, activeColor, currentValue)!;
     // Blend the thumb color against a `surfaceColor` background in case the
     // thumbColor is not opaque. This way we do not see through the thumb to the

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -710,6 +710,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
         onHorizontalDragStart: _handleDragStart,
         onHorizontalDragUpdate: _handleDragUpdate,
         onHorizontalDragEnd: _handleDragEnd,
+        dragStartBehavior: widget.dragStartBehavior,
         child: buildToggleable(
           mouseCursor: effectiveMouseCursor,
           focusNode: widget.focusNode,
@@ -897,7 +898,6 @@ class _SwitchPainter extends ToggleablePainter {
     }
 
     final Color trackColor = Color.lerp(inactiveTrackColor, activeTrackColor, currentValue)!;
-    print('i: $inactiveTrackColor, a: $activeColor, t: $trackColor, v:$currentValue, l: $trackInnerLength');
     final Color lerpedThumbColor = Color.lerp(inactiveColor, activeColor, currentValue)!;
     // Blend the thumb color against a `surfaceColor` background in case the
     // thumbColor is not opaque. This way we do not see through the thumb to the

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -26,6 +26,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// dragged. These controls manipulate this animation controller to update
   /// their [position] and eventually trigger an [onChanged] callback when the
   /// animation reaches either 0.0 or 1.0.
+  @protected
   AnimationController get positionController => _positionController;
   late AnimationController _positionController;
 
@@ -37,6 +38,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// animation has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
   /// gradually updates from 0.0 to 1.0 (or vice versa).
+  @protected
   CurvedAnimation get position => _position;
   late CurvedAnimation _position;
 
@@ -47,6 +49,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
+  @protected
   AnimationController get reactionController => _reactionController;
   late AnimationController _reactionController;
 
@@ -57,9 +60,9 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
+  @protected
   Animation<double> get reaction => _reaction;
   late Animation<double> _reaction;
-
 
   /// Controls the radial reaction's opacity animation for hover changes.
   ///
@@ -69,6 +72,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
+  @protected
   Animation<double> get reactionHoverFade => _reactionHoverFade;
   late Animation<double> _reactionHoverFade;
   late AnimationController _reactionHoverFadeController;
@@ -80,6 +84,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
+  @protected
   Animation<double> get reactionFocusFade => _reactionFocusFade;
   late Animation<double> _reactionFocusFade;
   late AnimationController _reactionFocusFadeController;
@@ -135,6 +140,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     );
   }
 
+  @protected
   void animateToValue() {
     if (tristate) {
       if (value == null)
@@ -160,6 +166,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     super.dispose();
   }
 
+  @protected
   Offset? get downPosition => _downPosition;
   Offset? _downPosition;
 
@@ -220,6 +227,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     }
   }
 
+  @protected
   Set<MaterialState> get states => <MaterialState>{
     if (!isInteractive) MaterialState.disabled,
     if (_hovering) MaterialState.hovered,
@@ -227,6 +235,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     if (value != false) MaterialState.selected,
   };
 
+  @protected
   Widget buildToggleable({
     FocusNode? focusNode,
     bool autofocus = false,

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -272,7 +272,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// The returned set will include:
   ///
-  ///  * [MaterialState.disabled], if [interactive] is false
+  ///  * [MaterialState.disabled], if [isInteractive] is false
   ///  * [MaterialState.hovered], if a pointer is hovering over the Toggleable
   ///  * [MaterialState.focused], if the Toggleable has input focus
   ///  * [MaterialState.selected], if [value] is true or null

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -17,15 +17,19 @@ const Duration _kToggleDuration = Duration(milliseconds: 200);
 // Duration of the fade animation for the reaction when focus and hover occur.
 const Duration _kReactionFadeDuration = Duration(milliseconds: 50);
 
-/// A mixin for [StatefulWidget]s that implement toggleable controls with toggle
-/// animations (e.g. [Switch]es, [Checkbox]es, and [Radio]s).
+/// A mixin for [StatefulWidget]s that implement material-themed toggleable
+/// controls with toggle animations (e.g. [Switch]es, [Checkbox]es, and
+/// [Radio]s).
 ///
-/// This mixin implements the logic for toggeling the control (e.g. when tapped)
+/// The mixin implements the logic for toggling the control (e.g. when tapped)
 /// and provides a series of animation controllers to transition the control
 /// from one state to another. It does not have any opinion about the visual
 /// representation of the toggleable widget. The visuals are defined by a
 /// [CustomPainter] passed to the [buildToggleable]. [State] objects using this
 /// mixin should call that method from their [build] method.
+///
+/// This mixin is used to implement the material components for [Switch],
+/// [Checkbox], and [Radio] controls.
 @optionalTypeArgs
 mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin<S> {
   /// Used by subclasses to manipulate the visual value of the control.
@@ -204,10 +208,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     super.dispose();
   }
 
-  /// The [Offset] within the Toggleable at which a pointer touched the
-  /// Toggleable.
+  /// The most recent [Offset] at which a pointer touched the Toggleable.
   ///
-  /// This is null if currently no pointer is touching the Toggleable.
+  /// This is null if currently no pointer is touching the Toggleable or if
+  /// [isInteractive] is false.
   Offset? get downPosition => _downPosition;
   Offset? _downPosition;
 
@@ -238,9 +242,9 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   }
 
   void _handleTapEnd([TapUpDetails? _]) {
-    setState(() {
-      _downPosition = null;
-    });
+    if (_downPosition != null) {
+      setState(() { _downPosition = null; });
+    }
     _reactionController.reverse();
   }
 
@@ -283,8 +287,8 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     if (value != false) MaterialState.selected,
   };
 
-  /// Wraps a `painter` that draws the actual visuals of the Toggleable with
-  /// logic to toggle it.
+  /// Typically wraps a `painter` that draws the actual visuals of the
+  /// Toggleable with logic to toggle it.
   ///
   /// Consider providing a subclass of [ToggleablePainter] as a `painter`, which
   /// implements logic to draw a radial ink reaction for this control. The
@@ -292,7 +296,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// [reactionHoverFade], and [reactionFocusFade] animation provided by this
   /// mixin. It is expected to draw the visuals of the Toggleable based on the
   /// current value of these animations. The animations are triggered by
-  /// this mixin to transition the Toggleable from one [state] to another.
+  /// this mixin to transition the Toggleable from one state to another.
   ///
   /// This method must be called from the [build] method of the [State] class
   /// that uses this mixin. The returned [Widget] must be returned from the

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -2,13 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
@@ -35,31 +32,57 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// The visual value of the control.
   ///
   /// When the control is inactive, the [value] is false and this animation has
-  /// the value 0.0. When the control is active, the value either true or tristate
-  /// is true and the value is null. When the control is active the animation
-  /// has a value of 1.0. When the control is changing from inactive
+  /// the value 0.0. When the control is active, the value is either true or
+  /// tristate is true and the value is null. When the control is active the
+  /// animation has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
   /// gradually updates from 0.0 to 1.0 (or vice versa).
   CurvedAnimation get position => _position;
   late CurvedAnimation _position;
 
+  /// Used by subclasses to control the radial reaction animation.
+  ///
+  /// Some controls have a radial ink reaction to user input. This animation
+  /// controller can be used to start or stop these ink reactions.
+  ///
+  /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
+  /// may be used.
   AnimationController get reactionController => _reactionController;
   late AnimationController _reactionController;
 
+  /// The visual value of the radial reaction animation.
+  ///
+  /// Some controls have a radial ink reaction to user input. This animation
+  /// controls the progress of these ink reactions.
+  ///
+  /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
+  /// may be used.
   Animation<double> get reaction => _reaction;
   late Animation<double> _reaction;
 
-  AnimationController get reactionHoverFadeController => _reactionHoverFadeController;
-  late AnimationController _reactionHoverFadeController;
 
+  /// Controls the radial reaction's opacity animation for hover changes.
+  ///
+  /// Some controls have a radial ink reaction to pointer hover. This animation
+  /// controls these ink reaction fade-ins and
+  /// fade-outs.
+  ///
+  /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
+  /// may be used.
   Animation<double> get reactionHoverFade => _reactionHoverFade;
   late Animation<double> _reactionHoverFade;
+  late AnimationController _reactionHoverFadeController;
 
-  AnimationController get reactionFocusFadeController => _reactionFocusFadeController;
-  late AnimationController _reactionFocusFadeController;
-
+  /// Controls the radial reaction's opacity animation for focus changes.
+  ///
+  /// Some controls have a radial ink reaction to focus. This animation
+  /// controls these ink reaction fade-ins and fade-outs.
+  ///
+  /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
+  /// may be used.
   Animation<double> get reactionFocusFade => _reactionFocusFade;
   late Animation<double> _reactionFocusFade;
+  late AnimationController _reactionFocusFadeController;
 
   bool get isInteractive => onChanged != null;
 
@@ -442,508 +465,4 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
 
   @override
   bool shouldRebuildSemantics(covariant CustomPainter oldDelegate) => false;
-}
-
-/// A base class for material style toggleable controls with toggle animations.
-///
-/// This class handles storing the current value, dispatching ValueChanged on a
-/// tap gesture and driving a changed animation. Subclasses are responsible for
-/// painting.
-abstract class RenderToggleable extends RenderConstrainedBox {
-  /// Creates a toggleable render object.
-  ///
-  /// The [activeColor], and [inactiveColor] arguments must not be
-  /// null. The [value] can only be null if tristate is true.
-  RenderToggleable({
-    required bool? value,
-    bool tristate = false,
-    required Color activeColor,
-    required Color inactiveColor,
-    Color? hoverColor,
-    Color? focusColor,
-    Color? reactionColor,
-    Color? inactiveReactionColor,
-    required double splashRadius,
-    ValueChanged<bool?>? onChanged,
-    required BoxConstraints additionalConstraints,
-    required TickerProvider vsync,
-    bool hasFocus = false,
-    bool hovering = false,
-  }) : assert(tristate != null),
-       assert(tristate || value != null),
-       assert(activeColor != null),
-       assert(inactiveColor != null),
-       assert(vsync != null),
-       _value = value,
-       _tristate = tristate,
-       _activeColor = activeColor,
-       _inactiveColor = inactiveColor,
-       _hoverColor = hoverColor ?? activeColor.withAlpha(kRadialReactionAlpha),
-       _focusColor = focusColor ?? activeColor.withAlpha(kRadialReactionAlpha),
-       _reactionColor = reactionColor ?? activeColor.withAlpha(kRadialReactionAlpha),
-       _inactiveReactionColor = inactiveReactionColor ?? activeColor.withAlpha(kRadialReactionAlpha),
-       _splashRadius = splashRadius,
-       _onChanged = onChanged,
-       _hasFocus = hasFocus,
-       _hovering = hovering,
-       _vsync = vsync,
-       super(additionalConstraints: additionalConstraints) {
-    _tap = TapGestureRecognizer()
-      ..onTapDown = _handleTapDown
-      ..onTap = _handleTap
-      ..onTapUp = _handleTapUp
-      ..onTapCancel = _handleTapCancel;
-    _positionController = AnimationController(
-      duration: _kToggleDuration,
-      value: value == false ? 0.0 : 1.0,
-      vsync: vsync,
-    );
-    _position = CurvedAnimation(
-      parent: _positionController,
-      curve: Curves.linear,
-    )..addListener(markNeedsPaint);
-    _reactionController = AnimationController(
-      duration: kRadialReactionDuration,
-      vsync: vsync,
-    );
-    _reaction = CurvedAnimation(
-      parent: _reactionController,
-      curve: Curves.fastOutSlowIn,
-    )..addListener(markNeedsPaint);
-    _reactionHoverFadeController = AnimationController(
-      duration: _kReactionFadeDuration,
-      value: hovering || hasFocus ? 1.0 : 0.0,
-      vsync: vsync,
-    );
-    _reactionHoverFade = CurvedAnimation(
-      parent: _reactionHoverFadeController,
-      curve: Curves.fastOutSlowIn,
-    )..addListener(markNeedsPaint);
-    _reactionFocusFadeController = AnimationController(
-      duration: _kReactionFadeDuration,
-      value: hovering || hasFocus ? 1.0 : 0.0,
-      vsync: vsync,
-    );
-    _reactionFocusFade = CurvedAnimation(
-      parent: _reactionFocusFadeController,
-      curve: Curves.fastOutSlowIn,
-    )..addListener(markNeedsPaint);
-  }
-
-  /// Used by subclasses to manipulate the visual value of the control.
-  ///
-  /// Some controls respond to user input by updating their visual value. For
-  /// example, the thumb of a switch moves from one position to another when
-  /// dragged. These controls manipulate this animation controller to update
-  /// their [position] and eventually trigger an [onChanged] callback when the
-  /// animation reaches either 0.0 or 1.0.
-  @protected
-  AnimationController get positionController => _positionController;
-  late AnimationController _positionController;
-
-  /// The visual value of the control.
-  ///
-  /// When the control is inactive, the [value] is false and this animation has
-  /// the value 0.0. When the control is active, the value either true or tristate
-  /// is true and the value is null. When the control is active the animation
-  /// has a value of 1.0. When the control is changing from inactive
-  /// to active (or vice versa), [value] is the target value and this animation
-  /// gradually updates from 0.0 to 1.0 (or vice versa).
-  CurvedAnimation get position => _position;
-  late CurvedAnimation _position;
-
-  /// Used by subclasses to control the radial reaction animation.
-  ///
-  /// Some controls have a radial ink reaction to user input. This animation
-  /// controller can be used to start or stop these ink reactions.
-  ///
-  /// Subclasses should call [paintRadialReaction] to actually paint the radial
-  /// reaction.
-  @protected
-  AnimationController get reactionController => _reactionController;
-  late AnimationController _reactionController;
-  late Animation<double> _reaction;
-
-  /// Used by subclasses to control the radial reaction's opacity animation for
-  /// [hasFocus] changes.
-  ///
-  /// Some controls have a radial ink reaction to focus. This animation
-  /// controller can be used to start or stop these ink reaction fade-ins and
-  /// fade-outs.
-  ///
-  /// Subclasses should call [paintRadialReaction] to actually paint the radial
-  /// reaction.
-  @protected
-  AnimationController get reactionFocusFadeController => _reactionFocusFadeController;
-  late AnimationController _reactionFocusFadeController;
-  late Animation<double> _reactionFocusFade;
-
-  /// Used by subclasses to control the radial reaction's opacity animation for
-  /// [hovering] changes.
-  ///
-  /// Some controls have a radial ink reaction to pointer hover. This animation
-  /// controller can be used to start or stop these ink reaction fade-ins and
-  /// fade-outs.
-  ///
-  /// Subclasses should call [paintRadialReaction] to actually paint the radial
-  /// reaction.
-  @protected
-  AnimationController get reactionHoverFadeController => _reactionHoverFadeController;
-  late AnimationController _reactionHoverFadeController;
-  late Animation<double> _reactionHoverFade;
-
-  /// True if this toggleable has the input focus.
-  bool get hasFocus => _hasFocus;
-  bool _hasFocus;
-  set hasFocus(bool value) {
-    assert(value != null);
-    if (value == _hasFocus)
-      return;
-    _hasFocus = value;
-    if (_hasFocus) {
-      _reactionFocusFadeController.forward();
-    } else {
-      _reactionFocusFadeController.reverse();
-    }
-    markNeedsPaint();
-  }
-
-  /// True if this toggleable is being hovered over by a pointer.
-  bool get hovering => _hovering;
-  bool _hovering;
-  set hovering(bool value) {
-    assert(value != null);
-    if (value == _hovering)
-      return;
-    _hovering = value;
-    if (_hovering) {
-      _reactionHoverFadeController.forward();
-    } else {
-      _reactionHoverFadeController.reverse();
-    }
-    markNeedsPaint();
-  }
-
-  /// The [TickerProvider] for the [AnimationController]s that run the animations.
-  TickerProvider get vsync => _vsync;
-  TickerProvider _vsync;
-  set vsync(TickerProvider value) {
-    assert(value != null);
-    if (value == _vsync)
-      return;
-    _vsync = value;
-    positionController.resync(vsync);
-    reactionController.resync(vsync);
-  }
-
-  /// False if this control is "inactive" (not checked, off, or unselected).
-  ///
-  /// If value is true then the control "active" (checked, on, or selected). If
-  /// tristate is true and value is null, then the control is considered to be
-  /// in its third or "indeterminate" state.
-  ///
-  /// When the value changes, this object starts the [positionController] and
-  /// [position] animations to animate the visual appearance of the control to
-  /// the new value.
-  bool? get value => _value;
-  bool? _value;
-  set value(bool? value) {
-    assert(tristate || value != null);
-    if (value == _value)
-      return;
-    _value = value;
-    markNeedsSemanticsUpdate();
-    _position
-      ..curve = Curves.easeIn
-      ..reverseCurve = Curves.easeOut;
-    if (tristate) {
-      if (value == null)
-        _positionController.value = 0.0;
-      if (value != false)
-        _positionController.forward();
-      else
-        _positionController.reverse();
-    } else {
-      if (value == true)
-        _positionController.forward();
-      else
-        _positionController.reverse();
-    }
-  }
-
-  /// If true, [value] can be true, false, or null, otherwise [value] must
-  /// be true or false.
-  ///
-  /// When [tristate] is true and [value] is null, then the control is
-  /// considered to be in its third or "indeterminate" state.
-  bool get tristate => _tristate;
-  bool _tristate;
-  set tristate(bool value) {
-    assert(tristate != null);
-    if (value == _tristate)
-      return;
-    _tristate = value;
-    markNeedsSemanticsUpdate();
-  }
-
-  /// The color that should be used in the active state (i.e., when [value] is true).
-  ///
-  /// For example, a checkbox should use this color when checked.
-  Color get activeColor => _activeColor;
-  Color _activeColor;
-  set activeColor(Color value) {
-    assert(value != null);
-    if (value == _activeColor)
-      return;
-    _activeColor = value;
-    markNeedsPaint();
-  }
-
-  /// The color that should be used in the inactive state (i.e., when [value] is false).
-  ///
-  /// For example, a checkbox should use this color when unchecked.
-  Color get inactiveColor => _inactiveColor;
-  Color _inactiveColor;
-  set inactiveColor(Color value) {
-    assert(value != null);
-    if (value == _inactiveColor)
-      return;
-    _inactiveColor = value;
-    markNeedsPaint();
-  }
-
-  /// The color that should be used for the reaction when [hovering] is true.
-  ///
-  /// Used when the toggleable needs to change the reaction color/transparency,
-  /// when it is being hovered over.
-  ///
-  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
-  Color get hoverColor => _hoverColor;
-  Color _hoverColor;
-  set hoverColor(Color value) {
-    assert(value != null);
-    if (value == _hoverColor)
-      return;
-    _hoverColor = value;
-    markNeedsPaint();
-  }
-
-  /// The color that should be used for the reaction when [hasFocus] is true.
-  ///
-  /// Used when the toggleable needs to change the reaction color/transparency,
-  /// when it has focus.
-  ///
-  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
-  Color get focusColor => _focusColor;
-  Color _focusColor;
-  set focusColor(Color value) {
-    assert(value != null);
-    if (value == _focusColor)
-      return;
-    _focusColor = value;
-    markNeedsPaint();
-  }
-
-  /// The color that should be used for the reaction when the toggleable is
-  /// active.
-  ///
-  /// Used when the toggleable needs to change the reaction color/transparency
-  /// that is displayed when the toggleable is active and tapped.
-  ///
-  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
-  Color? get reactionColor => _reactionColor;
-  Color? _reactionColor;
-  set reactionColor(Color? value) {
-    assert(value != null);
-    if (value == _reactionColor)
-      return;
-    _reactionColor = value;
-    markNeedsPaint();
-  }
-
-  /// The color that should be used for the reaction when the toggleable is
-  /// inactive.
-  ///
-  /// Used when the toggleable needs to change the reaction color/transparency
-  /// that is displayed when the toggleable is inactive and tapped.
-  ///
-  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
-  Color? get inactiveReactionColor => _inactiveReactionColor;
-  Color? _inactiveReactionColor;
-  set inactiveReactionColor(Color? value) {
-    assert(value != null);
-    if (value == _inactiveReactionColor)
-      return;
-    _inactiveReactionColor = value;
-    markNeedsPaint();
-  }
-
-  /// The splash radius for the radial reaction.
-  double get splashRadius => _splashRadius;
-  double _splashRadius;
-  set splashRadius(double value) {
-    if (value == _splashRadius)
-      return;
-    _splashRadius = value;
-    markNeedsPaint();
-  }
-
-  /// Called when the control changes value.
-  ///
-  /// If the control is tapped, [onChanged] is called immediately with the new
-  /// value.
-  ///
-  /// The control is considered interactive (see [isInteractive]) if this
-  /// callback is non-null. If the callback is null, then the control is
-  /// disabled, and non-interactive. A disabled checkbox, for example, is
-  /// displayed using a grey color and its value cannot be changed.
-  ValueChanged<bool?>? get onChanged => _onChanged;
-  ValueChanged<bool?>? _onChanged;
-  set onChanged(ValueChanged<bool?>? value) {
-    if (value == _onChanged)
-      return;
-    final bool wasInteractive = isInteractive;
-    _onChanged = value;
-    if (wasInteractive != isInteractive) {
-      markNeedsPaint();
-      markNeedsSemanticsUpdate();
-    }
-  }
-
-  /// Whether [value] of this control can be changed by user interaction.
-  ///
-  /// The control is considered interactive if the [onChanged] callback is
-  /// non-null. If the callback is null, then the control is disabled, and
-  /// non-interactive. A disabled checkbox, for example, is displayed using a
-  /// grey color and its value cannot be changed.
-  bool get isInteractive => onChanged != null;
-
-  late TapGestureRecognizer _tap;
-  Offset? _downPosition;
-
-  @override
-  void attach(PipelineOwner owner) {
-    super.attach(owner);
-    if (value == false)
-      _positionController.reverse();
-    else
-      _positionController.forward();
-    if (isInteractive) {
-      switch (_reactionController.status) {
-        case AnimationStatus.forward:
-          _reactionController.forward();
-          break;
-        case AnimationStatus.reverse:
-          _reactionController.reverse();
-          break;
-        case AnimationStatus.dismissed:
-        case AnimationStatus.completed:
-          // nothing to do
-          break;
-      }
-    }
-  }
-
-  @override
-  void detach() {
-    _positionController.stop();
-    _reactionController.stop();
-    _reactionHoverFadeController.stop();
-    _reactionFocusFadeController.stop();
-    super.detach();
-  }
-
-  void _handleTapDown(TapDownDetails details) {
-    if (isInteractive) {
-      _downPosition = globalToLocal(details.globalPosition);
-      _reactionController.forward();
-    }
-  }
-
-  void _handleTap() {
-    if (!isInteractive)
-      return;
-    switch (value) {
-      case false:
-        onChanged!(true);
-        break;
-      case true:
-        onChanged!(tristate ? null : false);
-        break;
-      case null:
-        onChanged!(false);
-        break;
-    }
-    sendSemanticsEvent(const TapSemanticEvent());
-  }
-
-  void _handleTapUp(TapUpDetails details) {
-    _downPosition = null;
-    if (isInteractive)
-      _reactionController.reverse();
-  }
-
-  void _handleTapCancel() {
-    _downPosition = null;
-    if (isInteractive)
-      _reactionController.reverse();
-  }
-
-  @override
-  bool hitTestSelf(Offset position) => true;
-
-  @override
-  void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
-    assert(debugHandleEvent(event, entry));
-    if (event is PointerDownEvent && isInteractive)
-      _tap.addPointer(event);
-  }
-
-  /// Used by subclasses to paint the radial ink reaction for this control.
-  ///
-  /// The reaction is painted on the given canvas at the given offset. The
-  /// origin is the center point of the reaction (usually distinct from the
-  /// point at which the user interacted with the control, which is handled
-  /// automatically).
-  void paintRadialReaction(Canvas canvas, Offset offset, Offset origin) {
-    if (!_reaction.isDismissed || !_reactionFocusFade.isDismissed || !_reactionHoverFade.isDismissed) {
-      final Paint reactionPaint = Paint()
-        ..color = Color.lerp(
-          Color.lerp(
-            Color.lerp(inactiveReactionColor, reactionColor, _position.value),
-            hoverColor,
-            _reactionHoverFade.value,
-          ),
-          focusColor,
-          _reactionFocusFade.value,
-        )!;
-      final Offset center = Offset.lerp(_downPosition ?? origin, origin, _reaction.value)!;
-      final Animatable<double> radialReactionRadiusTween = Tween<double>(
-        begin: 0.0,
-        end: splashRadius,
-      );
-      final double reactionRadius = hasFocus || hovering
-          ? splashRadius
-          : radialReactionRadiusTween.evaluate(_reaction);
-      if (reactionRadius > 0.0) {
-        canvas.drawCircle(center + offset, reactionRadius, reactionPaint);
-      }
-    }
-  }
-
-  @override
-  void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    super.describeSemanticsConfiguration(config);
-
-    config.isEnabled = isInteractive;
-    if (isInteractive)
-      config.onTap = _handleTap;
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(FlagProperty('value', value: value, ifTrue: 'checked', ifFalse: 'unchecked', showName: true));
-    properties.add(FlagProperty('isInteractive', value: isInteractive, ifTrue: 'enabled', ifFalse: 'disabled', defaultValue: true));
-  }
 }

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -17,6 +17,15 @@ const Duration _kToggleDuration = Duration(milliseconds: 200);
 // Duration of the fade animation for the reaction when focus and hover occur.
 const Duration _kReactionFadeDuration = Duration(milliseconds: 50);
 
+/// A mixin for [StatefulWidget]s that implement toggleable controls with toggle
+/// animations (e.g. [Switch]es, [Checkbox]es, and [Radio]s).
+///
+/// This mixin implements the logic for toggeling the control (e.g. when tapped)
+/// and provides a series of animation controllers to transition the control
+/// from one state to another. It does not have any opinion about the visual
+/// representation of the toggleable widget. The visuals are defined by a
+/// [CustomPainter] passed to the [buildToggleable]. [State] objects using this
+/// mixin should call that method from their [build] method.
 @optionalTypeArgs
 mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin<S> {
   /// Used by subclasses to manipulate the visual value of the control.
@@ -26,7 +35,6 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// dragged. These controls manipulate this animation controller to update
   /// their [position] and eventually trigger an [onChanged] callback when the
   /// animation reaches either 0.0 or 1.0.
-  @protected
   AnimationController get positionController => _positionController;
   late AnimationController _positionController;
 
@@ -38,7 +46,6 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// animation has a value of 1.0. When the control is changing from inactive
   /// to active (or vice versa), [value] is the target value and this animation
   /// gradually updates from 0.0 to 1.0 (or vice versa).
-  @protected
   CurvedAnimation get position => _position;
   late CurvedAnimation _position;
 
@@ -49,7 +56,6 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  @protected
   AnimationController get reactionController => _reactionController;
   late AnimationController _reactionController;
 
@@ -60,7 +66,6 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  @protected
   Animation<double> get reaction => _reaction;
   late Animation<double> _reaction;
 
@@ -72,7 +77,6 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  @protected
   Animation<double> get reactionHoverFade => _reactionHoverFade;
   late Animation<double> _reactionHoverFade;
   late AnimationController _reactionHoverFadeController;
@@ -84,19 +88,49 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   ///
   /// To paint the actual radial reaction, [ToggleablePainter.paintRadialReaction]
   /// may be used.
-  @protected
   Animation<double> get reactionFocusFade => _reactionFocusFade;
   late Animation<double> _reactionFocusFade;
   late AnimationController _reactionFocusFadeController;
 
+  /// Whether [value] of this control can be changed by user interaction.
+  ///
+  /// The control is considered interactive if the [onChanged] callback is
+  /// non-null. If the callback is null, then the control is disabled, and
+  /// non-interactive. A disabled checkbox, for example, is displayed using a
+  /// grey color and its value cannot be changed.
   bool get isInteractive => onChanged != null;
 
   late final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
     ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: _handleTap),
   };
 
+  /// Called when the control changes value.
+  ///
+  /// If the control is tapped, [onChanged] is called immediately with the new
+  /// value.
+  ///
+  /// The control is considered interactive (see [isInteractive]) if this
+  /// callback is non-null. If the callback is null, then the control is
+  /// disabled, and non-interactive. A disabled checkbox, for example, is
+  /// displayed using a grey color and its value cannot be changed.
   ValueChanged<bool?>? get onChanged;
+
+  /// False if this control is "inactive" (not checked, off, or unselected).
+  ///
+  /// If value is true then the control "active" (checked, on, or selected). If
+  /// tristate is true and value is null, then the control is considered to be
+  /// in its third or "indeterminate" state.
+  ///
+  /// When the value changes, this object starts the [positionController] and
+  /// [position] animations to animate the visual appearance of the control to
+  /// the new value.
   bool? get value;
+
+  /// If true, [value] can be true, false, or null, otherwise [value] must
+  /// be true or false.
+  ///
+  /// When [tristate] is true and [value] is null, then the control is
+  /// considered to be in its third or "indeterminate" state.
   bool get tristate;
 
   @override
@@ -140,7 +174,11 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     );
   }
 
-  @protected
+  /// Runs the [position] animation to transition the Toggleable's appearance
+  /// to match [value].
+  ///
+  /// This method must be called whenever [value] changes to ensure that the
+  /// visual representation of the Toggleable matches the current [value].
   void animateToValue() {
     if (tristate) {
       if (value == null)
@@ -166,7 +204,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     super.dispose();
   }
 
-  @protected
+  /// The [Offset] within the Toggleable at which a pointer touched the
+  /// Toggleable.
+  ///
+  /// This is null if currently no pointer is touching the Toggleable.
   Offset? get downPosition => _downPosition;
   Offset? _downPosition;
 
@@ -227,7 +268,14 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     }
   }
 
-  @protected
+  /// Describes the current [MaterialState] of the Toggleable.
+  ///
+  /// The returned set will include:
+  ///
+  ///  * [MaterialState.disabled], if [interactive] is false
+  ///  * [MaterialState.hovered], if a pointer is hovering over the Toggleable
+  ///  * [MaterialState.focused], if the Toggleable has input focus
+  ///  * [MaterialState.selected], if [value] is true or null
   Set<MaterialState> get states => <MaterialState>{
     if (!isInteractive) MaterialState.disabled,
     if (_hovering) MaterialState.hovered,
@@ -235,7 +283,20 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     if (value != false) MaterialState.selected,
   };
 
-  @protected
+  /// Wraps a `painter` that draws the actual visuals of the Toggleable with
+  /// logic to toggle it.
+  ///
+  /// Consider providing a subclass of [ToggleablePainter] as a `painter`, which
+  /// implements logic to draw a radial ink reaction for this control. The
+  /// painter is usually configured with the [reaction], [position],
+  /// [reactionHoverFade], and [reactionFocusFade] animation provided by this
+  /// mixin. It is expected to draw the visuals of the Toggleable based on the
+  /// current value of these animations. The animations are triggered by
+  /// this mixin to transition the Toggleable from one [state] to another.
+  ///
+  /// This method must be called from the [build] method of the [State] class
+  /// that uses this mixin. The returned [Widget] must be returned from the
+  /// build method - potentially after wrapping it in other widgets.
   Widget buildToggleable({
     FocusNode? focusNode,
     bool autofocus = false,
@@ -269,7 +330,17 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   }
 }
 
+/// A base class for a [CustomPainter] that may be passed to
+/// [ToggleableStateMixin.buildToggleable] to draw the visual representation of
+/// a Toggleable.
+///
+/// Subclasses must implement the [paint] method to draw the actual visuals of
+/// the Toggleable. In their [paint] method subclasses may call
+/// [paintRadialReaction] to draw a radial ink reaction for this control.
 abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter  {
+  /// The visual value of the control.
+  ///
+  /// Usually set to [ToggleableStateMixin.position].
   Animation<double> get position => _position!;
   Animation<double>? _position;
   set position(Animation<double> value) {
@@ -282,6 +353,9 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The visual value of the radial reaction animation.
+  ///
+  /// Usually set to [ToggleableStateMixin.reaction].
   Animation<double> get reaction => _reaction!;
   Animation<double>? _reaction;
   set reaction(Animation<double> value) {
@@ -294,6 +368,9 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// Controls the radial reaction's opacity animation for focus changes.
+  ///
+  /// Usually set to [ToggleableStateMixin.reactionFocusFade].
   Animation<double> get reactionFocusFade => _reactionFocusFade!;
   Animation<double>? _reactionFocusFade;
   set reactionFocusFade(Animation<double> value) {
@@ -306,6 +383,9 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// Controls the radial reaction's opacity animation for hover changes.
+  ///
+  /// Usually set to [ToggleableStateMixin.reactionHoverFade].
   Animation<double> get reactionHoverFade => _reactionHoverFade!;
   Animation<double>? _reactionHoverFade;
   set reactionHoverFade(Animation<double> value) {
@@ -318,6 +398,10 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used in the active state (i.e., when
+  /// [ToggleableStateMixin.value] is true).
+  ///
+  /// For example, a checkbox should use this color when checked.
   Color get activeColor => _activeColor!;
   Color? _activeColor;
   set activeColor(Color value) {
@@ -328,6 +412,10 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used in the inactive state (i.e., when
+  /// [ToggleableStateMixin.value] is false).
+  ///
+  /// For example, a checkbox should use this color when unchecked.
   Color get inactiveColor => _inactiveColor!;
   Color? _inactiveColor;
   set inactiveColor(Color value) {
@@ -338,6 +426,11 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used for the reaction when the toggleable is
+  /// inactive.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency
+  /// that is displayed when the toggleable is inactive and tapped.
   Color get inactiveReactionColor => _inactiveReactionColor!;
   Color? _inactiveReactionColor;
   set inactiveReactionColor(Color value) {
@@ -348,6 +441,11 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used for the reaction when the toggleable is
+  /// active.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency
+  /// that is displayed when the toggleable is active and tapped.
   Color get reactionColor => _reactionColor!;
   Color? _reactionColor;
   set reactionColor(Color value) {
@@ -358,6 +456,10 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used for the reaction when [isHovered] is true.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency,
+  /// when it is being hovered over.
   Color get hoverColor => _hoverColor!;
   Color? _hoverColor;
   set hoverColor(Color value) {
@@ -368,6 +470,10 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The color that should be used for the reaction when [isFocused] is true.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency,
+  /// when it has focus.
   Color get focusColor => _focusColor!;
   Color? _focusColor;
   set focusColor(Color value) {
@@ -378,6 +484,7 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The splash radius for the radial reaction.
   double get splashRadius => _splashRadius!;
   double? _splashRadius;
   set splashRadius(double value) {
@@ -388,6 +495,11 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// The [Offset] within the Toggleable at which a pointer touched the Toggleable.
+  ///
+  /// This is null if currently no pointer is touching the Toggleable.
+  ///
+  /// Usually set to [ToggleableStateMixin.downPosition].
   Offset? get downPosition => _downPosition;
   Offset? _downPosition;
   set downPosition(Offset? value) {
@@ -398,6 +510,7 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// True if this toggleable has the input focus.
   bool get isFocused => _isFocused!;
   bool? _isFocused;
   set isFocused(bool? value) {
@@ -408,6 +521,7 @@ abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter
     notifyListeners();
   }
 
+  /// True if this toggleable is being hovered over by a pointer.
   bool get isHovered => _isHovered!;
   bool? _isHovered;
   set isHovered(bool? value) {

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -99,7 +99,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_CheckboxRenderObjectWidget')), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       // isFocusable is delayed by 1 frame.
@@ -108,7 +108,7 @@ void main() {
 
     await tester.pump();
     // isFocusable should be false now after the 1 frame delay.
-    expect(tester.getSemantics(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_CheckboxRenderObjectWidget')), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
     ));
@@ -120,7 +120,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_CheckboxRenderObjectWidget')), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -319,10 +319,8 @@ void main() {
       );
     }
 
-    RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
-        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
-      }));
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Toggleable));
     }
 
     await tester.pumpWidget(buildFrame(false));
@@ -377,10 +375,8 @@ void main() {
       );
     }
 
-    RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
-        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
-      }));
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Toggleable));
     }
 
     await tester.pumpWidget(buildFrame(checkColor: checkColor));
@@ -453,11 +449,10 @@ void main() {
       paints
         ..circle(color: Colors.orange[500])
         ..drrect(
-            color: const Color(0x8a000000),
-            outer: RRect.fromLTRBR(
-                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)),
-        inner: RRect.fromLTRBR(393.0,
-            293.0, 407.0, 307.0, const Radius.circular(-1.0))),
+          color: const Color(0x8a000000),
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(1.0)),
+          inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, const Radius.circular(-1.0)),
+        ),
     );
 
     // Check what happens when disabled.
@@ -469,11 +464,10 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..drrect(
-            color: const Color(0x61000000),
-            outer: RRect.fromLTRBR(
-                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)),
-            inner: RRect.fromLTRBR(393.0,
-                293.0, 407.0, 307.0, const Radius.circular(-1.0))),
+          color: const Color(0x61000000),
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(1.0)),
+          inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, const Radius.circular(-1.0)),
+        ),
     );
   });
 
@@ -825,10 +819,8 @@ void main() {
       );
     }
 
-    RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
-        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
-      }));
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Toggleable));
     }
 
     await tester.pumpWidget(buildFrame(enabled: true));
@@ -878,10 +870,8 @@ void main() {
       );
     }
 
-    RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
-        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
-      }));
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Toggleable));
     }
 
     await tester.pumpWidget(buildFrame());
@@ -937,11 +927,9 @@ void main() {
       paints
         ..drrect(
           color: const Color(0xfff44336),
-            outer: RRect.fromLTRBR(
-                391.0, 291.0, 409.0, 309.0, const Radius.circular(5)),
-            inner: RRect.fromLTRBR(
-                395.0, 295.0, 405.0, 305.0, const Radius.circular(1)))
-        ,
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(5)),
+          inner: RRect.fromLTRBR(19.0, 19.0, 29.0, 29.0, const Radius.circular(1)),
+        ),
     );
   });
 
@@ -1183,6 +1171,37 @@ void main() {
     );
 
     await gesture.up();
+  });
+
+  testWidgets('Do not crash when widget disappears while pointer is down', (WidgetTester tester) async {
+    Widget buildCheckbox(bool show) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return MediaQuery(
+                data: MediaQueryData.fromWindow(window),
+                child: Material(
+                  child: show ? Checkbox(value: true, onChanged: (_) { }) : Container(),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildCheckbox(true));
+    final Offset center = tester.getCenter(find.byType(Checkbox));
+    // Put a pointer down on the screen.
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump();
+    // While the pointer is down, the widget disappears.
+    await tester.pumpWidget(buildCheckbox(false));
+    expect(find.byType(Checkbox), findsNothing);
+    // Release pointer after widget disappeared.
+    gesture.up();
   });
 }
 

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -290,7 +290,7 @@ void main() {
     );
 
     await tester.tap(find.byType(Checkbox));
-    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
+    final RenderObject object = tester.firstRenderObject(find.byType(Checkbox));
 
     expect(checkboxValue, true);
     expect(semanticEvent, <String, dynamic>{
@@ -1176,17 +1176,9 @@ void main() {
   testWidgets('Do not crash when widget disappears while pointer is down', (WidgetTester tester) async {
     Widget buildCheckbox(bool show) {
       return MaterialApp(
-        home: Directionality(
-          textDirection: TextDirection.ltr,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return MediaQuery(
-                data: MediaQueryData.fromWindow(window),
-                child: Material(
-                  child: show ? Checkbox(value: true, onChanged: (_) { }) : Container(),
-                ),
-              );
-            },
+        home: Material(
+          child: Center(
+            child: show ? Checkbox(value: true, onChanged: (_) { }) : Container(),
           ),
         ),
       );

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -99,7 +99,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       // isFocusable is delayed by 1 frame.
@@ -108,7 +108,7 @@ void main() {
 
     await tester.pump();
     // isFocusable should be false now after the 1 frame delay.
-    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
     ));
@@ -120,7 +120,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Toggleable)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -320,7 +320,7 @@ void main() {
     }
 
     RenderBox getCheckboxRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(Toggleable));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(false));
@@ -376,7 +376,7 @@ void main() {
     }
 
     RenderBox getCheckboxRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(Toggleable));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(checkColor: checkColor));
@@ -820,7 +820,7 @@ void main() {
     }
 
     RenderBox getCheckboxRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(Toggleable));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(enabled: true));
@@ -871,7 +871,7 @@ void main() {
     }
 
     RenderBox getCheckboxRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(Toggleable));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame());

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -308,7 +308,7 @@ void main() {
     ));
 
     await tester.tap(find.byKey(key));
-    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
+    final RenderObject object = tester.firstRenderObject(find.byKey(key));
 
     expect(radioValue, 1);
     expect(semanticEvent, <String, dynamic>{
@@ -1077,5 +1077,30 @@ void main() {
         ),
       reason: 'Hovered Radio should use overlay color $hoverOverlayColor over $hoverColor',
     );
+  });
+
+  testWidgets('Do not crash when widget disappears while pointer is down', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+
+    Widget buildRadio(bool show) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: show ? Radio<bool>(key: key, value: true, groupValue: false, onChanged: (_) { }) : Container(),
+          )
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildRadio(true));
+    final Offset center = tester.getCenter(find.byKey(key));
+    // Put a pointer down on the screen.
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump();
+    // While the pointer is down, the widget disappears.
+    await tester.pumpWidget(buildRadio(false));
+    expect(find.byKey(key), findsNothing);
+    // Release pointer after widget disappeared.
+    gesture.up();
   });
 }

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -37,7 +37,7 @@ void main() {
     expect(log, equals(<dynamic>[false, '-', false]));
   });
 
-  testWidgets('SwitchListTile control test', (WidgetTester tester) async {
+  testWidgets('SwitchListTile semantics test', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(wrap(
       child: Column(

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -301,8 +301,7 @@ void main() {
         paints
           ..rrect(
               color: const Color(0x52000000), // Black with 32% opacity
-              rrect: RRect.fromLTRBR(
-                  383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+              rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
           ..circle(color: const Color(0x33000000))
           ..circle(color: const Color(0x24000000))
           ..circle(color: const Color(0x1f000000))
@@ -317,8 +316,7 @@ void main() {
         paints
           ..rrect(
               color: Colors.blue[600]!.withAlpha(0x80),
-              rrect: RRect.fromLTRBR(
-                  383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+              rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
           ..circle(color: const Color(0x33000000))
           ..circle(color: const Color(0x24000000))
           ..circle(color: const Color(0x1f000000))
@@ -351,8 +349,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -383,8 +380,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -427,8 +423,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.blue[500],
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -442,8 +437,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.green[500],
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -528,19 +522,19 @@ void main() {
     await gesture.up();
     await tester.pump();
     expect(value, isFalse);
-    final RenderToggleable renderObject = tester.renderObject<RenderToggleable>(
+    final ToggleableStateMixin state = tester.state<ToggleableStateMixin>(
       find.descendant(
         of: find.byType(Switch),
         matching: find.byWidgetPredicate(
-          (Widget widget) => widget.runtimeType.toString() == '_SwitchRenderObjectWidget',
+          (Widget widget) => widget.runtimeType.toString() == '_MaterialSwitch',
         ),
       ),
     );
-    expect(renderObject.position.value, lessThan(0.5));
+    expect(state.position.value, lessThan(0.5));
     await tester.pump();
     await tester.pumpAndSettle();
     expect(value, isFalse);
-    expect(renderObject.position.value, 0);
+    expect(state.position.value, 0);
 
     // Move past the middle.
     gesture = await tester.startGesture(tester.getRect(find.byType(Switch)).center);
@@ -549,12 +543,12 @@ void main() {
     await gesture.up();
     await tester.pump();
     expect(value, isTrue);
-    expect(renderObject.position.value, greaterThan(0.5));
+    expect(state.position.value, greaterThan(0.5));
 
     await tester.pump();
     await tester.pumpAndSettle();
     expect(value, isTrue);
-    expect(renderObject.position.value, 1.0);
+    expect(state.position.value, 1.0);
 
     // Now move back to the left, the revert animation should play.
     gesture = await tester.startGesture(tester.getRect(find.byType(Switch)).center);
@@ -563,12 +557,12 @@ void main() {
     await gesture.up();
     await tester.pump();
     expect(value, isTrue);
-    expect(renderObject.position.value, lessThan(0.5));
+    expect(state.position.value, lessThan(0.5));
 
     await tester.pump();
     await tester.pumpAndSettle();
     expect(value, isTrue);
-    expect(renderObject.position.value, 1.0);
+    expect(state.position.value, 1.0);
   });
 
   testWidgets('switch has semantic events', (WidgetTester tester) async {
@@ -601,7 +595,7 @@ void main() {
       ),
     );
     await tester.tap(find.byType(Switch));
-    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
+    final RenderObject object = tester.firstRenderObject(find.byType(Switch));
 
     expect(value, true);
     expect(semanticEvent, <String, dynamic>{
@@ -750,8 +744,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x801e88e5),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: Colors.orange[500])
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
@@ -769,8 +762,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x52000000),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: Colors.orange[500])
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
@@ -788,8 +780,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x1f000000),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -854,8 +845,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x801e88e5),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -875,8 +865,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x801e88e5),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: Colors.orange[500])
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
@@ -892,8 +881,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x1f000000),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1137,8 +1125,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1154,8 +1141,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1171,8 +1157,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x52000000), // Black with 32% opacity,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1188,8 +1173,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1246,8 +1230,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x801e88e5),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x1f000000))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
@@ -1268,8 +1251,7 @@ void main() {
       paints
         ..rrect(
             color: const Color(0x801e88e5),
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x1f000000))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
@@ -1327,8 +1309,7 @@ void main() {
       paints
         ..rrect(
             color: inactiveDisabledTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Inactive disabled switch track should use this value',
     );
 
@@ -1340,8 +1321,7 @@ void main() {
       paints
         ..rrect(
             color: activeDisabledTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Active disabled switch should match these colors',
     );
 
@@ -1353,8 +1333,7 @@ void main() {
       paints
         ..rrect(
             color: inactiveEnabledTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Inactive enabled switch should match these colors',
     );
 
@@ -1366,8 +1345,7 @@ void main() {
       paints
         ..rrect(
             color: inactiveDisabledTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Inactive disabled switch should match these colors',
     );
   });
@@ -1420,8 +1398,7 @@ void main() {
       paints
         ..rrect(
             color: focusedTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Inactive enabled switch should match these colors',
     );
 
@@ -1437,8 +1414,7 @@ void main() {
       paints
         ..rrect(
             color: hoveredTrackColor,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0))),
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0))),
       reason: 'Inactive enabled switch should match these colors',
     );
   });
@@ -1488,8 +1464,7 @@ void main() {
       paints
         ..rrect(
             color: Colors.black12,
-            rrect: RRect.fromLTRBR(
-                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+            rrect: RRect.fromLTRBR(13.0, 17.0, 46.0, 31.0, const Radius.circular(7.0)))
         ..circle(color: const Color(0x33000000))
         ..circle(color: const Color(0x24000000))
         ..circle(color: const Color(0x1f000000))
@@ -1637,5 +1612,28 @@ void main() {
         ),
       reason: 'Hovered Switch should use overlay color $hoverOverlayColor over $hoverColor',
     );
+  });
+
+  testWidgets('Do not crash when widget disappears while pointer is down', (WidgetTester tester) async {
+    Widget buildSwitch(bool show) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: show ? Switch(value: true, onChanged: (_) { }) : Container(),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch(true));
+    final Offset center = tester.getCenter(find.byType(Switch));
+    // Put a pointer down on the screen.
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump();
+    // While the pointer is down, the widget disappears.
+    await tester.pumpWidget(buildSwitch(false));
+    expect(find.byType(Switch), findsNothing);
+    // Release pointer after widget disappeared.
+    gesture.up();
   });
 }

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1058,8 +1058,7 @@ void main() {
       ),
     );
 
-    final RenderToggleable oldSwitchRenderObject = tester
-      .renderObject(find.byWidgetPredicate((Widget widget) => widget is LeafRenderObjectWidget));
+    final ToggleableStateMixin oldSwitchState = tester.state(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MaterialSwitch'));
 
     stateSetter(() { value = false; });
     await tester.pump();
@@ -1067,14 +1066,12 @@ void main() {
     stateSetter(() { enabled = false; });
     await tester.pump();
 
-    final RenderToggleable updatedSwitchRenderObject = tester
-      .renderObject(find.byWidgetPredicate((Widget widget) => widget is LeafRenderObjectWidget));
+    final ToggleableStateMixin updatedSwitchState = tester.state(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MaterialSwitch'));
 
-
-    expect(updatedSwitchRenderObject.isInteractive, false);
-    expect(updatedSwitchRenderObject, oldSwitchRenderObject);
-    expect(updatedSwitchRenderObject.position.isCompleted, false);
-    expect(updatedSwitchRenderObject.position.isDismissed, false);
+    expect(updatedSwitchState.isInteractive, false);
+    expect(updatedSwitchState, oldSwitchState);
+    expect(updatedSwitchState.position.isCompleted, false);
+    expect(updatedSwitchState.position.isDismissed, false);
   });
 
   testWidgets('Switch thumb color resolves in active/enabled states', (WidgetTester tester) async {


### PR DESCRIPTION
This started out as a simple fix for https://github.com/flutter/flutter/issues/76411, which was caused by RenderToggleable not disposing its GestureRecognizer. Unfortunately, the RenderObject doesn't have a point where it is appropriate to dispose the recognizer.

In this refactoring, I am removing the RenderToggleable class altogether. Instead, I am introducing a ToggleableStateMixin that toggleable widgets (like Switch, Checkbox, Radio) can mix into their state. The ToggleableStateMixin implements logic to trigger state transitions of the toggleable (e.g. when it is tapped). For this, it also manages a bunch of AnimationControllers that drive the transition.

ToggleableStateMixin has no opinion on the visual appearance of the toggleable widget. Users of the ToggleableStateMixin have to provide a CustomPainter, that draws the current visual appearance of the toggleable based on the Animations provided by the mixin.

The idea is that managing the lifecycle of various elements a toggleable needs (e.g. a GestureRecognizer) is easier in the widget layer (i.e. in the ToggleableStateMixin) than it is in the render layer (as it was implemented before in the RenderToggleable).

Prior to this change, concrete Toggleable implementations would subclass RenderToggleable and implement a LeafRenderObjectWidget as well as a StatefulWidget. With this change, they mixin the ToggleableStateMixin into their StatefulWidget and provide a CustomPainter that draws the visual appearance.

The ToggleableStateMixin also implements some common logic (e.g. the FocusableActionDetector) that was previously repeated in the various toggleable widgets.