### PR TITLE
Allow iOS Flutter.framework thinning to be skipped

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -27,34 +27,34 @@ import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
 
 /// All currently implemented targets.
-List<Target> _kDefaultTargets = <Target>[
+const List<Target> _kDefaultTargets = <Target>[
   // Shared targets
-  const CopyAssets(),
-  const KernelSnapshot(),
-  const AotElfProfile(TargetPlatform.android_arm),
-  const AotElfRelease(TargetPlatform.android_arm),
-  const AotAssemblyProfile(),
-  const AotAssemblyRelease(),
+  CopyAssets(),
+  KernelSnapshot(),
+  AotElfProfile(TargetPlatform.android_arm),
+  AotElfRelease(TargetPlatform.android_arm),
+  AotAssemblyProfile(),
+  AotAssemblyRelease(),
   // macOS targets
-  const DebugMacOSFramework(),
-  const DebugMacOSBundleFlutterAssets(),
-  const ProfileMacOSBundleFlutterAssets(),
-  const ReleaseMacOSBundleFlutterAssets(),
+  DebugMacOSFramework(),
+  DebugMacOSBundleFlutterAssets(),
+  ProfileMacOSBundleFlutterAssets(),
+  ReleaseMacOSBundleFlutterAssets(),
   // Linux targets
-  const DebugBundleLinuxAssets(TargetPlatform.linux_x64),
-  const DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
-  const ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
-  const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
-  const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
-  const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
+  DebugBundleLinuxAssets(TargetPlatform.linux_x64),
+  DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
+  ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
+  ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
+  ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
+  ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
   // Web targets
-  const WebServiceWorker(),
-  const ReleaseAndroidApplication(),
+  WebServiceWorker(),
+  ReleaseAndroidApplication(),
   // This is a one-off rule for bundle and aot compat.
-  const CopyFlutterBundle(),
+  CopyFlutterBundle(),
   // Android targets,
-  const DebugAndroidApplication(),
-  const ProfileAndroidApplication(),
+  DebugAndroidApplication(),
+  ProfileAndroidApplication(),
   // Android ABI specific AOT rules.
   androidArmProfileBundle,
   androidArm64ProfileBundle,
@@ -63,15 +63,15 @@ List<Target> _kDefaultTargets = <Target>[
   androidArm64ReleaseBundle,
   androidx64ReleaseBundle,
   // iOS targets
-  const DebugIosApplicationBundle(),
-  const ProfileIosApplicationBundle(),
-  const ReleaseIosApplicationBundle(),
+  DebugIosApplicationBundle(),
+  ProfileIosApplicationBundle(),
+  ReleaseIosApplicationBundle(),
   ThinIosApplicationFrameworks(),
   // Windows targets
-  const UnpackWindows(),
-  const DebugBundleWindowsAssets(),
-  const ProfileBundleWindowsAssets(),
-  const ReleaseBundleWindowsAssets(),
+  UnpackWindows(),
+  DebugBundleWindowsAssets(),
+  ProfileBundleWindowsAssets(),
+  ReleaseBundleWindowsAssets(),
 ];
 
 // TODO(ianh): https://github.com/dart-lang/args/issues/181 will allow us to remove useLegacyNames

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -27,34 +27,34 @@ import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
 
 /// All currently implemented targets.
-const List<Target> _kDefaultTargets = <Target>[
+List<Target> _kDefaultTargets = <Target>[
   // Shared targets
-  CopyAssets(),
-  KernelSnapshot(),
-  AotElfProfile(TargetPlatform.android_arm),
-  AotElfRelease(TargetPlatform.android_arm),
-  AotAssemblyProfile(),
-  AotAssemblyRelease(),
+  const CopyAssets(),
+  const KernelSnapshot(),
+  const AotElfProfile(TargetPlatform.android_arm),
+  const AotElfRelease(TargetPlatform.android_arm),
+  const AotAssemblyProfile(),
+  const AotAssemblyRelease(),
   // macOS targets
-  DebugMacOSFramework(),
-  DebugMacOSBundleFlutterAssets(),
-  ProfileMacOSBundleFlutterAssets(),
-  ReleaseMacOSBundleFlutterAssets(),
+  const DebugMacOSFramework(),
+  const DebugMacOSBundleFlutterAssets(),
+  const ProfileMacOSBundleFlutterAssets(),
+  const ReleaseMacOSBundleFlutterAssets(),
   // Linux targets
-  DebugBundleLinuxAssets(TargetPlatform.linux_x64),
-  DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
-  ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
-  ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
-  ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
-  ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
+  const DebugBundleLinuxAssets(TargetPlatform.linux_x64),
+  const DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
+  const ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
+  const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
+  const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
+  const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
   // Web targets
-  WebServiceWorker(),
-  ReleaseAndroidApplication(),
+  const WebServiceWorker(),
+  const ReleaseAndroidApplication(),
   // This is a one-off rule for bundle and aot compat.
-  CopyFlutterBundle(),
+  const CopyFlutterBundle(),
   // Android targets,
-  DebugAndroidApplication(),
-  ProfileAndroidApplication(),
+  const DebugAndroidApplication(),
+  const ProfileAndroidApplication(),
   // Android ABI specific AOT rules.
   androidArmProfileBundle,
   androidArm64ProfileBundle,
@@ -63,15 +63,15 @@ const List<Target> _kDefaultTargets = <Target>[
   androidArm64ReleaseBundle,
   androidx64ReleaseBundle,
   // iOS targets
-  DebugIosApplicationBundle(),
-  ProfileIosApplicationBundle(),
-  ReleaseIosApplicationBundle(),
+  const DebugIosApplicationBundle(),
+  const ProfileIosApplicationBundle(),
+  const ReleaseIosApplicationBundle(),
   ThinIosApplicationFrameworks(),
   // Windows targets
-  UnpackWindows(),
-  DebugBundleWindowsAssets(),
-  ProfileBundleWindowsAssets(),
-  ReleaseBundleWindowsAssets(),
+  const UnpackWindows(),
+  const DebugBundleWindowsAssets(),
+  const ProfileBundleWindowsAssets(),
+  const ReleaseBundleWindowsAssets(),
 ];
 
 // TODO(ianh): https://github.com/dart-lang/args/issues/181 will allow us to remove useLegacyNames

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -315,7 +315,7 @@ void main() {
         outputDir: outputDir,
         defines: <String, String>{},
       );
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isFalse);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isFalse);
       expect(processManager.hasRemainingExpectations, isFalse);
     });
 
@@ -343,7 +343,7 @@ void main() {
           binary.path,
         ], stdout: 'Non-fat file: Flutter.framework/Flutter is architecture: arm64'),
       );
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isFalse);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isFalse);
     });
 
     testWithoutContext('do not skip when lipo -info fails', () async {
@@ -370,7 +370,7 @@ void main() {
           binary.path,
         ], exitCode: 1),
       );
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isFalse);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isFalse);
     });
 
     testWithoutContext('do not skip when cannot parse lipo', () async {
@@ -397,7 +397,7 @@ void main() {
           binary.path,
         ], stdout: 'Bogus output'),
       );
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isFalse);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isFalse);
     });
 
     testWithoutContext('do not skip when thinning is required', () async {
@@ -425,23 +425,7 @@ void main() {
         ], stdout: 'Architectures in the fat file: Flutter.framework/Flutter are: armv7 arm64 '),
       );
 
-      final ThinIosApplicationFrameworks thinIosApplicationFrameworks = ThinIosApplicationFrameworks();
-      expect(thinIosApplicationFrameworks.canSkip(environment), isFalse);
-      expect(processManager.hasRemainingExpectations, isFalse);
-
-      processManager.addCommand(
-        FakeCommand(command: <String>[
-          'lipo',
-          '-output',
-          binary.path,
-          '-extract',
-          'arm64',
-          binary.path,
-        ]),
-      );
-
-      await thinIosApplicationFrameworks.build(environment);
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isFalse);
     });
 
     testWithoutContext('skip when thinning is not required for fat', () async {
@@ -469,7 +453,7 @@ void main() {
         ], stdout: 'Architectures in the fat file: Flutter.framework/Flutter are: arm64 armv7 '), // arch order doesn't matter
       );
 
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isTrue);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isTrue);
     });
 
     testWithoutContext('skip when thinning is not required for non-fat', () async {
@@ -496,7 +480,7 @@ void main() {
           binary.path,
         ], stdout: 'Non-fat file: Flutter.framework/Flutter is architecture: x86_64'),
       );
-      expect(ThinIosApplicationFrameworks().canSkip(environment), isTrue);
+      expect(const ThinIosApplicationFrameworks().canSkip(environment), isTrue);
     });
 
     testWithoutContext('fails when frameworks missing', () async {
@@ -514,7 +498,7 @@ void main() {
         },
       );
       await expectLater(
-        ThinIosApplicationFrameworks().build(environment),
+        const ThinIosApplicationFrameworks().build(environment),
         throwsA(isA<Exception>().having(
           (Exception exception) => exception.toString(),
           'description',
@@ -548,11 +532,11 @@ void main() {
       );
 
       await expectLater(
-          ThinIosApplicationFrameworks().build(environment),
+          const ThinIosApplicationFrameworks().build(environment),
           throwsA(isA<Exception>().having(
                 (Exception exception) => exception.toString(),
             'description',
-            contains('does not contain arm64 armv7. Running lipo -info:\nNon-fat file:'),
+            contains('does not contain arm64 armv7, contains arm64'),
           )));
     });
 
@@ -583,11 +567,11 @@ void main() {
       );
 
       await expectLater(
-          ThinIosApplicationFrameworks().build(environment),
+          const ThinIosApplicationFrameworks().build(environment),
           throwsA(isA<Exception>().having(
                 (Exception exception) => exception.toString(),
             'description',
-            contains('does not contain arm64 armv7. Running lipo -info:\nBogus output'),
+            contains('architectures cannot be parsed'),
           )));
     });
 
@@ -631,43 +615,12 @@ void main() {
       );
 
       await expectLater(
-        ThinIosApplicationFrameworks().build(environment),
+        const ThinIosApplicationFrameworks().build(environment),
         throwsA(isA<Exception>().having(
               (Exception exception) => exception.toString(),
           'description',
-          contains('Failed to extract arm64 armv7 for Runner.app/Frameworks/Flutter.framework/Flutter.\nlipo error\nRunning lipo -info:\nArchitectures in the fat file:'),
+          contains('Failed to extract arm64 armv7 for Runner.app/Frameworks/Flutter.framework/Flutter.\nlipo error'),
         )));
-    });
-
-    testWithoutContext('skips thin frameworks', () async {
-      final FileSystem fileSystem = MemoryFileSystem.test();
-      final Directory outputDir = fileSystem.directory('Runner.app').childDirectory('Frameworks')..createSync(recursive: true);
-      final File binary = outputDir.childDirectory('Flutter.framework').childFile('Flutter')..createSync(recursive: true);
-
-      final Environment environment = Environment.test(
-        fileSystem.currentDirectory,
-        processManager: processManager,
-        artifacts: artifacts,
-        logger: logger,
-        fileSystem: fileSystem,
-        outputDir: outputDir,
-        defines: <String, String>{
-          kIosArchs: 'arm64',
-        },
-      );
-
-      processManager.addCommand(
-        FakeCommand(command: <String>[
-          'lipo',
-          '-info',
-          binary.path,
-        ], stdout: 'Non-fat file: Flutter.framework/Flutter is architecture: arm64'),
-      );
-      await ThinIosApplicationFrameworks().build(environment);
-
-      expect(logger.traceText, contains('Skipping lipo for non-fat file Runner.app/Frameworks/Flutter.framework/Flutter'));
-
-      expect(processManager.hasRemainingExpectations, isFalse);
     });
 
     testWithoutContext('thins fat frameworks', () async {
@@ -708,7 +661,7 @@ void main() {
         ]),
       );
 
-      await ThinIosApplicationFrameworks().build(environment);
+      await const ThinIosApplicationFrameworks().build(environment);
       expect(processManager.hasRemainingExpectations, isFalse);
     });
   });


### PR DESCRIPTION
Implement `ThinIosApplicationFrameworks.canSkip()`.  If Flutter.framework contains exactly the requested architectures (the x86_64 simulator framework or `xcarchive`, for example), then don't `lipo -extract` anything.

Follow up to #76665.