### PR TITLE
Fix prepare package

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -383,7 +383,7 @@ class ArchiveCreator {
     // Ensure the above commands do not clean out the cache
     final Directory flutterCache = Directory(path.join(flutterRoot.absolute.path, 'bin', 'cache'));
     if (!flutterCache.existsSync()) {
-      throw Exception('The flutter was not found at ${flutterCache.path}!');
+      throw Exception('The flutter cache was not found at ${flutterCache.path}!');
     }
 
     /// Remove git subfolder from .pub-cache, this contains the flutter goldens

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -370,7 +370,13 @@ class ArchiveCreator {
     // Yes, we could just skip all .packages files when constructing
     // the archive, but some are checked in, and we don't want to skip
     // those.
-    await _runGit(<String>['clean', '-f', '-x', '**/.packages']);
+    await _runGit(<String>[
+      'clean',
+      '-f',
+      // Do not -X as it could lead to entire bin/cache getting cleaned
+      '-x',
+      '**/.packages',
+    ]);
     /// Remove package_config files and any contents in .dart_tool
     await _runGit(<String>['clean', '-f', '-x', '**/.dart_tool']);
     /// Remove git subfolder from .pub-cache, this contains the flutter goldens

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -379,6 +379,13 @@ class ArchiveCreator {
     ]);
     /// Remove package_config files and any contents in .dart_tool
     await _runGit(<String>['clean', '-f', '-x', '**/.dart_tool']);
+
+    // Ensure the above commands do not clean out the cache
+    final Directory flutterCache = Directory(path.join(flutterRoot.absolute.path, 'bin', 'cache'));
+    if (!flutterCache.existsSync()) {
+      throw Exception('The flutter was not found at ${flutterCache.path}!');
+    }
+
     /// Remove git subfolder from .pub-cache, this contains the flutter goldens
     /// and new flutter_gallery.
     final Directory gitCache = Directory(path.join(flutterRoot.absolute.path, '.pub-cache', 'git'));

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -375,10 +375,17 @@ class ArchiveCreator {
       '-f',
       // Do not -X as it could lead to entire bin/cache getting cleaned
       '-x',
+      '--',
       '**/.packages',
     ]);
     /// Remove package_config files and any contents in .dart_tool
-    await _runGit(<String>['clean', '-f', '-x', '**/.dart_tool']);
+    await _runGit(<String>[
+      'clean',
+      '-f',
+      '-x',
+      '--',
+      '**/.dart_tool/',
+    ]);
 
     // Ensure the above commands do not clean out the cache
     final Directory flutterCache = Directory(path.join(flutterRoot.absolute.path, 'bin', 'cache'));

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -370,9 +370,9 @@ class ArchiveCreator {
     // Yes, we could just skip all .packages files when constructing
     // the archive, but some are checked in, and we don't want to skip
     // those.
-    await _runGit(<String>['clean', '-f', '-X', '**/.packages']);
+    await _runGit(<String>['clean', '-f', '-x', '**/.packages']);
     /// Remove package_config files and any contents in .dart_tool
-    await _runGit(<String>['clean', '-f', '-X', '**/.dart_tool']);
+    await _runGit(<String>['clean', '-f', '-x', '**/.dart_tool']);
     /// Remove git subfolder from .pub-cache, this contains the flutter goldens
     /// and new flutter_gallery.
     final Directory gitCache = Directory(path.join(flutterRoot.absolute.path, '.pub-cache', 'git'));

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -120,8 +120,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -X **/.packages': null,
-          'git clean -f -X **/.dart_tool': null,
+          'git clean -f -x **/.packages': null,
+          'git clean -f -x **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -156,8 +156,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -X **/.packages': null,
-          'git clean -f -X **/.dart_tool': null,
+          'git clean -f -x **/.packages': null,
+          'git clean -f -x **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -206,8 +206,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -X **/.packages': null,
-          'git clean -f -X **/.dart_tool': null,
+          'git clean -f -x **/.packages': null,
+          'git clean -f -x **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -70,6 +70,7 @@ void main() {
       ArchiveCreator creator;
       Directory tempDir;
       Directory flutterDir;
+      Directory cacheDir;
       FakeProcessManager processManager;
       final List<List<String>> args = <List<String>>[];
       final List<Map<Symbol, dynamic>> namedArgs = <Map<Symbol, dynamic>>[];
@@ -86,6 +87,8 @@ void main() {
         tempDir = Directory.systemTemp.createTempSync('flutter_prepage_package_test.');
         flutterDir = Directory(path.join(tempDir.path, 'flutter'));
         flutterDir.createSync(recursive: true);
+        cacheDir = Directory(path.join(flutterDir.path, 'bin', 'cache'));
+        cacheDir.createSync(recursive: true);
         creator = ArchiveCreator(
           tempDir,
           tempDir,
@@ -120,8 +123,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -x **/.packages': null,
-          'git clean -f -x **/.dart_tool': null,
+          'git clean -f -x -- **/.packages': null,
+          'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -156,8 +159,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -x **/.packages': null,
-          'git clean -f -x **/.dart_tool': null,
+          'git clean -f -x -- **/.packages': null,
+          'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -206,8 +209,8 @@ void main() {
           '$flutter create --template=app ${createBase}app': null,
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
-          'git clean -f -x **/.packages': null,
-          'git clean -f -x **/.dart_tool': null,
+          'git clean -f -x -- **/.packages': null,
+          'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null


### PR DESCRIPTION
Fix bug where we were inadvertently deleting the entire `bin/cache` directory because two files contained in it matched the `git clean` file glob:

```
./bin/cache/dart-sdk/bin/resources/dartdoc/.packages
./bin/cache/dart-sdk/lib/_internal/js_runtime/.packages
```

fixes https://github.com/flutter/flutter/issues/76894