### PR TITLE
[flutter_tools] simplify packages pass-through testing

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:args/command_runner.dart';
@@ -11,6 +12,7 @@ import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -21,7 +23,6 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
-import '../../src/mocks.dart' show MockProcessManager;
 import '../../src/testbed.dart';
 
 void main() {
@@ -438,23 +439,24 @@ void main() {
   });
 
   group('packages test/pub', () {
-    MockProcessManager mockProcessManager;
+    FakeProcessManager processManager;
     FakeStdio mockStdio;
 
     setUp(() {
-      mockProcessManager = MockProcessManager();
+      processManager = FakeProcessManager.list(<FakeCommand>[]);
       mockStdio = FakeStdio()..stdout.terminalColumns = 80;
     });
 
     testUsingContext('test without bot', () async {
+      processManager.addCommand(
+        FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
+      );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(3));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'run');
-      expect(commands[2], 'test');
+
+      expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
+      ProcessManager: () => processManager,
       Stdio: () => mockStdio,
       BotDetector: () => const FakeBotDetector(false),
       Pub: () => Pub(
@@ -468,15 +470,15 @@ void main() {
     });
 
     testUsingContext('test with bot', () async {
+      processManager.addCommand(
+        FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
+      );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(4));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], '--trace');
-      expect(commands[2], 'run');
-      expect(commands[3], 'test');
+
+      expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
+      ProcessManager: () => processManager,
       Stdio: () => mockStdio,
       BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
@@ -489,238 +491,21 @@ void main() {
       ),
     });
 
-    testUsingContext('run', () async {
+    testUsingContext('run pass arguments through to pub', () async {
+      final IOSink stdin = IOSink(StreamController<List<int>>().sink);
+      processManager.addCommand(
+        FakeCommand(command: <String>[
+          '${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
+          stdin: stdin,
+        ),
+      );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', '--verbose', 'pub', 'run', '--foo', 'bar']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(4));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'run');
-      expect(commands[2], '--foo');
-      expect(commands[3], 'bar');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
 
-    testUsingContext('pub publish', () async {
-      final PromptingProcess process = PromptingProcess();
-      mockProcessManager.processFactory = (List<String> commands) => process;
-      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'publish']);
-      final Future<void> runPrompt = process.showPrompt('Proceed (y/n)? ', <String>['hello', 'world']);
-      final Future<void> simulateUserInput = Future<void>(() {
-        mockStdio.simulateStdin('y');
-      });
-      await Future.wait<void>(<Future<void>>[runPackages, runPrompt, simulateUserInput]);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
-      final List<String> stdout = mockStdio.writtenToStdout;
-      expect(stdout, hasLength(4));
-      expect(stdout.sublist(0, 2), contains('Proceed (y/n)? '));
-      expect(stdout.sublist(0, 2), contains('y\n'));
-      expect(stdout[2], 'hello\n');
-      expect(stdout[3], 'world\n');
+      expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
+      ProcessManager: () => processManager,
       Stdio: () => mockStdio,
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('pub publish input fails', () async {
-      final PromptingProcess process = PromptingProcess(stdinError: true);
-      mockProcessManager.processFactory = (List<String> commands) => process;
-      final Future<void> runPackages = createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'publish']);
-      final Future<void> runPrompt = process.showPrompt('Proceed (y/n)? ', <String>['hello', 'world']);
-      final Future<void> simulateUserInput = Future<void>(() {
-        mockStdio.simulateStdin('y');
-      });
-      await Future.wait<void>(<Future<void>>[runPackages, runPrompt, simulateUserInput]);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
-      // We get a trace message about the write to stdin failing.
-      expect(testLogger.traceText, contains('Echoing stdin to the pub subprocess failed'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('publish', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['pub', 'publish']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('packages publish', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'pub', 'publish']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'publish');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('deps', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'deps']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'deps');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('cache', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'cache']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'cache');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('version', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'version']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'version');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('uploader', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'uploader']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'uploader');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('global', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'global', 'list']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(3));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'global');
-      expect(commands[2], 'list');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
-      Pub: () => Pub(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        usage: globals.flutterUsage,
-        botDetector: globals.botDetector,
-        platform: globals.platform,
-      ),
-    });
-
-    testUsingContext('outdated', () async {
-      await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'outdated']);
-      final List<String> commands = mockProcessManager.commands;
-      expect(commands, hasLength(2));
-      expect(commands[0], matches(r'dart-sdk[\\/]bin[\\/]pub'));
-      expect(commands[1], 'outdated');
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Stdio: () => mockStdio,
-      BotDetector: () => const FakeBotDetector(true),
       Pub: () => Pub(
         fileSystem: globals.fs,
         logger: globals.logger,

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -452,7 +452,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        FakeCommand(command: <String>['bin/cache/dart-sdk/bin/pub', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -477,7 +477,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        FakeCommand(command: <String>['bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -503,8 +503,8 @@ void main() {
       globals.fs.file('pubspec.yaml').createSync();
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
-        FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
+        FakeCommand(command: const <String>[
+          '/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -449,6 +449,7 @@ void main() {
     });
 
     testUsingContext('test without bot', () async {
+      globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
         FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
       );
@@ -472,6 +473,7 @@ void main() {
     });
 
     testUsingContext('test with bot', () async {
+      globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
         FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
       );
@@ -495,6 +497,7 @@ void main() {
     });
 
     testUsingContext('run pass arguments through to pub', () async {
+      globals.fs.file('pubspec.yaml').createSync();
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: <String>[

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -449,9 +449,10 @@ void main() {
     });
 
     testUsingContext('test without bot', () async {
+      Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
+        FakeCommand(command: <String>['bin/cache/dart-sdk/bin/pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -473,9 +474,10 @@ void main() {
     });
 
     testUsingContext('test with bot', () async {
+      Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        FakeCommand(command: <String>['${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
+        FakeCommand(command: <String>['bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -497,11 +499,12 @@ void main() {
     });
 
     testUsingContext('run pass arguments through to pub', () async {
+      Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: <String>[
-          '${getFlutterRoot()}/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
+          'bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -455,6 +455,7 @@ void main() {
 
       expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
       ProcessManager: () => processManager,
       Stdio: () => mockStdio,
@@ -477,6 +478,7 @@ void main() {
 
       expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
       ProcessManager: () => processManager,
       Stdio: () => mockStdio,
@@ -503,6 +505,7 @@ void main() {
 
       expect(processManager.hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
       ProcessManager: () => processManager,
       Stdio: () => mockStdio,


### PR DESCRIPTION
The flutter pub/packages command treats most provided pub arguments as a pass through, forwarding the stdout/stderr and otherwise performing no validation or arg checking.

Simplify the unit test cases that had more complex mocks for testing stdin/stdout behavior to avoid testing our own mocks. Remove the mock process manager and replace with the fake.

https://github.com/flutter/flutter/issues/71511