### PR TITLE
To solve the problem of window losing response caused by MoveWindow

### DIFF
--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/win32_window.cpp
@@ -4,6 +4,8 @@
 
 #include "resource.h"
 
+#define WM_SIZE_CHILD WM_USER + 1
+
 namespace {
 
 constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
@@ -174,15 +176,19 @@ Win32Window::MessageHandler(HWND hwnd,
       return 0;
     }
     case WM_SIZE: {
-      RECT rect = GetClientArea();
-      if (child_content_ != nullptr) {
-        // Size and position the child window.
-        MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
-                   rect.bottom - rect.top, TRUE);
-      }
+		PostMessage(hwnd, WM_SIZE_CHILD, 0, 0);
       return 0;
     }
-
+	case WM_SIZE_CHILD:
+	{
+		if (child_content_ != nullptr) {
+			// Size and position the child window.
+			RECT rect = GetClientArea();
+			MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
+				rect.bottom - rect.top, TRUE);
+		}
+	}
+	break;
     case WM_ACTIVATE:
       if (child_content_ != nullptr) {
         SetFocus(child_content_);


### PR DESCRIPTION
In windows desktop projects, the window loses its response when the MoveWindow function of win32 is called directly from the Flutter interface. It is suspected WM_SIZE the modification of the sub-window in the message.
I raised this issue in the win32 plug-in project, and it has been agreed that this is not a win32 plug-in issue.
(https://github.com/timsneath/win32/issues/157)
![2021-03-01_174635](https://user-images.githubusercontent.com/18590422/109480267-3e4d1980-7a73-11eb-9c76-3f0de217b7f0.jpg)

I found a solution. By modifying the (windows\runner\win32_window.cpp) file, create a custom message that delays the code WM_SIZE the modified sub-window in "Windows".


