### PR TITLE
Move iOS Flutter.framework thinning into copy assemble build target

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -204,19 +204,6 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
   return 0
 }
 
-# Destructively thins the Flutter and App frameworks to include only the specified
-# architectures.
-ThinAppFrameworks() {
-  RunCommand "${FLUTTER_ROOT}/bin/flutter"                                \
-    ${verbose_flag}                                                       \
-    assemble                                                              \
-    --no-version-check                                                    \
-    --output="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"              \
-    -dTargetPlatform=ios                                                  \
-    -dIosArchs="${ARCHS}"                                                 \
-    "thin_ios_application_frameworks"
-}
-
 # Adds the App.framework as an embedded binary and the flutter_assets as
 # resources.
 EmbedFlutterFrameworks() {
@@ -273,11 +260,6 @@ AddObservatoryBonjourService() {
   fi
 }
 
-EmbedAndThinFrameworks() {
-  EmbedFlutterFrameworks
-  ThinAppFrameworks
-}
-
 # Main entry point.
 if [[ $# == 0 ]]; then
   # Named entry points were introduced in Flutter v0.0.7.
@@ -288,11 +270,13 @@ else
     "build")
       BuildApp ;;
     "thin")
-      ThinAppFrameworks ;;
+      # No-op, thinning is handled during the bundle asset assemble build target.
+      ;;
     "embed")
       EmbedFlutterFrameworks ;;
     "embed_and_thin")
-      EmbedAndThinFrameworks ;;
+      # Thinning is handled during the bundle asset assemble build target, so just embed.
+      EmbedFlutterFrameworks ;;
     "test_observatory_bonjour_service")
       # Exposed for integration testing only.
       AddObservatoryBonjourService ;;

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -277,6 +277,14 @@ abstract class UnpackIOS extends Target {
     if (environment.defines[kSdkRoot] == null) {
       throw MissingDefineException(kSdkRoot, name);
     }
+    if (environment.defines[kIosArchs] == null) {
+      throw MissingDefineException(kIosArchs, name);
+    }
+    await _copyFramework(environment);
+    await _thinFramework(environment);
+  }
+
+  Future<void> _copyFramework(Environment environment) async {
     final Directory sdkRoot = environment.fileSystem.directory(environment.defines[kSdkRoot]);
     final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot);
     final String basePath = environment.artifacts.getArtifactPath(
@@ -300,6 +308,59 @@ abstract class UnpackIOS extends Target {
         'Failed to copy framework (exit ${result.exitCode}:\n'
         '${result.stdout}\n---\n${result.stderr}',
       );
+    }
+  }
+
+  /// Destructively thin Flutter.framework to include only the specified architectures.
+  Future<void> _thinFramework(Environment environment) async {
+    final Directory frameworkDirectory = environment.outputDir;
+
+    final File flutterFramework = frameworkDirectory.childDirectory('Flutter.framework').childFile('Flutter');
+    final String binaryPath = flutterFramework.path;
+    if (!flutterFramework.existsSync()) {
+      throw Exception('Binary $binaryPath does not exist, cannot thin');
+    }
+    final String archs = environment.defines[kIosArchs];
+    final List<String> archList = archs.split(' ').toList();
+    final ProcessResult infoResult = environment.processManager.runSync(<String>[
+      'lipo',
+      '-info',
+      binaryPath,
+    ]);
+    final String lipoInfo = infoResult.stdout as String;
+
+    final ProcessResult verifyResult = environment.processManager.runSync(<String>[
+      'lipo',
+      binaryPath,
+      '-verify_arch',
+      ...archList
+    ]);
+
+    if (verifyResult.exitCode != 0) {
+      throw Exception('Binary $binaryPath does not contain $archs. Running lipo -info:\n$lipoInfo');
+    }
+
+    // Skip thinning for non-fat executables.
+    if (lipoInfo.startsWith('Non-fat file:')) {
+      environment.logger.printTrace('Skipping lipo for non-fat file $binaryPath');
+      return;
+    }
+
+    // Thin in-place.
+    final ProcessResult extractResult = environment.processManager.runSync(<String>[
+      'lipo',
+      '-output',
+      binaryPath,
+      for (final String arch in archList)
+        ...<String>[
+          '-extract',
+          arch,
+        ],
+      ...<String>[binaryPath],
+    ]);
+
+    if (extractResult.exitCode != 0) {
+      throw Exception('Failed to extract $archs for $binaryPath.\n${extractResult.stderr}\nRunning lipo -info:\n$lipoInfo');
     }
   }
 }
@@ -531,81 +592,6 @@ Future<RunResult> createStubAppFramework(File outputFile, String sdkRoot,
       // Best effort. Sometimes we can't delete things from system temp.
     } on Exception catch (e) {
       throwToolExit('Failed to create App.framework stub at ${outputFile.path}: $e');
-    }
-  }
-}
-
-/// Destructively thins the Flutter.framework to include only the specified architectures.
-///
-/// This target is not fingerprinted and will always run.
-class ThinIosApplicationFrameworks extends Target {
-  const ThinIosApplicationFrameworks();
-
-  @override
-  String get name => 'thin_ios_application_frameworks';
-
-  @override
-  List<Target> get dependencies => const <Target>[];
-
-  @override
-  List<Source> get inputs => const <Source>[];
-
-  @override
-  List<Source> get outputs => const <Source>[];
-
-  @override
-  Future<void> build(Environment environment) async {
-    if (environment.defines[kIosArchs] == null) {
-      throw MissingDefineException(kIosArchs, 'thin_ios_application_frameworks');
-    }
-    final Directory frameworkDirectory = environment.outputDir;
-
-    final File flutterFramework = frameworkDirectory.childDirectory('Flutter.framework').childFile('Flutter');
-    final String binaryPath = flutterFramework.path;
-    if (!flutterFramework.existsSync()) {
-      throw Exception('Binary $binaryPath does not exist, cannot thin');
-    }
-    final String archs = environment.defines[kIosArchs];
-    final List<String> archList = archs.split(' ').toList();
-    final ProcessResult infoResult = environment.processManager.runSync(<String>[
-      'lipo',
-      '-info',
-      binaryPath,
-    ]);
-    final String lipoInfo = infoResult.stdout as String;
-
-    final ProcessResult verifyResult = environment.processManager.runSync(<String>[
-      'lipo',
-      binaryPath,
-      '-verify_arch',
-      ...archList
-    ]);
-
-    if (verifyResult.exitCode != 0) {
-      throw Exception('Binary $binaryPath does not contain $archs. Running lipo -info:\n$lipoInfo');
-    }
-
-    // Skip this step for non-fat executables.
-    if (lipoInfo.startsWith('Non-fat file:')) {
-      environment.logger.printTrace('Skipping lipo for non-fat file $binaryPath');
-      return;
-    }
-
-    // Thin in-place.
-    final ProcessResult extractResult = environment.processManager.runSync(<String>[
-      'lipo',
-      '-output',
-      binaryPath,
-      for (final String arch in archList)
-        ...<String>[
-          '-extract',
-          arch,
-        ],
-      ...<String>[binaryPath],
-    ]);
-
-    if (extractResult.exitCode != 0) {
-      throw Exception('Failed to extract $archs for $binaryPath.\n${extractResult.stderr}\nRunning lipo -info:\n$lipoInfo');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -66,7 +66,6 @@ const List<Target> _kDefaultTargets = <Target>[
   DebugIosApplicationBundle(),
   ProfileIosApplicationBundle(),
   ReleaseIosApplicationBundle(),
-  ThinIosApplicationFrameworks(),
   // Windows targets
   UnpackWindows(),
   DebugBundleWindowsAssets(),

--- a/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
@@ -23,6 +23,7 @@ void main() {
 
       Directory buildPath;
       Directory outputApp;
+      Directory frameworkDirectory;
       Directory outputFlutterFramework;
       File outputFlutterFrameworkBinary;
       Directory outputAppFramework;
@@ -70,22 +71,11 @@ void main() {
 
         outputApp = buildPath.childDirectory('Runner.app');
 
-        outputFlutterFramework = fileSystem.directory(
-          fileSystem.path.join(
-            outputApp.path,
-            'Frameworks',
-            'Flutter.framework',
-          ),
-        );
-
+        frameworkDirectory = outputApp.childDirectory('Frameworks');
+        outputFlutterFramework = frameworkDirectory.childDirectory('Flutter.framework');
         outputFlutterFrameworkBinary = outputFlutterFramework.childFile('Flutter');
 
-        outputAppFramework = fileSystem.directory(fileSystem.path.join(
-          outputApp.path,
-          'Frameworks',
-          'App.framework',
-        ));
-
+        outputAppFramework = frameworkDirectory.childDirectory('App.framework');
         outputAppFrameworkBinary = outputAppFramework.childFile('App');
       });
 
@@ -94,6 +84,8 @@ void main() {
       });
 
       testWithoutContext('flutter build ios builds a valid app', () {
+        // Should only contain Flutter.framework and App.framework.
+        expect(frameworkDirectory.listSync().length, 2);
         expect(outputAppFramework.childFile('App'), exists);
 
         final File vmSnapshot = fileSystem.file(fileSystem.path.join(
@@ -195,8 +187,6 @@ void main() {
             'VERBOSE_SCRIPT_LOGGING': '1',
             'FLUTTER_BUILD_MODE': 'release',
             'ACTION': 'install',
-            'ARCHS': 'arm64 armv7',
-            'FLUTTER_ROOT': flutterRoot,
             // Skip bitcode stripping since we just checked that above.
           },
         );


### PR DESCRIPTION
#76665 added a `ThinIosApplicationFrameworks` assemble build target that output the thinned framework directly into `Runner.app/Frameworks`.  This had the side effect of leaving a `.last_build_id` file in the bundle, which fails App Store validation.

Instead, move the Flutter.framework architecture thinning out of its own assemble build target and into the existing `UnpackIOS` target.  The framework will be copied from the artifacts cached and thinned in the same step.  I could have kept `ThinIosApplicationFrameworks` with `UnpackIOS` as a dependency, but they really are one concept with the same inputs, outputs, and skip conditions.

Fixes https://github.com/flutter/flutter/issues/76958
Closes https://github.com/flutter/flutter/pull/76886 (thinning will be skipped when copy is also skipped.