### PR TITLE
Removed BottomNavigationBar accentColor dependency

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -58,7 +58,7 @@ enum BottomNavigationBarType {
 ///    four [items]. The selected item is rendered with the
 ///    [selectedItemColor] if it's non-null, otherwise the theme's
 ///    [ColorScheme.primary] color is used for [Brightness.light] themes
-///    and [Color.secondary] for [Brightness.dark] themes.
+///    and [ColorScheme.secondary] for [Brightness.dark] themes.
 ///    If [backgroundColor] is null, The
 ///    navigation bar's background color defaults to the [Material] background
 ///    color, [ThemeData.canvasColor] (essentially opaque white).

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -939,10 +939,10 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     final Color themeColor;
     switch (themeData.brightness) {
       case Brightness.light:
-        themeColor = themeData.primaryColor;
+        themeColor = themeData.colorScheme.primary;
         break;
       case Brightness.dark:
-        themeColor = themeData.accentColor;
+        themeColor = themeData.colorScheme.secondary;
         break;
     }
 

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -57,7 +57,9 @@ enum BottomNavigationBarType {
 ///  * [BottomNavigationBarType.fixed], the default when there are less than
 ///    four [items]. The selected item is rendered with the
 ///    [selectedItemColor] if it's non-null, otherwise the theme's
-///    [ThemeData.primaryColor] is used. If [backgroundColor] is null, The
+///    [ColorScheme.primary] color is used for [Brightness.light] themes
+///    and [Color.secondary] for [Brightness.dark] themes.
+///    If [backgroundColor] is null, The
 ///    navigation bar's background color defaults to the [Material] background
 ///    color, [ThemeData.canvasColor] (essentially opaque white).
 ///  * [BottomNavigationBarType.shifting], the default when there are four

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -77,7 +77,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.light().copyWith(
-          colorScheme: ColorScheme.light().copyWith(primary: primaryColor),
+          colorScheme: const ColorScheme.light().copyWith(primary: primaryColor),
           unselectedWidgetColor: unselectedWidgetColor,
         ),
         home: Scaffold(

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -76,8 +76,8 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(
-          primaryColor: primaryColor,
+        theme: ThemeData.light().copyWith(
+          colorScheme: ColorScheme.light().copyWith(primary: primaryColor),
           unselectedWidgetColor: unselectedWidgetColor,
         ),
         home: Scaffold(


### PR DESCRIPTION
Addresses the BottomNavigationBar item from https://github.com/flutter/flutter/issues/56918.

When the BottomNavigationBar's type is BottomNavigationBarType.fixed, it now uses the theme's `ColorScheme.primary` color as the default selectedItemColor for light themes, and `ColorScheme.secondary` for dark themes.

This PR was tested locally (internal link): cl/359596877

This is a breaking change. The default selectedItemColor for light themes was the theme's `primaryColor` for light themes and `accentColor` for dark themes. 

Apps that need to configure the selectedItemColor (or the unselectedItemColor) can do so by either setting those parameters in the BottomNavigationBar constructor or with a BottomNavigationBarTheme.