### PR TITLE
FocusableActionDetector now exposes descendantsAreFocusable property

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1246,6 +1246,7 @@ class FocusableActionDetector extends StatefulWidget {
     this.enabled = true,
     this.focusNode,
     this.autofocus = false,
+    this.descendantsAreFocusable = true,
     this.shortcuts,
     this.actions,
     this.onShowFocusHighlight,
@@ -1273,6 +1274,9 @@ class FocusableActionDetector extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
+
+  /// {@macro flutter.widgets.Focus.descendantsAreFocusable}
+  final bool descendantsAreFocusable;
 
   /// {@macro flutter.widgets.actions.actions}
   final Map<Type, Action<Intent>>? actions;
@@ -1459,6 +1463,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
       child: Focus(
         focusNode: widget.focusNode,
         autofocus: widget.autofocus,
+        descendantsAreFocusable: widget.descendantsAreFocusable,
         canRequestFocus: _canRequestFocus,
         onFocusChange: _handleFocusChange,
         child: widget.child,

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -921,7 +921,7 @@ void main() {
     });
 
     testWidgets(
-        'FocusableActionDetector can prevent it descendants to be focusable',
+        'FocusableActionDetector can prevent its descendants from being focusable',
         (WidgetTester tester) async {
       final FocusNode buttonNode = FocusNode(debugLabel: 'Test');
 

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -919,6 +919,50 @@ void main() {
       expect(hovering, isFalse);
       expect(focusing, isFalse);
     });
+
+    testWidgets(
+        'FocusableActionDetector can prevent it descendants to be focusable',
+        (WidgetTester tester) async {
+      final FocusNode buttonNode = FocusNode(debugLabel: 'Test');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FocusableActionDetector(
+            descendantsAreFocusable: true,
+            child: MaterialButton(
+              focusNode: buttonNode,
+              child: const Text('Test'),
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Button is focusable
+      expect(buttonNode.hasFocus, isFalse);
+      buttonNode.requestFocus();
+      await tester.pump();
+      expect(buttonNode.hasFocus, isTrue);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FocusableActionDetector(
+            descendantsAreFocusable: false,
+            child: MaterialButton(
+              focusNode: buttonNode,
+              child: const Text('Test'),
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Button is NOT focusable
+      expect(buttonNode.hasFocus, isFalse);
+      buttonNode.requestFocus();
+      await tester.pump();
+      expect(buttonNode.hasFocus, isFalse);
+    });
   });
 
   group('Diagnostics', () {


### PR DESCRIPTION
Add a new property `descendantsAreFocusable` on `FocusableActionDetector` widget. This property will just be passed to the underlying `Focus` widget

Fixe https://github.com/flutter/flutter/issues/77266

## Pre-launch Checklist

- [X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.