### PR TITLE
Add debug_second_compile_millis benchmark metric

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1000,9 +1000,21 @@ class CompileTest {
       await device.unlock();
       await flutter('packages', options: <String>['get']);
 
+      final Map<String, dynamic> compileRelease = await _compileApp(reportPackageContentSizes: reportPackageContentSizes);
+      final Map<String, dynamic> compileDebug = await _compileDebug(
+        clean: true,
+        metricKey: 'debug_full_compile_millis',
+      );
+      // Build again without cleaning, should be faster.
+      final Map<String, dynamic> compileSecondDebug = await _compileDebug(
+        clean: false,
+        metricKey: 'debug_second_compile_millis',
+      );
+
       final Map<String, dynamic> metrics = <String, dynamic>{
-        ...await _compileApp(reportPackageContentSizes: reportPackageContentSizes),
-        ...await _compileDebug(),
+        ...compileRelease,
+        ...compileDebug,
+        ...compileSecondDebug,
       };
 
       return TaskResult.success(metrics, benchmarkScoreKeys: metrics.keys.toList());
@@ -1082,8 +1094,13 @@ class CompileTest {
     return metrics;
   }
 
-  static Future<Map<String, dynamic>> _compileDebug() async {
-    await flutter('clean');
+  static Future<Map<String, dynamic>> _compileDebug({
+    @required bool clean,
+    @required String metricKey,
+  }) async {
+    if (clean) {
+      await flutter('clean');
+    }
     final Stopwatch watch = Stopwatch();
     final List<String> options = <String>['--debug'];
     switch (deviceOperatingSystem) {
@@ -1109,7 +1126,7 @@ class CompileTest {
     watch.stop();
 
     return <String, dynamic>{
-      'debug_full_compile_millis': watch.elapsedMilliseconds,
+      metricKey: watch.elapsedMilliseconds,
     };
   }
 


### PR DESCRIPTION
Start measuring how long the second compilation of an app takes, without cleaning, with the same parameters.
This will allow us to track how effectively build steps are being cached between runs and catch regressions.

```
$ dart bin/run.dart -t hello_world_ios__compile
...
    "debug_full_compile_millis": 18052,
    "debug_second_compile_millis": 11001
```
```
$ dart bin/run.dart -t hello_world_android__compile
    "debug_full_compile_millis": 15143,
    "debug_second_compile_millis": 4530
```

https://github.com/flutter/flutter/issues/67580#issuecomment-791695934