### PR TITLE
Opt into CocoaPods parallel codesigning

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -172,6 +172,10 @@ List<String> _xcodeBuildSettingsLines({
   // This holds because requiresProjectRoot is true for this command
   xcodeBuildSettings.add('FLUTTER_APPLICATION_PATH=${globals.fs.path.normalize(project.directory.path)}');
 
+  // Tell CocoaPods behavior to codesign in parallel with rest of scripts to speed it up.
+  // Value must be "true", not "YES". https://github.com/CocoaPods/CocoaPods/pull/6088
+  xcodeBuildSettings.add('COCOAPODS_PARALLEL_CODE_SIGN=true');
+
   // Relative to FLUTTER_APPLICATION_PATH, which is [Directory.current].
   if (targetOverride != null) {
     xcodeBuildSettings.add('FLUTTER_TARGET=$targetOverride');

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -273,7 +273,8 @@ void main() {
       'TRACK_WIDGET_CREATION=true',
       'TREE_SHAKE_ICONS=true',
       'BUNDLE_SKSL_PATH=foo/bar.sksl.json',
-      'PACKAGE_CONFIG=/.dart_tool/package_config.json'
+      'PACKAGE_CONFIG=/.dart_tool/package_config.json',
+      'COCOAPODS_PARALLEL_CODE_SIGN=true',
     ]));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1055,6 +1055,7 @@ void main() {
     expect(xcodeConfig, contains('FLUTTER_ROOT='));
     expect(xcodeConfig, contains('FLUTTER_APPLICATION_PATH='));
     expect(xcodeConfig, contains('FLUTTER_TARGET='));
+    expect(xcodeConfig, contains('COCOAPODS_PARALLEL_CODE_SIGN=true'));
 
     // Generated export environment variables script
     final String buildPhaseScriptPath = globals.fs.path.join('.ios', 'Flutter', 'flutter_export_environment.sh');
@@ -1064,6 +1065,7 @@ void main() {
     expect(buildPhaseScript, contains('FLUTTER_ROOT='));
     expect(buildPhaseScript, contains('FLUTTER_APPLICATION_PATH='));
     expect(buildPhaseScript, contains('FLUTTER_TARGET='));
+    expect(buildPhaseScript, contains('COCOAPODS_PARALLEL_CODE_SIGN=true'));
 
     // Generated podspec
     final String podspecPath = globals.fs.path.join('.ios', 'Flutter', 'flutter_project.podspec');
@@ -1156,6 +1158,7 @@ void main() {
     final String xcodeConfig = xcodeConfigFile.readAsStringSync();
     expect(xcodeConfig, contains('FLUTTER_ROOT='));
     expect(xcodeConfig, contains('FLUTTER_APPLICATION_PATH='));
+    expect(xcodeConfig, contains('COCOAPODS_PARALLEL_CODE_SIGN=true'));
     // App identification
     final String xcodeProjectPath = globals.fs.path.join('ios', 'Runner.xcodeproj', 'project.pbxproj');
     expectExists(xcodeProjectPath);


### PR DESCRIPTION
This sped up the gallery build by 0.5s when I forced it to use dynamic frameworks with  `use_frameworks!`.  It's only relevant for projects with plugins with `use_frameworks!` in the Podfile (Flutter iOS Swift and Flutter macOS by default), but it doesn't hurt anything for non-CocoaPods projects.  See https://github.com/CocoaPods/CocoaPods/pull/6088