### PR TITLE
Support block delete with word and line modifiers

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -657,10 +657,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       // _handleShortcuts depends on being started in the same stack invocation
       // as the _handleKeyEvent method
       _handleShortcuts(key);
-    } else if (key == LogicalKeyboardKey.delete) {
-      _handleDelete(forward: true);
-    } else if (key == LogicalKeyboardKey.backspace) {
-      _handleDelete(forward: false);
     }
   }
 
@@ -1000,6 +996,292 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final double preferredLineHeight = _textPainter.preferredLineHeight;
     final double verticalOffset = 1.5 * preferredLineHeight;
     return _getTextPositionVertical(offset, verticalOffset);
+  }
+
+  void _deleteSelection(SelectionChangedCause cause) {
+    assert(_selection != null);
+
+    if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
+      return;
+    }
+    
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = _selection!.textBefore(text);
+    final String textAfter = _selection!.textAfter(text);
+    final int cursorPosition = math.min(_selection!.start, _selection!.end);
+
+    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  /// Deletes a single character before the current collapsed selection.
+  ///
+  /// If current [selection] is not collapsed then it should delete the text
+  /// within the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [deleteForward], which is same but in the opposite direction.
+  void delete(SelectionChangedCause cause) {
+    assert(_selection != null);
+
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    String textBefore = _selection!.textBefore(text);
+    if (textBefore.isEmpty) {
+      return;
+    }
+       
+    final int characterBoundary = previousCharacter(textBefore.length, textBefore);
+    textBefore = textBefore.substring(0, characterBoundary);
+
+    final String textAfter = _selection!.textAfter(text);
+    final TextSelection newSelection = TextSelection.collapsed(offset: characterBoundary);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  /// Deletes a single word before the current collapsed selection.
+  ///
+  /// If the [selection] is not collapsed then it should delete the text
+  /// contained in the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [deleteForwardByWord], which is same but in the opposite direction.
+  void deleteByWord(SelectionChangedCause cause) {
+    assert(_selection != null);
+    
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }    
+    
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    String textBefore = _selection!.textBefore(text);
+    if (textBefore.isEmpty) {
+      return;
+    }
+
+    // When there is a line break, word delete should delete a single character
+    final bool isPreviousCharacterBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
+    if (isPreviousCharacterBreakLine) {
+      return delete(cause);
+    }
+
+    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, false);
+    textBefore = textBefore.trimRight().substring(0, characterBoundary);
+
+    final String textAfter = _selection!.textAfter(text);
+    final TextSelection newSelection = TextSelection.collapsed(offset: characterBoundary);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  /// Deletes a single line before the current collapsed selection.
+  ///
+  /// If current [selection] is not collapsed then it should delete the text
+  /// within the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [deleteForwardByWord], which is same but in the opposite direction.
+  void deleteByLine(SelectionChangedCause cause) {
+    assert(_selection != null);
+    
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    String textBefore = _selection!.textBefore(text);
+    if (textBefore.isEmpty) {
+      return;
+    }
+
+    // When there is a line break, line delete shouldn't do anything
+    final bool isPreviousCharacterBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
+    if (isPreviousCharacterBreakLine) {
+      return;
+    }
+
+    final TextSelection line = _getLineAtOffset(TextPosition(offset: textBefore.length - 1));
+    textBefore = textBefore.substring(0, line.start);
+
+    final String textAfter = _selection!.textAfter(text);
+    final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  /// Deletes a single character after the current collapsed selection.
+  ///
+  /// If current [selection] is not collapsed then it should delete the text
+  /// within the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [delete], which is same but in the opposite direction.
+  void deleteForward(SelectionChangedCause cause) {
+    assert(_selection != null);
+    
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = _selection!.textBefore(text);
+    String textAfter = _selection!.textAfter(text);
+
+    if (textAfter.isNotEmpty) {
+      final int deleteCount = nextCharacter(0, textAfter);
+      textAfter = textAfter.substring(deleteCount);
+    }
+
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
+      cause,
+    );
+  }
+
+  /// Deletes a single word after the current collapsed selection.
+  ///
+  /// If the [selection] is not collapsed then it should delete the text
+  /// contained in the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [deleteByWord], which is same but in the opposite direction.
+  void deleteForwardByWord(SelectionChangedCause cause) {
+    assert(_selection != null);
+    
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }    
+    
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    String textAfter = _selection!.textAfter(text);
+    
+    if (textAfter.isEmpty) {
+      return;
+    }
+
+    // When next character is a line break, it should delete a single character
+    final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
+    if (isNextCharacterBreakLine) {
+      return deleteForward(cause);
+    }
+
+    final String textBefore = _selection!.textBefore(text);
+    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, false);
+    textAfter = textAfter.substring(characterBoundary - textBefore.length);
+
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
+      cause,
+    );
+  }
+
+  /// Deletes a single line after the current collapsed selection.
+  ///
+  /// If current [selection] is not collapsed then it should delete the text
+  /// within the selection.
+  ///
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  ///   * [deleteByWord], which is same but in the opposite direction.
+  void deleteForwardByLine(SelectionChangedCause cause) {
+    assert(_selection != null);
+    
+    if (_readOnly || !_selection!.isValid) {
+      return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(cause);
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    String textAfter = _selection!.textAfter(text);
+    if (textAfter.isEmpty) {
+      return;
+    }
+
+    // When there is a line break, it shouldn't do anything
+    final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
+    if (isNextCharacterBreakLine) {
+      return;
+    }
+
+    final String textBefore = _selection!.textBefore(text);
+    final TextSelection line = _getLineAtOffset(TextPosition(offset: textBefore.length));
+    textAfter = textAfter.substring(line.end - textBefore.length, textAfter.length);
+
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
+      cause,
+    );
   }
 
   /// Keeping [selection]'s [TextSelection.baseOffset] fixed, move the
@@ -1803,38 +2085,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         SelectionChangedCause.keyboard,
       );
     }
-  }
-
-  void _handleDelete({ required bool forward }) {
-    final TextSelection selection = textSelectionDelegate.textEditingValue.selection;
-    final String text = textSelectionDelegate.textEditingValue.text;
-    assert(_selection != null);
-    if (_readOnly || !selection.isValid) {
-      return;
-    }
-    String textBefore = selection.textBefore(text);
-    String textAfter = selection.textAfter(text);
-    int cursorPosition = math.min(selection.start, selection.end);
-    // If not deleting a selection, delete the next/previous character.
-    if (selection.isCollapsed) {
-      if (!forward && textBefore.isNotEmpty) {
-        final int characterBoundary = previousCharacter(textBefore.length, textBefore);
-        textBefore = textBefore.substring(0, characterBoundary);
-        cursorPosition = characterBoundary;
-      }
-      if (forward && textAfter.isNotEmpty) {
-        final int deleteCount = nextCharacter(0, textAfter);
-        textAfter = textAfter.substring(deleteCount);
-      }
-    }
-    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
-    _setTextEditingValue(
-      TextEditingValue(
-        text: textBefore + textAfter,
-        selection: newSelection,
-      ),
-      SelectionChangedCause.keyboard,
-    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -998,7 +998,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
-  // Deletes the current uncollapsed [selection].
+  // Deletes the current uncollapsed selection.
   void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed == false);
 
@@ -1020,14 +1020,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   // Deletes the from the current collapsed selection to the start of the field.
   //
-  // The given [SelectionChangedCause] indicates the cause of this change and
-  // will be passed to [onSelectionChanged].
+  // The given SelectionChangedCause indicates the cause of this change and
+  // will be passed to onSelectionChanged.
   //
   // See also:
-  //
   //   * _deleteToEnd
   void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed == true);
+
     if (_readOnly || !selection.isValid) {
       return;
     }
@@ -1042,7 +1042,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   // Deletes the from the current collapsed selection to the end of the field.
+  //
+  // The given SelectionChangedCause indicates the cause of this change and
+  // will be passed to onSelectionChanged.
+  //
+  // See also:
+  //   * _deleteToStart
   void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == true);
+
     if (_readOnly || !selection.isValid) {
       return;
     }
@@ -1158,7 +1166,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// See also:
   ///
-  ///   * [deleteForwardByWord], which is same but in the opposite direction.
+  ///   * [deleteForwardByLine], which is same but in the opposite direction.
   void deleteByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
@@ -1285,7 +1293,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// See also:
   ///
-  ///   * [deleteByWord], which is same but in the opposite direction.
+  ///   * [deleteByLine], which is same but in the opposite direction.
   void deleteForwardByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
@@ -1308,7 +1316,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    // When there is a line break, it shouldn't do anything
+    // When there is a line break, it shouldn't do anything.
     final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
     if (isNextCharacterBreakLine) {
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1018,6 +1018,44 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
+  // Deletes the from the current collapsed selection to the start of the field.
+  //
+  // The given [SelectionChangedCause] indicates the cause of this change and
+  // will be passed to [onSelectionChanged].
+  //
+  // See also:
+  //
+  //   * _deleteToEnd
+  void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == true);
+    if (_readOnly || !selection.isValid) {
+      return;
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textAfter = _selection!.textAfter(text);
+    const TextSelection newSelection = TextSelection.collapsed(offset: 0);
+    _setTextEditingValue(
+      TextEditingValue(text: textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  // Deletes the from the current collapsed selection to the end of the field.
+  void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
+    if (_readOnly || !selection.isValid) {
+      return;
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = _selection!.textBefore(text);
+    final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore, selection: newSelection),
+      cause,
+    );
+  }
+
   /// Deletes backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a single character before the
@@ -1042,6 +1080,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big word.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1081,6 +1124,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1205,6 +1253,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return _deleteSelection(_selection!, cause);
     }
 
+    // When the text is obscured, the whole thing is treated as one big word.
+    if (obscureText) {
+      return _deleteToEnd(_selection!, cause);
+    }
+
     final String text = textSelectionDelegate.textEditingValue.text;
     String textAfter = _selection!.textAfter(text);
 
@@ -1242,6 +1295,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToEnd(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1033,6 +1033,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = selection.textBefore(text);
+
+    if (textBefore.isEmpty) {
+      return;
+    }
+
     final String textAfter = selection.textAfter(text);
     const TextSelection newSelection = TextSelection.collapsed(offset: 0);
     _setTextEditingValue(
@@ -1056,6 +1062,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
+    final String textAfter = selection.textAfter(text);
+
+    if (textAfter.isEmpty) {
+      return;
+    }
+
     final String textBefore = selection.textBefore(text);
     final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
     _setTextEditingValue(
@@ -1088,11 +1100,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big word.
-    if (obscureText) {
-      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1190,6 +1197,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return _deleteSelection(_selection!, cause);
     }
 
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
+    }
+
     final String text = textSelectionDelegate.textEditingValue.text;
     String textBefore = _selection!.textBefore(text);
     if (textBefore.isEmpty) {
@@ -1240,10 +1252,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final String textBefore = _selection!.textBefore(text);
     String textAfter = _selection!.textAfter(text);
 
-    if (textAfter.isNotEmpty) {
-      final int deleteCount = nextCharacter(0, textAfter);
-      textAfter = textAfter.substring(deleteCount);
+    if (textAfter.isEmpty) {
+      return;
     }
+
+    final int deleteCount = nextCharacter(0, textAfter);
+    textAfter = textAfter.substring(deleteCount);
 
     _setTextEditingValue(
       TextEditingValue(text: textBefore + textAfter, selection: _selection!),
@@ -1752,7 +1766,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
-  /// 
+  ///
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1117,12 +1117,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
-  /// 
+  ///
   /// {@template flutter.rendering.RenderEditable.whiteSpace}
   /// By default, includeWhitespace is set to true, meaning that whitespace can
   /// be considered a word in itself.  If set to false, the selection will be
@@ -1170,7 +1170,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
@@ -1256,12 +1256,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
-  /// 
+  ///
   /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
@@ -1305,7 +1305,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1021,7 +1021,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Deletes backwards from the current selection.
   ///
-  /// If the [selection] is collapsed, deletes a single character before the 
+  /// If the [selection] is collapsed, deletes a single character before the
   /// cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
@@ -1148,7 +1148,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Deletes in the foward direction from the current selection.
   ///
-  /// If the [selection] is collapsed, deletes a single character after the 
+  /// If the [selection] is collapsed, deletes a single character after the
   /// cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -999,18 +999,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   // Deletes the current uncollapsed [selection].
-  void _deleteSelection(SelectionChangedCause cause) {
-    assert(_selection != null);
-    assert(_selection?.isCollapsed == false);
+  void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == false);
 
-    if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
+    if (_readOnly || !selection.isValid || selection.isCollapsed) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = _selection!.textBefore(text);
-    final String textAfter = _selection!.textAfter(text);
-    final int cursorPosition = math.min(_selection!.start, _selection!.end);
+    final String textBefore = selection.textBefore(text);
+    final String textAfter = selection.textAfter(text);
+    final int cursorPosition = math.min(selection.start, selection.end);
 
     final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
     _setTextEditingValue(
@@ -1042,7 +1041,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1081,7 +1080,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1120,7 +1119,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1166,7 +1165,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1203,7 +1202,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1242,7 +1241,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1090,12 +1090,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    // When there is a line break, word delete should delete a single character
-    final bool isPreviousCharacterBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
-    if (isPreviousCharacterBreakLine) {
-      return delete(cause);
-    }
-
     final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, false);
     textBefore = textBefore.trimRight().substring(0, characterBoundary);
 
@@ -1217,12 +1211,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (textAfter.isEmpty) {
       return;
-    }
-
-    // When next character is a line break, it should delete a single character
-    final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
-    if (isNextCharacterBreakLine) {
-      return deleteForward(cause);
     }
 
     final String textBefore = _selection!.textBefore(text);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1122,11 +1122,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
+  /// 
+  /// {@template flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, includeWhitespace is set to true, meaning that whitespace can
+  /// be considered a word in itself.  If set to false, the selection will be
+  /// extended past any whitespace and the first word following the whitespace.
+  /// {@endtemplate}
   ///
   /// See also:
   ///
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
-  void deleteByWord(SelectionChangedCause cause) {
+  void deleteByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid) {
@@ -1148,7 +1154,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, false);
+    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, includeWhitespace);
     textBefore = textBefore.trimRight().substring(0, characterBoundary);
 
     final String textAfter = _selection!.textAfter(text);
@@ -1255,11 +1261,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
+  /// 
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///
   ///   * [deleteByWord], which is same but in the opposite direction.
-  void deleteForwardByWord(SelectionChangedCause cause) {
+  void deleteForwardByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid) {
@@ -1283,7 +1291,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String textBefore = _selection!.textBefore(text);
-    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, false);
+    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, includeWhitespace);
     textAfter = textAfter.substring(characterBoundary - textBefore.length);
 
     _setTextEditingValue(
@@ -1701,10 +1709,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, `includeWhitespace` is set to true, meaning that whitespace
-  /// can be considered a word in itself.  If set to false, the selection will
-  /// be extended past any whitespace and the first word following the
-  /// whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@template flutter.rendering.RenderEditable.stopAtReversal}
   /// The `stopAtReversal` parameter is false by default, meaning that it's
@@ -1744,12 +1749,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, `includeWhitespace` is set to true, meaning that whitespace
-  /// can be considered a word in itself.  If set to false, the selection will
-  /// be extended past any whitespace and the first word following the
-  /// whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
+  /// 
   ///
   /// See also:
   ///
@@ -1907,9 +1910,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// moved past any whitespace and the first word following the whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///
@@ -1993,9 +1994,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// moved past any whitespace and the first word following the whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -998,9 +998,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
-  // Deletes the current uncollapsed [selection]
+  // Deletes the current uncollapsed [selection].
   void _deleteSelection(SelectionChangedCause cause) {
     assert(_selection != null);
+    assert(_selection?.isCollapsed == false);
 
     if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
       return;
@@ -1018,10 +1019,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single character before the current collapsed selection.
+  /// Deletes backwards from the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a single character before the 
+  /// cursor.
+  ///
+  /// If the [selection] is not collapsed, deletes the selection.
   ///
   /// {@template flutter.rendering.RenderEditable.cause}
   /// The given [SelectionChangedCause] indicates the cause of this change and
@@ -1059,15 +1062,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single word before the current collapsed selection.
+  /// Deletes a word before the current selection.
   ///
-  /// If the [selection] is not collapsed then it should delete the text
-  /// contained in the selection.
+  /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1106,15 +1107,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single line before the current collapsed selection.
+  /// Deletes a line before the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1153,15 +1152,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single character after the current collapsed selection.
+  /// Deletes in the foward direction from the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a single character after the 
+  /// cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1192,15 +1190,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single word after the current collapsed selection.
+  /// Deletes a word after the current selection.
   ///
-  /// If the [selection] is not collapsed then it should delete the text
-  /// contained in the selection.
+  /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1239,15 +1235,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single line after the current collapsed selection.
+  /// Deletes a line after the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1291,10 +1285,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If [selectionEnabled] is false, keeps the selection collapsed and just
   /// moves it down.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1026,14 +1026,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // See also:
   //   * _deleteToEnd
   void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed == true);
+    assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textAfter = _selection!.textAfter(text);
+    final String textAfter = selection.textAfter(text);
     const TextSelection newSelection = TextSelection.collapsed(offset: 0);
     _setTextEditingValue(
       TextEditingValue(text: textAfter, selection: newSelection),
@@ -1049,14 +1049,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // See also:
   //   * _deleteToStart
   void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed == true);
+    assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = _selection!.textBefore(text);
+    final String textBefore = selection.textBefore(text);
     final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
     _setTextEditingValue(
       TextEditingValue(text: textBefore, selection: newSelection),
@@ -1117,6 +1117,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1161,6 +1164,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1244,6 +1250,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1288,6 +1297,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1062,7 +1062,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a word before the current selection.
+  /// Deletes a word backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
@@ -1107,7 +1107,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a line before the current selection.
+  /// Deletes a line backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
@@ -1190,7 +1190,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a word after the current selection.
+  /// Deletes a word in the foward direction from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
@@ -1235,7 +1235,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a line after the current selection.
+  /// Deletes a line in the foward direction from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -998,13 +998,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
+  // Deletes the current uncollapsed [selection]
   void _deleteSelection(SelectionChangedCause cause) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
       return;
     }
-    
+
     final String text = textSelectionDelegate.textEditingValue.text;
     final String textBefore = _selection!.textBefore(text);
     final String textAfter = _selection!.textAfter(text);
@@ -1046,7 +1047,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (textBefore.isEmpty) {
       return;
     }
-       
+
     final int characterBoundary = previousCharacter(textBefore.length, textBefore);
     textBefore = textBefore.substring(0, characterBoundary);
 
@@ -1073,11 +1074,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
   void deleteByWord(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
-    }    
-    
+    }
+
     if (!_selection!.isCollapsed) {
       return _deleteSelection(cause);
     }
@@ -1120,7 +1121,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
   void deleteByLine(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }
@@ -1167,7 +1168,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [delete], which is same but in the opposite direction.
   void deleteForward(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }
@@ -1206,18 +1207,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByWord], which is same but in the opposite direction.
   void deleteForwardByWord(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
-    }    
-    
+    }
+
     if (!_selection!.isCollapsed) {
       return _deleteSelection(cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
     String textAfter = _selection!.textAfter(text);
-    
+
     if (textAfter.isEmpty) {
       return;
     }
@@ -1253,7 +1254,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByWord], which is same but in the opposite direction.
   void deleteForwardByLine(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -38,6 +38,10 @@ class DefaultTextEditingActions extends Actions{
   // are called on which platform.
   static final Map<Type, Action<Intent>> _shortcutsActions = <Type, Action<Intent>>{
     DoNothingAndStopPropagationTextIntent: _DoNothingAndStopPropagationTextAction(),
+    DeleteTextIntent: _DeleteTextAction(),
+    DeleteByWordTextIntent: _DeleteByWordTextAction(),
+    DeleteByLineTextIntent: _DeleteByLineTextAction(),
+    DeleteForwardTextIntent: _DeleteForwardTextAction(),
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
@@ -76,6 +80,34 @@ class _DoNothingAndStopPropagationTextAction extends TextEditingAction<DoNothing
 
   @override
   void invoke(DoNothingAndStopPropagationTextIntent intent, [BuildContext? context]) {}
+}
+
+class _DeleteTextAction extends TextEditingAction<DeleteTextIntent> {
+  @override
+  Object? invoke(DeleteTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.delete(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteByWordTextAction extends TextEditingAction<DeleteByWordTextIntent> {
+  @override
+  Object? invoke(DeleteByWordTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteByLineTextAction extends TextEditingAction<DeleteByLineTextIntent> {
+  @override
+  Object? invoke(DeleteByLineTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteByLine(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForward(SelectionChangedCause.keyboard);
+  }
 }
 
 class _ExpandSelectionLeftByLineTextAction extends TextEditingAction<ExpandSelectionLeftByLineTextIntent> {

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -112,16 +112,16 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
   }
 }
 
-class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardByWordTextIntent> {
   @override
-  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+  Object? invoke(DeleteForwardByWordTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
   }
 }
 
-class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardByLineTextIntent> {
   @override
-  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+  Object? invoke(DeleteForwardByLineTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForwardByLine(SelectionChangedCause.keyboard);
   }
 }

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -42,6 +42,8 @@ class DefaultTextEditingActions extends Actions{
     DeleteByWordTextIntent: _DeleteByWordTextAction(),
     DeleteByLineTextIntent: _DeleteByLineTextAction(),
     DeleteForwardTextIntent: _DeleteForwardTextAction(),
+    DeleteForwardByWordTextIntent: _DeleteForwardByWordTextAction(),
+    DeleteForwardByLineTextIntent: _DeleteForwardByLineTextAction(),
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
@@ -107,6 +109,20 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
   @override
   Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForward(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForwardByLine(SelectionChangedCause.keyboard);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -94,7 +94,7 @@ class _DeleteTextAction extends TextEditingAction<DeleteTextIntent> {
 class _DeleteByWordTextAction extends TextEditingAction<DeleteByWordTextIntent> {
   @override
   Object? invoke(DeleteByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard);
+    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard, false);
   }
 }
 
@@ -115,7 +115,7 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
 class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardByWordTextIntent> {
   @override
   Object? invoke(DeleteForwardByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
+    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -161,6 +161,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   );
 
   static final Map<LogicalKeySet, Intent> _androidShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -198,6 +204,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -235,6 +247,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -272,6 +290,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -309,6 +333,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionRightByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByWordTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByWordTextIntent(),
@@ -346,6 +376,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -385,6 +421,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   // Web handles its text selection natively and doesn't use any of these
   // shortcuts in Flutter.
   static final Map<LogicalKeySet, Intent> _webShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -201,6 +201,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
@@ -244,6 +245,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
@@ -287,6 +289,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
@@ -330,6 +333,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
@@ -373,6 +377,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Home
     //   * Shift + end
     //   * Shift + home
+    //   * Control + delete
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
@@ -416,6 +421,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow left
     //   * Meta + shift + arrow right
     //   * Meta + shift + arrow up
+    //   * Meta + delete
   };
 
   // Web handles its text selection natively and doesn't use any of these
@@ -425,6 +431,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -294,11 +294,11 @@ class DefaultTextEditingShortcuts extends Shortcuts {
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -382,11 +382,11 @@ class DefaultTextEditingShortcuts extends Shortcuts {
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -202,6 +202,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
@@ -246,6 +247,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
@@ -290,6 +292,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
@@ -334,6 +337,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
@@ -378,6 +382,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Control + delete
+    //   * Control + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
@@ -422,18 +427,20 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow right
     //   * Meta + shift + arrow up
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   // Web handles its text selection natively and doesn't use any of these
   // shortcuts in Flutter.
   static final Map<LogicalKeySet, Intent> _webShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -4,7 +4,7 @@
 
 import 'actions.dart';
 
-/// An [Intent] to delete a character
+/// An [Intent] to delete a character in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteTextIntent extends Intent{
@@ -12,7 +12,7 @@ class DeleteTextIntent extends Intent{
   const DeleteTextIntent();
 }
 
-/// An [Intent] to delete a word
+/// An [Intent] to delete a word in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteByWordTextIntent extends Intent{
@@ -20,7 +20,7 @@ class DeleteByWordTextIntent extends Intent{
   const DeleteByWordTextIntent();
 }
 
-/// An [Intent] to delete a line
+/// An [Intent] to delete a line in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteByLineTextIntent extends Intent{
@@ -28,7 +28,7 @@ class DeleteByLineTextIntent extends Intent{
   const DeleteByLineTextIntent();
 }
 
-/// An [Intent] to delete a character forward
+/// An [Intent] to delete in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardTextIntent extends Intent{
@@ -36,7 +36,7 @@ class DeleteForwardTextIntent extends Intent{
   const DeleteForwardTextIntent();
 }
 
-/// An [Intent] to delete a word forward
+/// An [Intent] to delete a word in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardByWordTextIntent extends Intent{
@@ -44,7 +44,7 @@ class DeleteForwardByWordTextIntent extends Intent{
   const DeleteForwardByWordTextIntent();
 }
 
-/// An [Intent] to delete a line forward
+/// An [Intent] to delete a line in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardByLineTextIntent extends Intent{

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -4,6 +4,54 @@
 
 import 'actions.dart';
 
+/// An [Intent] to delete a character
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteTextIntent extends Intent{
+  /// Creates an instance of DeleteTextIntent.
+  const DeleteTextIntent();
+}
+
+/// An [Intent] to delete a word
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByWordTextIntent extends Intent{
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteByWordTextIntent();
+}
+
+/// An [Intent] to delete a line
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByLineTextIntent extends Intent{
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteByLineTextIntent();
+}
+
+/// An [Intent] to delete a character forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardTextIntent extends Intent{
+  /// Creates an instance of DeleteForwardTextIntent.
+  const DeleteForwardTextIntent();
+}
+
+/// An [Intent] to delete a word forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByWordTextIntent extends Intent{
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteForwardByWordTextIntent();
+}
+
+/// An [Intent] to delete a line forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByLineTextIntent extends Intent{
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteForwardByLineTextIntent();
+}
+
 /// An [Intent] to send the event straight to the engine, but only if a
 /// TextEditingTarget is focused.
 ///

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1218,7 +1218,7 @@ void main() {
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/58068
 
   group('delete', () {
-    test('handles selection', () async {
+    test('when as a non-collapsed selection, it should delete a selection', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1248,130 +1248,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tt');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 1);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('is a no-op at the end of the text', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 4),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 4),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
-      expect(delegate.textEditingValue.text, 'test');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 4);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('handles obscured text', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test',
-          selection: TextSelection.collapsed(offset: 0),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 0),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
-
-      expect(delegate.textEditingValue.text, 'est');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-  });
-
-  group('backspace', () {
-    test('handles selection', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      expect(delegate.textEditingValue.text, 'tt');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 1);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('handles simple text', () async {
+    test('when as simple text, it should delete the character to the left', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1401,14 +1284,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tet');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 2);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles surrogate pairs', () async {
+    test('when has surrogate pairs, it should delete the pair', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: '\u{1F44D}',
@@ -1438,14 +1320,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, '');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles grapheme clusters', () async {
+    test('when has grapheme clusters, it should delete the grapheme cluster', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: '0123👨‍👩‍👦2345',
@@ -1475,14 +1356,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, '01232345');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 4);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('is a no-op at the start of the text', () async {
+    test('when is at the start of the text, it should be a no-op', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1512,14 +1392,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles obscured text', () async {
+    test('when input has obscured text, it should delete the character to the left', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
           text: 'test',
@@ -1551,12 +1430,1120 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
-
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tes');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
+    }, skip: isBrowser);
+  
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 4;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.delete(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '用多個測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 3);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.delete(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'برنامج أهلا بالعال');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, text.length - 1);
+    }, skip: isBrowser);
+  });
+
+  group('deleteByWord', () {
+    test('when cursor is on the middle of a word, it should delete the left part of the word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is after a word, it should delete the whole word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test  multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word to the left', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by tabs spaces', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 4;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteByWord(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '用多個測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 3);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'برنامج أهلا ');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 12);
+    }, skip: isBrowser);
+  });
+
+  group('deleteByLine', () {
+    test('when cursor is on last character of a word, it should delete everything to the left', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, '');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('when cursor is on the middle of a word, it should delete delete everything to the left', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('when previous character is a breakline, it should preserve it', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, text);
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+
+    test('when text is multiline, it should delete until the first line break it finds', () async {
+      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
+      const int offset = 22;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nright here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+  });
+
+  group('deleteForward', () {
+    test('when as a non-collapsed selection, it should delete a selection', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: 'test',
+            selection: TextSelection(baseOffset: 1, extentOffset: 3),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'tt');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 1);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('when at the end of a text, it should be a no-op', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: 'test',
+            selection: TextSelection.collapsed(offset: 4),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 4),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 4);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('when the input has obscured text, it should delete the forward character', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 0),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 0),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'est');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+  
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 0;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteForward(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '多個塊測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 0);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = 0;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم'); 
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+ 
+  });
+
+  group('deleteForwardByWord', () {
+    test('when cursor is on the middle of a word, it should delete the next part of the word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 6;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test w multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is before a word, it should delete the whole word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 10;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with  blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is before tabs, it should delete the tabs and the next word', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is followed by break line, it should delete a single break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 0;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '多個塊測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, offset);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = 0;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, ' أهلا بالعالم');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+  });
+
+  group('deleteForwardByLine', () {
+    test('when cursor is on first character of a line, it should delete everything that follows', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is on the middle of a word, it should delete delete everything that follows', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test wit');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when next character is a breakline, it should preserve it', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, text);
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when text is multiline, it should delete until the first line break it finds', () async {
+      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
+      const int offset = 2;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'te\n\nMore stuff right here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
   });
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1817,7 +1817,7 @@ void main() {
   });
 
   group('deleteByLine', () {
-    test('when cursor is on last character of a word, it should delete everything to the left', () async {
+    test('when cursor is on last character of a line, it should delete everything to the left', () async {
       const String text = 'test with multiple blocks';
       const int offset = text.length;
       final TextSelectionDelegate delegate = FakeEditableTextState()

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1775,7 +1775,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything before the selection', () async {
       const int offset = 21;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -1968,7 +1968,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 11);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything before the selection', () async {
       const int offset = 21;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2464,7 +2464,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything after the selection', () async {
       const int offset = 4;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2657,7 +2657,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything after the selection', () async {
       const int offset = 4;
       final TextSelectionDelegate delegate = FakeEditableTextState()

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1542,10 +1542,48 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test h multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 10;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 9);
     }, skip: isBrowser);
 
     test('when cursor is after a word, it should delete the whole word', () async {
@@ -1580,7 +1618,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test  multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1618,7 +1656,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1656,7 +1694,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1694,7 +1732,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1732,7 +1770,7 @@ void main() {
         editable.hasFocus = true;
         pumpFrame();
 
-        editable.deleteByWord(SelectionChangedCause.keyboard);
+        editable.deleteByWord(SelectionChangedCause.keyboard, false);
         expect(delegate.textEditingValue.text, '用多個測試');
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
@@ -1770,7 +1808,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'برنامج أهلا ');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
@@ -1809,7 +1847,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'words');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
@@ -2046,6 +2084,44 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 1);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
+    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 9);
+    }, skip: isBrowser);
+
     test('when at the end of a text, it should be a no-op', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
@@ -2231,7 +2307,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test w multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2269,7 +2345,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with  blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2307,7 +2383,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2345,7 +2421,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2383,7 +2459,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2421,7 +2497,7 @@ void main() {
         editable.hasFocus = true;
         pumpFrame();
 
-        editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+        editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
         expect(delegate.textEditingValue.text, '多個塊測試');
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2459,7 +2535,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, ' أهلا بالعالم');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2498,7 +2574,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1662,9 +1662,9 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 5);
     }, skip: isBrowser);
 
-    test('when cursor is preceeded by break line', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
+    test('when cursor is preceeded by break line, it should delete the breaking line and the word right before it', () async {
+      const String text = 'test with\nmultiple blocks';
+      const int offset = 10;
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: text,
@@ -1695,9 +1695,9 @@ void main() {
       pumpFrame();
 
       editable.deleteByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 11);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
     }, skip: isBrowser);
 
     test('when using cjk characters', () async {
@@ -1855,8 +1855,8 @@ void main() {
     }, skip: isBrowser);
 
     test('when previous character is a breakline, it should preserve it', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
+      const String text = 'test with\nmultiple blocks';
+      const int offset = 10;
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: text,
@@ -1891,7 +1891,6 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-
 
     test('when text is multiline, it should delete until the first line break it finds', () async {
       const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
@@ -2274,7 +2273,7 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
 
-    test('when cursor is followed by break line, it should delete a single break line', () async {
+    test('when cursor is followed by break line, it should delete the next word', () async {
       const String text = 'test with\n\n\nmultiple blocks';
       const int offset = 9;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2307,7 +2306,7 @@ void main() {
       pumpFrame();
 
       editable.deleteForwardByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -826,8 +826,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 0);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, 'est');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -877,8 +876,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, '01236789');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -928,8 +926,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, '01232345');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1032,8 +1029,7 @@ void main() {
     expect(editable.selection?.isCollapsed, true);
     expect(editable.selection?.baseOffset, 3);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+     editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, 'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1435,7 +1431,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
-  
+
     test('when using cjk characters', () async {
         const String text = '用多個塊測試';
         const int offset = 4;
@@ -1473,7 +1469,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = text.length;
@@ -1741,7 +1737,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = text.length;
@@ -2046,7 +2042,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
-  
+
     test('when using cjk characters', () async {
         const String text = '用多個塊測試';
         const int offset = 0;
@@ -2084,7 +2080,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 0);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = 0;
@@ -2118,11 +2114,11 @@ void main() {
       pumpFrame();
 
       editable.deleteForward(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم'); 
+      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
- 
+
   });
 
   group('deleteForwardByWord', () {
@@ -2353,7 +2349,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, offset);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = 0;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1775,6 +1775,45 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
     }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything before the selection', () async {
+      const int offset = 21;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'words');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
   });
 
   group('deleteByLine', () {
@@ -1928,6 +1967,45 @@ void main() {
       expect(delegate.textEditingValue.text, 'test with\n\nright here.\nmultiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything before the selection', () async {
+      const int offset = 21;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'words');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
   });
 
@@ -2386,6 +2464,45 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything after the selection', () async {
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
   });
 
   group('deleteForwardByLine', () {
@@ -2537,6 +2654,45 @@ void main() {
 
       editable.deleteForwardByLine(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'te\n\nMore stuff right here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything after the selection', () async {
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);


### PR DESCRIPTION
This PR focuses on supporting modifiers to delete blocks of text in a editable widget.

### Shortcuts per OS
* macOS
  * **CMD (⌘) + Backspace**: Delete all words left to the cursor
  * **Option + Backspace**: Delete word left to the cursor
* Non macOS
  * **Alt + Backspace**: Delete all words left to the cursor
  * **Ctrl + Backspace**: Delete word left to the cursor

### Some cases for reference:

**case: 'text with| multiple words'**
word modifier + backspace: 'text | multiple words'
line modifier + backspace: '| multiple words'
word modifier + delete: 'text with| words'
line modifier + delete: 'text with|'

**case: 'text with multiple\n|words'**
word modifier + backspace: 'text with |words'
line modifier + backspace: 'text with multiple\n|words'
word modifier + delete: 'text with multiple\n|'
line modifier + delete: 'text with multiple\n|'

**case: 'text with multiple|\nwords'**
word modifier + backspace: 'text with |\nwords'
line modifier + backspace: '|\nwords'
word modifier + delete: 'text with multiple|'
line modifier + delete: 'text with multiple|\nwords'

**case: 'text with\n|\nmultiple words' in obscure text**
word modifier + backspace: '|\nmultiple words'
line modifier + backspace: '|\nmultiple words'
word modifier + delete: 'text with\n|'
line modifier + delete: 'text with\n|'

**case: 用多個塊測試** (cursor at offset 4)
backspace: '用多個測試' (cursor at offset 3)
word modifier + backspace: '用多個測試' (cursor at offset 3)
line modifier + backspace: '測試' (cursor at offset 0)
word modifier + delete: '用多個塊試' (cursor at offset 4)
line modifier + delete: '用多個塊' (cursor at offset 4)

**case: برنامج أهلا بالعالم** (cursor at offset 4 - from the right)
backspace: برنمج أهلا بالعالم  (cursor at offset 3 - from the right)
word modifier + backspace: مج أهلا بالعالم (cursor at offset 0 - from the right)
word modifier + delete: برنا أهلا بالعالم  (cursor at offset 4 - from the right)

### Related issue: 
* Fixes https://github.com/flutter/flutter/issues/57015
* Fixes https://github.com/flutter/flutter/issues/77547

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
