### PR TITLE
Removed ListTile accentColor dependency

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/main.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/main.dart
@@ -64,7 +64,7 @@ class StocksAppState extends State<StocksApp> {
       case StockMode.pessimistic:
         return ThemeData(
           brightness: Brightness.dark,
-          accentColor: Colors.redAccent,
+          primarySwatch: Colors.purple,
         );
     }
     assert(_configuration.stockMode != null);

--- a/dev/benchmarks/test_apps/stocks/lib/main.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/main.dart
@@ -60,6 +60,11 @@ class StocksAppState extends State<StocksApp> {
         return ThemeData(
           brightness: Brightness.light,
           primarySwatch: Colors.purple,
+          colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.purple).copyWith(
+            // Override for backwards compatibility. The correct onPrimary color
+            // is actually white, but for the sake of test/icon_color_test...
+            onPrimary: Colors.black,
+          ),
         );
       case StockMode.pessimistic:
         return ThemeData(

--- a/dev/benchmarks/test_apps/stocks/lib/main.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/main.dart
@@ -60,11 +60,6 @@ class StocksAppState extends State<StocksApp> {
         return ThemeData(
           brightness: Brightness.light,
           primarySwatch: Colors.purple,
-          colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.purple).copyWith(
-            // Override for backwards compatibility. The correct onPrimary color
-            // is actually white, but for the sake of test/icon_color_test...
-            onPrimary: Colors.black,
-          ),
         );
       case StockMode.pessimistic:
         return ThemeData(

--- a/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
@@ -83,7 +83,7 @@ void main() {
     await tester.pump(const Duration(seconds: 5)); // end the transition
 
     // check the color of the icon - dark mode
-    checkIconColor(tester, 'Stock List', Colors.redAccent); // theme accent color
+    checkIconColor(tester, 'Stock List', Colors.purple); // theme primary color
     checkIconColor(tester, 'Account Balance', Colors.white38); // disabled
     checkIconColor(tester, 'About', Colors.white); // enabled
   });

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -790,8 +790,8 @@ class ListTile extends StatelessWidget {
   ///
   /// When [selected] is true, the text color is set to [ListTileTheme.selectedColor]
   /// if it's not null. If [ListTileTheme.selectedColor] is null, the text color
-  /// is set to [ThemeData.ColorScheme.primary] when [ThemeData.brightness] is
-  /// [Brightness.light] and to [ThemeData.ColorScheme.secondary] when it is [Brightness.dark].
+  /// is set to [ThemeData.colorScheme.primary] when [ThemeData.brightness] is
+  /// [Brightness.light] and to [ThemeData.colorScheme.secondary] when it is [Brightness.dark].
   ///
   /// When [selected] is false, the text color is set to [ListTileTheme.textColor]
   /// if it's not null and to [TextTheme.caption]'s color if [ListTileTheme.textColor]

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -788,11 +788,6 @@ class ListTile extends StatelessWidget {
   ///
   /// When [enabled] is false, the text color is set to [ThemeData.disabledColor].
   ///
-  /// When [selected] is true, the text color is set to [ListTileTheme.selectedColor]
-  /// if it's not null. If [ListTileTheme.selectedColor] is null, the text color
-  /// is set to [ThemeData.colorScheme.primary] when [ThemeData.brightness] is
-  /// [Brightness.light] and to [ThemeData.colorScheme.secondary] when it is [Brightness.dark].
-  ///
   /// When [selected] is false, the text color is set to [ListTileTheme.textColor]
   /// if it's not null and to [TextTheme.caption]'s color if [ListTileTheme.textColor]
   /// is null.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1015,8 +1015,8 @@ class ListTile extends StatelessWidget {
     switch (theme.brightness) {
       case Brightness.light:
         // For the sake of backwards compatibility, the default for unselected
-        // tiles - with the default light theme - is the same as Colors.black45.
-        return selected ? theme.colorScheme.primary : theme.colorScheme.onSurface.withAlpha(0x73);
+        // tiles is Colors.black45 rather than colorScheme.onSurface.withAlpha(0x73).
+      return selected ? theme.colorScheme.primary : Colors.black45;
       case Brightness.dark:
         return selected ? theme.colorScheme.secondary : null; // null - use current icon theme color
     }

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1016,7 +1016,7 @@ class ListTile extends StatelessWidget {
       case Brightness.light:
         // For the sake of backwards compatibility, the default for unselected
         // tiles - with the default light theme - is the same as Colors.black45.
-        return selected ? theme.colorScheme.primary : theme.colorScheme.onPrimary.withAlpha(0x73);
+        return selected ? theme.colorScheme.primary : theme.colorScheme.onSurface.withAlpha(0x73);
       case Brightness.dark:
         return selected ? theme.colorScheme.secondary : null; // null - use current icon theme color
     }

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -790,8 +790,8 @@ class ListTile extends StatelessWidget {
   ///
   /// When [selected] is true, the text color is set to [ListTileTheme.selectedColor]
   /// if it's not null. If [ListTileTheme.selectedColor] is null, the text color
-  /// is set to [ThemeData.primaryColor] when [ThemeData.brightness] is
-  /// [Brightness.light] and to [ThemeData.accentColor] when it is [Brightness.dark].
+  /// is set to [ThemeData.ColorScheme.primary] when [ThemeData.brightness] is
+  /// [Brightness.light] and to [ThemeData.ColorScheme.secondary] when it is [Brightness.dark].
   ///
   /// When [selected] is false, the text color is set to [ListTileTheme.textColor]
   /// if it's not null and to [TextTheme.caption]'s color if [ListTileTheme.textColor]
@@ -1019,9 +1019,11 @@ class ListTile extends StatelessWidget {
 
     switch (theme.brightness) {
       case Brightness.light:
-        return selected ? theme.primaryColor : Colors.black45;
+        // For the sake of backwards compatibility, the default for unselected
+        // tiles - with the default light theme - is the same as Colors.black45.
+        return selected ? theme.colorScheme.primary : theme.colorScheme.onPrimary.withAlpha(0x73);
       case Brightness.dark:
-        return selected ? theme.accentColor : null; // null - use current icon theme color
+        return selected ? theme.colorScheme.secondary : null; // null - use current icon theme color
     }
   }
 
@@ -1038,9 +1040,9 @@ class ListTile extends StatelessWidget {
     if (selected) {
       switch (theme.brightness) {
         case Brightness.light:
-          return theme.primaryColor;
+          return theme.colorScheme.primary;
         case Brightness.dark:
-          return theme.accentColor;
+          return theme.colorScheme.secondary;
       }
     }
     return defaultColor;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1016,9 +1016,9 @@ class ListTile extends StatelessWidget {
       case Brightness.light:
         // For the sake of backwards compatibility, the default for unselected
         // tiles is Colors.black45 rather than colorScheme.onSurface.withAlpha(0x73).
-      return selected ? theme.colorScheme.primary : Colors.black45;
+        return selected ? theme.colorScheme.primary : Colors.black45;
       case Brightness.dark:
-        return selected ? theme.colorScheme.secondary : null; // null - use current icon theme color
+        return selected ? theme.colorScheme.primary : null; // null - use current icon theme color
     }
   }
 
@@ -1032,14 +1032,9 @@ class ListTile extends StatelessWidget {
     if (!selected && tileTheme?.textColor != null)
       return tileTheme!.textColor;
 
-    if (selected) {
-      switch (theme.brightness) {
-        case Brightness.light:
-          return theme.colorScheme.primary;
-        case Brightness.dark:
-          return theme.colorScheme.secondary;
-      }
-    }
+    if (selected)
+      return theme.colorScheme.primary;
+
     return defaultColor;
   }
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2286,6 +2286,8 @@ void main() {
   });
 
   testWidgets('selected, enabled ListTile default icon color, light and dark themes', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/pull/77004
+
     const ColorScheme lightColorScheme = ColorScheme.light();
     const ColorScheme darkColorScheme = ColorScheme.dark();
     final Key leadingKey = UniqueKey();
@@ -2326,7 +2328,7 @@ void main() {
     expect(iconColor(trailingKey), darkColorScheme.secondary);
 
     // For this configuration, ListTile defers to the default IconTheme.
-    // Default dark theme IconTheme has color:white
+    // The default dark theme's IconTheme has color:white
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: false));
     expect(iconColor(leadingKey),  Colors.white);
     expect(iconColor(trailingKey), Colors.white);

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2319,8 +2319,8 @@ void main() {
     expect(iconColor(trailingKey), lightColorScheme.primary);
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: false));
-    expect(iconColor(leadingKey), lightColorScheme.onPrimary.withAlpha(0x73));
-    expect(iconColor(trailingKey), lightColorScheme.onPrimary.withAlpha(0x73));
+    expect(iconColor(leadingKey), lightColorScheme.onSurface.withAlpha(0x73));
+    expect(iconColor(trailingKey), lightColorScheme.onSurface.withAlpha(0x73));
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
     await tester.pumpAndSettle(); // Animated theme change

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2284,4 +2284,51 @@ void main() {
     expect(textColor(leadingKey), theme.disabledColor);
     expect(textColor(trailingKey), theme.disabledColor);
   });
+
+  testWidgets('selected, enabled ListTile default icon color, light and dark themes', (WidgetTester tester) async {
+    const ColorScheme lightColorScheme = ColorScheme.light();
+    const ColorScheme darkColorScheme = ColorScheme.dark();
+    final Key leadingKey = UniqueKey();
+    final Key trailingKey = UniqueKey();
+
+    Widget buildFrame({ required Brightness brightness, required bool selected }) {
+      final ThemeData theme = brightness == Brightness.light
+        ? ThemeData.from(colorScheme: const ColorScheme.light())
+        : ThemeData.from(colorScheme: const ColorScheme.dark());
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: ListTile(
+              enabled: true,
+              selected: selected,
+              leading: TestIcon(key: leadingKey),
+              trailing: TestIcon(key: trailingKey),
+            ),
+          ),
+        ),
+      );
+    }
+
+    Color iconColor(Key key) => tester.state<TestIconState>(find.byKey(key)).iconTheme.color!;
+
+    await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: true));
+    expect(iconColor(leadingKey), lightColorScheme.primary);
+    expect(iconColor(trailingKey), lightColorScheme.primary);
+
+    await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: false));
+    expect(iconColor(leadingKey), lightColorScheme.onPrimary.withAlpha(0x73));
+    expect(iconColor(trailingKey), lightColorScheme.onPrimary.withAlpha(0x73));
+
+    await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
+    await tester.pumpAndSettle(); // Animated theme change
+    expect(iconColor(leadingKey), darkColorScheme.secondary);
+    expect(iconColor(trailingKey), darkColorScheme.secondary);
+
+    // For this configuration, ListTile defers to the default IconTheme.
+    // Default dark theme IconTheme has color:white
+    await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: false));
+    expect(iconColor(leadingKey),  Colors.white);
+    expect(iconColor(trailingKey), Colors.white);
+  });
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2319,8 +2319,8 @@ void main() {
     expect(iconColor(trailingKey), lightColorScheme.primary);
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: false));
-    expect(iconColor(leadingKey), lightColorScheme.onSurface.withAlpha(0x73));
-    expect(iconColor(trailingKey), lightColorScheme.onSurface.withAlpha(0x73));
+    expect(iconColor(leadingKey), Colors.black45);
+    expect(iconColor(trailingKey), Colors.black45);
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
     await tester.pumpAndSettle(); // Animated theme change

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2324,8 +2324,8 @@ void main() {
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
     await tester.pumpAndSettle(); // Animated theme change
-    expect(iconColor(leadingKey), darkColorScheme.secondary);
-    expect(iconColor(trailingKey), darkColorScheme.secondary);
+    expect(iconColor(leadingKey), darkColorScheme.primary);
+    expect(iconColor(trailingKey), darkColorScheme.primary);
 
     // For this configuration, ListTile defers to the default IconTheme.
     // The default dark theme's IconTheme has color:white


### PR DESCRIPTION
This PR removes the ListTile widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

ListTile used the accentColor for title text and for leading/trailing icons, in selected:true tiles, when the ListTileTheme did not specify a selectedColor. The Color scheme's primary color is now used instead.

If the ListTileTheme doesn't specify a non-null value for `selectedColor`, the new default icon colors for the tile's leading and trailing widgets, and the default text color for the titles' descendant text widgets:

|  brightness | new  (selected:true)         | old (selected: true) |
| -----------|---------------------------|------|
| light            | colorScheme.primary        |  primaryColor |
| dark            | colorScheme.primary        |  accentColor | 

These colors should be indistinguishable from the original version when using one of the default themes.

The text and icon colors for selected:false tiles have not changed.

## Breaking change

This is a breaking change, although most apps will not notice the change from theme.primaryColor to theme.colorScheme.primary, because they are typically the same color. Apps should use the ListTileTheme's selectedColor to override the default.

```dart
import 'package:flutter/material.dart';

class Sample extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: ListTileTheme(
        selectedColor: Colors.orange,
        child: Container(
          padding: const EdgeInsets.all(32),
          alignment: Alignment.center,
          child: Column(
            mainAxisSize: MainAxisSize.min,
            children: <Widget>[
              ListTile(
                selected: true,
                title: Text('selected'),
                leading: Icon(Icons.android),
                trailing: Text('trailing')
              ),
              SizedBox(height: 32),
              ListTile(
                selected: false,
                title: Text('unselected'),
                leading: Icon(Icons.android),
                trailing: Icon(Icons.android),
              ),
            ],
          ),
        ),
      ),
    );
  }
}

void main() {
  runApp(
    MaterialApp(
      theme: ThemeData.light(),
      home: Scaffold(body: Sample())
    ),
  );
}
```

This PR was tested against internal Google apps in cl/360280942

