### PR TITLE
Removed RadioListTile accentColor dependency

### DIFF
--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -26,7 +26,7 @@ import 'theme_data.dart';
 /// those of the same name on [ListTile].
 ///
 /// The [selected] property on this widget is similar to the [ListTile.selected]
-/// property. This tile's [activeColor] for the selected item color, or
+/// property. This tile's [activeColor] is used for the selected item's text color, or
 /// the theme's [ThemeData.toggleableActiveColor] if [activeColor] is null.
 ///
 /// This widget does not coordinate the [selected] state and the

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -26,11 +26,13 @@ import 'theme_data.dart';
 /// those of the same name on [ListTile].
 ///
 /// The [selected] property on this widget is similar to the [ListTile.selected]
-/// property, but the color used is that described by [activeColor], if any,
-/// defaulting to the accent color of the current [Theme]. No effort is made to
-/// coordinate the [selected] state and the [checked] state; to have the list
-/// tile appear selected when the radio button is the selected radio button, set
-/// [selected] to true when [value] matches [groupValue].
+/// property. This tile's [activeColor] for the selected item color, or
+/// the theme's [ThemeData.toggleableActiveColor] if [activeColor] is null.
+///
+/// This widget does not coordinate the [selected] state and the
+/// [checked] state; to have the list tile appear selected when the
+/// radio button is the selected radio button, set [selected] to true
+/// when [value] matches [groupValue].
 ///
 /// The radio button is shown on the left by default in left-to-right languages
 /// (i.e. the leading edge). This can be changed using [controlAffinity]. The
@@ -520,7 +522,7 @@ class RadioListTile<T> extends StatelessWidget {
     }
     return MergeSemantics(
       child: ListTileTheme.merge(
-        selectedColor: activeColor ?? Theme.of(context).accentColor,
+        selectedColor: activeColor ?? Theme.of(context).toggleableActiveColor,
         child: ListTile(
           leading: leading,
           title: title,

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -710,7 +710,7 @@ void main() {
   });
 
   testWidgets('RadioListTile selected item text Color', (WidgetTester tester) async {
-    // Regression test for
+    // Regression test for https://github.com/flutter/flutter/pull/76906
 
     const Color activeColor = Color(0xff00ff00);
 

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -708,4 +708,40 @@ void main() {
     final ColoredBox coloredBox = tester.firstWidget(find.byType(ColoredBox));
     expect(coloredBox.color, equals(selectedTileColor));
   });
+
+  testWidgets('RadioListTile selected item text Color', (WidgetTester tester) async {
+    // Regression test for
+
+    const Color activeColor = Color(0xff00ff00);
+
+    Widget buildFrame({ Color? activeColor, Color? toggleableActiveColor }) {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          toggleableActiveColor: toggleableActiveColor,
+        ),
+        home: Scaffold(
+          body: Center(
+            child: RadioListTile<bool>(
+              activeColor: activeColor,
+              selected: true,
+              title: const Text('title'),
+              value: false,
+              groupValue: true,
+              onChanged: (bool? newValue) { },
+            ),
+          ),
+        ),
+      );
+    }
+
+    Color? textColor(String text) {
+      return tester.renderObject<RenderParagraph>(find.text(text)).text.style?.color;
+    }
+
+    await tester.pumpWidget(buildFrame(toggleableActiveColor: activeColor));
+    expect(textColor('title'), activeColor);
+
+    await tester.pumpWidget(buildFrame(activeColor: activeColor));
+    expect(textColor('title'), activeColor);
+  });
 }


### PR DESCRIPTION
For tiles with `selected: true`, if the tile's `activeColor` is null, the selected item's text color now defaults to `ThemeData.toggleableActiveColor` instead of `ThemeData.accentColor`.  This removes the widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

This is technically not a breaking change, because it doesn't break any existing tests. However the dependency had been documented. 