### PR TITLE
Add supported custom font formats in official docs

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -333,6 +333,7 @@ const double _kDefaultFontSize = 14.0;
 /// const TextStyle(fontFamily: 'Raleway')
 /// ```
 /// {@end-tool}
+///
 /// #### Supported font formats
 ///
 /// Font formats currently supported by Flutter :
@@ -340,6 +341,7 @@ const double _kDefaultFontSize = 14.0;
 /// * `.otf`
 ///
 /// Flutter does not support `.woff` and `.woff2` fonts for all platforms.
+///
 /// ### Custom Font Fallback
 ///
 /// A custom [fontFamilyFallback] list can be provided. The list should be an

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -333,7 +333,13 @@ const double _kDefaultFontSize = 14.0;
 /// const TextStyle(fontFamily: 'Raleway')
 /// ```
 /// {@end-tool}
+/// #### Supported font formats
 ///
+/// Font formats currently supported by Flutter :
+/// * `.ttf`
+/// * `.otf`
+///
+/// Flutter does not support `.woff` and `.woff2` fonts for all platforms.
 /// ### Custom Font Fallback
 ///
 /// A custom [fontFamilyFallback] list can be provided. The list should be an

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -339,6 +339,7 @@ const double _kDefaultFontSize = 14.0;
 /// Font formats currently supported by Flutter :
 /// * `.ttf`
 /// * `.otf`
+/// * `.ttc`
 ///
 /// Flutter does not support `.woff` and `.woff2` fonts for all platforms.
 ///

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -337,9 +337,10 @@ const double _kDefaultFontSize = 14.0;
 /// #### Supported font formats
 ///
 /// Font formats currently supported by Flutter :
-/// * `.ttf`
-/// * `.otf`
-/// * `.ttc`
+///
+///  * `.ttc`
+///  * `.ttf`
+///  * `.otf`
 ///
 /// Flutter does not support `.woff` and `.woff2` fonts for all platforms.
 ///


### PR DESCRIPTION
This PR adds the custom font formats that are supported by flutter in the text style docs.

Issues - #76715 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
