### PR TITLE
archiveing -> archiving

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -255,7 +255,8 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
 
     if (!result.success) {
       await diagnoseXcodeBuildFailure(result, globals.flutterUsage, globals.logger);
-      throwToolExit('Encountered error while ${xcodeBuildActionToString(xcodeBuildAction)}ing for $logTarget.');
+      final String presentParticiple = xcodeBuildAction == XcodeBuildAction.build ? 'building' : 'archiving';
+      throwToolExit('Encountered error while $presentParticiple for $logTarget.');
     }
 
     if (buildInfo.codeSizeDirectory != null) {


### PR DESCRIPTION
Fix spelling of "archiving" with the tool's poor excuse for localization--string concatenation!
```
Encountered error while archiveing for device.
```