### PR TITLE
Bitcode strip Flutter.framework in assemble build target

### DIFF
--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -42,7 +42,7 @@ Future<bool> containsBitcode(String pathToBinary) async {
     if (line.contains('segname __LLVM') && lines.length - index - 1 > 3) {
       final String emptyBitcodeMarker = lines
         .skip(index - 1)
-        .take(3)
+        .take(4)
         .firstWhere(
           (String line) => line.contains(' size 0x0000000000000001'),
           orElse: () => null,

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -137,9 +137,8 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     local_engine_flag="--local-engine=${LOCAL_ENGINE}"
     flutter_framework="${FLUTTER_ENGINE}/out/${LOCAL_ENGINE}/Flutter.xcframework"
   fi
-
   local bitcode_flag=""
-  if [[ "$ENABLE_BITCODE" == "YES" ]]; then
+  if [[ "$ENABLE_BITCODE" == "YES" && "$ACTION" == "install" ]]; then
     bitcode_flag="true"
   fi
 
@@ -218,10 +217,6 @@ EmbedFlutterFrameworks() {
 
   # Copy Xcode behavior and don't copy over headers or modules.
   RunCommand rsync -av --delete --filter "- .DS_Store" --filter "- Headers" --filter "- Modules" "${BUILT_PRODUCTS_DIR}/Flutter.framework" "${xcode_frameworks_dir}/"
-  if [[ "$ACTION" != "install" || "$ENABLE_BITCODE" == "NO" ]]; then
-    # Strip bitcode from the destination unless archiving, or if bitcode is disabled entirely.
-    RunCommand "${DT_TOOLCHAIN_DIR}"/usr/bin/bitcode_strip "${BUILT_PRODUCTS_DIR}/Flutter.framework/Flutter" -r -o "${xcode_frameworks_dir}/Flutter.framework/Flutter"
-  fi
 
   # Sign the binaries we moved.
   if [[ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then

--- a/packages/flutter_tools/test/src/darwin_common.dart
+++ b/packages/flutter_tools/test/src/darwin_common.dart
@@ -40,7 +40,7 @@ bool containsBitcode(String pathToBinary, ProcessManager processManager) {
   lines.asMap().forEach((int index, String line) {
     if (line.contains('segname __LLVM') && lines.length - index - 1 > 3) {
       final String emptyBitcodeMarker =
-      lines.skip(index - 1).take(3).firstWhere(
+      lines.skip(index - 1).take(4).firstWhere(
             (String line) => line.contains(' size 0x0000000000000001'),
         orElse: () => null,
       );


### PR DESCRIPTION
The `xcode_backend` script stripped bitcode from the `Flutter.framework` when bitcode is off or when not archiving to reduce install app size.

1. Move bitcode stripping into the copy Flutter.framework assemble target.
2. Don't generate bitcode for the `App.framework` unless archiving.
2. Switch the [`bitcode_strip`](https://www.manpagez.com/man/1/bitcode_strip/) flag from `-r` (which removes the bitcode section entirely) to `-m` (which leaves the bitcode marker).  This seems safer to me in case bitcode gets switched off or on, and matches the Xcode default behavior.

Added assemble target unit tests, but this is also already covered by existing tests like
https://github.com/flutter/flutter/blob/3082a2806eaf1f6e1aa6b446291e602af331d157/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart#L433-L435
https://github.com/flutter/flutter/blob/42c9e276d861986c0b7c274da19b83c064163f35/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart#L128

More of https://github.com/flutter/flutter/pull/77007