### PR TITLE
[flutter_tools] enable single widget reload for beta channel

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -301,11 +301,11 @@ const Feature singleWidgetReload = Feature(
   ),
   dev: FeatureChannelSetting(
     available: true,
-    enabledByDefault: false,
+    enabledByDefault: true,
   ),
   beta: FeatureChannelSetting(
     available: true,
-    enabledByDefault: false,
+    enabledByDefault: true,
   ),
   stable: FeatureChannelSetting(
     available: false,


### PR DESCRIPTION
The number of users on dev did not give us enough information to rule out increases from changes to tooling. Send the swr experiment to the next beta so we can see what the overall affect on reload times is.