### PR TITLE
Turn on iOS podspec linting in test

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -44,14 +44,13 @@ Future<void> main() async {
             'lib',
             'lint',
             objcPodspecPath,
+            '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
             '--allow-warnings',
             '--verbose',
           ],
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
-          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
-          canFail: true,
         );
       });
 
@@ -64,6 +63,7 @@ Future<void> main() async {
             'lib',
             'lint',
             objcPodspecPath,
+            '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
             '--allow-warnings',
             '--use-libraries',
             '--verbose',
@@ -71,8 +71,6 @@ Future<void> main() async {
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
-          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
-          canFail: true,
         );
       });
 
@@ -103,6 +101,7 @@ Future<void> main() async {
           <String>[
             'lib',
             'lint',
+            '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
             swiftPodspecPath,
             '--allow-warnings',
             '--verbose',
@@ -110,8 +109,6 @@ Future<void> main() async {
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
-          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
-          canFail: true,
         );
       });
 
@@ -124,6 +121,7 @@ Future<void> main() async {
             'lib',
             'lint',
             swiftPodspecPath,
+            '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
             '--allow-warnings',
             '--use-libraries',
             '--verbose',
@@ -131,8 +129,6 @@ Future<void> main() async {
           environment: <String, String>{
             'LANG': 'en_US.UTF-8',
           },
-          // TODO(jmagman): Flutter cannot build against ARM simulators https://github.com/flutter/flutter/issues/64502
-          canFail: true,
         );
       });
 


### PR DESCRIPTION
Add `--configuration=Debug` option ([available as of CocoaPods 1.10](https://github.com/CocoaPods/CocoaPods/pull/9760)) to `pod lib lint` CI script so the build only targets the supported x86_64 simulator, not the unsupported (by Flutter) arm64 simulator.

Passed at https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8853911490085422848/+/steps/run_plugin_lint_mac/0/stdout

Turned off in #63252
See also https://github.com/flutter/flutter/issues/64502