### PR TITLE
[flutter_tools] remove all mock artifacts usage

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -19,7 +19,6 @@ import 'package:flutter_tools/src/commands/analyze.dart';
 import 'package:flutter_tools/src/dart/analysis.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
@@ -179,23 +178,20 @@ void main() {
       <FakeCommand>[
         FakeCommand(
           command: const <String>[
-            'custom-dart-sdk/bin/dart',
+            'Artifact.engineDartSdkPath/bin/dart',
             '--disable-dart-dev',
-            'custom-dart-sdk/bin/snapshots/analysis_server.dart.snapshot',
+            'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
             '--disable-server-feature-completion',
             '--disable-server-feature-search',
             '--sdk',
-            'custom-dart-sdk',
+            'Artifact.engineDartSdkPath',
           ],
           completer: completer,
           stdin: IOSink(stdin.sink),
         ),
       ]);
 
-    final Artifacts artifacts = MockArtifacts();
-    when(artifacts.getArtifactPath(Artifact.engineDartSdkPath))
-      .thenReturn('custom-dart-sdk');
-
+    final Artifacts artifacts = Artifacts.test();
     final AnalyzeCommand command = AnalyzeCommand(
       terminal: Terminal.test(),
       artifacts: artifacts,
@@ -220,23 +216,20 @@ void main() {
       <FakeCommand>[
         FakeCommand(
           command: const <String>[
-            'custom-dart-sdk/bin/dart',
+            'Artifact.engineDartSdkPath/bin/dart',
             '--disable-dart-dev',
-            'custom-dart-sdk/bin/snapshots/analysis_server.dart.snapshot',
+            'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
             '--disable-server-feature-completion',
             '--disable-server-feature-search',
             '--sdk',
-            'custom-dart-sdk',
+            'Artifact.engineDartSdkPath',
           ],
           completer: completer,
           stdin: IOSink(stdin.sink),
         ),
       ]);
 
-    final Artifacts artifacts = MockArtifacts();
-    when(artifacts.getArtifactPath(Artifact.engineDartSdkPath))
-      .thenReturn('custom-dart-sdk');
-
+    final Artifacts artifacts = Artifacts.test();
     final AnalyzeCommand command = AnalyzeCommand(
       terminal: Terminal.test(),
       artifacts: artifacts,
@@ -254,5 +247,3 @@ void main() {
     expect(processManager.hasRemainingExpectations, false);
   });
 }
-
-class MockArtifacts extends Mock implements Artifacts {}

--- a/packages/flutter_tools/test/general.shard/build_system/source_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/source_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -218,10 +217,10 @@ void main() {
   }));
 
   test('Non-local engine builds use the engine.version file as an Artifact dependency', () => testbed.run(() {
-    final MockArtifacts artifacts = MockArtifacts();
+    final Artifacts artifacts = Artifacts.test();
     final Environment environment = Environment.test(
       globals.fs.currentDirectory,
-      artifacts: artifacts, // using real artifacts
+      artifacts: artifacts,
       processManager: FakeProcessManager.any(),
       fileSystem: globals.fs,
       logger: globals.logger,
@@ -233,9 +232,5 @@ void main() {
     fizzSource.accept(visitor);
 
     expect(visitor.sources.single.path, contains('engine.version'));
-    verifyNever(artifacts.getArtifactPath(
-      any, platform: anyNamed('platform'), mode: anyNamed('mode')));
   }));
 }
-
-class MockArtifacts extends Mock implements Artifacts {}


### PR DESCRIPTION
Replaces the last two Artifacts mocks with the test class 

https://github.com/flutter/flutter/issues/71511