### PR TITLE
[flutter_tools] make Platform.operatingSystem required, null safe

### DIFF
--- a/packages/flutter_tools/lib/src/base/platform.dart
+++ b/packages/flutter_tools/lib/src/base/platform.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io' as io show Platform, stdin, stdout;
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using
 /// instance properties rather than static properties. This difference enables
-/// the use of these APIs in tests, where you can provide mock implementations.
+/// the use of these APIs in tests, where you can provide fake implementations.
 abstract class Platform {
   /// Creates a new [Platform].
   const Platform();
@@ -103,7 +101,7 @@ abstract class Platform {
   /// specifies how Dart packages are looked up.
   ///
   /// If there is no `--packages` flag, `null` is returned.
-  String get packageConfig;
+  String? get packageConfig;
 
   /// The version of the current Dart runtime.
   ///
@@ -158,7 +156,7 @@ class LocalPlatform extends Platform {
   List<String> get executableArguments => io.Platform.executableArguments;
 
   @override
-  String get packageConfig => io.Platform.packageConfig;
+  String? get packageConfig => io.Platform.packageConfig;
 
   @override
   String get version => io.Platform.version;
@@ -176,89 +174,119 @@ class LocalPlatform extends Platform {
 /// Provides a mutable implementation of the [Platform] interface.
 class FakePlatform extends Platform {
   /// Creates a new [FakePlatform] with the specified properties.
-  ///
-  /// Unspecified properties will *not* be assigned default values (they will
-  /// remain `null`).
   FakePlatform({
-    this.numberOfProcessors,
-    this.pathSeparator,
-    this.operatingSystem,
-    this.operatingSystemVersion,
-    this.localHostname,
-    this.environment,
-    this.executable,
-    this.resolvedExecutable,
-    this.script,
-    this.executableArguments,
+    this.numberOfProcessors = 1,
+    String? pathSeparator,
+    required this.operatingSystem,
+    String? operatingSystemVersion,
+    String? localHostname,
+    Map<String, String>? environment,
+    String? executable,
+    String? resolvedExecutable,
+    Uri? script,
+    List<String>? executableArguments,
     this.packageConfig,
-    this.version,
-    this.stdinSupportsAnsi,
-    this.stdoutSupportsAnsi,
-    this.localeName,
-  });
+    String? version,
+    bool stdinSupportsAnsi = false,
+    bool stdoutSupportsAnsi = false,
+    String? localeName,
+  })  : _pathSeparator = pathSeparator,
+        _operatingSystemVersion = operatingSystemVersion,
+        _localHostname = localHostname,
+        _environment = environment,
+        _executable = executable,
+        _resolvedExecutable = resolvedExecutable,
+        _script = script,
+        _executableArguments = executableArguments,
+        _version = version,
+        _stdinSupportsAnsi = stdinSupportsAnsi,
+        _stdoutSupportsAnsi = stdoutSupportsAnsi,
+        _localeName = localeName;
 
   /// Creates a new [FakePlatform] with properties whose initial values mirror
   /// the specified [platform].
   FakePlatform.fromPlatform(Platform platform)
       : numberOfProcessors = platform.numberOfProcessors,
-        pathSeparator = platform.pathSeparator,
+        _pathSeparator = platform.pathSeparator,
         operatingSystem = platform.operatingSystem,
-        operatingSystemVersion = platform.operatingSystemVersion,
-        localHostname = platform.localHostname,
-        environment = Map<String, String>.from(platform.environment),
-        executable = platform.executable,
-        resolvedExecutable = platform.resolvedExecutable,
-        script = platform.script,
-        executableArguments =
-            List<String>.from(platform.executableArguments),
+        _operatingSystemVersion = platform.operatingSystemVersion,
+        _localHostname = platform.localHostname,
+        _environment = Map<String, String>.from(platform.environment),
+        _executable = platform.executable,
+        _resolvedExecutable = platform.resolvedExecutable,
+        _script = platform.script,
+        _executableArguments = List<String>.from(platform.executableArguments),
         packageConfig = platform.packageConfig,
-        version = platform.version,
-        stdinSupportsAnsi = platform.stdinSupportsAnsi,
-        stdoutSupportsAnsi = platform.stdoutSupportsAnsi,
-        localeName = platform.localeName;
+        _version = platform.version,
+        _stdinSupportsAnsi = platform.stdinSupportsAnsi,
+        _stdoutSupportsAnsi = platform.stdoutSupportsAnsi,
+        _localeName = platform.localeName;
 
   @override
-  int numberOfProcessors;
+  final int numberOfProcessors;
 
   @override
-  String pathSeparator;
+  String get pathSeparator => _throwIfNull(_pathSeparator);
+  final String? _pathSeparator;
 
   @override
-  String operatingSystem;
+  final String operatingSystem;
 
   @override
-  String operatingSystemVersion;
+  String get operatingSystemVersion => _throwIfNull(_operatingSystemVersion);
+  final String? _operatingSystemVersion;
 
   @override
-  String localHostname;
+  String get localHostname => _throwIfNull(_localHostname);
+  final String? _localHostname;
 
   @override
-  Map<String, String> environment;
+  Map<String, String> get environment => _throwIfNull(_environment);
+  set environment(Map<String, String> value) {
+    _environment = value;
+  }
+  Map<String, String>? _environment;
 
   @override
-  String executable;
+  String get executable => _throwIfNull(_executable);
+  final String? _executable;
 
   @override
-  String resolvedExecutable;
+  String get resolvedExecutable => _throwIfNull(_resolvedExecutable);
+  final String? _resolvedExecutable;
 
   @override
-  Uri script;
+  Uri get script => _throwIfNull(_script);
+  final Uri? _script;
 
   @override
-  List<String> executableArguments;
+  List<String> get executableArguments => _throwIfNull(_executableArguments);
+  final List<String>? _executableArguments;
 
   @override
-  String packageConfig;
+  String? packageConfig;
 
   @override
-  String version;
+  String get version => _throwIfNull(_version);
+  final String? _version;
 
   @override
-  bool stdinSupportsAnsi;
+  bool get stdinSupportsAnsi => _throwIfNull(_stdinSupportsAnsi);
+  final bool? _stdinSupportsAnsi;
 
   @override
-  bool stdoutSupportsAnsi;
+  bool get stdoutSupportsAnsi => _throwIfNull(_stdoutSupportsAnsi);
+  final bool? _stdoutSupportsAnsi;
 
   @override
-  String localeName;
+  String get localeName => _throwIfNull(_localeName);
+  final String? _localeName;
+
+  T _throwIfNull<T>(T? value) {
+    if (value == null) {
+      throw StateError(
+        'Tried to read property of FakePlatform but it was unset.');
+    }
+    return value;
+  }
 }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -162,7 +162,7 @@ class Cache {
     ProcessManager processManager,
   }) {
     fileSystem ??= rootOverride?.fileSystem ?? MemoryFileSystem.test();
-    platform ??= FakePlatform(environment: <String, String>{});
+    platform ??= FakePlatform(environment: <String, String>{}, operatingSystem: 'linux');
     logger ??= BufferLogger.test();
     return Cache(
       rootOverride: rootOverride ??= fileSystem.directory('cache'),

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -41,6 +41,7 @@ final Generator _kNoColorOutputPlatform = () => FakePlatform(
   localeName: 'en_US.UTF-8',
   environment: <String, String>{},
   stdoutSupportsAnsi: false,
+  operatingSystem: 'linux',
 );
 
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -32,7 +32,7 @@ void main() {
   });
 
   testUsingContext('precache should acquire lock', () async {
-    final Platform platform = FakePlatform(environment: <String, String>{});
+    final Platform platform = FakePlatform(environment: <String, String>{}, operatingSystem: 'linux');
     final PrecacheCommand command = PrecacheCommand(
       cache: cache,
       logger: BufferLogger.test(),
@@ -71,7 +71,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isWebEnabled: true),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--web', '--no-android', '--no-ios']);
 
@@ -86,7 +86,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isWebEnabled: false),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--web', '--no-android', '--no-ios']);
 
@@ -100,7 +100,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isMacOSEnabled: true),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
 
@@ -115,7 +115,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isMacOSEnabled: false),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
 
@@ -129,7 +129,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isWindowsEnabled: true),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
 
@@ -144,7 +144,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isWindowsEnabled: false),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
 
@@ -158,7 +158,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isLinuxEnabled: true),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
 
@@ -173,7 +173,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isLinuxEnabled: false),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
 
@@ -187,7 +187,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(isWebEnabled: false),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     expect(createTestCommandRunner(command).run(const <String>['precache',
@@ -207,7 +207,7 @@ void main() {
         isWindowsEnabled: true,
         isFuchsiaEnabled: true,
       ),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(
       const <String>[
@@ -242,7 +242,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(
       const <String>[
@@ -264,7 +264,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(
       const <String>[
@@ -289,7 +289,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     await createTestCommandRunner(command).run(
@@ -318,7 +318,7 @@ void main() {
         isWindowsEnabled: true,
         isFuchsiaEnabled: true,
       ),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     await createTestCommandRunner(command).run(
@@ -348,7 +348,7 @@ void main() {
       cache: cache,
       logger: BufferLogger.test(),
       featureFlags: TestFeatureFlags(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     await createTestCommandRunner(command).run(
@@ -400,7 +400,7 @@ void main() {
       featureFlags: TestFeatureFlags(
         isMacOSEnabled: true,
       ),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache', '--force']);
 
@@ -419,7 +419,7 @@ void main() {
         isIOSEnabled: false,
         isAndroidEnabled: false,
       ),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
     await createTestCommandRunner(command).run(const <String>['precache']);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/proxy_validator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/proxy_validator_test.dart
@@ -12,31 +12,44 @@ import '../../src/common.dart';
 
 void main() {
   testWithoutContext('ProxyValidator does not show if HTTP_PROXY is not set', () {
-    final Platform platform = FakePlatform(environment: <String, String>{});
+    final Platform platform = FakePlatform(
+      environment: <String, String>{},
+      operatingSystem: 'linux',
+    );
 
     expect(ProxyValidator(platform: platform).shouldShow, isFalse);
   });
 
   testWithoutContext('ProxyValidator does not show if HTTP_PROXY is only whitespace', () {
-    final Platform platform = FakePlatform(environment: <String, String>{'HTTP_PROXY': ' '});
+    final Platform platform = FakePlatform(
+      environment: <String, String>{'HTTP_PROXY': ' '},
+      operatingSystem: 'linux',
+    );
 
     expect(ProxyValidator(platform: platform).shouldShow, isFalse);
   });
 
   testWithoutContext('ProxyValidator shows when HTTP_PROXY is set', () {
-    final Platform platform = FakePlatform(environment: <String, String>{'HTTP_PROXY': 'fakeproxy.local'});
+    final Platform platform = FakePlatform(
+      operatingSystem: 'linux',
+      environment: <String, String>{'HTTP_PROXY': 'fakeproxy.local'},
+    );
 
     expect(ProxyValidator(platform: platform).shouldShow, isTrue);
   });
 
   testWithoutContext('ProxyValidator shows when http_proxy is set', () {
-    final Platform platform = FakePlatform(environment: <String, String>{'http_proxy': 'fakeproxy.local'});
+    final Platform platform = FakePlatform(
+      operatingSystem: 'linux',
+      environment: <String, String>{'http_proxy': 'fakeproxy.local'},
+    );
 
     expect(ProxyValidator(platform: platform).shouldShow, isTrue);
   });
 
   testWithoutContext('ProxyValidator reports success when NO_PROXY is configured correctly', () async {
     final Platform platform = FakePlatform(
+      operatingSystem: 'linux',
       environment: <String, String>{
         'HTTP_PROXY': 'fakeproxy.local',
         'NO_PROXY': 'localhost,127.0.0.1',
@@ -54,6 +67,7 @@ void main() {
 
   testWithoutContext('ProxyValidator reports success when no_proxy is configured correctly', () async {
     final Platform platform = FakePlatform(
+      operatingSystem: 'linux',
       environment: <String, String>{
         'http_proxy': 'fakeproxy.local',
         'no_proxy': 'localhost,127.0.0.1',
@@ -71,6 +85,7 @@ void main() {
 
   testWithoutContext('ProxyValidator reports issues when NO_PROXY is missing localhost', () async {
     final Platform platform = FakePlatform(
+      operatingSystem: 'linux',
       environment: <String, String>{
         'HTTP_PROXY': 'fakeproxy.local',
         'NO_PROXY': '127.0.0.1',
@@ -87,10 +102,13 @@ void main() {
   });
 
   testWithoutContext('ProxyValidator reports issues when NO_PROXY is missing 127.0.0.1', () async {
-    final Platform platform =  FakePlatform(environment: <String, String>{
-      'HTTP_PROXY': 'fakeproxy.local',
-      'NO_PROXY': 'localhost',
-    });
+    final Platform platform =  FakePlatform(
+      operatingSystem: 'linux',
+      environment: <String, String>{
+        'HTTP_PROXY': 'fakeproxy.local',
+        'NO_PROXY': 'localhost',
+      },
+    );
     final ValidationResult results = await ProxyValidator(platform: platform).validate();
 
     expect(results.messages, const <ValidationMessage>[

--- a/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
@@ -22,7 +22,10 @@ import 'package:process/process.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 
-final Platform _kNoColorTerminalPlatform = FakePlatform(stdoutSupportsAnsi: false);
+final Platform _kNoColorTerminalPlatform = FakePlatform(
+  operatingSystem: 'linux',
+  stdoutSupportsAnsi: false,
+);
 
 void main() {
   String analyzerSeparator;

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -56,6 +56,12 @@ const String samplesIndexJson = '''
   { "id": "sample2" }
 ]''';
 
+const Platform localPlatform = LocalPlatform();
+
+final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', localPlatform.isWindows ? 'flutter.bat' : 'flutter');
+
+final String dartfmt = globals.fs.path.join(getFlutterRoot(), 'bin', 'cache', 'dart-sdk', 'bin', localPlatform.isWindows ? 'dartfmt.bat' : 'dartfmt');
+
 void main() {
   Directory tempDir;
   Directory projectDir;
@@ -195,7 +201,6 @@ void main() {
 
   testUsingContext('cannot create a project in flutter root', () async {
     Cache.flutterRoot = '../..';
-    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', globals.platform.isWindows ? 'flutter.bat' : 'flutter');
     final ProcessResult exec = await Process.run(
       flutterBin,
       <String>[
@@ -1038,11 +1043,7 @@ void main() {
         final String original = file.readAsStringSync();
 
         final Process process = await Process.start(
-          globals.fs.path.join(
-            globals.artifacts.getArtifactPath(Artifact.engineDartSdkPath),
-            'bin',
-            globals.platform.isWindows ? 'dartfmt.bat' : 'dartfmt',
-          ),
+          dartfmt,
           <String>[file.path],
           workingDirectory: projectDir.path,
         );
@@ -1142,11 +1143,7 @@ void main() {
         final String original = file.readAsStringSync();
 
         final Process process = await Process.start(
-          globals.fs.path.join(
-            globals.artifacts.getArtifactPath(Artifact.engineDartSdkPath),
-            'bin',
-            globals.platform.isWindows ? 'dartfmt.bat' : 'dartfmt',
-          ),
+          dartfmt,
           <String>[file.path],
           workingDirectory: projectDir.path,
         );

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -40,10 +40,16 @@ const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 const String _kDisabledPlatformRequestedMessage = 'currently not supported on your local environment.';
 
-final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false, operatingSystem: 'linux');
+final Generator _kNoColorTerminalPlatform = () => FakePlatform(
+  stdoutSupportsAnsi: false,
+  operatingSystem: 'linux',
+  environment: <String, String>{},
+);
+
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };
+
 const String samplesIndexJson = '''
 [
   { "id": "sample1" },

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -39,8 +39,8 @@ const String _kNoPlatformsMessage = 'You\'ve created a plugin project that doesn
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 const String _kDisabledPlatformRequestedMessage = 'currently not supported on your local environment.';
-// TODO(fujino): replace FakePlatform.fromPlatform() with FakePlatform()
-final Generator _kNoColorTerminalPlatform = () => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false;
+
+final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false, operatingSystem: 'linux');
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -43,10 +43,13 @@ void main() {
       realCommandRunner = UpgradeCommandRunner();
       processManager = FakeProcessManager.list(<FakeCommand>[]);
       fakeCommandRunner.willHaveUncommittedChanges = false;
-      fakePlatform = FakePlatform()..environment = Map<String, String>.unmodifiable(<String, String>{
-        'ENV1': 'irrelevant',
-        'ENV2': 'irrelevant',
-      });
+      fakePlatform = FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'ENV1': 'irrelevant',
+          'ENV2': 'irrelevant',
+        },
+      );
     });
 
     testUsingContext('throws on unknown tag, official branch,  noforce', () async {

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -115,9 +115,12 @@ void main() {
     }, overrides: <Type, Generator>{
       FlutterVersion: () => FlutterVersion(clock: const SystemClock()),
       Config: () => testConfig,
-      Platform: () => FakePlatform(environment: <String, String>{
-        'FLUTTER_ANALYTICS_LOG_FILE': 'test',
-      }),
+      Platform: () => FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'FLUTTER_ANALYTICS_LOG_FILE': 'test',
+        },
+      ),
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
@@ -138,9 +141,12 @@ void main() {
     }, overrides: <Type, Generator>{
       FlutterVersion: () => FlutterVersion(clock: const SystemClock()),
       Config: () => testConfig,
-      Platform: () => FakePlatform(environment: <String, String>{
-        'FLUTTER_ANALYTICS_LOG_FILE': 'test',
-      }),
+      Platform: () => FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'FLUTTER_ANALYTICS_LOG_FILE': 'test',
+        },
+      ),
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
@@ -243,6 +249,7 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
       SystemClock: () => fakeClock,
       Platform: () => FakePlatform(
+        operatingSystem: 'linux',
         environment: <String, String>{
           'FLUTTER_ANALYTICS_LOG_FILE': 'analytics.log',
         },
@@ -273,6 +280,7 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
       SystemClock: () => fakeClock,
       Platform: () => FakePlatform(
+        operatingSystem: 'linux',
         environment: <String, String>{
           'FLUTTER_ANALYTICS_LOG_FILE': 'analytics.log',
         },

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -41,7 +41,7 @@ void main() {
       ),
       processManager: FakeProcessManager.list(<FakeCommand>[]),
       fileSystem: MemoryFileSystem.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       userMessages: UserMessages(),
     );
 
@@ -62,7 +62,7 @@ void main() {
       ),
       processManager: fakeProcessManager,
       fileSystem: MemoryFileSystem.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       userMessages: UserMessages(),
     );
 
@@ -82,7 +82,7 @@ void main() {
       ),
       processManager: FakeProcessManager.list(<FakeCommand>[]),
       fileSystem: MemoryFileSystem.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       userMessages: UserMessages(),
     );
 
@@ -103,7 +103,7 @@ void main() {
       androidWorkflow: androidWorkflow,
       processManager: processManager,
       fileSystem: MemoryFileSystem.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       userMessages: UserMessages(),
     );
 
@@ -124,7 +124,7 @@ void main() {
       ),
       processManager: FakeProcessManager.any(),
       fileSystem: MemoryFileSystem.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       userMessages: UserMessages(),
     );
 
@@ -147,7 +147,7 @@ List of devices attached
   ''',
         )
       ]),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       fileSystem: MemoryFileSystem.test(),
     );
 
@@ -176,7 +176,7 @@ emulator-5612          host features:shell_2
   ''',
         )
       ]),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       fileSystem: MemoryFileSystem.test(),
     );
 
@@ -204,7 +204,7 @@ ZX1G22JJWR             device usb:3-3 product:shamu model:Nexus_6 device:shamu f
 ''',
         )
       ]),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       fileSystem: MemoryFileSystem.test(),
     );
 
@@ -230,7 +230,7 @@ Use the 'android' tool to install them:
 ''',
         )
       ]),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       fileSystem: MemoryFileSystem.test(),
     );
 

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -47,7 +47,7 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+       platform: FakePlatform(operatingSystem: 'linux'),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -134,7 +134,7 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -236,7 +236,7 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -323,7 +323,7 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
       processManager.addCommand(FakeCommand(
         command: const <String>[
@@ -383,7 +383,7 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -482,6 +482,7 @@ void main() {
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
           environment: <String, String>{
             'HOME': '/home',
           },
@@ -578,7 +579,9 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -689,7 +692,9 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -753,7 +758,9 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -816,7 +823,9 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -872,7 +881,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_arm'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -946,7 +957,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_arm64'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1020,7 +1033,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_x86'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1094,7 +1109,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_x64'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1168,7 +1185,9 @@ void main() {
         artifacts: Artifacts.test(),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(
         const FakeCommand(command: <String>[
@@ -1223,7 +1242,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_arm'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1308,7 +1329,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_arm64'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1393,7 +1416,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_x86'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -1478,7 +1503,9 @@ void main() {
         artifacts: Artifacts.test(localEngine: 'out/android_x64'),
         usage: testUsage,
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+        ),
       );
       processManager.addCommand(const FakeCommand(
         command: <String>[

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -92,7 +92,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -111,7 +114,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -129,7 +135,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -154,7 +163,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -178,7 +190,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -202,7 +217,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -222,7 +240,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -241,7 +262,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -260,7 +284,10 @@ void main() {
       androidSdk: sdk,
       fileSystem: fileSystem,
       processManager: processManager,
-      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       stdio: stdio,
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
@@ -280,7 +307,10 @@ void main() {
       fileSystem: fileSystem,
       logger: logger,
       processManager: processManager,
-      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{'HOME': '/home/me'},
+      ),
       userMessages: UserMessages(),
     ).validate();
     expect(validationResult.type, ValidationType.partial);
@@ -306,7 +336,7 @@ void main() {
       sdk.sdkManagerPath,
       kAndroidSdkMinVersion,
       kAndroidSdkBuildToolsMinVersion.toString(),
-      FakePlatform(),
+      FakePlatform(operatingSystem: 'linux'),
     );
 
     final AndroidValidator androidValidator = AndroidValidator(
@@ -315,7 +345,7 @@ void main() {
       fileSystem: fileSystem,
       logger: logger,
       processManager: processManager,
-      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+      platform: FakePlatform(operatingSystem: 'linux', environment: <String, String>{'HOME': '/home/me'}),
       userMessages: UserMessages(),
     );
 
@@ -373,7 +403,7 @@ void main() {
       androidStudio: null,
       fileSystem: fileSystem,
       logger: logger,
-      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'},
+      platform: FakePlatform(operatingSystem: 'linux', environment: <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'}),
       processManager: processManager,
       userMessages: UserMessages(),
     ).validate();
@@ -396,7 +426,7 @@ void main() {
       androidStudio: null,
       fileSystem: fileSystem,
       logger: logger,
-      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'},
+      platform: FakePlatform(operatingSystem: 'linux', environment: <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'}),
       processManager: processManager,
       userMessages: UserMessages(),
     ).validate();

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -73,7 +73,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
-      Platform: () => FakePlatform(environment: <String, String>{'HOME': 'foo/'}),
+      Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{'HOME': 'foo/'}),
     });
 
     testUsingContext('retries if gradle fails while downloading', () async {

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -646,7 +646,7 @@ flutter:
         artifacts: Artifacts.test(),
         usage: TestUsage(),
         gradleUtils: FakeGradleUtils(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -25,7 +25,7 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fakes.dart';
 
-final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false);
+final Generator _kNoColorTerminalPlatform = () => FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: false);
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };

--- a/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifact_updater_test.dart
@@ -20,7 +20,7 @@ import '../src/common.dart';
 import '../src/fake_http_client.dart';
 import '../src/fakes.dart';
 
-final Platform testPlatform = FakePlatform(environment: const <String, String>{});
+final Platform testPlatform = FakePlatform(operatingSystem: 'linux', environment: const <String, String>{});
 
 void main() {
   testWithoutContext('ArtifactUpdater can download a zip archive', () async {
@@ -249,6 +249,7 @@ void main() {
       logger: logger,
       operatingSystemUtils: operatingSystemUtils,
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: <String, String>{
           'FLUTTER_STORAGE_BASE_URL': 'foo-bar'
         },

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -24,7 +24,7 @@ void main() {
     PersistentToolState persistentToolState;
 
     setUp(() {
-      fakePlatform = FakePlatform()..environment = <String, String>{};
+      fakePlatform = FakePlatform(operatingSystem: 'linux', environment: <String, String>{});
       fakeStdio = FakeStdio();
       persistentToolState = PersistentToolState.test(
         directory: MemoryFileSystem.test().currentDirectory,

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -18,6 +18,7 @@ CommandHelp _createCommandHelp({
   @required int wrapColumn,
 }) {
   final Platform platform = FakePlatform(
+    operatingSystem: 'linux',
     stdoutSupportsAnsi: ansi,
   );
   return CommandHelp(
@@ -82,7 +83,7 @@ void main() {
   group('CommandHelp', () {
     group('toString', () {
       testWithoutContext('ends with a resetBold when it has parenthetical text', () {
-        final Platform platform = FakePlatform(stdoutSupportsAnsi: true);
+        final Platform platform = FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: true);
         final AnsiTerminal terminal = AnsiTerminal(stdio: null, platform: platform);
 
         final CommandHelpOption commandHelpOption = CommandHelpOption(

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -26,7 +26,7 @@ void main() {
       fs = MemoryFileSystem.test();
       fsUtils = FileSystemUtils(
         fileSystem: fs,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -21,7 +21,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
 
-final Platform _kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false);
+final Platform _kNoAnsiPlatform = FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: false);
 final String red = RegExp.escape(AnsiTerminal.red);
 final String bold = RegExp.escape(AnsiTerminal.bold);
 final String resetBold = RegExp.escape(AnsiTerminal.resetBold);
@@ -266,7 +266,7 @@ void main() {
       final BufferLogger mockLogger = BufferLogger(
         terminal: AnsiTerminal(
           stdio:  FakeStdio(),
-          platform: FakePlatform(stdoutSupportsAnsi: true),
+          platform: FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: true),
         ),
         outputPreferences: OutputPreferences.test(showColor: true),
       );
@@ -404,8 +404,8 @@ void main() {
         AnsiStatus ansiStatus;
 
         setUp(() {
-          platform = FakePlatform(stdoutSupportsAnsi: false);
-          ansiPlatform = FakePlatform(stdoutSupportsAnsi: true);
+          platform = FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: false);
+          ansiPlatform = FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: true);
 
           terminal = AnsiTerminal(
             stdio: mockStdio,
@@ -830,7 +830,7 @@ void main() {
       final Logger logger = StdoutLogger(
         terminal: AnsiTerminal(
           stdio: fakeStdio,
-          platform: FakePlatform(stdoutSupportsAnsi: true),
+          platform: FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: true),
         ),
         stdio: fakeStdio,
         outputPreferences: OutputPreferences.test(showColor: true),
@@ -847,7 +847,7 @@ void main() {
       final Logger logger = StdoutLogger(
         terminal: AnsiTerminal(
           stdio: fakeStdio,
-          platform: FakePlatform(),
+          platform: FakePlatform(operatingSystem: 'linux'),
         ),
         stdio: fakeStdio,
         outputPreferences:  OutputPreferences.test(showColor: true),
@@ -864,7 +864,7 @@ void main() {
       final Logger logger = StdoutLogger(
         terminal: AnsiTerminal(
           stdio: fakeStdio,
-          platform: FakePlatform(),
+          platform: FakePlatform(operatingSystem: 'linux'),
         ),
         stdio: fakeStdio,
         outputPreferences: OutputPreferences.test(showColor: true),

--- a/packages/flutter_tools/test/general.shard/base/net_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/net_test.dart
@@ -30,7 +30,7 @@ void main() {
     return Net(
       httpClientFactory: () => client,
       logger: testLogger,
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
     );
   }
 
@@ -183,6 +183,7 @@ void main() {
       },
       logger: testLogger,
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: <String, String>{
           'FLUTTER_STORAGE_BASE_URL': 'example.invalid',
         },

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -90,7 +90,7 @@ void main() {
       mockLogger = BufferLogger(
         terminal: AnsiTerminal(
           stdio: FakeStdio(),
-          platform: FakePlatform(stdoutSupportsAnsi: false),
+          platform: FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
       );
@@ -280,7 +280,7 @@ void main() {
       testLogger = BufferLogger(
         terminal: AnsiTerminal(
           stdio: FakeStdio(),
-          platform: FakePlatform(stdinSupportsAnsi: false),
+          platform: FakePlatform(operatingSystem: 'linux', stdinSupportsAnsi: false),
         ),
         outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
       );

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -17,7 +17,7 @@ void main() {
     testWithoutContext('can wrap output', () async {
       final BufferLogger bufferLogger = BufferLogger(
         outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 40),
-        terminal: TestTerminal(platform: FakePlatform()..stdoutSupportsAnsi = true),
+        terminal: TestTerminal(platform: FakePlatform(stdoutSupportsAnsi: true, operatingSystem: 'linux')),
       );
       bufferLogger.printStatus('0123456789' * 8);
 
@@ -27,7 +27,7 @@ void main() {
     testWithoutContext('can turn off wrapping', () async {
       final BufferLogger bufferLogger = BufferLogger(
         outputPreferences: OutputPreferences.test(wrapText: false),
-        terminal: TestTerminal(platform: FakePlatform()..stdoutSupportsAnsi = true),
+        terminal: TestTerminal(platform: FakePlatform(stdoutSupportsAnsi: true, operatingSystem: 'linux')),
       );
       final String testString = '0123456789' * 20;
       bufferLogger.printStatus(testString);
@@ -42,7 +42,7 @@ void main() {
     setUp(() {
       terminal = AnsiTerminal(
         stdio: Stdio(), // Danger, using real stdio.
-        platform: FakePlatform()..stdoutSupportsAnsi = true,
+        platform: FakePlatform(operatingSystem: 'linux', stdoutSupportsAnsi: true),
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(message(macPlatform), contains('https://flutter.dev/docs/get-started/install/macos#android-setup'));
     expect(message(linuxPlatform), contains('https://flutter.dev/docs/get-started/install/linux#android-setup'));
     expect(message(windowsPlatform), contains('https://flutter.dev/docs/get-started/install/windows#android-setup'));
-    expect(message(FakePlatform()), contains('https://flutter.dev/docs/get-started/install '));
+    expect(message(FakePlatform(operatingSystem: 'none')), contains('https://flutter.dev/docs/get-started/install '));
   }
 
   testWithoutContext('Android installation instructions', () {

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -469,7 +469,9 @@ void main() {
     FlutterBuildSystem(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+      ),
     ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
@@ -489,7 +491,9 @@ void main() {
     FlutterBuildSystem(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+      ),
     ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
@@ -504,7 +508,9 @@ void main() {
     FlutterBuildSystem(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+      ),
     ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
 
     expect(environment.outputDir.childFile('.last_build_id').lastModifiedSync(),
@@ -524,7 +530,7 @@ void main() {
     FlutterBuildSystem(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
     ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
 
     expect(environment.outputDir.childFile('.last_build_id').readAsStringSync(),
@@ -547,7 +553,7 @@ void main() {
     FlutterBuildSystem(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
     ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
 
     expect(environment.outputDir.childFile('.last_build_id').readAsStringSync(),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/assets_test.dart
@@ -26,7 +26,7 @@ void main() {
   Platform platform;
 
   setUp(() {
-    platform = FakePlatform();
+    platform = FakePlatform(operatingSystem: 'linux');
     fileSystem = MemoryFileSystem.test();
     environment = Environment.test(
       fileSystem.currentDirectory,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -24,7 +24,7 @@ import '../../../src/common.dart';
 import '../../../src/context.dart';
 import '../../../src/fakes.dart';
 
-final Platform kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false);
+final Platform kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false, operatingSystem: 'linux');
 const List<int> _kTtfHeaderBytes = <int>[0, 1, 0, 0, 0, 15, 0, 128, 0, 3, 0, 112];
 
 const String inputPath = '/input/fonts/MaterialIcons-Regular.otf';

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -99,9 +99,13 @@ void main() {
     }, skip: true); // TODO(jonahwilliams): implement support for lock so this can be tested with the memory file system.
 
     testWithoutContext('should not throw when FLUTTER_ALREADY_LOCKED is set', () {
-     final Cache cache = Cache.test(platform: FakePlatform(environment: <String, String>{
-       'FLUTTER_ALREADY_LOCKED': 'true',
-     }));
+     final Cache cache = Cache.test(
+       platform: FakePlatform(
+         operatingSystem: 'linux',
+         environment: <String, String>{
+          'FLUTTER_ALREADY_LOCKED': 'true',
+        },
+      ));
 
       expect(cache.checkLockAcquired, returnsNormally);
     });
@@ -263,9 +267,11 @@ void main() {
 
     testWithoutContext('Invalid URI for FLUTTER_STORAGE_BASE_URL throws ToolExit', () async {
       final Cache cache = Cache.test(
-        platform: FakePlatform(environment: <String, String>{
-        'FLUTTER_STORAGE_BASE_URL': ' http://foo',
-        },
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+          environment: <String, String>{
+          'FLUTTER_STORAGE_BASE_URL': ' http://foo',
+          },
       ));
 
       expect(() => cache.storageBaseUrl, throwsToolExit());
@@ -576,7 +582,7 @@ void main() {
       ],
       logger: logger,
       fileSystem: fileSystem,
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       osUtils: MockOperatingSystemUtils(),
       rootOverride: fileSystem.currentDirectory,
     );
@@ -604,7 +610,7 @@ void main() {
       ],
       logger: logger,
       fileSystem: fileSystem,
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       osUtils: MockOperatingSystemUtils(),
       rootOverride: fileSystem.currentDirectory,
     );
@@ -631,7 +637,7 @@ void main() {
       ],
       logger: logger,
       fileSystem: fileSystem,
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       osUtils: MockOperatingSystemUtils(),
       rootOverride: fileSystem.currentDirectory,
     );
@@ -670,7 +676,7 @@ void main() {
     final FakeCache cache = FakeCache(
       fileSystem: fileSystem,
       logger: logger,
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       osUtils: MockOperatingSystemUtils()
     );
     final File file = fileSystem.file('stamp');
@@ -694,7 +700,7 @@ void main() {
     final FakeCache cache = FakeCache(
         fileSystem: fileSystem,
         logger: logger,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         osUtils: MockOperatingSystemUtils()
     );
 

--- a/packages/flutter_tools/test/general.shard/commands/flutter_root_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/flutter_root_test.dart
@@ -18,9 +18,10 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         userMessages: UserMessages(),
         platform: FakePlatform(
-            environment: <String, String>{
-              'FLUTTER_ROOT': 'path/to/flutter'
-            }
+          operatingSystem: 'linux',
+          environment: <String, String>{
+            'FLUTTER_ROOT': 'path/to/flutter'
+          }
         )
     );
 
@@ -39,6 +40,7 @@ void main() {
         fileSystem: fileSystem,
         userMessages: UserMessages(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
           environment: <String, String>{},
           script: Uri.parse('data:,Hello%2C%20World!'),
         )
@@ -53,6 +55,7 @@ void main() {
         fileSystem: fileSystem,
         userMessages: UserMessages(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
             environment: <String, String>{},
             script: Uri.parse('package:flutter_tools/flutter_tools.dart'),
             packageConfig: 'flutter/packages/flutter_tools/.packages'
@@ -68,6 +71,7 @@ void main() {
         fileSystem: fileSystem,
         userMessages: UserMessages(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
           environment: <String, String>{},
           script: Uri.parse('file:///flutter/bin/cache/flutter_tools.snapshot'),
         )
@@ -82,6 +86,7 @@ void main() {
         fileSystem: fileSystem,
         userMessages: UserMessages(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
           environment: <String, String>{},
           script: Uri.parse('file:///flutter/packages/flutter_tools/bin/flutter_tools.dart'),
         )
@@ -96,6 +101,7 @@ void main() {
         fileSystem: fileSystem,
         userMessages: UserMessages(),
         platform: FakePlatform(
+          operatingSystem: 'linux',
           environment: <String, String>{},
           script: Uri.parse('http://foo.bar'), // does not match any heuristics.
         )

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -45,6 +45,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -83,6 +84,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -121,6 +123,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -159,6 +162,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -196,6 +200,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -235,6 +240,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -276,6 +282,7 @@ void main() {
       processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -302,6 +309,7 @@ void main() {
       processManager: processMock,
       usage: TestUsage(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{},
       ),
       botDetector: const BotDetectorAlwaysNo(),
@@ -368,7 +376,7 @@ void main() {
     final BufferLogger logger = BufferLogger.test();
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Pub pub = Pub(
-      platform: FakePlatform(environment: const <String, String>{}),
+      platform: FakePlatform(environment: const <String, String>{}, operatingSystem: 'linux'),
       fileSystem: fileSystem,
       logger: logger,
       usage: TestUsage(),
@@ -401,7 +409,7 @@ void main() {
     fileSystem.directory(Cache.flutterRoot).childDirectory('.pub-cache').createSync();
 
     final Pub pub = Pub(
-      platform: FakePlatform(environment: const <String, String>{}),
+      platform: FakePlatform(environment: const <String, String>{}, operatingSystem: 'linux'),
       usage: TestUsage(),
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
@@ -435,6 +443,7 @@ void main() {
       usage: TestUsage(),
       botDetector: const BotDetectorAlwaysNo(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
         },
@@ -468,6 +477,7 @@ void main() {
       botDetector: const BotDetectorAlwaysNo(),
       usage: usage,
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
         }
@@ -498,6 +508,7 @@ void main() {
       botDetector: const BotDetectorAlwaysNo(),
       usage: usage,
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
         }
@@ -544,6 +555,7 @@ void main() {
       processManager: MockProcessManager(1),
       botDetector: const BotDetectorAlwaysNo(),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: const <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
         },
@@ -571,6 +583,7 @@ void main() {
         stderr: 'version solving failed',
       ),
       platform: FakePlatform(
+        operatingSystem: 'linux',
         environment: <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
         },

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   setUp(() {
     logger = BufferLogger.test();
-    platform = FakePlatform(environment: <String, String>{});
+    platform = FakePlatform(environment: <String, String>{}, operatingSystem: 'linux');
 
     final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('devtools_launcher_test');
     persistentToolState = PersistentToolState.test(
@@ -59,9 +59,12 @@ void main() {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
       pubExecutable: 'pub',
       logger: logger,
-      platform: FakePlatform(environment: <String, String>{
-        'PUB_HOSTED_URL': 'https://pub2.dev'
-      }),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'PUB_HOSTED_URL': 'https://pub2.dev'
+        },
+      ),
       persistentToolState: persistentToolState,
       httpClient: FakeHttpClient.list(<FakeRequest>[
         FakeRequest(
@@ -81,9 +84,12 @@ void main() {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
       pubExecutable: 'pub',
       logger: logger,
-      platform: FakePlatform(environment: <String, String>{
-        'PUB_HOSTED_URL': r'not_an_http_url'
-      }),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'PUB_HOSTED_URL': r'not_an_http_url'
+        },
+      ),
       persistentToolState: persistentToolState,
       httpClient: FakeHttpClient.list(<FakeRequest>[]),
       processManager: FakeProcessManager.list(<FakeCommand>[]),

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -22,7 +22,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
 
-final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false);
+final Generator _kNoColorTerminalPlatform = () => FakePlatform(stdoutSupportsAnsi: false, operatingSystem: 'linux');
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -1,3 +1,4 @@
+
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -622,7 +622,7 @@ Information about project "Runner":
     FakePlatform platform;
 
     setUp(() {
-      platform = FakePlatform();
+      platform = FakePlatform(operatingSystem: 'linux');
     });
 
     testWithoutContext('environment variables as Xcode build settings', () {

--- a/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
@@ -199,7 +199,7 @@ void main() {
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
 
 final Generator _kNoColorTerminalPlatform =
-    () => FakePlatform(stdoutSupportsAnsi: false);
+    () => FakePlatform(stdoutSupportsAnsi: false, operatingSystem: 'linux');
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorTerminalPlatform,
 };

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -23,7 +23,7 @@ void main() {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         logger: BufferLogger.test(),
       );
       fileSystem.file('.packages').writeAsStringSync('\n');
@@ -44,7 +44,7 @@ void main() {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         logger: BufferLogger.test(),
       );
       fileSystem.file('.packages').writeAsStringSync('\n');
@@ -65,7 +65,7 @@ void main() {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: MemoryFileSystem.test(),
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         logger: BufferLogger.test(),
       );
       fileSystem.file('.packages').writeAsStringSync('\n');
@@ -88,7 +88,7 @@ void main() {
       const PackageConfig packageConfig = PackageConfig.empty;
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         logger: BufferLogger.test(),
       );
       fileSystem.file('.packages')
@@ -128,7 +128,7 @@ void main() {
       const PackageConfig packageConfig = PackageConfig.empty;
       final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
         fileSystem: fileSystem,
-        platform: FakePlatform(),
+        platform: FakePlatform(operatingSystem: 'linux'),
         logger: BufferLogger.test(),
       );
       fileSystem.file('.packages')

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -128,7 +128,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[]),
       pubExecutable: 'pub',
       logger: BufferLogger.test(),
-      platform: FakePlatform(),
+      platform: FakePlatform(operatingSystem: 'linux'),
       persistentToolState: null,
     );
     final ResidentDevtoolsHandler handler = FlutterResidentDevtoolsHandler(

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -45,6 +45,7 @@ void main() {
           'FLUTTER_ROOT': _kFlutterRoot,
         },
         version: '1 2 3 4 5',
+        operatingSystem: 'linux'
       );
 
       runner = createTestCommandRunner(DummyFlutterCommand()) as FlutterCommandRunner;

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -41,7 +41,7 @@ void main() {
       flutterRoot: '',
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     expect(
@@ -79,7 +79,7 @@ void main() {
       flutterRoot: '',
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     expect(
@@ -110,7 +110,7 @@ void main() {
       flutterRoot: 'flutter/flutter',
       logger: BufferLogger.test(),
       userMessages: UserMessages(),
-      platform: FakePlatform(environment: <String, String>{}),
+      platform: FakePlatform(environment: <String, String>{}, operatingSystem: 'linux'),
     );
 
     expect(

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -88,10 +88,14 @@ void main() {
       final CrashingUsage crashingUsage = globals.flutterUsage as CrashingUsage;
       expect(crashingUsage.sentException, 'an exception % --');
     }, overrides: <Type, Generator>{
-      Platform: () => FakePlatform(environment: <String, String>{
-        'FLUTTER_ANALYTICS_LOG_FILE': 'test',
-        'FLUTTER_ROOT': '/',
-      }),
+      Platform: () => FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'FLUTTER_ANALYTICS_LOG_FILE': 'test',
+          'FLUTTER_ROOT': '/',
+        },
+        localeName: 'US_en',
+      ),
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       Usage: () => CrashingUsage(),
@@ -130,10 +134,14 @@ void main() {
       ));
       await completer.future;
     }, overrides: <Type, Generator>{
-      Platform: () => FakePlatform(environment: <String, String>{
-        'FLUTTER_ANALYTICS_LOG_FILE': 'test',
-        'FLUTTER_ROOT': '/',
-      }),
+      Platform: () => FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{
+          'FLUTTER_ANALYTICS_LOG_FILE': 'test',
+          'FLUTTER_ROOT': '/',
+        },
+        localeName: 'US_en',
+      ),
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       CrashReporter: () => WaitingCrashReporter(commandCompleter.future),
@@ -192,7 +200,8 @@ void main() {
           'FLUTTER_ANALYTICS_LOG_FILE': 'test',
           'FLUTTER_ROOT': '/',
         },
-        operatingSystem: 'linux'
+        operatingSystem: 'linux',
+        localeName: 'US_en',
       ),
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -741,7 +741,9 @@ void main() {
       environment: anyNamed('environment'),
     )).called(1);
   }, overrides: <Type, Generator>{
-    Platform: () => FakePlatform(environment: <String, String>{
+    Platform: () => FakePlatform(
+      operatingSystem: 'linux',
+      environment: <String, String>{
       'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter.git',
     }),
   });


### PR DESCRIPTION
The platform class is a fairly widespread dependency, migrate to null safety.

Unfortunately, the fake platform left its fields as nullable, which isn't a valid override once the platform class is null safe. To fix, I added some defaults + made some arguments required. For the other fields, I used a sort of late/not really late getter/setter that will throw if a test reads the value without it being set.
