### PR TITLE
Add ephemeral iOS directory to put future generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ unlinked_spec.ds
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Flutter.podspec
 **/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/dev/benchmarks/complex_layout/ios/.gitignore
+++ b/dev/benchmarks/complex_layout/ios/.gitignore
@@ -18,6 +18,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/ephemeral
 Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/

--- a/dev/integration_tests/ios_app_with_extensions/ios/.gitignore
+++ b/dev/integration_tests/ios_app_with_extensions/ios/.gitignore
@@ -18,6 +18,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/ephemeral
 Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/

--- a/dev/integration_tests/non_nullable/ios/.gitignore
+++ b/dev/integration_tests/non_nullable/ios/.gitignore
@@ -18,6 +18,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/ephemeral
 Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/

--- a/dev/integration_tests/release_smoke_test/.gitignore
+++ b/dev/integration_tests/release_smoke_test/.gitignore
@@ -60,6 +60,7 @@
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Flutter.podspec
 **/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -421,7 +421,7 @@ abstract class IosAssetBundle extends Target {
     // TODO(jonahwilliams): add plist to inputs
     final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
     final Directory plistRoot = flutterProject.isModule
-      ? flutterProject.ios.ephemeralDirectory
+      ? flutterProject.ios.ephemeralModuleDirectory
       : environment.projectDir.childDirectory('ios');
     plistRoot
       .childDirectory('Flutter')

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -51,6 +51,7 @@ class CleanCommand extends FlutterCommand {
     deleteFile(flutterProject.android.ephemeralDirectory);
 
     deleteFile(flutterProject.ios.ephemeralDirectory);
+    deleteFile(flutterProject.ios.ephemeralModuleDirectory);
     deleteFile(flutterProject.ios.generatedXcodePropertiesFile);
     deleteFile(flutterProject.ios.generatedEnvironmentVariableExportScript);
     deleteFile(flutterProject.ios.deprecatedCompiledDartFramework);

--- a/packages/flutter_tools/templates/app/ios.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app/ios.tmpl/.gitignore
@@ -18,6 +18,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/ephemeral/
 Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/

--- a/packages/flutter_tools/templates/package/.gitignore.tmpl
+++ b/packages/flutter_tools/templates/package/.gitignore.tmpl
@@ -60,6 +60,7 @@ build/
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Flutter.podspec
 **/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/packages/flutter_tools/templates/plugin/ios.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/plugin/ios.tmpl/.gitignore
@@ -34,4 +34,5 @@ Icon?
 .tags*
 
 /Flutter/Generated.xcconfig
+/Flutter/ephemeral/
 /Flutter/flutter_export_environment.sh

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -53,6 +53,7 @@ void main() {
         projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
 
         projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.ios.ephemeralModuleDirectory.createSync(recursive: true);
         projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
         projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
         projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
@@ -77,6 +78,7 @@ void main() {
         expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
 
         expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.ios.ephemeralModuleDirectory.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
         expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
         expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);

--- a/packages/integration_test/example/ios/.gitignore
+++ b/packages/integration_test/example/ios/.gitignore
@@ -18,6 +18,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/ephemeral
 Flutter/app.flx
 Flutter/app.zip
 Flutter/flutter_assets/

--- a/packages/integration_test/ios/.gitignore
+++ b/packages/integration_test/ios/.gitignore
@@ -34,4 +34,5 @@ Icon?
 .tags*
 
 /Flutter/Generated.xcconfig
+/Flutter/ephemeral
 /Flutter/flutter_export_environment.sh


### PR DESCRIPTION
Future prevention of https://github.com/flutter/flutter/issues/39491 on iOS.  There's nothing currently generated in this ephemeral directory, but I'm about to put out a PR that will generate a few files to this location.

- Rename iOS module directory property `ephemeralDirectory` -> `ephemeralModuleDirectory`
- Create a project property for `Flutter/ephemeral` directory.  
- Remove the `ephemeralDirectory` on `flutter clean`
- Add to .gitignore

This doesn't actually move any existing generated files to this location--that can be done in individual follow-up PRs as needed.