### PR TITLE
Expose the diff from ComparisonResult

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -170,11 +170,15 @@ class LocalComparisonOutput {
 /// [test] and [master] image bytes provided.
 Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async {
   if (identical(test, master))
-    return ComparisonResult(passed: true);
+    return ComparisonResult(
+      passed: true
+      diffPercent: 0.0,
+    );
 
   if (test == null || master == null || test.isEmpty || master.isEmpty) {
     return ComparisonResult(
       passed: false,
+      diffPercent: 1.0,
       error: 'Pixel test failed, null image provided.',
     );
   }
@@ -195,6 +199,7 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
   if (width != masterImage.width || height != masterImage.height) {
     return ComparisonResult(
       passed: false,
+      diffPercent: 1.0,
       error: 'Pixel test failed, image sizes do not match.\n'
         'Master Image: ${masterImage.width} X ${masterImage.height}\n'
         'Test Image: ${testImage.width} X ${testImage.height}',
@@ -240,10 +245,12 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
   }
 
   if (pixelDiffCount > 0) {
+    final double diffPercent = pixelDiffCount/totalPixels) * 100;
     return ComparisonResult(
       passed: false,
+      diffPercent: diffPercent,
       error: 'Pixel test failed, '
-        '${((pixelDiffCount/totalPixels) * 100).toStringAsFixed(2)}% '
+        '${diffPercent.toStringAsFixed(2)}% '
         'diff detected.',
       diffs:  <String, Image>{
         'masterImage' : masterImage,
@@ -253,7 +260,7 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
       },
     );
   }
-  return ComparisonResult(passed: true);
+  return ComparisonResult(passed: true, diffPercent: 0.0);
 }
 
 /// Inverts [imageBytes], returning a new [ByteData] object.

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -245,12 +245,12 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
   }
 
   if (pixelDiffCount > 0) {
-    final double diffPercent = pixelDiffCount/totalPixels) * 100;
+    final double diffPercent = pixelDiffCount / totalPixels;
     return ComparisonResult(
       passed: false,
       diffPercent: diffPercent,
       error: 'Pixel test failed, '
-        '${diffPercent.toStringAsFixed(2)}% '
+        '${(diffPercent * 100).toStringAsFixed(2)}% '
         'diff detected.',
       diffs:  <String, Image>{
         'masterImage' : masterImage,

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -171,7 +171,7 @@ class LocalComparisonOutput {
 Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async {
   if (identical(test, master))
     return ComparisonResult(
-      passed: true
+      passed: true,
       diffPercent: 0.0,
     );
 

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -319,6 +319,7 @@ class ComparisonResult {
   /// Creates a new [ComparisonResult] for the current test.
   ComparisonResult({
     required this.passed,
+    required this.diffPercent,
     this.error,
     this.diffs,
   });
@@ -335,4 +336,7 @@ class ComparisonResult {
   /// values in the execution of the pixel test.
   // TODO(jonahwilliams): fix type signature when image is updated to support web.
   final Map<String, Object>? diffs;
+
+  /// The calculated percentage of pixel difference between two images.
+  final double diffPercent;
 }

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -104,7 +104,7 @@ void main() {
     test('throws if local output is not awaited', () {
       try {
         comparator.generateFailureOutput(
-          ComparisonResult(passed: false),
+          ComparisonResult(passed: false, diffPercent: 1.0),
           Uri.parse('foo_test.dart'),
           Uri.parse('/foo/bar/'),
         );


### PR DESCRIPTION
This exposes the diff percentage of a ComparisonResult, which will enable sub-classed LocalFileComparators to set a tolerance level for golden file testing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
