### PR TITLE
Update minimum required version to Xcode 12

### DIFF
--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -72,9 +72,7 @@ const String fixWithDevelopmentTeamInstruction = '''
        open ios/Runner.xcworkspace
   2- Select the 'Runner' project in the navigator then the 'Runner' target
      in the project settings
-  3- Make sure a 'Development Team' is selected.\u0020
-     - For Xcode 10, look under General > Signing > Team.
-     - For Xcode 11 and newer, look under Signing & Capabilities > Team.
+  3- Make sure a 'Development Team' is selected under Signing & Capabilities > Team.\u0020
      You may need to:
          - Log in with your Apple ID in Xcode first
          - Ensure you have a valid unique Bundle ID

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -106,7 +106,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   final List<ProjectMigrator> migrators = <ProjectMigrator>[
-    RemoveFrameworkLinkAndEmbeddingMigration(app.project, globals.logger, globals.xcode, globals.flutterUsage),
+    RemoveFrameworkLinkAndEmbeddingMigration(app.project, globals.logger, globals.flutterUsage),
     XcodeBuildSystemMigration(app.project, globals.logger),
     ProjectBaseConfigurationMigration(app.project, globals.logger),
     ProjectBuildLocationMigration(app.project, globals.logger),

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -8,8 +8,6 @@ import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
-import '../../base/version.dart';
-import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../../reporting/reporting.dart';
 
@@ -20,15 +18,12 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   RemoveFrameworkLinkAndEmbeddingMigration(
     IosProject project,
     Logger logger,
-    Xcode xcode,
     Usage usage,
   ) : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _xcode = xcode,
         _usage = usage,
         super(logger);
 
   final File _xcodeProjectInfoFile;
-  final Xcode _xcode;
   final Usage _usage;
 
   @override
@@ -100,12 +95,9 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
     }
 
     if (line.contains('/* App.framework ') || line.contains('/* Flutter.framework ')) {
-      // Print scary message if the user is on Xcode 11.4 or greater, or if Xcode isn't installed.
-      final bool xcodeIsInstalled = _xcode.isInstalled;
-      if(!xcodeIsInstalled || _xcode.currentVersion >= Version(11, 4, 0)) {
-        UsageEvent('ios-migration', 'remove-frameworks', label: 'failure', flutterUsage: _usage).send();
-        throwToolExit('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
-      }
+      // Print scary message.
+      UsageEvent('ios-migration', 'remove-frameworks', label: 'failure', flutterUsage: _usage).send();
+      throwToolExit('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
     }
 
     return line;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -29,8 +29,11 @@ import '../ios/mac.dart';
 import '../ios/xcodeproj.dart';
 import '../reporting/reporting.dart';
 
-Version get xcodeRequiredVersion => Version(11, 0, 0, text: '11.0');
-Version get xcodeRecommendedVersion => Version(12, 0, 1, text: '12.0.1');
+Version get xcodeRequiredVersion => Version(12, 0, 1, text: '12.0.1');
+
+/// Diverging this number from the minimum required version will provide a doctor
+/// warning, not error, that users should upgrade Xcode.
+Version get xcodeRecommendedVersion => xcodeRequiredVersion;
 
 /// SDK name passed to `xcrun --sdk`. Corresponds to undocumented Xcode
 /// SUPPORTED_PLATFORMS values.

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -151,16 +151,16 @@ void main() {
 
         testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(1);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
         });
 
         testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(13);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
           when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
 
@@ -169,7 +169,7 @@ void main() {
 
         testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
           when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
 
@@ -178,16 +178,16 @@ void main() {
 
         testWithoutContext('xcodeVersionSatisfactory is true when patch version exceeds minimum', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(1);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(2);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
         });
 
         testWithoutContext('isRecommendedVersionSatisfactory is false when version is less than minimum', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
           when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
 
@@ -255,9 +255,9 @@ void main() {
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
           when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+          when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
           when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(0);
+          when(mockXcodeProjectInterpreter.patchVersion).thenReturn(1);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
@@ -69,7 +69,7 @@ void main() {
       expect(result.type, ValidationType.partial);
       expect(result.messages.last.type, ValidationMessageType.hint);
       expect(result.messages.last.message, contains('Xcode 11.0.0 out of date (12.0.1 is recommended)'));
-    });
+    }, skip: true); // Unskip and update when minimum and required check versions diverge.
 
     testWithoutContext('Emits partial status when Xcode EULA not signed', () async {
       when(xcode.isInstalled).thenReturn(true);

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -338,16 +338,16 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   bool get isInstalled => true;
 
   @override
-  String get versionText => 'Xcode 11.0';
+  String get versionText => 'Xcode 12.0.1';
 
   @override
-  int get majorVersion => 11;
+  int get majorVersion => 12;
 
   @override
   int get minorVersion => 0;
 
   @override
-  int get patchVersion => 0;
+  int get patchVersion => 1;
 
   @override
   Future<Map<String, String>> getBuildSettings(


### PR DESCRIPTION
Devicelab and CI migration to Xcode 12 is complete as of https://github.com/flutter/flutter/issues/73392.

<img width="711" alt="Screen Shot 2021-03-01 at 4 35 22 PM" src="https://user-images.githubusercontent.com/682784/109582859-c05d3280-7ab3-11eb-8cbe-aaeae6e0ed15.png">


Fixes https://github.com/flutter/flutter/issues/76900
Blocked by Xcode 12 adoption in plugins CI https://github.com/flutter/plugins/pull/3653
Unblocks re-landing https://github.com/flutter/flutter/pull/73458 for iOS simulator ARM support.

Previous Xcode 11 bump at https://github.com/flutter/flutter/pull/50315.