### PR TITLE
Remove dart_plugin_registry_test timeouts

### DIFF
--- a/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
+++ b/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
@@ -159,16 +159,14 @@ class PluginPlatformInterfaceMacOS {
         });
 
         section('Wait for registry execution');
-        await registryExecutedCompleter.future
-            .timeout(const Duration(minutes: 1));
+        await registryExecutedCompleter.future;
 
         // Hot restart.
         run.stdin.write('R');
         registryExecutedCompleter = Completer<void>();
 
         section('Wait for registry execution after hot restart');
-        await registryExecutedCompleter.future
-            .timeout(const Duration(minutes: 1));
+        await registryExecutedCompleter.future;
 
         subscription.cancel();
         run.kill();


### PR DESCRIPTION
Remove individual step timeouts.  If it's going to time out, prefer the overall devicelab task timeout.

Fixes https://github.com/flutter/flutter/issues/76837