### PR TITLE
Fix typo in Windows template

### DIFF
--- a/dev/manual_tests/windows/runner/flutter_window.cpp
+++ b/dev/manual_tests/windows/runner/flutter_window.cpp
@@ -44,7 +44,7 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
-  // Give Flutter, including plugins, an opporutunity to handle window messages.
+  // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =
         flutter_controller_->HandleTopLevelWindowProc(hwnd, message, wparam,

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/flutter_window.cpp
@@ -44,7 +44,7 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
-  // Give Flutter, including plugins, an opporutunity to handle window messages.
+  // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =
         flutter_controller_->HandleTopLevelWindowProc(hwnd, message, wparam,


### PR DESCRIPTION
Fix a typo in a comment that is present in the Windows template. There is a manual test that has the contents of the same template, so the same typo was fixed there too.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.