### PR TITLE
Fix semantics node id overflow issue

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1236,8 +1236,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     return _lastIdentifier;
   }
 
-
-
   /// Uniquely identifies this node in the list of sibling nodes.
   ///
   /// Keys are used during the construction of the semantics tree. They are not

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1210,7 +1210,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   }) : _id = _generateNewId(),
        _showOnScreen = showOnScreen;
 
-
   /// Creates a semantic node to represent the root of the semantics tree.
   ///
   /// The root node is assigned an identifier of zero.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1230,7 +1230,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   // reserved for framework generated IDs(generated with _generateNewId), and most significant 32
   // bits are reserved for engine generated IDs.
   static const int _maxFrameworkAccessibilityIdentifier = (1<<16) - 1;
-  
+
   static int _lastIdentifier = 0;
   static int _generateNewId() {
     _lastIdentifier = (_lastIdentifier + 1) % _maxFrameworkAccessibilityIdentifier;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1552,7 +1552,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       // regenerating the id until we found an id that is not used.
       _id = _generateNewId();
     }
-    owner._nodes[_id] = this;
+    owner._nodes[id] = this;
     owner._detachedNodes.remove(this);
     if (_dirty) {
       _dirty = false;
@@ -1566,9 +1566,9 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   @override
   void detach() {
-    assert(owner!._nodes.containsKey(_id));
+    assert(owner!._nodes.containsKey(id));
     assert(!owner!._detachedNodes.contains(this));
-    owner!._nodes.remove(_id);
+    owner!._nodes.remove(id);
     owner!._detachedNodes.add(this);
     super.detach();
     assert(owner == null);

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1230,6 +1230,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   // reserved for framework generated IDs(generated with _generateNewId), and most significant 32
   // bits are reserved for engine generated IDs.
   static const int _maxFrameworkAccessibilityIdentifier = (1<<16) - 1;
+  
   static int _lastIdentifier = 0;
   static int _generateNewId() {
     _lastIdentifier = (_lastIdentifier + 1) % _maxFrameworkAccessibilityIdentifier;

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart';
 
+const int kmaxFrameworkAccessibilityIdentifier = (1<<16) - 1;
+
 void main() {
   setUp(() {
     debugResetSemanticsIdCounter();
@@ -565,6 +567,24 @@ void main() {
       '   elevation: 0.0\n'
       '   thickness: 0.0\n',
     );
+  });
+
+  test('Semantics id does not repeat', () {
+    final SemanticsOwner owner = SemanticsOwner();
+    const int expectId = 1400;
+    SemanticsNode? nodeToRemove;
+    for (int i = 0; i < kmaxFrameworkAccessibilityIdentifier; i++) {
+      final SemanticsNode node = SemanticsNode();
+      node.attach(owner);
+      if (node.id == expectId) {
+        nodeToRemove = node;
+      }
+    }
+    nodeToRemove!.detach();
+    final SemanticsNode newNode = SemanticsNode();
+    newNode.attach(owner);
+    // Id is reused.
+    expect(newNode.id, expectId);
   });
 
   test('Tags show up in debug properties', () {

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart';
 
-const int kmaxFrameworkAccessibilityIdentifier = (1<<16) - 1;
+const int kMaxFrameworkAccessibilityIdentifier = (1<<16) - 1;
 
 void main() {
   setUp(() {
@@ -573,7 +573,7 @@ void main() {
     final SemanticsOwner owner = SemanticsOwner();
     const int expectId = 1400;
     SemanticsNode? nodeToRemove;
-    for (int i = 0; i < kmaxFrameworkAccessibilityIdentifier; i++) {
+    for (int i = 0; i < kMaxFrameworkAccessibilityIdentifier; i++) {
       final SemanticsNode node = SemanticsNode();
       node.attach(owner);
       if (node.id == expectId) {


### PR DESCRIPTION
The semantics id may overflow if the app generate too many semantics node.

This PR makes it so we updates semantics id if the id has repeated when it is attached to the semantics owner.

Fixes https://github.com/flutter/flutter/issues/77036

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
