### PR TITLE
Add instructions to integration_test example README

### DIFF
--- a/packages/integration_test/example/README.md
+++ b/packages/integration_test/example/README.md
@@ -14,6 +14,15 @@ flutter drive \
 
 Web:
 
+In one shell, run Chromedriver ([download
+here](https://chromedriver.chromium.org/downloads)):
+
+```
+chromedriver --port 8444
+```
+
+Then, in another shell, run `flutter drive`:
+
 ```sh
 flutter drive \
   --driver=test_driver/integration_test.dart \

--- a/packages/integration_test/example/README.md
+++ b/packages/integration_test/example/README.md
@@ -4,7 +4,7 @@ Demonstrates how to use the `package:integration_test`.
 
 To run `integration_test/example_test.dart`,
 
-Android / iOS:
+## Android / iOS
 
 ```sh
 flutter drive \

--- a/packages/integration_test/example/README.md
+++ b/packages/integration_test/example/README.md
@@ -12,7 +12,7 @@ flutter drive \
   --target=integration_test/example_test.dart
 ```
 
-Web:
+## Web
 
 In one shell, run Chromedriver ([download
 here](https://chromedriver.chromium.org/downloads)):


### PR DESCRIPTION
Adds Chromedriver instructions to the integration_test example's README

This was previously submitted to flutter/plugins but now integration_test is in flutter/flutter: https://github.com/flutter/plugins/pull/3289