### PR TITLE
RawKeyboardWindows: Filter out IME events

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -226,6 +226,23 @@ abstract class RawKeyEventData {
   /// interacting with an input method editor (IME).
   /// {@endtemplate}
   String get keyLabel;
+
+  /// Whether a down event should be disapatched.
+  ///
+  /// Certain events on some platforms should not be dispatched to listeners
+  /// according to Flutter's event model. For example, on macOS, Fn keys are
+  /// skipped to be consistant with other platform. On Win32, events dispatched
+  /// for IME (`VK_PROCESSKEY`) are also skipped.
+  ///
+  /// This method will be called upon every down events. By default, this method
+  /// always return true. Subclasses should override this method to define the
+  /// filtering rule for the platform. If this method returns false for an event
+  /// message, the event will not be dispatched to listeners, but respond with
+  /// "handled: true" immediately. Moreover, the following up event with the
+  /// same physical key will also be skipped.
+  bool shouldDispatchEvent() {
+    return true;
+  }
 }
 
 /// Defines the interface for raw key events.
@@ -613,24 +630,29 @@ class RawKeyboard {
   RawKeyEventHandler? keyEventHandler;
 
   Future<dynamic> _handleKeyEvent(dynamic message) async {
+    print('message $message');
     final RawKeyEvent event = RawKeyEvent.fromMessage(message as Map<String, dynamic>);
-    if (event.data is RawKeyEventDataMacOs && event.logicalKey == LogicalKeyboardKey.fn) {
-      // On macOS laptop keyboards, the fn key is used to generate home/end and
-      // f1-f12, but it ALSO generates a separate down/up event for the fn key
-      // itself. Other platforms hide the fn key, and just produce the key that
-      // it is combined with, so to keep it possible to write cross platform
-      // code that looks at which keys are pressed, the fn key is ignored on
-      // macOS.
-      return;
-    }
+    bool shouldDispatch = true;
     if (event is RawKeyDownEvent) {
-      _keysPressed[event.physicalKey] = event.logicalKey;
+      if (event.data.shouldDispatchEvent()) {
+        _keysPressed[event.physicalKey] = event.logicalKey;
+      } else {
+        shouldDispatch = false;
+        _hiddenKeysPressed.add(event.physicalKey);
+      }
+    } else if (event is RawKeyUpEvent) {
+      if (!_hiddenKeysPressed.contains(event.physicalKey)) {
+        // Use the physical key in the key up event to find the physical key from
+        // the corresponding key down event and remove it, even if the logical
+        // keys don't match.
+        _keysPressed.remove(event.physicalKey);
+      } else {
+        _hiddenKeysPressed.remove(event.physicalKey);
+        shouldDispatch = false;
+      }
     }
-    if (event is RawKeyUpEvent) {
-      // Use the physical key in the key up event to find the physical key from
-      // the corresponding key down event and remove it, even if the logical
-      // keys don't match.
-      _keysPressed.remove(event.physicalKey);
+    if (!shouldDispatch) {
+      return <String, dynamic>{ 'handled': true };
     }
     // Make sure that the modifiers reflect reality, in case a modifier key was
     // pressed/released while the app didn't have focus.
@@ -742,6 +764,7 @@ class RawKeyboard {
   }
 
   final Map<PhysicalKeyboardKey, LogicalKeyboardKey> _keysPressed = <PhysicalKeyboardKey, LogicalKeyboardKey>{};
+  final Set<PhysicalKeyboardKey> _hiddenKeysPressed = <PhysicalKeyboardKey>{};
 
   /// Returns the set of keys currently pressed.
   Set<LogicalKeyboardKey> get keysPressed => _keysPressed.values.toSet();

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -234,7 +234,7 @@ abstract class RawKeyEventData {
   /// according to Flutter's event model. For example, on macOS, Fn keys are
   /// skipped to be consistant with other platform. On Win32, events dispatched
   /// for IME (`VK_PROCESSKEY`) are also skipped.
-  ///https://github.com/flutter/engine/pull/2346i
+  ///
   /// This method will be called upon every down events. By default, this method
   /// always return true. Subclasses should override this method to define the
   /// filtering rule for the platform. If this method returns false for an event

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -227,13 +227,14 @@ abstract class RawKeyEventData {
   /// {@endtemplate}
   String get keyLabel;
 
-  /// Whether a down event should be disapatched.
+  /// Whether a key down event, and likewise its accompanying key up event,
+  /// should be disapatched.
   ///
   /// Certain events on some platforms should not be dispatched to listeners
   /// according to Flutter's event model. For example, on macOS, Fn keys are
   /// skipped to be consistant with other platform. On Win32, events dispatched
   /// for IME (`VK_PROCESSKEY`) are also skipped.
-  ///
+  ///https://github.com/flutter/engine/pull/2346i
   /// This method will be called upon every down events. By default, this method
   /// always return true. Subclasses should override this method to define the
   /// filtering rule for the platform. If this method returns false for an event
@@ -630,7 +631,6 @@ class RawKeyboard {
   RawKeyEventHandler? keyEventHandler;
 
   Future<dynamic> _handleKeyEvent(dynamic message) async {
-    print('message $message');
     final RawKeyEvent event = RawKeyEvent.fromMessage(message as Map<String, dynamic>);
     bool shouldDispatch = true;
     if (event is RawKeyDownEvent) {

--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -221,6 +221,17 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
     }
   }
 
+  @override
+  bool shouldDispatchEvent() {
+    // On macOS laptop keyboards, the fn key is used to generate home/end and
+    // f1-f12, but it ALSO generates a separate down/up event for the fn key
+    // itself. Other platforms hide the fn key, and just produce the key that
+    // it is combined with, so to keep it possible to write cross platform
+    // code that looks at which keys are pressed, the fn key is ignored on
+    // macOS.
+    return logicalKey != LogicalKeyboardKey.fn;
+  }
+
   /// Returns true if the given label represents an unprintable key.
   ///
   /// Examples of unprintable keys are "NSUpArrowFunctionKey = 0xF700"

--- a/packages/flutter/lib/src/services/raw_keyboard_windows.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_windows.dart
@@ -9,6 +9,11 @@ import 'keyboard_key.dart';
 import 'keyboard_maps.dart';
 import 'raw_keyboard.dart';
 
+// Virtual key VK_PROCESSKEY in Win32 API.
+//
+// Key down events related to IME operations use this as keyCode.
+const int _vkProcessKey = 0xe5;
+
 /// Platform-specific key event data for Windows.
 ///
 /// This object contains information about key events obtained from Windows's
@@ -192,6 +197,15 @@ class RawKeyEventDataWindows extends RawKeyEventData {
       case ModifierKey.symbolModifier:
         return KeyboardSide.all;
     }
+  }
+
+  @override
+  bool shouldDispatchEvent() {
+    // In Win32 API, down events related to IME operations use VK_PROCESSKEY as
+    // keyCode. This event, as well as the following key up event (which uses a
+    // normal keyCode), should be skipped, because the effect of IME operations
+    // will be handled by the text input API.
+    return keyCode != _vkProcessKey;
   }
 
   // These are not the values defined by the Windows header for each modifier. Since they


### PR DESCRIPTION
This PR fixes a problem where IME events cause crash in Win32 apps.

This fix that was once landed in https://github.com/flutter/engine/pull/23853 had a flaw: because on Windows, only down events of IME operations has `VK_PROCESSKEY` as keyCode, while the accompanying up event uses a normal keycode, filtering events in engine using `VK_PROCESSKEY` does not exclude the up events. 

This PR instead filters these events in the framework, since the `RawKeyboard` API keeps states in the framework.

(For the new HardwareKeyboard API, the filtering will be done in the embedding converter.)

Fixes https://github.com/flutter/flutter/issues/74819

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
