### PR TITLE
Revert "[showModalBottomSheet] fix: showModalBottomSheet does not mov…

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -374,24 +374,21 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 
     return AnimatedBuilder(
       animation: widget.route!.animation!,
-      child: Padding(
-        padding: MediaQuery.of(context).viewInsets,
-        child: BottomSheet(
-          animationController: widget.route!._animationController,
-          onClosing: () {
-            if (widget.route!.isCurrent) {
-              Navigator.pop(context);
-            }
-          },
-          builder: widget.route!.builder!,
-          backgroundColor: widget.backgroundColor,
-          elevation: widget.elevation,
-          shape: widget.shape,
-          clipBehavior: widget.clipBehavior,
-          enableDrag: widget.enableDrag,
-          onDragStart: handleDragStart,
-          onDragEnd: handleDragEnd,
-        ),
+      child: BottomSheet(
+        animationController: widget.route!._animationController,
+        onClosing: () {
+          if (widget.route!.isCurrent) {
+            Navigator.pop(context);
+          }
+        },
+        builder: widget.route!.builder!,
+        backgroundColor: widget.backgroundColor,
+        elevation: widget.elevation,
+        shape: widget.shape,
+        clipBehavior: widget.clipBehavior,
+        enableDrag: widget.enableDrag,
+        onDragStart: handleDragStart,
+        onDragEnd: handleDragEnd,
       ),
       builder: (BuildContext context, Widget? child) {
         // Disable the initial animation when accessible navigation is on so

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -843,41 +843,6 @@ void main() {
     // The bottom sheet should not be showing any longer.
     expect(find.text('BottomSheet'), findsNothing);
   });
-
-  testWidgets('showModalBottomSheet should move along on-screen keyboard',
-          (WidgetTester tester) async {
-    late BuildContext savedContext;
-
-    // Show a keyboard (simulate by space at the bottom of the screen).
-    await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 200)),
-          child: Builder(
-            builder: (BuildContext context) {
-              savedContext = context;
-              return Container();
-            },
-          ),
-        ),
-      ),
-    );
-
-    await tester.pump();
-    expect(find.text('BottomSheet'), findsNothing);
-
-    showModalBottomSheet<void>(
-      context: savedContext,
-      builder: (BuildContext context) {
-        return const Text('BottomSheet');
-      },
-    );
-
-    await tester.pumpAndSettle();
-
-    expect(find.text('BottomSheet'), findsOneWidget);
-    expect(tester.getBottomLeft(find.text('BottomSheet')).dy, 600);
-  });
 }
 
 class _TestPage extends StatelessWidget {


### PR DESCRIPTION
This PR reverts https://github.com/flutter/flutter/pull/71636, due to internal regression b/179496145 and various public complaints.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
