### PR TITLE
Store symlinks in package archive

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -466,6 +466,7 @@ class ArchiveCreator {
         'zip',
         '-r',
         '-9',
+        '--symlinks',
         output.absolute.path,
         path.basename(source.path),
       ];

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -127,7 +127,7 @@ void main() {
           'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
-          else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
+          else if (platform.isMacOS) 'zip -r -9 --symlinks $archiveName flutter': null
           else if (platform.isLinux) 'tar cJf $archiveName flutter': null,
         };
         await creator.initializeRepo();
@@ -163,7 +163,7 @@ void main() {
           'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
-          else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
+          else if (platform.isMacOS) 'zip -r -9 --symlinks $archiveName flutter': null
           else if (platform.isLinux) 'tar cJf $archiveName flutter': null,
         };
         processManager.fakeResults = calls;
@@ -213,7 +213,7 @@ void main() {
           'git clean -f -x -- **/.dart_tool/': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
-          else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
+          else if (platform.isMacOS) 'zip -r -9 --symlinks $archiveName flutter': null
           else if (platform.isLinux) 'tar cJf $archiveName flutter': null,
         };
         processManager.fakeResults = calls;


### PR DESCRIPTION
Compressed publish package should preserve symlinks, or the `FlutterMacOS.framework` will be malformed and the app won't build.

```
--symlinks
              For UNIX and VMS (V8.3 and later), store symbolic links as such in the zip archive, instead of compressing and storing the file referred to by the link.  This can avoid multiple copies of files being included in the archive as zip recurses the directory trees and accesses files directly and by links.
```

Confirmed locally that `zip -9 -r` removed the `FlutterMacOS.framework` symlinks and `zip -9 -r --symlinks` preserves them.

Fixes https://github.com/flutter/flutter/issues/77173.