### PR TITLE
changed 'constrains' to 'constraints' in ChildLayoutHelper.dryLayoutC…

### DIFF
--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -11,8 +11,7 @@ import 'box.dart';
 /// [BoxConstraints].
 ///
 /// The methods of [ChildLayoutHelper] adhere to this signature.
-typedef ChildLayouter = Size Function(
-    RenderBox child, BoxConstraints constraints);
+typedef ChildLayouter = Size Function(RenderBox child, BoxConstraints constraints);
 
 /// A collection of static functions to layout a [RenderBox] child with the
 /// given set of [BoxConstraints].

--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -11,7 +11,8 @@ import 'box.dart';
 /// [BoxConstraints].
 ///
 /// The methods of [ChildLayoutHelper] adhere to this signature.
-typedef ChildLayouter = Size Function(RenderBox child, BoxConstraints constraints);
+typedef ChildLayouter = Size Function(
+    RenderBox child, BoxConstraints constraints);
 
 /// A collection of static functions to layout a [RenderBox] child with the
 /// given set of [BoxConstraints].
@@ -33,8 +34,8 @@ class ChildLayoutHelper {
   ///
   ///  * [layoutChild], which actually lays out the child with the given
   ///    constraints.
-  static Size dryLayoutChild(RenderBox child, BoxConstraints constrains) {
-    return child.getDryLayout(constrains);
+  static Size dryLayoutChild(RenderBox child, BoxConstraints constraints) {
+    return child.getDryLayout(constraints);
   }
 
   /// Lays out the [RenderBox] with the given constraints and returns its


### PR DESCRIPTION
This PR just fixes a typo in packages/flutter/lib/src/rendering/layout_helper.dart. Changes 'constrains' to 'constraints'

it changes ,
  static Size dryLayoutChild(RenderBox child, BoxConstraints constrains) {
    return child.getDryLayout(constrains);
  }
to
  static Size dryLayoutChild(RenderBox child, BoxConstraints constraints) {
    return child.getDryLayout(constraints);
  } 

fixes #76935. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
