### PR TITLE
Update dartdoc to 0.40.0.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.38.0
+    "$PUB" global activate dartdoc 0.40.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Update dartdoc version to 0.40.0.

I apparently deleted by accident the waiting-for-tree-to-go-green label on 0.39.0 and so that never landed, so this change will move us two revisions instead of one.

Release notes: https://github.com/dart-lang/dartdoc/releases/tag/v0.39.0
Release notes: https://github.com/dart-lang/dartdoc/releases/tag/v0.40.0