### PR TITLE
fix Autovalidate enum references in fix data

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -899,7 +899,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.always'
+              expression: 'AutovalidateMode.always'
               requiredIf: "autovalidate == 'true'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -910,7 +910,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.disabled'
+              expression: 'AutovalidateMode.disabled'
               requiredIf: "autovalidate == 'false'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -945,7 +945,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.always'
+              expression: 'AutovalidateMode.always'
               requiredIf: "autovalidate == 'true'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -956,7 +956,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.disabled'
+              expression: 'AutovalidateMode.disabled'
               requiredIf: "autovalidate == 'false'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -980,7 +980,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.always'
+              expression: 'AutovalidateMode.always'
               requiredIf: "autovalidate == 'true'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -991,7 +991,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.disabled'
+              expression: 'AutovalidateMode.disabled'
               requiredIf: "autovalidate == 'false'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -1015,7 +1015,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.always'
+              expression: 'AutovalidateMode.always'
               requiredIf: "autovalidate == 'true'"
           - kind: 'removeParameter'
             name: 'autovalidate'
@@ -1026,7 +1026,7 @@ transforms:
             name: 'autovalidateMode'
             style: optional_named
             argumentValue:
-              expression: 'AutoValidateMode.disabled'
+              expression: 'AutovalidateMode.disabled'
               requiredIf: "autovalidate == 'false'"
           - kind: 'removeParameter'
             name: 'autovalidate'

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -47,13 +47,13 @@ void main() {
   final behavior = stack.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const Form form = Form(autovalidateMode: AutoValidateMode.always);
-  const Form form = Form(autovalidateMode: AutoValidateMode.disabled);
+  const Form form = Form(autovalidateMode: AutovalidateMode.always);
+  const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.always);
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.disabled);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/68736

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -50,22 +50,22 @@ void main() {
   final behavior = stack.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const Form form = Form(autovalidateMode: AutoValidateMode.always);
-  const Form form = Form(autovalidateMode: AutoValidateMode.disabled);
+  const Form form = Form(autovalidateMode: AutovalidateMode.always);
+  const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.always);
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.disabled);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const TextFormField textFormField = TextFormField(autovalidateMode: AutoValidateMode.always);
-  const TextFormField textFormField = TextFormField(autovalidateMode: AutoValidateMode.disabled);
+  const TextFormField textFormField = TextFormField(autovalidateMode: AutovalidateMode.always);
+  const TextFormField textFormField = TextFormField(autovalidateMode: AutovalidateMode.disabled);
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const DropdownButtonFormField dropDownButtonFormField = DropdownButtonFormField(autovalidateMode: AutoValidateMode.always);
-  const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(autovalidateMode: AutoValidateMode.disabled);
+  const DropdownButtonFormField dropDownButtonFormField = DropdownButtonFormField(autovalidateMode: AutovalidateMode.always);
+  const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(autovalidateMode: AutovalidateMode.disabled);
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var TextTheme textTheme = TextTheme(

--- a/packages/flutter/test_fixes/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets.dart.expect
@@ -38,13 +38,13 @@ void main() {
   buildContext.findAncestorRenderObjectOfType<targetType>();
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const Form form = Form(autovalidateMode: AutoValidateMode.always);
-  const Form form = Form(autovalidateMode: AutoValidateMode.disabled);
+  const Form form = Form(autovalidateMode: AutovalidateMode.always);
+  const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.always);
-  const FormField formField = FormField(autovalidateMode: AutoValidateMode.disabled);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
+  const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/66305


### PR DESCRIPTION
This fixes a typo in the fix data file which leads to generating bogus (non-existent) enum references.

It's also worth noting that these fixes don't auto add the required import.  (There's a way to do that with variables but I don't quite know the magic...)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
