### PR TITLE
[flutter_tools] replace MockFlutterVersion usage with fake where possible, move from context

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -720,7 +720,7 @@ class FlutterValidator extends DoctorValidator {
       messages.add(ValidationMessage(_userMessages.flutterRevision(
         version.frameworkRevisionShort,
         version.frameworkAge,
-        version.frameworkDate,
+        version.frameworkCommitDate,
       )));
       messages.add(ValidationMessage(_userMessages.engineRevision(version.engineRevisionShort)));
       messages.add(ValidationMessage(_userMessages.dartRevision(version.dartSdkVersion)));

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -179,6 +179,8 @@ class FlutterVersion {
     'dartSdkVersion': dartSdkVersion,
   };
 
+  String get frameworkDate => frameworkCommitDate;
+
   /// A date String describing the last framework commit.
   ///
   /// If a git command fails, this will return a placeholder date.

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -144,8 +144,6 @@ class FlutterVersion {
   String _frameworkVersion;
   String get frameworkVersion => _frameworkVersion;
 
-  String get frameworkDate => frameworkCommitDate;
-
   String get dartSdkVersion => globals.cache.dartSdkVersion;
 
   String get engineRevision => globals.cache.engineRevision;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -53,12 +53,12 @@ final Platform macPlatform = FakePlatform(
 );
 
 void main() {
-  MockFlutterVersion mockFlutterVersion;
+  FakeFlutterVersion flutterVersion;
   BufferLogger logger;
   FakeProcessManager fakeProcessManager;
 
   setUp(() {
-    mockFlutterVersion = MockFlutterVersion();
+    flutterVersion = FakeFlutterVersion();
     logger = BufferLogger.test();
     fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
   });
@@ -667,13 +667,12 @@ void main() {
 
     await commandRunner.run(<String>['doctor']);
 
-    verify(mockFlutterVersion.fetchTagsAndUpdate()).called(1);
-
+    expect(flutterVersion.didFetchTagsAndUpdate, true);
     Cache.enableLocking();
   }, overrides: <Type, Generator>{
     ProcessManager: () => FakeProcessManager.any(),
     FileSystem: () => MemoryFileSystem.test(),
-    FlutterVersion: () => mockFlutterVersion,
+    FlutterVersion: () => flutterVersion,
     Doctor: () => NoOpDoctor(),
   }, initializeFlutterRoot: false);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/downgrade_test.dart
@@ -17,6 +17,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/mocks.dart';
 
 void main() {
   FileSystem fileSystem;

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -20,6 +20,7 @@ import 'package:process/process.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
+import '../../src/mocks.dart';
 
 void main() {
   group('UpgradeCommandRunner', () {

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/drive/drive_service.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:test/fake.dart';
@@ -21,6 +22,7 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 
 final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
@@ -288,9 +290,13 @@ void main() {
     expect(json.decode(fileSystem.file('out.json').readAsStringSync()), <String, Object>{
       'platform': 'android',
       'name': 'test',
-      'engineRevision': null,
+      'engineRevision': 'abcdefghijklmnopqrstuvwxyz',
       'data': <String, Object>{'A': 'B'}
     });
+  }, overrides: <Type, Generator>{
+    FlutterVersion: () => FakeFlutterVersion(
+      engineRevision: 'abcdefghijklmnopqrstuvwxyz',
+    )
   });
 
   testWithoutContext('Can connect to existing application and stop it during cleanup', () async {

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -91,12 +91,9 @@ void main() {
   });
 
   testWithoutContext('FlutterValidator handles exception thrown by version checking', () async {
-    final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
-      frameworkVersion: '0.0.0',
-    );
     final FlutterValidator flutterValidator = FlutterValidator(
       platform: FakePlatform(operatingSystem: 'windows', localeName: 'en_US.UTF-8'),
-      flutterVersion: () => flutterVersion,
+      flutterVersion: () => FakeThrowingFlutterVersion(),
       userMessages: UserMessages(),
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
@@ -104,8 +101,6 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[]),
       flutterRoot: () => 'sdk/flutter',
     );
-
-    when(flutterVersion.frameworkCommitDate).thenThrow(VersionCheckError('version error'));
 
     expect(await flutterValidator.validate(), matchDoctorValidation(
       validationType: ValidationType.partial,
@@ -115,7 +110,7 @@ void main() {
         ValidationMessage.error('version error'),
       ]),
     );
-  }, skip: true);
+  });
 
   testWithoutContext('FlutterValidator shows mirrors on pub and flutter cloud storage', () async {
     final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
@@ -158,4 +153,11 @@ class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
 
   @override
   final String name;
+}
+
+class FakeThrowingFlutterVersion extends FakeFlutterVersion {
+  @override
+   String get frameworkCommitDate {
+     throw VersionCheckError('version error');
+   }
 }

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -15,11 +15,14 @@ import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fakes.dart';
 
 void main() {
   testWithoutContext('FlutterValidator shows an error message if gen_snapshot is '
     'downloaded and exits with code 1', () async {
-    final MockFlutterVersion flutterVersion = MockFlutterVersion();
+    final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+      frameworkVersion: '1.0.0',
+    );
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Artifacts artifacts = Artifacts.test();
     final FlutterValidator flutterValidator = FlutterValidator(
@@ -46,7 +49,7 @@ void main() {
 
     expect(await flutterValidator.validate(), matchDoctorValidation(
       validationType: ValidationType.partial,
-      statusInfo: 'Channel unknown, Unknown, on Linux, locale en_US.UTF-8',
+      statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
       messages: containsAll(const <ValidationMessage>[
         ValidationMessage.error(
           'Downloaded executables cannot execute on host.\n'
@@ -60,13 +63,16 @@ void main() {
   });
 
   testWithoutContext('FlutterValidator does not run gen_snapshot binary check if it is not already downloaded', () async {
+    final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+      frameworkVersion: '1.0.0',
+    );
     final FlutterValidator flutterValidator = FlutterValidator(
       platform: FakePlatform(
         operatingSystem: 'windows',
         localeName: 'en_US.UTF-8',
         environment: <String, String>{},
       ),
-      flutterVersion: () => MockFlutterVersion(),
+      flutterVersion: () => flutterVersion,
       userMessages: UserMessages(),
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
@@ -79,13 +85,15 @@ void main() {
     // fail if the gen_snapshot binary is not present.
     expect(await flutterValidator.validate(), matchDoctorValidation(
       validationType: ValidationType.installed,
-      statusInfo: 'Channel unknown, Unknown, on Windows, locale en_US.UTF-8',
+      statusInfo: 'Channel unknown, 1.0.0, on Windows, locale en_US.UTF-8',
       messages: anything,
     ));
   });
 
   testWithoutContext('FlutterValidator handles exception thrown by version checking', () async {
-    final MockFlutterVersion flutterVersion = MockFlutterVersion();
+    final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+      frameworkVersion: '0.0.0',
+    );
     final FlutterValidator flutterValidator = FlutterValidator(
       platform: FakePlatform(operatingSystem: 'windows', localeName: 'en_US.UTF-8'),
       flutterVersion: () => flutterVersion,
@@ -97,9 +105,7 @@ void main() {
       flutterRoot: () => 'sdk/flutter',
     );
 
-    when(flutterVersion.channel).thenReturn('unknown');
-    when(flutterVersion.frameworkVersion).thenReturn('0.0.0');
-    when(flutterVersion.frameworkDate).thenThrow(VersionCheckError('version error'));
+    when(flutterVersion.frameworkCommitDate).thenThrow(VersionCheckError('version error'));
 
     expect(await flutterValidator.validate(), matchDoctorValidation(
       validationType: ValidationType.partial,
@@ -109,9 +115,12 @@ void main() {
         ValidationMessage.error('version error'),
       ]),
     );
-  });
+  }, skip: true);
 
   testWithoutContext('FlutterValidator shows mirrors on pub and flutter cloud storage', () async {
+    final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+      frameworkVersion: '1.0.0',
+    );
     final Platform platform = FakePlatform(
       operatingSystem: 'windows',
       localeName: 'en_US.UTF-8',
@@ -120,7 +129,6 @@ void main() {
         'FLUTTER_STORAGE_BASE_URL': 'https://example.com/flutter',
       },
     );
-    final MockFlutterVersion flutterVersion = MockFlutterVersion();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final Artifacts artifacts = Artifacts.test();
     final FlutterValidator flutterValidator = FlutterValidator(
@@ -136,7 +144,7 @@ void main() {
 
     expect(await flutterValidator.validate(), matchDoctorValidation(
       validationType: ValidationType.installed,
-      statusInfo: 'Channel unknown, Unknown, on Windows, locale en_US.UTF-8',
+      statusInfo: 'Channel unknown, 1.0.0, on Windows, locale en_US.UTF-8',
       messages: containsAll(const <ValidationMessage>[
         ValidationMessage('Pub download mirror https://example.com/pub'),
         ValidationMessage('Flutter download mirror https://example.com/flutter'),
@@ -145,7 +153,6 @@ void main() {
   });
 }
 
-class MockFlutterVersion extends Mock implements FlutterVersion {}
 class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
   FakeOperatingSystemUtils({this.name});
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -44,7 +44,7 @@ void main() {
     MockWindowsProject windowsProject;
     MockLinuxProject linuxProject;
     FakeSystemClock systemClock;
-    FlutterVersion mockVersion;
+    FlutterVersion flutterVersion;
     // A Windows-style filesystem. This is not populated by default, so tests
     // using it instead of fs must re-run any necessary setup (e.g.,
     // setUpProject).
@@ -126,15 +126,11 @@ void main() {
       fsWindows = MemoryFileSystem(style: FileSystemStyle.windows);
       systemClock = FakeSystemClock()
         ..currentTime = DateTime(1970, 1, 1);
-      mockVersion = MockFlutterVersion();
+      flutterVersion = FakeFlutterVersion(frameworkVersion: '1.0.0');
 
       // Add basic properties to the Flutter project and subprojects
       setUpProject(fs);
       flutterProject.directory.childFile('.packages').createSync(recursive: true);
-
-      when(mockVersion.frameworkVersion).thenAnswer(
-        (Invocation _) => '1.0.0'
-      );
     });
 
     // Makes fake plugin packages for each plugin, adds them to flutterProject,
@@ -436,10 +432,6 @@ dependencies:
 
         final DateTime dateCreated = DateTime(1970, 1, 1);
         systemClock.currentTime = dateCreated;
-        const String version = '1.0.0';
-        when(mockVersion.frameworkVersion).thenAnswer(
-          (Invocation _) => version
-        );
 
         await refreshPluginsList(flutterProject);
 
@@ -510,7 +502,7 @@ dependencies:
 
         expect(jsonContent['dependencyGraph'], expectedDependencyGraph);
         expect(jsonContent['date_created'], dateCreated.toString());
-        expect(jsonContent['version'], version);
+        expect(jsonContent['version'], '1.0.0');
 
         // Make sure tests are updated if a new object is added/removed.
         final List<String> expectedKeys = <String>[
@@ -525,7 +517,7 @@ dependencies:
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         SystemClock: () => systemClock,
-        FlutterVersion: () => mockVersion
+        FlutterVersion: () => flutterVersion
       });
 
       testUsingContext('Changes to the plugin list invalidates the Cocoapod lockfiles', () async {
@@ -542,7 +534,7 @@ dependencies:
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         SystemClock: () => systemClock,
-        FlutterVersion: () => mockVersion
+        FlutterVersion: () => flutterVersion
       });
 
       testUsingContext('No changes to the plugin list does not invalidate the Cocoapod lockfiles', () async {
@@ -565,7 +557,7 @@ dependencies:
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         SystemClock: () => systemClock,
-        FlutterVersion: () => mockVersion
+        FlutterVersion: () => flutterVersion
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -1585,7 +1586,7 @@ void main() {
     expect(json.decode(globals.fs.file('flutter_01.sksl.json').readAsStringSync()), <String, Object>{
       'platform': 'android',
       'name': 'FakeDevice',
-      'engineRevision': '42.2', // From FakeFlutterVersion
+      'engineRevision': 'abcdefg',
       'data': <String, Object>{'A': 'B'}
     });
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
@@ -1593,7 +1594,8 @@ void main() {
     FileSystemUtils: () => FileSystemUtils(
       fileSystem: globals.fs,
       platform: globals.platform,
-    )
+    ),
+    FlutterVersion: () => FakeFlutterVersion(engineRevision: 'abcdefg')
   }));
 
   testUsingContext('ResidentRunner ignores DevToolsLauncher when attaching with enableDevTools: false', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -16,8 +16,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/tester/flutter_tester.dart';
-import 'package:flutter_tools/src/version.dart';
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -100,7 +98,7 @@ void main() {
         artifacts: Artifacts.test(),
         buildDirectory: 'build',
         logger: BufferLogger.test(),
-        flutterVersion: MockFlutterVersion(),
+        flutterVersion: FakeFlutterVersion(),
         operatingSystemUtils: FakeOperatingSystemUtils(),
       );
       logLines = <String>[];
@@ -183,9 +181,7 @@ FlutterTesterDevices setUpFlutterTesterDevices() {
     processManager: FakeProcessManager.any(),
     fileSystem: MemoryFileSystem.test(),
     config: Config.test(),
-    flutterVersion: MockFlutterVersion(),
+    flutterVersion: FakeFlutterVersion(),
     operatingSystemUtils: FakeOperatingSystemUtils(),
   );
 }
-
-class MockFlutterVersion extends Mock implements FlutterVersion {}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -112,7 +112,7 @@ void testUsingContext(
           Config: () => buildConfig(globals.fs),
           DeviceManager: () => FakeDeviceManager(),
           Doctor: () => FakeDoctor(globals.logger),
-          FlutterVersion: () => MockFlutterVersion(),
+          FlutterVersion: () => FakeFlutterVersion(),
           HttpClient: () => FakeHttpClient.any(),
           IOSSimulatorUtils: () {
             final MockIOSSimulatorUtils mock = MockIOSSimulatorUtils();
@@ -376,8 +376,6 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   @override
   List<String> xcrunCommand() => <String>['xcrun'];
 }
-
-class MockFlutterVersion extends Mock implements FlutterVersion {}
 
 class MockCrashReporter extends Mock implements CrashReporter {}
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -498,6 +498,9 @@ class FakeFlutterVersion implements FlutterVersion {
   final String frameworkCommitDate;
 
   @override
+  String get frameworkDate => frameworkCommitDate;
+
+  @override
   void fetchTagsAndUpdate() {
     _didFetchTagsAndUpdate = true;
   }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -448,14 +448,64 @@ class FakePub extends Fake implements Pub {
 }
 
 class FakeFlutterVersion implements FlutterVersion {
-  @override
-  void fetchTagsAndUpdate() {  }
+  FakeFlutterVersion({
+    this.channel = 'unknown',
+    this.dartSdkVersion = '12',
+    this.engineRevision = 'abcdefghijklmnopqrstuvwxyz',
+    this.engineRevisionShort = 'abcde',
+    this.repositoryUrl = 'https://github.com/flutter/flutter.git',
+    this.frameworkVersion = '1000.0.0',
+    this.frameworkRevision = '11111111111111111111',
+    this.frameworkRevisionShort = '11111',
+    this.frameworkAge = '0 hours ago',
+    this.frameworkCommitDate = '12/01/01'
+  });
+
+  bool get didFetchTagsAndUpdate => _didFetchTagsAndUpdate;
+  bool _didFetchTagsAndUpdate = false;
+
+  bool get didCheckFlutterVersionFreshness => _didCheckFlutterVersionFreshness;
+  bool _didCheckFlutterVersionFreshness = false;
 
   @override
-  String get channel => 'master';
+  final String channel;
 
   @override
-  Future<void> checkFlutterVersionFreshness() async { }
+  final String dartSdkVersion;
+
+  @override
+  final String engineRevision;
+
+  @override
+  final String engineRevisionShort;
+
+  @override
+  final String repositoryUrl;
+
+  @override
+  final String frameworkVersion;
+
+  @override
+  final String frameworkRevision;
+
+  @override
+  final String frameworkRevisionShort;
+
+  @override
+  final String frameworkAge;
+
+  @override
+  final String frameworkCommitDate;
+
+  @override
+  void fetchTagsAndUpdate() {
+    _didFetchTagsAndUpdate = true;
+  }
+
+  @override
+  Future<void> checkFlutterVersionFreshness() async {
+    _didCheckFlutterVersionFreshness = true;
+  }
 
   @override
   bool checkRevisionAncestry({String tentativeDescendantRevision, String tentativeAncestorRevision}) {
@@ -463,37 +513,12 @@ class FakeFlutterVersion implements FlutterVersion {
   }
 
   @override
-  String get dartSdkVersion => '12';
-
-  @override
-  String get engineRevision => '42.2';
-
-  @override
-  String get engineRevisionShort => '42';
+  GitTagVersion get gitTagVersion {
+    throw UnimplementedError();
+  }
 
   @override
   Future<void> ensureVersionFile() async { }
-
-  @override
-  String get frameworkAge => null;
-
-  @override
-  String get frameworkCommitDate => null;
-
-  @override
-  String get frameworkDate => null;
-
-  @override
-  String get frameworkRevision => null;
-
-  @override
-  String get frameworkRevisionShort => null;
-
-  @override
-  String get frameworkVersion => null;
-
-  @override
-  GitTagVersion get gitTagVersion => null;
 
   @override
   String getBranchName({bool redactUnknownBranches = false}) {
@@ -506,11 +531,8 @@ class FakeFlutterVersion implements FlutterVersion {
   }
 
   @override
-  String get repositoryUrl => null;
-
-  @override
   Map<String, Object> toJson() {
-    return null;
+    return <String, Object>{};
   }
 }
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -454,7 +454,7 @@ class FakeFlutterVersion implements FlutterVersion {
     this.engineRevision = 'abcdefghijklmnopqrstuvwxyz',
     this.engineRevisionShort = 'abcde',
     this.repositoryUrl = 'https://github.com/flutter/flutter.git',
-    this.frameworkVersion = '1000.0.0',
+    this.frameworkVersion = '0.0.0',
     this.frameworkRevision = '11111111111111111111',
     this.frameworkRevisionShort = '11111',
     this.frameworkAge = '0 hours ago',

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -232,3 +233,4 @@ class MockStdIn extends Mock implements IOSink {
 }
 
 class MockStream extends Mock implements Stream<List<int>> {}
+class MockFlutterVersion extends Mock implements FlutterVersion {}


### PR DESCRIPTION
* Removes `frameworkDate ` since it is exactly the same as `frameworkCommitDate`.
* Removes several trivial usages of MockFlutterVersion, but there are more complicated mocks that still need to be fixed.
* Move MockFlutterVersion into mocks and remove from default testUsingContext injection
* Update SkSL tests that rely on engineRevision to use a MockFlutterVersion

Part of https://github.com/flutter/flutter/issues/71511