### PR TITLE
Enable avoid_type_to_string lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -87,7 +87,7 @@ linter:
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
-    # - avoid_type_to_string # we do this commonly
+    - avoid_type_to_string
     - avoid_types_as_parameter_names
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
     # - avoid_unnecessary_containers # not yet tested


### PR DESCRIPTION
When looking at the list of proposed lints in https://github.com/flutter/flutter/issues/75663 I noticed that this lint is disabled in the framework with the comments "we do this commonly". Turns out, we don't do this anymore and the lint can be enabled now.