### PR TITLE
[flutter_tools] remove mocks from android SDK tests

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -8,25 +8,22 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart' show ProcessResult;
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:meta/meta.dart';
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 
-class MockProcessManager extends Mock implements ProcessManager {}
 
 void main() {
   MemoryFileSystem fileSystem;
-  MockProcessManager processManager;
+  FakeProcessManager processManager;
   Config config;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
-    processManager = MockProcessManager();
+    processManager = FakeProcessManager.list(<FakeCommand>[]);
     config = Config.test();
   });
 
@@ -153,17 +150,16 @@ void main() {
     testUsingContext('returns sdkmanager version', () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       config.setValue('android-sdk', sdkDir.path);
-
+      processManager.addCommand(
+        const FakeCommand(
+            command: <String>[
+            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+            '--version',
+          ],
+          stdout: '26.1.1\n',
+        ),
+      );
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(true);
-      when(processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
-          environment: argThat(isNotNull,  named: 'environment')))
-          .thenReturn(ProcessResult(1, 0, '26.1.1\n', ''));
-      when(processManager.runSync(
-        <String>['/usr/libexec/java_home', '-v', '1.8'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 0, '', ''));
 
       expect(sdk.sdkManagerVersion, '26.1.1');
     }, overrides: <Type, Generator>{
@@ -173,13 +169,15 @@ void main() {
     });
 
     testUsingContext('returns validate sdk is well formed', () {
-      sdkDir = MockBrokenAndroidSdk.createSdkDirectory(
+      sdkDir = createSdkDirectory(
         fileSystem: fileSystem,
       );
+      processManager.addCommand(const FakeCommand(command: <String>[
+        '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+        '--version',
+      ]));
       config.setValue('android-sdk', sdkDir.path);
-
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      when(processManager.canRun(sdk.adbPath)).thenReturn(true);
 
       final List<String> validationIssues = sdk.validateSdkWellFormed();
       expect(validationIssues.first, 'No valid Android SDK platforms found in'
@@ -196,17 +194,19 @@ void main() {
     testUsingContext('does not throw on sdkmanager version check failure', () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       config.setValue('android-sdk', sdkDir.path);
+      processManager.addCommand(
+        const FakeCommand(
+          command: <String>[
+            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+            '--version',
+          ],
+          stdout: '\n',
+          stderr: 'Mystery error',
+          exitCode: 1,
+        ),
+      );
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(true);
-      when(processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
-          environment: argThat(isNotNull,  named: 'environment')))
-          .thenReturn(ProcessResult(1, 1, '26.1.1\n', 'Mystery error'));
-      when(processManager.runSync(
-        <String>['/usr/libexec/java_home', '-v', '1.8'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 0, '', ''));
 
       expect(sdk.sdkManagerVersion, isNull);
     }, overrides: <Type, Generator>{
@@ -218,9 +218,9 @@ void main() {
     testUsingContext('throws on sdkmanager version check if sdkmanager not found', () {
       sdkDir = MockAndroidSdk.createSdkDirectory(withSdkManager: false);
       config.setValue('android-sdk', sdkDir.path);
-
+      processManager.excludedExecutables.add('/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat');
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
-      when(processManager.canRun(sdk.sdkManagerPath)).thenReturn(false);
+
       expect(() => sdk.sdkManagerVersion, throwsToolExit());
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -231,31 +231,29 @@ void main() {
 }
 
 /// A broken SDK installation.
-class MockBrokenAndroidSdk extends Mock implements AndroidSdk {
-  static Directory createSdkDirectory({
-    bool withAndroidN = false,
-    bool withSdkManager = true,
-    @required FileSystem fileSystem,
-  }) {
-    final Directory dir = fileSystem.systemTempDirectory.createTempSync('flutter_mock_android_sdk.');
-    _createSdkFile(dir, 'licenses/dummy');
-    _createSdkFile(dir, 'platform-tools/adb');
+Directory createSdkDirectory({
+  bool withAndroidN = false,
+  bool withSdkManager = true,
+  @required FileSystem fileSystem,
+}) {
+  final Directory dir = fileSystem.systemTempDirectory.createTempSync('flutter_mock_android_sdk.');
+  _createSdkFile(dir, 'licenses/dummy');
+  _createSdkFile(dir, 'platform-tools/adb');
 
-    _createSdkFile(dir, 'build-tools/sda/aapt');
-    _createSdkFile(dir, 'build-tools/af/aapt');
-    _createSdkFile(dir, 'build-tools/ljkasd/aapt');
+  _createSdkFile(dir, 'build-tools/sda/aapt');
+  _createSdkFile(dir, 'build-tools/af/aapt');
+  _createSdkFile(dir, 'build-tools/ljkasd/aapt');
 
-    _createSdkFile(dir, 'platforms/android-22/android.jar');
-    _createSdkFile(dir, 'platforms/android-23/android.jar');
+  _createSdkFile(dir, 'platforms/android-22/android.jar');
+  _createSdkFile(dir, 'platforms/android-23/android.jar');
 
-    return dir;
-  }
+  return dir;
+}
 
-  static void _createSdkFile(Directory dir, String filePath, { String contents }) {
-    final File file = dir.childFile(filePath);
-    file.createSync(recursive: true);
-    if (contents != null) {
-      file.writeAsStringSync(contents, flush: true);
-    }
+void _createSdkFile(Directory dir, String filePath, { String contents }) {
+  final File file = dir.childFile(filePath);
+  file.createSync(recursive: true);
+  if (contents != null) {
+    file.writeAsStringSync(contents, flush: true);
   }
 }

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -153,7 +153,7 @@ void main() {
       processManager.addCommand(
         const FakeCommand(
             command: <String>[
-            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager',
             '--version',
           ],
           stdout: '26.1.1\n',
@@ -166,6 +166,7 @@ void main() {
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Config: () => config,
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
     });
 
     testUsingContext('returns validate sdk is well formed', () {
@@ -173,7 +174,7 @@ void main() {
         fileSystem: fileSystem,
       );
       processManager.addCommand(const FakeCommand(command: <String>[
-        '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+        '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager',
         '--version',
       ]));
       config.setValue('android-sdk', sdkDir.path);
@@ -197,7 +198,7 @@ void main() {
       processManager.addCommand(
         const FakeCommand(
           command: <String>[
-            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat',
+            '/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager',
             '--version',
           ],
           stdout: '\n',
@@ -213,12 +214,13 @@ void main() {
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Config: () => config,
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
     });
 
     testUsingContext('throws on sdkmanager version check if sdkmanager not found', () {
       sdkDir = MockAndroidSdk.createSdkDirectory(withSdkManager: false);
       config.setValue('android-sdk', sdkDir.path);
-      processManager.excludedExecutables.add('/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager.bat');
+      processManager.excludedExecutables.add('/.tmp_rand0/flutter_mock_android_sdk.rand0/tools/bin/sdkmanager');
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
 
       expect(() => sdk.sdkManagerVersion, throwsToolExit());
@@ -226,6 +228,7 @@ void main() {
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
       Config: () => config,
+      Platform: () => FakePlatform(operatingSystem: 'linux'),
     });
   });
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/71511

Replaces MockProcessManager with FakeProcessManager and removes mock that could have been a top level method.