### PR TITLE
Removed SwitchListTile accentColor dependency

### DIFF
--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -35,10 +35,12 @@ enum _SwitchListTileType { material, adaptive }
 /// those of the same name on [ListTile].
 ///
 /// The [selected] property on this widget is similar to the [ListTile.selected]
-/// property, but the color used is that described by [activeColor], if any,
-/// defaulting to the accent color of the current [Theme]. No effort is made to
-/// coordinate the [selected] state and the [value] state; to have the list tile
-/// appear selected when the switch is on, pass the same value to both.
+/// property. This tile's [activeColor] is used for the selected item's text color, or
+/// the theme's [ThemeData.toggleableActiveColor] if [activeColor] is null.
+///
+/// This widget does not coordinate the [selected] state and the
+/// [value]; to have the list tile appear selected when the
+/// switch button is on, use the same value for both.
 ///
 /// The switch is shown on the right by default in left-to-right languages (i.e.
 /// in the [ListTile.trailing] slot) which can be changed using [controlAffinity].
@@ -503,7 +505,7 @@ class SwitchListTile extends StatelessWidget {
 
     return MergeSemantics(
       child: ListTileTheme.merge(
-        selectedColor: activeColor ?? Theme.of(context).accentColor,
+        selectedColor: activeColor ?? Theme.of(context).toggleableActiveColor,
         child: ListTile(
           leading: leading,
           title: title,

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
@@ -399,4 +400,38 @@ void main() {
     expect(coloredBox.color, equals(selectedTileColor));
   });
 
+  testWidgets('SwitchListTile selected item text Color', (WidgetTester tester) async {
+    // Regression test for
+
+    const Color activeColor = Color(0xff00ff00);
+
+    Widget buildFrame({ Color? activeColor, Color? toggleableActiveColor }) {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          toggleableActiveColor: toggleableActiveColor,
+        ),
+        home: Scaffold(
+          body: Center(
+            child: SwitchListTile(
+              activeColor: activeColor,
+              selected: true,
+              title: const Text('title'),
+              value: true,
+              onChanged: (bool? value) { },
+            ),
+          ),
+        ),
+      );
+    }
+
+    Color? textColor(String text) {
+      return tester.renderObject<RenderParagraph>(find.text(text)).text.style?.color;
+    }
+
+    await tester.pumpWidget(buildFrame(toggleableActiveColor: activeColor));
+    expect(textColor('title'), activeColor);
+
+    await tester.pumpWidget(buildFrame(activeColor: activeColor));
+    expect(textColor('title'), activeColor);
+  });
 }

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -401,7 +401,7 @@ void main() {
   });
 
   testWidgets('SwitchListTile selected item text Color', (WidgetTester tester) async {
-    // Regression test for
+    // Regression test for https://github.com/flutter/flutter/pull/76909
 
     const Color activeColor = Color(0xff00ff00);
 


### PR DESCRIPTION
For tiles with `selected: true`, if the tile's `activeColor` is null, the selected item's text color now defaults to `ThemeData.toggleableActiveColor` instead of `ThemeData.accentColor`.  This removes the widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

This is technically not a breaking change, because it doesn't break any existing tests. However the dependency had been documented. 