### PR TITLE
Delete unzipped FlutterMacOS.framework before replacing artifact

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -934,6 +934,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
       final File frameworkZip = fileSystem.file(fileSystem.path.join(dir.path, 'FlutterMacOS.framework.zip'));
       if (frameworkZip.existsSync()) {
         final Directory framework = fileSystem.directory(fileSystem.path.join(dir.path, 'FlutterMacOS.framework'));
+        ErrorHandlingFileSystem.deleteIfExists(framework, recursive: true);
         framework.createSync();
         operatingSystemUtils.unzip(frameworkZip, framework);
       }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -331,13 +331,6 @@ void main() {
       requiredArtifacts: DevelopmentArtifact.universal,
     );
     await artifact.updateInner(MockArtifactUpdater(), fileSystem, operatingSystemUtils);
-    final Directory dir = fileSystem.systemTempDirectory
-        .listSync(recursive: true)
-        .whereType<Directory>()
-        .singleWhere((Directory directory) => directory.basename == 'bin_dir', orElse: () => null);
-
-    expect(dir, isNotNull);
-    expect(dir.path, artifactDir.childDirectory('bin_dir').path);
     expect(unzippedFramework, exists);
     expect(staleFile, isNot(exists));
   });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -308,6 +308,40 @@ void main() {
     verify(operatingSystemUtils.chmod(argThat(hasPath(dir.path)), 'a+r,a+x'));
   });
 
+  testWithoutContext('EngineCachedArtifact removes unzipped FlutterMacOS.framework before replacing', () async {
+    final OperatingSystemUtils operatingSystemUtils = MockOperatingSystemUtils();
+    final MockCache cache = MockCache();
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Directory artifactDir = fileSystem.systemTempDirectory.createTempSync('flutter_cache_test_artifact.');
+    final Directory downloadDir = fileSystem.systemTempDirectory.createTempSync('flutter_cache_test_download.');
+
+    when(cache.getArtifactDirectory(any)).thenReturn(artifactDir);
+    when(cache.getDownloadDir()).thenReturn(downloadDir);
+    final Directory binDir = artifactDir.childDirectory('bin_dir')..createSync();
+    binDir.childFile('FlutterMacOS.framework.zip').createSync();
+    final Directory unzippedFramework = binDir.childDirectory('FlutterMacOS.framework');
+    final File staleFile = unzippedFramework.childFile('stale_file')..createSync(recursive: true);
+    artifactDir.childFile('unused_url_path').createSync();
+
+    final FakeCachedArtifact artifact = FakeCachedArtifact(
+      cache: cache,
+      binaryDirs: <List<String>>[
+        <String>['bin_dir', 'unused_url_path'],
+      ],
+      requiredArtifacts: DevelopmentArtifact.universal,
+    );
+    await artifact.updateInner(MockArtifactUpdater(), fileSystem, operatingSystemUtils);
+    final Directory dir = fileSystem.systemTempDirectory
+        .listSync(recursive: true)
+        .whereType<Directory>()
+        .singleWhere((Directory directory) => directory.basename == 'bin_dir', orElse: () => null);
+
+    expect(dir, isNotNull);
+    expect(dir.path, artifactDir.childDirectory('bin_dir').path);
+    expect(unzippedFramework, exists);
+    expect(staleFile, isNot(exists));
+  });
+
   testWithoutContext('IosUsbArtifacts verifies executables for libimobiledevice in isUpToDateInner', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Cache cache = Cache.test(fileSystem: fileSystem, processManager: FakeProcessManager.any());


### PR DESCRIPTION
Remove unzipped `FlutterMacOS.framework` before unzipping a newly downloaded version of the artifact on top.
Fixes https://github.com/flutter/flutter/issues/77234