### PR TITLE
[flutter_tools] Show version in update message

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -244,10 +244,6 @@ class FlutterVersion {
       await _run(<String>['git', 'fetch', _versionCheckRemote, branch]);
       final String revision = await _run(gitLog(<String>['$_versionCheckRemote/$branch', '-n', '1', '--pretty=format:%H']));
       return revision;
-      //return _latestGitCommitDate(
-        //branch: '$_versionCheckRemote/$branch',
-        //lenient: false,
-      //);
     } on VersionCheckError catch (error) {
       if (globals.platform.environment.containsKey('FLUTTER_GIT_URL')) {
         globals.logger.printError('Warning: the Flutter git upstream was overridden '


### PR DESCRIPTION
*This is an updated version of PR #71537, focusing on minimum code changes as possible.*
## Description
Modifies the warning and update message to display the channel, update version, 
installed version, and informs the user about `--verify-only` flag of `flutter upgrade`.

#### Before:
```
╔════════════════════════════════════════════════════════════════════════════╗
║ A new version of Flutter is available!                                     ║
║                                                                            ║
║ To update to the latest version, run "flutter upgrade".                    ║
╚════════════════════════════════════════════════════════════════════════════╝

╔════════════════════════════════════════════════════════════════════════════╗
║ WARNING: your installation of Flutter is 42 days old.                      ║
║                                                                            ║
║ To update to the latest version, run "flutter upgrade".                    ║
╚════════════════════════════════════════════════════════════════════════════╝
```
#### After:
```
╔════════════════════════════════════════════════════════════════════════════╗
║ A new version of Flutter is available on channel master!                   ║
║                                                                            ║
║ The latest version: 1.25.0-5.0.pre.45 (revision 81e1f7d1ed)                ║
║ Your current version: 1.24.0-8.0.pre.374 (revision 183f0e797a)             ║
║                                                                            ║
║ To update to the latest version, run "flutter upgrade".                    ║
║ To view this information next time, run "flutter upgrade --verify-only".   ║
╚════════════════════════════════════════════════════════════════════════════╝

╔════════════════════════════════════════════════════════════════════════════╗
║ WARNING: your installation of Flutter is 42 days old.                      ║
║                                                                            ║
║ To update to the latest version, run "flutter upgrade".                    ║
║ To check for updates only, run "flutter upgrade --verify-only".            ║
╚════════════════════════════════════════════════════════════════════════════╝
```

## Related Issues
Fixes #68936.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
