### PR TITLE
Removed CheckboxListTile accentColor dependency

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -26,10 +26,10 @@ import 'theme_data.dart';
 /// those of the same name on [ListTile].
 ///
 /// The [selected] property on this widget is similar to the [ListTile.selected]
-/// property, but the color used is that described by [activeColor], if any,
-/// defaulting to the accent color of the current [Theme]. No effort is made to
-/// coordinate the [selected] state and the [value] state; to have the list tile
-/// appear selected when the checkbox is checked, pass the same value to both.
+/// property, but the color used is [activeColor], if it's non-null.
+/// No effort is made to coordinate the [selected] state and the
+/// [value] state; to have the list tile appear selected when the
+/// checkbox is checked, pass the same value to both.
 ///
 /// The checkbox is shown on the right by default in left-to-right languages
 /// (i.e. the trailing edge). This can be changed using [controlAffinity]. The
@@ -432,7 +432,7 @@ class CheckboxListTile extends StatelessWidget {
     }
     return MergeSemantics(
       child: ListTileTheme.merge(
-        selectedColor: activeColor ?? Theme.of(context).accentColor,
+        selectedColor: activeColor,
         child: ListTile(
           leading: leading,
           title: title,

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -314,7 +314,8 @@ class CheckboxListTile extends StatelessWidget {
 
   /// The color to use when this checkbox is checked.
   ///
-  /// Defaults to accent color of the current [Theme].
+  /// If this property is null, then the checkbox's default is used, which is
+  /// [ThemeData.toggleableActiveColor].
   final Color? activeColor;
 
   /// The color to use for the check icon when this checkbox is checked.
@@ -430,25 +431,23 @@ class CheckboxListTile extends StatelessWidget {
         trailing = control;
         break;
     }
+
     return MergeSemantics(
-      child: ListTileTheme.merge(
-        selectedColor: activeColor,
-        child: ListTile(
-          leading: leading,
-          title: title,
-          subtitle: subtitle,
-          trailing: trailing,
-          isThreeLine: isThreeLine,
-          dense: dense,
-          enabled: onChanged != null,
-          onTap: onChanged != null ? _handleValueChange : null,
-          selected: selected,
-          autofocus: autofocus,
-          contentPadding: contentPadding,
-          shape: shape,
-          selectedTileColor: selectedTileColor,
-          tileColor: tileColor,
-        ),
+      child: ListTile(
+        leading: leading,
+        title: title,
+        subtitle: subtitle,
+        trailing: trailing,
+        isThreeLine: isThreeLine,
+        dense: dense,
+        enabled: onChanged != null,
+        onTap: onChanged != null ? _handleValueChange : null,
+        selected: selected,
+        autofocus: autofocus,
+        contentPadding: contentPadding,
+        shape: shape,
+        selectedTileColor: selectedTileColor,
+        tileColor: tileColor,
       ),
     );
   }


### PR DESCRIPTION
Addresses the CheckboxListTile item from https://github.com/flutter/flutter/issues/56918.

Removes the unnecessary accentColor dependency from CheckboxListTile. The accentColor property was merged into a ListTileTheme if activeColor was null however that's had no effect since (at least)  https://github.com/flutter/flutter/pull/68831, i.e. the check box's activeColor/fillColor did not depend on the ListTileTheme (directly or indirectly via DefaultTextStyle or IconTheme).

Apps that want to override the default checkbox fill color should specify the `activeColor` constructor parameter or  specify the theme's `toggleableActiveColor`.

Since this code just removes dead code, there is no test.

This PR was tested locally (internal link): cl/359789262
