### PR TITLE
Enable use_function_type_syntax_for_parameters lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -214,7 +214,7 @@ linter:
     - unrelated_type_equality_checks
     # - unsafe_html # not yet tested
     - use_full_hex_values_for_flutter_colors
-    # - use_function_type_syntax_for_parameters # not yet tested
+    - use_function_type_syntax_for_parameters
     # - use_if_null_to_convert_nulls_to_bools # not yet tested
     - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -40,8 +40,8 @@ void macroPerfTest(
     { Duration pageDelay,
       Duration duration = const Duration(seconds: 3),
       Duration timeout = kTimeout,
-      Future<void> driverOps(FlutterDriver driver),
-      Future<void> setupOps(FlutterDriver driver),
+      Future<void> Function(FlutterDriver driver) driverOps,
+      Future<void> Function(FlutterDriver driver) setupOps,
     }) {
   test(testName, () async {
     Timeline timeline;

--- a/dev/bots/test/fake_process_manager.dart
+++ b/dev/bots/test/fake_process_manager.dart
@@ -115,7 +115,7 @@ class FakeProcessManager extends Mock implements ProcessManager {
 
 /// A fake process that can be used to interact with a process "started" by the FakeProcessManager.
 class FakeProcess extends Mock implements Process {
-  FakeProcess(ProcessResult result, {void stdinResults(String input)})
+  FakeProcess(ProcessResult result, {void Function(String input) stdinResults})
       : stdoutStream = Stream<List<int>>.value((result.stdout as String).codeUnits),
         stderrStream = Stream<List<int>>.value((result.stderr as String).codeUnits),
         desiredExitCode = result.exitCode,

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -30,7 +30,7 @@ final List<String> baseApkFiles = <String> [
 ];
 
 /// Runs the given [testFunction] on a freshly generated Flutter project.
-Future<void> runProjectTest(Future<void> testFunction(FlutterProject project)) async {
+Future<void> runProjectTest(Future<void> Function(FlutterProject project) testFunction) async {
   final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_gradle_plugin_test.');
   final FlutterProject project = await FlutterProject.create(tempDir, 'hello');
 
@@ -42,7 +42,7 @@ Future<void> runProjectTest(Future<void> testFunction(FlutterProject project)) a
 }
 
 /// Runs the given [testFunction] on a freshly generated Flutter plugin project.
-Future<void> runPluginProjectTest(Future<void> testFunction(FlutterPluginProject pluginProject)) async {
+Future<void> runPluginProjectTest(Future<void> Function(FlutterPluginProject pluginProject) testFunction) async {
   final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_gradle_plugin_test.');
   final FlutterPluginProject pluginProject = await FlutterPluginProject.create(tempDir, 'aaa');
 
@@ -54,7 +54,7 @@ Future<void> runPluginProjectTest(Future<void> testFunction(FlutterPluginProject
 }
 
 /// Runs the given [testFunction] on a freshly generated Flutter module project.
-Future<void> runModuleProjectTest(Future<void> testFunction(FlutterModuleProject moduleProject)) async {
+Future<void> runModuleProjectTest(Future<void> Function(FlutterModuleProject moduleProject) testFunction) async {
   final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_gradle_module_test.');
   final FlutterModuleProject moduleProject = await FlutterModuleProject.create(tempDir, 'hello_module');
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -514,7 +514,7 @@ Future<String> findJavaHome() async {
   return path.dirname(path.dirname(javaBinary));
 }
 
-Future<T> inDirectory<T>(dynamic directory, Future<T> action()) async {
+Future<T> inDirectory<T>(dynamic directory, Future<T> Function() action) async {
   final String previousCwd = cwd;
   try {
     cd(directory);
@@ -629,7 +629,7 @@ Iterable<String> grep(Pattern pattern, {@required String from}) {
 ///     } catch (error, chain) {
 ///
 ///     }
-Future<void> runAndCaptureAsyncStacks(Future<void> callback()) {
+Future<void> runAndCaptureAsyncStacks(Future<void> Function() callback) {
   final Completer<void> completer = Completer<void>();
   Chain.capture(() async {
     await callback();

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
@@ -78,7 +78,7 @@ class DessertDataSource extends DataTableSource {
     Dessert('Coconut slice and KitKat',             677, 41.0,  72,  8.5,  63, 12, 12),
   ];
 
-  void _sort<T>(Comparable<T> getField(Dessert d), bool ascending) {
+  void _sort<T>(Comparable<T> Function(Dessert d) getField, bool ascending) {
     _desserts.sort((Dessert a, Dessert b) {
       if (!ascending) {
         final Dessert c = a;
@@ -156,7 +156,7 @@ class _DataTableDemoState extends State<DataTableDemo> {
   bool _sortAscending = true;
   final DessertDataSource _dessertsDataSource = DessertDataSource();
 
-  void _sort<T>(Comparable<T> getField(Dessert d), int columnIndex, bool ascending) {
+  void _sort<T>(Comparable<T> Function(Dessert d) getField, int columnIndex, bool ascending) {
     _dessertsDataSource._sort<T>(getField, ascending);
     setState(() {
       _sortColumnIndex = columnIndex;

--- a/dev/integration_tests/flutter_gallery/test/example_code_parser_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/example_code_parser_test.dart
@@ -53,7 +53,7 @@ class TestAssetBundle extends AssetBundle {
   }
 
   @override
-  Future<T> loadStructuredData<T>(String key, Future<T> parser(String value)) async {
+  Future<T> loadStructuredData<T>(String key, Future<T> Function(String value) parser) async {
     return parser(await loadString(key));
   }
 

--- a/dev/integration_tests/flutter_gallery/test/live_smoketest.dart
+++ b/dev/integration_tests/flutter_gallery/test/live_smoketest.dart
@@ -109,7 +109,7 @@ class _LiveWidgetController extends LiveWidgetController {
   bool frameSync = true;
 
   /// Waits until at the end of a frame the provided [condition] is [true].
-  Future<void> _waitUntilFrame(bool condition(), [Completer<void>? completer]) {
+  Future<void> _waitUntilFrame(bool Function() condition, [Completer<void>? completer]) {
     completer ??= Completer<void>();
     if (!condition()) {
       SchedulerBinding.instance!.addPostFrameCallback((Duration timestamp) {

--- a/dev/manual_tests/lib/card_collection.dart
+++ b/dev/manual_tests/lib/card_collection.dart
@@ -182,7 +182,7 @@ class CardCollectionState extends State<CardCollection> {
     });
   }
 
-  Widget buildDrawerCheckbox(String label, bool value, void callback(), { bool enabled = true }) {
+  Widget buildDrawerCheckbox(String label, bool value, void Function() callback, { bool enabled = true }) {
     return ListTile(
       onTap: enabled ? callback : null,
       title: Text(label),

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -313,7 +313,7 @@ void createSearchMetadata(String templatePath, String metadataPath) {
 /// specified, for each source/destination file pair.
 ///
 /// Creates `destDir` if needed.
-void copyDirectorySync(Directory srcDir, Directory destDir, [void onFileCopied(File srcFile, File destFile)]) {
+void copyDirectorySync(Directory srcDir, Directory destDir, [void Function(File srcFile, File destFile) onFileCopied]) {
   if (!srcDir.existsSync())
     throw Exception('Source directory "${srcDir.path}" does not exist, nothing to copy');
 

--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -136,17 +136,17 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
-  Iterable<T> map<T>(T f(E e)) {
+  Iterable<T> map<T>(T Function(E e) f) {
     return CachingIterable<T>(super.map<T>(f).iterator);
   }
 
   @override
-  Iterable<E> where(bool test(E element)) {
+  Iterable<E> where(bool Function(E element) test) {
     return CachingIterable<E>(super.where(test).iterator);
   }
 
   @override
-  Iterable<T> expand<T>(Iterable<T> f(E element)) {
+  Iterable<T> expand<T>(Iterable<T> Function(E element) f) {
     return CachingIterable<T>(super.expand<T>(f).iterator);
   }
 
@@ -156,7 +156,7 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
-  Iterable<E> takeWhile(bool test(E value)) {
+  Iterable<E> takeWhile(bool Function(E value) test) {
     return CachingIterable<E>(super.takeWhile(test).iterator);
   }
 
@@ -166,7 +166,7 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
-  Iterable<E> skipWhile(bool test(E value)) {
+  Iterable<E> skipWhile(bool Function(E value) test) {
     return CachingIterable<E>(super.skipWhile(test).iterator);
   }
 

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -290,7 +290,7 @@ abstract class BindingBase {
   ///
   /// The [Future] returned by the `callback` argument is returned by [lockEvents].
   @protected
-  Future<void> lockEvents(Future<void> callback()) {
+  Future<void> lockEvents(Future<void> Function() callback) {
     developer.Timeline.startSync('Lock events');
 
     assert(callback != null);

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -51,7 +51,7 @@ bool debugInstrumentationEnabled = false;
 ///  * [Timeline], which is used to record synchronous tracing events for
 ///    visualization in Chrome's tracing format. This method does not
 ///    implicitly add any timeline events.
-Future<T> debugInstrumentAction<T>(String description, Future<T> action()) async {
+Future<T> debugInstrumentAction<T>(String description, Future<T> Function() action) async {
   bool instrument = false;
   assert(() {
     instrument = debugInstrumentationEnabled;

--- a/packages/flutter/lib/src/foundation/synchronous_future.dart
+++ b/packages/flutter/lib/src/foundation/synchronous_future.dart
@@ -34,10 +34,10 @@ class SynchronousFuture<T> implements Future<T> {
   }
 
   @override
-  Future<T> catchError(Function onError, { bool test(Object error)? }) => Completer<T>().future;
+  Future<T> catchError(Function onError, { bool Function(Object error)? test }) => Completer<T>().future;
 
   @override
-  Future<R> then<R>(FutureOr<R> onValue(T value), { Function? onError }) {
+  Future<R> then<R>(FutureOr<R> Function(T value) onValue, { Function? onError }) {
     final dynamic result = onValue(_value);
     if (result is Future<R>)
       return result;
@@ -45,12 +45,12 @@ class SynchronousFuture<T> implements Future<T> {
   }
 
   @override
-  Future<T> timeout(Duration timeLimit, { FutureOr<T> onTimeout()? }) {
+  Future<T> timeout(Duration timeLimit, { FutureOr<T> Function()? onTimeout }) {
     return Future<T>.value(_value).timeout(timeLimit, onTimeout: onTimeout);
   }
 
   @override
-  Future<T> whenComplete(FutureOr<dynamic> action()) {
+  Future<T> whenComplete(FutureOr<dynamic> Function() action) {
     try {
       final FutureOr<dynamic> result = action();
       if (result is Future)

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1978,7 +1978,7 @@ class _FifoCache<K, V> {
   /// if not, calls the given callback to obtain it first.
   ///
   /// The arguments must not be null.
-  V putIfAbsent(K key, V loader()) {
+  V putIfAbsent(K key, V Function() loader) {
     assert(key != null);
     assert(loader != null);
     final V? result = _cache[key];

--- a/packages/flutter/lib/src/painting/clip.dart
+++ b/packages/flutter/lib/src/painting/clip.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 
-import 'dart:ui' show Canvas, Clip, Path, Paint, Rect, RRect;
+import 'dart:ui' show Canvas, Clip, Path, Paint, Rect, RRect, VoidCallback;
 
 /// Clip utilities used by [PaintingContext].
 abstract class ClipContext {
   /// The canvas on which to paint.
   Canvas get canvas;
 
-  void _clipAndPaint(void canvasClipCall(bool doAntiAlias), Clip clipBehavior, Rect bounds, void painter()) {
+  void _clipAndPaint(void Function(bool doAntiAlias) canvasClipCall, Clip clipBehavior, Rect bounds, VoidCallback painter) {
     assert(canvasClipCall != null);
     canvas.save();
     switch (clipBehavior) {
@@ -38,7 +38,7 @@ abstract class ClipContext {
   /// restored to the pre-clip status afterwards.
   ///
   /// `bounds` is the saveLayer bounds used for [Clip.antiAliasWithSaveLayer].
-  void clipPathAndPaint(Path path, Clip clipBehavior, Rect bounds, void painter()) {
+  void clipPathAndPaint(Path path, Clip clipBehavior, Rect bounds, VoidCallback painter) {
     _clipAndPaint((bool doAntiAias) => canvas.clipPath(path, doAntiAlias: doAntiAias), clipBehavior, bounds, painter);
   }
 
@@ -46,7 +46,7 @@ abstract class ClipContext {
   /// restored to the pre-clip status afterwards.
   ///
   /// `bounds` is the saveLayer bounds used for [Clip.antiAliasWithSaveLayer].
-  void clipRRectAndPaint(RRect rrect, Clip clipBehavior, Rect bounds, void painter()) {
+  void clipRRectAndPaint(RRect rrect, Clip clipBehavior, Rect bounds, VoidCallback painter) {
     _clipAndPaint((bool doAntiAias) => canvas.clipRRect(rrect, doAntiAlias: doAntiAias), clipBehavior, bounds, painter);
   }
 
@@ -54,7 +54,7 @@ abstract class ClipContext {
   /// restored to the pre-clip status afterwards.
   ///
   /// `bounds` is the saveLayer bounds used for [Clip.antiAliasWithSaveLayer].
-  void clipRectAndPaint(Rect rect, Clip clipBehavior, Rect bounds, void painter()) {
+  void clipRectAndPaint(Rect rect, Clip clipBehavior, Rect bounds, VoidCallback painter) {
     _clipAndPaint((bool doAntiAias) => canvas.clipRect(rect, doAntiAlias: doAntiAias), clipBehavior, bounds, painter);
   }
 }

--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -314,7 +314,7 @@ class ImageCache {
   /// `onError` is also provided. When an exception is caught resolving an image,
   /// no completers are cached and `null` is returned instead of a new
   /// completer.
-  ImageStreamCompleter? putIfAbsent(Object key, ImageStreamCompleter loader(), { ImageErrorListener? onError }) {
+  ImageStreamCompleter? putIfAbsent(Object key, ImageStreamCompleter Function() loader, { ImageErrorListener? onError }) {
     assert(key != null);
     assert(loader != null);
     TimelineTask? timelineTask;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1360,7 +1360,7 @@ abstract class RenderBox extends RenderObject {
 
   Map<_IntrinsicDimensionsCacheEntry, double>? _cachedIntrinsicDimensions;
 
-  double _computeIntrinsicDimension(_IntrinsicDimension dimension, double argument, double computer(double argument)) {
+  double _computeIntrinsicDimension(_IntrinsicDimension dimension, double argument, double Function(double argument) computer) {
     assert(RenderObject.debugCheckingIntrinsics || !debugDoingThisResize); // performResize should not depend on anything except the incoming constraints
     bool shouldCache = true;
     assert(() {
@@ -2238,7 +2238,7 @@ abstract class RenderBox extends RenderObject {
         RenderObject.debugCheckingIntrinsics = true;
         final List<DiagnosticsNode> failures = <DiagnosticsNode>[];
 
-        double testIntrinsic(double function(double extent), String name, double constraint) {
+        double testIntrinsic(double Function(double extent) function, String name, double constraint) {
           final double result = function(constraint);
           if (result < 0) {
             failures.add(ErrorDescription(' * $name($constraint) returned a negative value: $result'));
@@ -2249,7 +2249,7 @@ abstract class RenderBox extends RenderObject {
           return result;
         }
 
-        void testIntrinsicsForValues(double getMin(double extent), double getMax(double extent), String name, double constraint) {
+        void testIntrinsicsForValues(double Function(double extent) getMin, double Function(double extent) getMax, String name, double constraint) {
           final double min = testIntrinsic(getMin, 'getMinIntrinsic$name', constraint);
           final double max = testIntrinsic(getMax, 'getMaxIntrinsic$name', constraint);
           if (min > max) {

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -436,7 +436,7 @@ class RenderStack extends RenderBox
   }
 
   /// Helper function for calculating the intrinsics metrics of a Stack.
-  static double getIntrinsicDimension(RenderBox? firstChild, double mainChildSizeGetter(RenderBox child)) {
+  static double getIntrinsicDimension(RenderBox? firstChild, double Function(RenderBox child) mainChildSizeGetter) {
     double extent = 0.0;
     RenderBox? child = firstChild;
     while (child != null) {

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -442,7 +442,7 @@ class TickerFuture implements Future<void> {
   }
 
   @override
-  Future<R> then<R>(FutureOr<R> onValue(void value), { Function? onError }) {
+  Future<R> then<R>(FutureOr<R> Function(void value) onValue, { Function? onError }) {
     return _primaryCompleter.future.then<R>(onValue, onError: onError);
   }
 
@@ -452,7 +452,7 @@ class TickerFuture implements Future<void> {
   }
 
   @override
-  Future<void> whenComplete(dynamic action()) {
+  Future<void> whenComplete(dynamic Function() action) {
     return _primaryCompleter.future.whenComplete(action);
   }
 

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -90,7 +90,7 @@ abstract class AssetBundle {
   ///
   /// Implementations may cache the result, so a particular key should only be
   /// used with one parser for the lifetime of the asset bundle.
-  Future<T> loadStructuredData<T>(String key, Future<T> parser(String value));
+  Future<T> loadStructuredData<T>(String key, Future<T> Function(String value) parser);
 
   /// If this is a caching asset bundle, and the given key describes a cached
   /// asset, then evict the asset from the cache so that the next time it is
@@ -136,7 +136,7 @@ class NetworkAssetBundle extends AssetBundle {
   /// The result is not cached. The parser is run each time the resource is
   /// fetched.
   @override
-  Future<T> loadStructuredData<T>(String key, Future<T> parser(String value)) async {
+  Future<T> loadStructuredData<T>(String key, Future<T> Function(String value) parser) async {
     assert(key != null);
     assert(parser != null);
     return parser(await loadString(key));
@@ -180,7 +180,7 @@ abstract class CachingAssetBundle extends AssetBundle {
   /// subsequent calls will be a [SynchronousFuture], which resolves its
   /// callback synchronously.
   @override
-  Future<T> loadStructuredData<T>(String key, Future<T> parser(String value)) {
+  Future<T> loadStructuredData<T>(String key, Future<T> Function(String value) parser) {
     assert(key != null);
     assert(parser != null);
     if (_structuredDataCache.containsKey(key))

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -429,7 +429,7 @@ class MethodChannel {
   /// is not set.
   bool checkMockMethodCallHandler(Future<dynamic> Function(MethodCall call)? handler) => _methodChannelMockHandlers[this] == handler;
 
-  Future<ByteData?> _handleAsMethodCall(ByteData? message, Future<dynamic>? handler(MethodCall call)) async {
+  Future<ByteData?> _handleAsMethodCall(ByteData? message, Future<dynamic>? Function(MethodCall call) handler) async {
     final MethodCall call = codec.decodeMethodCall(message);
     try {
       return codec.encodeSuccessEnvelope(await handler(call));

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -530,7 +530,7 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
 
 TextEditingValue _selectionAwareTextManipulation(
   TextEditingValue value,
-  String substringManipulation(String substring),
+  String Function(String substring) substringManipulation,
 ) {
   final int selectionStartIndex = value.selection.start;
   final int selectionEndIndex = value.selection.end;

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -733,7 +733,7 @@ class Actions extends StatefulWidget {
   // Visits the Actions widget ancestors of the given element using
   // getElementForInheritedWidgetOfExactType. Returns true if the visitor found
   // what it was looking for.
-  static bool _visitActionsAncestors(BuildContext context, bool visitor(InheritedElement element)) {
+  static bool _visitActionsAncestors(BuildContext context, bool Function(InheritedElement element) visitor) {
     InheritedElement? actionsElement = context.getElementForInheritedWidgetOfExactType<_ActionsMarker>();
     while (actionsElement != null) {
       if (visitor(actionsElement) == true) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2232,7 +2232,7 @@ abstract class BuildContext {
   /// because the element tree is no longer stable at that time. To refer to
   /// an ancestor from one of those methods, save a reference to the ancestor
   /// by calling [visitAncestorElements] in [State.didChangeDependencies].
-  void visitAncestorElements(bool visitor(Element element));
+  void visitAncestorElements(bool Function(Element element) visitor);
 
   /// Walks the children of this widget.
   ///
@@ -2458,7 +2458,7 @@ class BuildOwner {
   ///
   /// This mechanism is used to ensure that, for instance, [State.dispose] does
   /// not call [State.setState].
-  void lockState(void callback()) {
+  void lockState(VoidCallback callback) {
     assert(callback != null);
     assert(_debugStateLockLevel >= 0);
     assert(() {
@@ -4031,7 +4031,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   }
 
   @override
-  void visitAncestorElements(bool visitor(Element element)) {
+  void visitAncestorElements(bool Function(Element element) visitor) {
     assert(_debugCheckStateIsActiveForAncestorLookup());
     Element? ancestor = _parent;
     while (ancestor != null && visitor(ancestor))

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -767,7 +767,7 @@ mixin WidgetInspectorService {
   /// name "ext.flutter.inspector.name"), which takes no arguments.
   void _registerSignalServiceExtension({
     required String name,
-    required FutureOr<Object?> callback(),
+    required FutureOr<Object?> Function() callback,
   }) {
     registerServiceExtension(
       name: name,
@@ -785,7 +785,7 @@ mixin WidgetInspectorService {
   /// references to avoid leaking memory.
   void _registerObjectGroupServiceExtension({
     required String name,
-    required FutureOr<Object?> callback(String objectGroup),
+    required FutureOr<Object?> Function(String objectGroup) callback,
   }) {
     registerServiceExtension(
       name: name,
@@ -854,7 +854,7 @@ mixin WidgetInspectorService {
   /// lifetimes of object references in the returned JSON (see [disposeGroup]).
   void _registerServiceExtensionWithArg({
     required String name,
-    required FutureOr<Object?> callback(String? objectId, String objectGroup),
+    required FutureOr<Object?> Function(String? objectId, String objectGroup) callback,
   }) {
     registerServiceExtension(
       name: name,
@@ -872,7 +872,7 @@ mixin WidgetInspectorService {
   /// "arg0", "arg1", "arg2", ..., "argn".
   void _registerServiceExtensionVarArgs({
     required String name,
-    required FutureOr<Object?> callback(List<String> args),
+    required FutureOr<Object?> Function(List<String> args) callback,
   }) {
     registerServiceExtension(
       name: name,

--- a/packages/flutter/test/_goldens_web.dart
+++ b/packages/flutter/test/_goldens_web.dart
@@ -5,4 +5,4 @@
 import 'dart:async';
 
 // package:flutter_goldens is not used as part of the test process for web.
-Future<void> testExecutable(FutureOr<void> testMain()) async => testMain();
+Future<void> testExecutable(FutureOr<void> Function() testMain) async => testMain();

--- a/packages/flutter/test/flutter_test_config.dart
+++ b/packages/flutter/test/flutter_test_config.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '_goldens_io.dart'
   if (dart.library.html) '_goldens_web.dart' as flutter_goldens;
 
-Future<void> testExecutable(FutureOr<void> testMain()) {
+Future<void> testExecutable(FutureOr<void> Function() testMain) {
   // Enable checks because there are many implementations of [RenderBox] in this
   // package can benefit from the additional validations.
   debugCheckIntrinsicSizes = true;

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -56,7 +56,7 @@ void main() {
 
   Future<void> prepareDatePicker(
     WidgetTester tester,
-    Future<void> callback(Future<DateTime?> date),
+    Future<void> Function(Future<DateTime?> date) callback,
     { TextDirection textDirection = TextDirection.ltr }
   ) async {
     late BuildContext buttonContext;

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -52,7 +52,7 @@ void main() {
 
   Future<void> preparePicker(
     WidgetTester tester,
-    Future<void> callback(Future<DateTimeRange?> date),
+    Future<void> Function(Future<DateTimeRange?> date) callback,
     { TextDirection textDirection = TextDirection.ltr }
   ) async {
     late BuildContext buttonContext;

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -560,7 +560,7 @@ void main() {
   });
 
   group('close button', () {
-    Future<void> expectCloseIcon(WidgetTester tester, PageRoute<void> routeBuilder(), String type) async {
+    Future<void> expectCloseIcon(WidgetTester tester, PageRoute<void> Function() routeBuilder, String type) async {
       const IconData expectedIcon = Icons.close;
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -215,7 +215,7 @@ void main() {
     );
   });
 
-  void checkNeedsAddToScene(Layer layer, void mutateCallback()) {
+  void checkNeedsAddToScene(Layer layer, void Function() mutateCallback) {
     layer.debugMarkClean();
     layer.updateSubtreeNeedsAddToScene();
     expect(layer.debugSubtreeNeedsAddToScene, false);

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -117,7 +117,7 @@ void main() {
         scheduler.scheduleTask(() { taskExecuted = true; }, Priority.touch);
       },
       zoneSpecification: ZoneSpecification(
-        createTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration duration, void f()) {
+        createTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration duration, void Function() f) {
           // Don't actually run the tasks, just record that it was scheduled.
           timerQueueTasks.add(f);
           return DummyTimer();

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -24,7 +24,7 @@ class StructureErrorTestWidgetInspectorService extends Object with WidgetInspect
   @override
   void registerServiceExtension({
     required String name,
-    required FutureOr<Map<String, Object?>> callback(Map<String, String> parameters),
+    required FutureOr<Map<String, Object?>> Function(Map<String, String> parameters) callback,
   }) {
     assert(!extensions.containsKey(name));
     extensions[name] = callback;

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -478,7 +478,7 @@ mixin CommandHandlerFactory {
   }
 
   // Waits until at the end of a frame the provided [condition] is [true].
-  Future<void> _waitUntilFrame(bool condition(), [ Completer<void>? completer ]) {
+  Future<void> _waitUntilFrame(bool Function() condition, [ Completer<void>? completer ]) {
     completer ??= Completer<void>();
     if (!condition()) {
       SchedulerBinding.instance!.addPostFrameCallback((Duration timestamp) {

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -656,7 +656,7 @@ abstract class FlutterDriver {
   ///
   /// For [WebFlutterDriver], this is only supported for Chrome.
   Future<Timeline> traceAction(
-    Future<dynamic> action(), {
+    Future<dynamic> Function() action, {
     List<TimelineStream> streams = const <TimelineStream>[TimelineStream.all],
     bool retainPriorEvents = false,
   }) async {
@@ -691,7 +691,7 @@ abstract class FlutterDriver {
   /// With frame sync disabled, it's the responsibility of the test author to
   /// ensure that no action is performed while the app is undergoing a
   /// transition to avoid flakiness.
-  Future<T> runUnsynchronized<T>(Future<T> action(), { Duration? timeout }) async {
+  Future<T> runUnsynchronized<T>(Future<T> Function() action, { Duration? timeout }) async {
     await sendCommand(SetFrameSync(false, timeout: timeout));
     T result;
     try {

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -236,7 +236,7 @@ class TimelineSummary {
 
   List<Duration> _extractDurations(
     String name,
-    Duration extractor(TimelineEvent beginEvent, TimelineEvent endEvent),
+    Duration Function(TimelineEvent beginEvent, TimelineEvent endEvent) extractor,
   ) {
     final List<Duration> result = <Duration>[];
     final List<TimelineEvent> events = _extractNamedEvents(name);

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -440,7 +440,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
 
   @override
   Future<Timeline> traceAction(
-      Future<dynamic> action(), {
+      Future<dynamic> Function() action, {
         List<TimelineStream> streams = const <TimelineStream>[TimelineStream.all],
         bool retainPriorEvents = false,
       }) async {
@@ -493,7 +493,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
   }
 
   @override
-  Future<T> runUnsynchronized<T>(Future<T> action(), { Duration? timeout }) async {
+  Future<T> runUnsynchronized<T>(Future<T> Function() action, { Duration? timeout }) async {
     await sendCommand(SetFrameSync(false, timeout: timeout));
     T result;
     try {

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -26,7 +26,7 @@ const String _kFlutterRootKey = 'FLUTTER_ROOT';
 /// [goldenFileComparator] to an instance of [FlutterGoldenFileComparator] that
 /// works for the current test. _Which_ FlutterGoldenFileComparator is
 /// instantiated is based on the current testing environment.
-Future<void> testExecutable(FutureOr<void> testMain()) async {
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   const Platform platform = LocalPlatform();
   if (FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform)) {
     goldenFileComparator = await FlutterPostSubmitFileComparator.fromDefaultComparator(platform);

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -35,7 +35,7 @@ const List<int> _kFailPngBytes =
   120, 1, 99, 249, 207, 240, 255, 63, 0, 7, 18, 3, 2, 164, 147, 160, 197, 0,
   0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130];
 
-Future<void> testWithOutput(String name, Future<void> body(), String expectedOutput) async {
+Future<void> testWithOutput(String name, Future<void> Function() body, String expectedOutput) async {
   test(name, () async {
     final StringBuffer output = StringBuffer();
     void _recordPrint(Zone self, ZoneDelegate parent, Zone zone, String line) {
@@ -780,9 +780,9 @@ class FakeHttpClientResponse extends Fake implements HttpClientResponse {
 
   @override
   StreamSubscription<List<int>> listen(
-    void onData(List<int> event)?, {
+    void Function(List<int> event)? onData, {
       Function? onError,
-      void onDone()?,
+      void Function()? onDone,
       bool? cancelOnError,
     }) {
     return Stream<List<int>>.fromFuture(Future<List<int>>.value(response))
@@ -796,7 +796,7 @@ class FakeHttpImageResponse extends Fake implements HttpClientResponse {
   final List<List<int>> response;
 
   @override
-  Future<void> forEach(void action(List<int> element)) async {
+  Future<void> forEach(void Function(List<int> element) action) async {
     response.forEach(action);
   }
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -402,7 +402,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// current timeout, if any. See [AutomatedTestWidgetsFlutterBinding.addTime]
   /// for details.
   Future<T?> runAsync<T>(
-    Future<T> callback(), {
+    Future<T> Function() callback, {
     Duration additionalTime = const Duration(milliseconds: 1000),
   });
 
@@ -600,7 +600,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   ///
   /// The `timeout` argument sets the initial timeout, if any. It can
   /// be increased with [addTime]. By default there is no timeout.
-  Future<void> runTest(Future<void> testBody(), VoidCallback invariantTester, { String description = '', Duration? timeout });
+  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, { String description = '', Duration? timeout });
 
   /// This is called during test execution before and after the body has been
   /// executed.
@@ -641,7 +641,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }
 
   Future<void> _runTest(
-    Future<void> testBody(),
+    Future<void> Function() testBody,
     VoidCallback invariantTester,
     String description, {
     Future<void>? timeout,
@@ -774,7 +774,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     return testCompleter.future;
   }
 
-  Future<void> _runTestBody(Future<void> testBody(), VoidCallback invariantTester) async {
+  Future<void> _runTestBody(Future<void> Function() testBody, VoidCallback invariantTester) async {
     assert(inTest);
     // So that we can assert that it remains the same after the test finishes.
     _beforeTestCheckIntrinsicSizes = debugCheckIntrinsicSizes;
@@ -979,7 +979,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<T?> runAsync<T>(
-    Future<T> callback(), {
+    Future<T> Function() callback, {
     Duration additionalTime = const Duration(milliseconds: 1000),
   }) {
     assert(additionalTime != null);
@@ -996,13 +996,13 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
     final Zone realAsyncZone = Zone.current.fork(
       specification: ZoneSpecification(
-        scheduleMicrotask: (Zone self, ZoneDelegate parent, Zone zone, void f()) {
+        scheduleMicrotask: (Zone self, ZoneDelegate parent, Zone zone, void Function() f) {
           Zone.root.scheduleMicrotask(f);
         },
-        createTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration duration, void f()) {
+        createTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration duration, void Function() f) {
           return Zone.root.createTimer(duration, f);
         },
-        createPeriodicTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration period, void f(Timer timer)) {
+        createPeriodicTimer: (Zone self, ZoneDelegate parent, Zone zone, Duration period, void Function(Timer timer) f) {
           return Zone.root.createPeriodicTimer(period, f);
         },
       ),
@@ -1166,7 +1166,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<void> runTest(
-    Future<void> testBody(),
+    Future<void> Function() testBody,
     VoidCallback invariantTester, {
     String description = '',
     Duration? timeout,
@@ -1582,7 +1582,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<T?> runAsync<T>(
-    Future<T> callback(), {
+    Future<T> Function() callback, {
     Duration additionalTime = const Duration(milliseconds: 1000),
   }) async {
     assert(() {
@@ -1615,7 +1615,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  Future<void> runTest(Future<void> testBody(), VoidCallback invariantTester, { String description = '', Duration? timeout }) async {
+  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, { String description = '', Duration? timeout }) async {
     assert(description != null);
     assert(!inTest);
     _inTest = true;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -890,7 +890,7 @@ abstract class WidgetController {
   /// in the documentation for the [flutter_test] library.
   static bool hitTestWarningShouldBeFatal = false;
 
-  Offset _getElementPoint(Finder finder, Offset sizeToPoint(Size size), { required bool warnIfMissed, required String callee }) {
+  Offset _getElementPoint(Finder finder, Offset Function(Size size) sizeToPoint, { required bool warnIfMissed, required String callee }) {
     TestAsyncUtils.guardSync();
     final Iterable<Element> elements = finder.evaluate();
     if (elements.isEmpty) {

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -685,7 +685,7 @@ class _FindsWidgetMatcher extends Matcher {
   }
 }
 
-bool _hasAncestorMatching(Finder finder, bool predicate(Widget widget)) {
+bool _hasAncestorMatching(Finder finder, bool Function(Widget widget) predicate) {
   final Iterable<Element> nodes = finder.evaluate();
   if (nodes.length != 1)
     return false;

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -60,7 +60,7 @@ class TestAsyncUtils {
   /// this one before this one has finished will throw an exception.
   ///
   /// This method first calls [guardSync].
-  static Future<T> guard<T>(Future<T> body()) {
+  static Future<T> guard<T>(Future<T> Function() body) {
     guardSync();
     final Zone zone = Zone.current.fork(
       zoneValues: <dynamic, dynamic>{

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -746,7 +746,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// * Expose a [Future] in your application code that signals the readiness of
   ///   your widget tree, then await that future inside [callback].
   Future<T?> runAsync<T>(
-    Future<T> callback(), {
+    Future<T> Function() callback, {
     Duration additionalTime = const Duration(milliseconds: 1000),
   }) => binding.runAsync<T?>(callback, additionalTime: additionalTime);
 

--- a/packages/flutter_test/test/custom_exception_reporter/flutter_test_config.dart
+++ b/packages/flutter_test/test/custom_exception_reporter/flutter_test_config.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Future<void> testExecutable(FutureOr<void> testMain()) async {
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   reportTestException = (FlutterErrorDetails details, String testDescription) {
     expect(details.exception, isA<StateError>());
     expect((details.exception as StateError).message, 'foo');

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -52,7 +52,7 @@ void main() {
     return path.replaceAll('/', fs.path.separator);
   }
 
-  void test(String description, FutureOr<void> body()) {
+  void test(String description, FutureOr<void> Function() body) {
     test_package.test(description, () async {
       await io.IOOverrides.runZoned<FutureOr<void>>(
         body,

--- a/packages/flutter_test/test/test_config/flutter_test_config.dart
+++ b/packages/flutter_test/test/test_config/flutter_test_config.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-Future<void> testExecutable(FutureOr<void> testMain()) async {
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   await runZoned<dynamic>(testMain, zoneValues: <Type, String>{
     String: '/test_config',
   });

--- a/packages/flutter_test/test/test_config/nested_config/flutter_test_config.dart
+++ b/packages/flutter_test/test/test_config/nested_config/flutter_test_config.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-Future<void> testExecutable(FutureOr<void> testMain()) async {
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   await runZoned<dynamic>(testMain, zoneValues: <Type, dynamic>{
     String: '/test_config/nested_config',
     int: 123,

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -94,7 +94,7 @@ Future<int> _handleToolError(
   bool verbose,
   List<String> args,
   bool reportCrashes,
-  String getFlutterVersion(),
+  String Function() getFlutterVersion,
 ) async {
   if (error is UsageException) {
     globals.printError('${error.message}\n');

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -136,7 +136,7 @@ class AppContext {
   /// name. This is useful for debugging purposes and is analogous to naming a
   /// thread in Java.
   Future<V> run<V>({
-    @required FutureOr<V> body(),
+    @required FutureOr<V> Function() body,
     String name,
     Map<Type, Generator> overrides,
     Map<Type, Generator> fallbacks,

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -123,8 +123,8 @@ class FileSystemUtils {
 void copyDirectory(
   Directory srcDir,
   Directory destDir, {
-  bool shouldCopyFile(File srcFile, File destFile),
-  void onFileCopied(File srcFile, File destFile),
+  bool Function(File srcFile, File destFile) shouldCopyFile,
+  void Function(File srcFile, File destFile) onFileCopied,
 }) {
   if (!srcDir.existsSync()) {
     throw Exception('Source directory "${srcDir.path}" does not exist, nothing to copy');

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -205,7 +205,7 @@ abstract class Target {
   }
 
   /// Performs a fold across this target and its dependencies.
-  T fold<T>(T initialValue, T combine(T previousValue, Target target)) {
+  T fold<T>(T initialValue, T Function(T previousValue, Target target) combine) {
     final T dependencyResult = dependencies.fold(
         initialValue, (T prev, Target t) => t.fold(prev, combine));
     return combine(dependencyResult, this);

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1075,7 +1075,7 @@ class AppInstance {
     _logger.close();
   }
 
-  Future<T> _runInZone<T>(AppDomain domain, FutureOr<T> method()) async {
+  Future<T> _runInZone<T>(AppDomain domain, FutureOr<T> Function() method) async {
     return method();
   }
 }

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1398,7 +1398,7 @@ class PubDependencyTree {
 
 // Produces a 16-bit checksum from the codePoints of the package name and
 // version strings using Fletcher's algorithm.
-String _computeChecksum(Iterable<String> names, String getVersion(String name)) {
+String _computeChecksum(Iterable<String> names, String Function(String name) getVersion) {
   int lowerCheck = 0;
   int upperCheck = 0;
   final List<String> sortedNames = names.toList()..sort();

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -62,7 +62,7 @@ import 'windows/visual_studio_validator.dart';
 import 'windows/windows_workflow.dart';
 
 Future<T> runInContext<T>(
-  FutureOr<T> runner(), {
+  FutureOr<T> Function() runner, {
   Map<Type, Generator> overrides,
 }) async {
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -645,7 +645,7 @@ class XcodeProjectInfo {
     return 'Release';
   }
 
-  static String _uniqueMatch(Iterable<String> strings, bool matches(String s)) {
+  static String _uniqueMatch(Iterable<String> strings, bool Function(String s) matches) {
     final List<String> options = strings.where(matches).toList();
     if (options.length == 1) {
       return options.first;

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -136,7 +136,7 @@ class CrashReportSender {
   Future<void> sendReport({
     @required dynamic error,
     @required StackTrace stackTrace,
-    @required String getFlutterVersion(),
+    @required String Function() getFlutterVersion,
     @required String command,
   }) async {
     // Only send one crash report per run.

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -272,7 +272,7 @@ class FlutterTesterTestDevice extends TestDevice {
 
   void _pipeStandardStreamsToConsole({
     @required Process process,
-    @required Future<void> reportObservatoryUri(Uri uri),
+    @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
     const String observatoryString = 'Observatory listening on ';
     for (final Stream<List<int>> stream in <Stream<List<int>>>[

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -652,7 +652,7 @@ class FakeWorkingAndroidConsoleSocket extends Fake implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
-  Stream<E> asyncMap<E>(FutureOr<E> convert(Uint8List event)) => _controller.stream as Stream<E>;
+  Stream<E> asyncMap<E>(FutureOr<E> Function(Uint8List event) convert) => _controller.stream as Stream<E>;
 
   @override
   void add(List<int> data) {
@@ -676,7 +676,7 @@ class FakeUnresponsiveAndroidConsoleSocket extends Fake implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
-  Stream<E> asyncMap<E>(FutureOr<E> convert(Uint8List event)) => _controller.stream as Stream<E>;
+  Stream<E> asyncMap<E>(FutureOr<E> Function(Uint8List event) convert) => _controller.stream as Stream<E>;
 
   @override
   void add(List<int> data) {}
@@ -697,7 +697,7 @@ class FakeDisconnectingAndroidConsoleSocket extends Fake implements Socket {
   final StreamController<String> _controller = StreamController<String>();
 
   @override
-  Stream<E> asyncMap<E>(FutureOr<E> convert(Uint8List event)) => _controller.stream as Stream<E>;
+  Stream<E> asyncMap<E>(FutureOr<E> Function(Uint8List event) convert) => _controller.stream as Stream<E>;
 
   @override
   void add(List<int> data) {

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -325,7 +325,7 @@ include ':app'
       android = fakePlatform('android');
     });
 
-    void testUsingAndroidContext(String description, dynamic testMethod()) {
+    void testUsingAndroidContext(String description, dynamic Function() testMethod) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
         Artifacts: () => localEngineArtifacts,
         Platform: () => android,

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -388,7 +388,7 @@ void main() {
     List<String> outputStdout() => mockStdio.writtenToStdout.join('').split('\n');
     List<String> outputStderr() => mockStdio.writtenToStderr.join('').split('\n');
 
-    void doWhileAsync(FakeAsync time, bool doThis()) {
+    void doWhileAsync(FakeAsync time, bool Function() doThis) {
       do {
         mockStopwatch.elapsed += const Duration(milliseconds: 1);
         time.elapse(const Duration(milliseconds: 1));

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -649,7 +649,7 @@ Information about project "Runner":
       fs.file(xcodebuild).createSync(recursive: true);
     });
 
-    void testUsingOsxContext(String description, dynamic testMethod()) {
+    void testUsingOsxContext(String description, dynamic Function() testMethod) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
         Artifacts: () => localArtifacts,
         Platform: () => macOS,

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -379,7 +379,7 @@ apply plugin: 'kotlin-android'
         );
       });
 
-      void testWithMocks(String description, Future<void> testMethod()) {
+      void testWithMocks(String description, Future<void> Function() testMethod) {
         testUsingContext(description, testMethod, overrides: <Type, Generator>{
           FileSystem: () => fs,
           ProcessManager: () => FakeProcessManager.any(),
@@ -808,7 +808,7 @@ flutter:
 /// Executes the [testMethod] in a context where the file system
 /// is in memory.
 @isTest
-void _testInMemory(String description, Future<void> testMethod()) {
+void _testInMemory(String description, Future<void> Function() testMethod) {
   Cache.flutterRoot = getFlutterRoot();
   final FileSystem testFileSystem = MemoryFileSystem(
     style: globals.platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
@@ -896,7 +896,7 @@ void expectNotExists(FileSystemEntity entity) {
   expect(entity.existsSync(), isFalse);
 }
 
-void addIosProjectFile(Directory directory, {String projectFileContent()}) {
+void addIosProjectFile(Directory directory, {String Function() projectFileContent}) {
   directory
       .childDirectory('ios')
       .childDirectory('Runner.xcodeproj')
@@ -905,7 +905,7 @@ void addIosProjectFile(Directory directory, {String projectFileContent()}) {
     ..writeAsStringSync(projectFileContent());
 }
 
-void addAndroidGradleFile(Directory directory, { String gradleFileContent() }) {
+void addAndroidGradleFile(Directory directory, { String Function() gradleFileContent }) {
   directory
       .childDirectory('android')
       .childDirectory('app')

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -179,7 +179,7 @@ Matcher containsIgnoringWhitespace(String toSearch) {
 /// system temporary directory are deleted after each test by calling
 /// `LocalFileSystem.dispose()`.
 @isTest
-void test(String description, FutureOr<void> body(), {
+void test(String description, FutureOr<void> Function() body, {
   String testOn,
   Timeout timeout,
   dynamic skip,
@@ -213,7 +213,7 @@ void test(String description, FutureOr<void> body(), {
 ///
 /// For more information, see https://github.com/flutter/flutter/issues/47161
 @isTest
-void testWithoutContext(String description, FutureOr<void> body(), {
+void testWithoutContext(String description, FutureOr<void> Function() body, {
   String testOn,
   Timeout timeout,
   dynamic skip,

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -56,7 +56,7 @@ typedef ContextInitializer = void Function(AppContext testContext);
 @isTest
 void testUsingContext(
   String description,
-  dynamic testMethod(), {
+  dynamic Function() testMethod, {
   Map<Type, Generator> overrides = const <Type, Generator>{},
   bool initializeFlutterRoot = true,
   String testOn,

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -372,7 +372,7 @@ class FuchsiaRemoteConnection {
   // will be updated in the event that ports are found to be broken/stale: they
   // will be shut down and removed from tracking.
   Future<List<E>> _invokeForAllVms<E>(
-    Future<E> vmFunction(DartVm vmService), [
+    Future<E> Function(DartVm vmService) vmFunction, [
     bool queueEvents = true,
   ]) async {
     final List<E> result = <E>[];

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -180,7 +180,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
 
   @override
   Future<void> runTest(
-    Future<void> testBody(),
+    Future<void> Function() testBody,
     VoidCallback invariantTester, {
     String description = '',
     Duration? timeout,
@@ -232,7 +232,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// [action]. Otherwise, prior events are cleared before calling [action]. By
   /// default, prior events are cleared.
   Future<vm.Timeline> traceTimeline(
-    Future<dynamic> action(), {
+    Future<dynamic> Function() action, {
     List<String> streams = const <String>['all'],
     bool retainPriorEvents = false,
   }) async {
@@ -268,7 +268,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// The `streams` and `retainPriorEvents` parameters are passed as-is to
   /// [traceTimeline].
   Future<void> traceAction(
-    Future<dynamic> action(), {
+    Future<dynamic> Function() action, {
     List<String> streams = const <String>['all'],
     bool retainPriorEvents = false,
     String reportKey = 'timeline',
@@ -288,7 +288,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   /// This can be used to implement performance tests previously using
   /// [traceAction] and [TimelineSummary] from [flutter_driver]
   Future<void> watchPerformance(
-    Future<void> action(), {
+    Future<void> Function() action, {
     String reportKey = 'performance',
   }) async {
     assert(() {


### PR DESCRIPTION
This lint is part of the recommended set: https://github.com/dart-lang/linter/blob/d0dd5c9c056b109b40fa8e005f131f14a9a0618e/tool/canonical/recommend.yaml

`dart fix --apply` was used to fix our codebase.

