### PR TITLE
[flutter_tools] remove most globals from resident web runner

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -73,13 +73,6 @@ class FileSystemUtils {
     }
   }
 
-  /// Return a relative path if [fullPath] is contained by the cwd, else return an
-  /// absolute path.
-  String getDisplayPath(String fullPath) {
-    final String cwd = _fileSystem.currentDirectory.path + _fileSystem.path.separator;
-    return fullPath.startsWith(cwd) ? fullPath.substring(cwd.length) : fullPath;
-  }
-
   /// Escapes [path].
   ///
   /// On Windows it replaces all '\' with '\\'. On other platforms, it returns the
@@ -113,6 +106,13 @@ class FileSystemUtils {
     }
     return path;
   }
+}
+
+/// Return a relative path if [fullPath] is contained by the cwd, else return an
+/// absolute path.
+String getDisplayPath(String fullPath, FileSystem fileSystem) {
+  final String cwd = fileSystem.currentDirectory.path + fileSystem.path.separator;
+  return fullPath.startsWith(cwd) ? fullPath.substring(cwd.length) : fullPath;
 }
 
 /// Creates `destDir` if needed, then recursively copies `srcDir` to

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -484,6 +484,10 @@ class AppDomain extends Domain {
         stayResident: true,
         urlTunneller: options.webEnableExposeUrl ? daemon.daemonDomain.exposeUrl : null,
         machine: machine,
+        usage: globals.flutterUsage,
+        systemClock: globals.systemClock,
+        logger: globals.logger,
+        fileSystem: globals.fs,
       );
     } else if (enableHotReload) {
       runner = HotRunner(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -495,6 +495,10 @@ class RunCommand extends RunCommandBase {
         debuggingOptions: await createDebuggingOptions(webMode),
         stayResident: stayResident,
         urlTunneller: null,
+        fileSystem: globals.fs,
+        usage: globals.flutterUsage,
+        logger: globals.logger,
+        systemClock: globals.systemClock,
       );
     }
     return ColdRunner(

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -72,6 +72,10 @@ class WebDriverService extends DriverService {
       stayResident: false,
       urlTunneller: null,
       flutterProject: FlutterProject.current(),
+      fileSystem: globals.fs,
+      usage: globals.flutterUsage,
+      logger: globals.logger,
+      systemClock: globals.systemClock,
     );
     final Completer<void> appStartedCompleter = Completer<void>.sync();
     final int result = await _residentRunner.run(

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -7,7 +7,6 @@
 import 'dart:async';
 
 import 'package:dwds/dwds.dart';
-import 'package:flutter_tools/src/base/time.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vmservice;
@@ -22,6 +21,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/net.dart';
 import '../base/terminal.dart';
+import '../base/time.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/targets/web.dart';

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 
 import 'package:dwds/dwds.dart';
+import 'package:flutter_tools/src/base/time.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vmservice;
@@ -28,7 +29,6 @@ import '../dart/language_version.dart';
 import '../devfs.dart';
 import '../device.dart';
 import '../features.dart';
-import '../globals.dart' as globals;
 import '../platform_plugins.dart';
 import '../plugins.dart';
 import '../project.dart';
@@ -53,9 +53,14 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
     @required UrlTunneller urlTunneller,
+    @required Logger logger,
+    @required FileSystem fileSystem,
+    @required SystemClock systemClock,
+    @required Usage usage,
+    @required FeatureFlags featureFlags,
     bool machine = false,
   }) {
-    return _ResidentWebRunner(
+    return ResidentWebRunner(
       device,
       target: target,
       flutterProject: flutterProject,
@@ -64,6 +69,11 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
       stayResident: stayResident,
       urlTunneller: urlTunneller,
       machine: machine,
+      usage: usage,
+      systemClock: systemClock,
+      fileSystem: fileSystem,
+      logger: logger,
+      featureFlags: featureFlags,
     );
   }
 }
@@ -72,24 +82,42 @@ const String kExitMessage = 'Failed to establish connection with the application
   'instance in Chrome.\nThis can happen if the websocket connection used by the '
   'web tooling is unable to correctly establish a connection, for example due to a firewall.';
 
-/// A hot-runner which handles browser specific delegation.
-abstract class ResidentWebRunner extends ResidentRunner {
+class ResidentWebRunner extends ResidentRunner {
   ResidentWebRunner(
     FlutterDevice device, {
     String target,
+    bool stayResident = true,
+    bool machine = false,
     @required this.flutterProject,
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
-    bool stayResident = true,
-    bool machine = false,
-  }) : super(
+    @required FileSystem fileSystem,
+    @required Logger logger,
+    @required SystemClock systemClock,
+    @required Usage usage,
+    @required UrlTunneller urlTunneller,
+    @required FeatureFlags featureFlags,
+  }) : _fileSystem = fileSystem,
+       _logger = logger,
+       _systemClock = systemClock,
+       _usage = usage,
+       _urlTunneller = urlTunneller,
+       _featureFlags = featureFlags,
+       super(
           <FlutterDevice>[device],
-          target: target ?? globals.fs.path.join('lib', 'main.dart'),
+          target: target ?? fileSystem.path.join('lib', 'main.dart'),
           debuggingOptions: debuggingOptions,
           ipv6: ipv6,
           stayResident: stayResident,
           machine: machine,
         );
+
+  final FileSystem _fileSystem;
+  final Logger _logger;
+  final SystemClock _systemClock;
+  final Usage _usage;
+  final UrlTunneller _urlTunneller;
+  final FeatureFlags _featureFlags;
 
   FlutterDevice get device => flutterDevices.first;
   final FlutterProject flutterProject;
@@ -171,7 +199,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
       _generatedEntrypointDirectory?.deleteSync(recursive: true);
     } on FileSystemException {
       // Best effort to clean up temp dirs.
-      globals.printTrace(
+      _logger.printTrace(
         'Failed to clean up temp directory: ${_generatedEntrypointDirectory.path}',
       );
     }
@@ -191,15 +219,13 @@ abstract class ResidentWebRunner extends ResidentRunner {
     const String fire = '🔥';
     const String rawMessage =
         '  To hot restart changes while running, press "r" or "R".';
-    final String message = globals.terminal.color(
-      fire + globals.terminal.bolden(rawMessage),
+    final String message = _logger.terminal.color(
+      fire + _logger.terminal.bolden(rawMessage),
       TerminalColor.red,
     );
-    globals.printStatus(message);
+    _logger.printStatus(message);
     const String quitMessage = 'To quit, press "q".';
-    if (device.device is! WebServerDevice) {
-      globals.printStatus('For a more detailed help message, press "h". $quitMessage');
-    }
+    _logger.printStatus('For a more detailed help message, press "h". $quitMessage');
   }
 
   @override
@@ -276,13 +302,13 @@ abstract class ResidentWebRunner extends ResidentRunner {
         ?.flutterPlatformOverride(
           isolateId: null,
         );
-      final String platform = nextPlatform(currentPlatform, featureFlags);
+      final String platform = nextPlatform(currentPlatform, _featureFlags);
       await _vmService
         ?.flutterPlatformOverride(
             platform: platform,
             isolateId: null,
           );
-      globals.printStatus('Switched operating system to $platform');
+      _logger.printStatus('Switched operating system to $platform');
     } on vmservice.RPCError {
       // do nothing.
     }
@@ -310,7 +336,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
             brightness: next,
             isolateId: null,
           );
-      globals.logger.printStatus('Changed brightness to $next.');
+      _logger.printStatus('Changed brightness to $next.');
     } on vmservice.RPCError {
       // do nothing.
     }
@@ -434,29 +460,6 @@ abstract class ResidentWebRunner extends ResidentRunner {
     }
     return true;
   }
-}
-
-class _ResidentWebRunner extends ResidentWebRunner {
-  _ResidentWebRunner(
-    FlutterDevice device, {
-    String target,
-    @required FlutterProject flutterProject,
-    @required bool ipv6,
-    @required DebuggingOptions debuggingOptions,
-    bool stayResident = true,
-    @required this.urlTunneller,
-    bool machine = false,
-  }) : super(
-          device,
-          flutterProject: flutterProject,
-          target: target ?? globals.fs.path.join('lib', 'main.dart'),
-          debuggingOptions: debuggingOptions,
-          ipv6: ipv6,
-          stayResident: stayResident,
-          machine: machine,
-        );
-
-  final UrlTunneller urlTunneller;
 
   @override
   Future<int> run({
@@ -472,12 +475,12 @@ class _ResidentWebRunner extends ResidentWebRunner {
       applicationBinary: null,
     );
     if (package == null) {
-      globals.printStatus('This application is not configured to build on the web.');
-      globals.printStatus('To add web support to a project, run `flutter create .`.');
+      _logger.printStatus('This application is not configured to build on the web.');
+      _logger.printStatus('To add web support to a project, run `flutter create .`.');
     }
     final String modeName = debuggingOptions.buildInfo.friendlyModeName;
-    globals.printStatus(
-      'Launching ${globals.fsUtils.getDisplayPath(target)} '
+    _logger.printStatus(
+      'Launching ${getDisplayPath(target, _fileSystem)} '
       'on ${device.device.name} in $modeName mode...',
     );
     if (device.device is ChromiumDevice) {
@@ -496,12 +499,12 @@ class _ResidentWebRunner extends ResidentWebRunner {
             ? int.tryParse(debuggingOptions.port)
             : null,
           packagesFilePath: packagesFilePath,
-          urlTunneller: urlTunneller,
+          urlTunneller: _urlTunneller,
           useSseForDebugProxy: debuggingOptions.webUseSseForDebugProxy,
           useSseForDebugBackend: debuggingOptions.webUseSseForDebugBackend,
           buildInfo: debuggingOptions.buildInfo,
           enableDwds: _enableDwds,
-          entrypoint: globals.fs.file(target).uri,
+          entrypoint: _fileSystem.file(target).uri,
           expressionCompiler: expressionCompiler,
           chromiumLauncher: _chromiumLauncher,
           nullAssertions: debuggingOptions.nullAssertions,
@@ -512,7 +515,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
         if (debuggingOptions.buildInfo.isDebug) {
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
-            globals.printError('Failed to compile application.');
+            _logger.printError('Failed to compile application.');
             appFailedToStart();
             return 1;
           }
@@ -569,8 +572,8 @@ class _ResidentWebRunner extends ResidentWebRunner {
     String reason,
     bool benchmarkMode = false,
   }) async {
-    final DateTime start = globals.systemClock.now();
-    final Status status = globals.logger.startProgress(
+    final DateTime start = _systemClock.now();
+    final Status status = _logger.startProgress(
       'Performing hot restart...',
       progressId: 'hot.restart',
     );
@@ -604,7 +607,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
 
     try {
       if (!deviceIsDebuggable) {
-        globals.printStatus('Recompile complete. Page requires refresh.');
+        _logger.printStatus('Recompile complete. Page requires refresh.');
       } else if (isRunningDebug) {
         await _vmService.service.callMethod('hotRestart');
       } else {
@@ -620,13 +623,13 @@ class _ResidentWebRunner extends ResidentWebRunner {
       status.stop();
     }
 
-    final Duration elapsed = globals.systemClock.now().difference(start);
+    final Duration elapsed = _systemClock.now().difference(start);
     final String elapsedMS = getElapsedAsMilliseconds(elapsed);
-    globals.printStatus('Restarted application in $elapsedMS.');
+    _logger.printStatus('Restarted application in $elapsedMS.');
 
     // Don't track restart times for dart2js builds or web-server devices.
     if (debuggingOptions.buildInfo.isDebug && deviceIsDebuggable) {
-      globals.flutterUsage.sendTiming('hot', 'web-incremental-restart', elapsed);
+      _usage.sendTiming('hot', 'web-incremental-restart', elapsed);
       HotEvent(
         'restart',
         targetPlatform: getNameForTargetPlatform(TargetPlatform.web_javascript),
@@ -647,7 +650,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
   Future<Uri> _generateEntrypoint(Uri mainUri, PackageConfig packageConfig) async {
     File result = _generatedEntrypointDirectory?.childFile('web_entrypoint.dart');
     if (_generatedEntrypointDirectory == null) {
-      _generatedEntrypointDirectory ??= globals.fs.systemTempDirectory.createTempSync('flutter_tools.')
+      _generatedEntrypointDirectory ??= _fileSystem.systemTempDirectory.createTempSync('flutter_tools.')
         ..createSync();
       result = _generatedEntrypointDirectory.childFile('web_entrypoint.dart');
 
@@ -655,7 +658,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
         .any((Plugin p) => p.platforms.containsKey(WebPlugin.kConfigKey));
       await injectPlugins(flutterProject, webPlatform: true);
 
-      final Uri generatedUri = globals.fs.currentDirectory
+      final Uri generatedUri = _fileSystem.currentDirectory
         .childDirectory('lib')
         .childFile('generated_plugin_registrant.dart')
         .absolute.uri;
@@ -663,16 +666,16 @@ class _ResidentWebRunner extends ResidentWebRunner {
       Uri importedEntrypoint = packageConfig.toPackageUri(mainUri);
       // Special handling for entrypoints that are not under lib, such as test scripts.
       if (importedEntrypoint == null) {
-        final String parent = globals.fs.file(mainUri).parent.path;
+        final String parent = _fileSystem.file(mainUri).parent.path;
         flutterDevices.first.generator.addFileSystemRoot(parent);
-        flutterDevices.first.generator.addFileSystemRoot(globals.fs.directory('test').absolute.path);
+        flutterDevices.first.generator.addFileSystemRoot(_fileSystem.directory('test').absolute.path);
         importedEntrypoint = Uri(
           scheme: 'org-dartlang-app',
           path: '/' + mainUri.pathSegments.last,
         );
       }
       final LanguageVersion languageVersion =  determineLanguageVersion(
-        globals.fs.file(mainUri),
+        _fileSystem.file(mainUri),
         packageConfig[flutterProject.manifest.appName],
       );
 
@@ -711,7 +714,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
     final bool isFirstUpload = !assetBundle.wasBuiltOnce();
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
-      globals.printTrace('Updating assets');
+      _logger.printTrace('Updating assets');
       final int result = await assetBundle.build(packagesPath: debuggingOptions.buildInfo.packagesPath);
       if (result != 0) {
         return UpdateFSReport(success: false);
@@ -724,12 +727,12 @@ class _ResidentWebRunner extends ResidentWebRunner {
       packageConfig: device.devFS.lastPackageConfig
         ?? debuggingOptions.buildInfo.packageConfig,
     );
-    final Status devFSStatus = globals.logger.startProgress(
+    final Status devFSStatus = _logger.startProgress(
       'Waiting for connection from debug service on ${device.device.name}...',
     );
     final UpdateFSReport report = await device.devFS.update(
       mainUri: await _generateEntrypoint(
-        globals.fs.file(mainPath).absolute.uri,
+        _fileSystem.file(mainPath).absolute.uri,
         invalidationResult.packageConfig,
       ),
       target: target,
@@ -747,7 +750,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
       devFSWriter: null,
     );
     devFSStatus.stop();
-    globals.printTrace('Synced ${getSizeAsMB(report.syncedBytes)}.');
+    _logger.printTrace('Synced ${getSizeAsMB(report.syncedBytes)}.');
     return report;
   }
 
@@ -777,7 +780,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
 
       void onLogEvent(vmservice.Event event)  {
         final String message = processVmServiceMessage(event);
-        globals.printStatus(message);
+        _logger.printStatus(message);
       }
 
       _stdOutSub = _vmService.service.onStdoutEvent.listen(onLogEvent);
@@ -836,20 +839,20 @@ class _ResidentWebRunner extends ResidentWebRunner {
     }
     if (websocketUri != null) {
       if (debuggingOptions.vmserviceOutFile != null) {
-        globals.fs.file(debuggingOptions.vmserviceOutFile)
+        _fileSystem.file(debuggingOptions.vmserviceOutFile)
           ..createSync(recursive: true)
           ..writeAsStringSync(websocketUri.toString());
       }
-      globals.printStatus('Debug service listening on $websocketUri');
-      globals.printStatus('');
+      _logger.printStatus('Debug service listening on $websocketUri');
+      _logger.printStatus('');
       if (debuggingOptions.buildInfo.nullSafetyMode ==  NullSafetyMode.sound) {
-        globals.printStatus('💪 Running with sound null safety 💪', emphasis: true);
+        _logger.printStatus('💪 Running with sound null safety 💪', emphasis: true);
       } else {
-        globals.printStatus(
+        _logger.printStatus(
           'Running with unsound null safety',
           emphasis: true,
         );
-        globals.printStatus(
+        _logger.printStatus(
           'For more information see https://dart.dev/null-safety/unsound-null-safety',
         );
       }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -565,7 +565,7 @@ class FlutterDevice {
     final bool prebuiltMode = hotRunner.applicationBinary != null;
     final String modeName = hotRunner.debuggingOptions.buildInfo.friendlyModeName;
     globals.printStatus(
-      'Launching ${globals.fsUtils.getDisplayPath(hotRunner.mainPath)} '
+      'Launching ${getDisplayPath(hotRunner.mainPath, globals.fs)} '
       'on ${device.name} in $modeName mode...',
     );
 
@@ -645,7 +645,7 @@ class FlutterDevice {
       );
     } else {
       globals.printStatus(
-        'Launching ${globals.fsUtils.getDisplayPath(coldRunner.mainPath)} '
+        'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
         'on ${device.name} in $modeName mode...',
       );
     }

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -7,9 +7,13 @@
 import 'package:meta/meta.dart';
 
 import '../base/context.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
 import '../base/net.dart';
+import '../base/time.dart';
 import '../device.dart';
 import '../project.dart';
+import '../reporting/reporting.dart';
 import '../resident_runner.dart';
 
 WebRunnerFactory get webRunnerFactory => context.get<WebRunnerFactory>();
@@ -27,6 +31,10 @@ abstract class WebRunnerFactory {
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,
     @required UrlTunneller urlTunneller,
+    @required Logger logger,
+    @required FileSystem fileSystem,
+    @required SystemClock systemClock,
+    @required Usage usage,
     bool machine = false,
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -29,7 +29,6 @@ import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
-import '../../general.shard/ios/code_signing_test.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
@@ -802,7 +801,7 @@ class StreamLogger extends Logger {
   void clear() => _log('[stdout] ${globals.terminal.clearScreen()}\n');
 
   @override
-  Terminal get terminal => TestTerminal();
+  Terminal get terminal => Terminal.test();
 }
 
 class LoggerInterrupted implements Exception {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -29,6 +29,7 @@ import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
+import '../../general.shard/ios/code_signing_test.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
@@ -799,6 +800,9 @@ class StreamLogger extends Logger {
 
   @override
   void clear() => _log('[stdout] ${globals.terminal.clearScreen()}\n');
+
+  @override
+  Terminal get terminal => TestTerminal();
 }
 
 class LoggerInterrupted implements Exception {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -48,14 +48,19 @@ void main() {
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     globals.fs.file(globals.fs.path.join('web', 'index.html')).createSync(recursive: true);
     final FlutterProject project = FlutterProject.fromDirectoryTest(globals.fs.currentDirectory);
-    residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    residentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: project,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      featureFlags: TestFeatureFlags(),
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      systemClock: globals.systemClock,
+      usage: globals.flutterUsage,
+    );
   }
 
   testUsingContext('Can successfully run and connect without vmservice', () async {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -14,13 +14,11 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:flutter_tools/src/isolated/resident_web_runner.dart';
 import 'package:flutter_tools/src/compile.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -169,14 +167,19 @@ void main() {
       logger: BufferLogger.test(),
     ));
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner profileResidentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
 
     expect(profileResidentWebRunner.debuggingEnabled, false);
 
@@ -187,8 +190,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('runner with web server device supports debugging with --start-paused', () {
@@ -200,13 +201,18 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(WebServerDevice(
       logger: BufferLogger.test(),
     ));
-    final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner profileResidentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
     );
 
     expect(profileResidentWebRunner.uri, mockWebDevFS.baseUri);
@@ -214,30 +220,38 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
   testUsingContext('profile does not supportsServiceProtocol', () {
     fileSystem.file('.packages')
       ..createSync(recursive: true)
       ..writeAsStringSync('\n');
-    final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner residentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     when(mockFlutterDevice.device).thenReturn(mockChromeDevice);
-    final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner profileResidentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
     );
 
     expect(profileResidentWebRunner.supportsServiceProtocol, false);
@@ -245,21 +259,19 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Can successfully run and connect to vmservice', () async {
+    final BufferLogger bufferLogger = BufferLogger.test();
+    final FakeStatusLogger logger = FakeStatusLogger(bufferLogger);
     fileSystem.file('.packages')
       ..createSync(recursive: true)
       ..writeAsStringSync('\n');
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
     _setupMocks();
-    final FakeStatusLogger fakeStatusLogger = globals.logger as FakeStatusLogger;
-    final BufferLogger bufferLogger = asLogger<BufferLogger>(fakeStatusLogger);
     final MockStatus status = MockStatus();
-    fakeStatusLogger.status = status;
+    logger.status = status;
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(residentWebRunner.run(
       connectionInfoCompleter: connectionInfoCompleter,
@@ -274,8 +286,6 @@ void main() {
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('WebRunner copies compiled app.dill to cache during startup', () async {
@@ -294,8 +304,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/60613
@@ -329,56 +337,62 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Can successfully run without an index.html including status warning', () async {
+    final BufferLogger logger = BufferLogger.test();
     fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
     _setupMocks();
     fileSystem.file(fileSystem.path.join('web', 'index.html'))
       .deleteSync();
-    final ResidentWebRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentWebRunner residentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: false,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: logger,
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
 
     expect(await residentWebRunner.run(), 0);
-    expect(testLogger.statusText,
+    expect(logger.statusText,
       contains('This application is not configured to build on the web'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Can successfully run and disconnect with --no-resident', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
     _setupMocks();
-    final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner residentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: false,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
 
     expect(await residentWebRunner.run(), 0);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Listens to stdout and stderr streams before running main', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
       FakeVmServiceStreamResponse(
@@ -406,17 +420,15 @@ void main() {
     ));
     await connectionInfoCompleter.future;
 
-    expect(testLogger.statusText, contains('THIS MESSAGE IS IMPORTANT'));
-    expect(testLogger.statusText, contains('SO IS THIS'));
+    expect(logger.statusText, contains('THIS MESSAGE IS IMPORTANT'));
+    expect(logger.statusText, contains('SO IS THIS'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Listens to extension events with structured errors', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: testLogger);
     final Map<String, String> extensionData = <String, String>{
       'test': 'data',
       'renderedErrorText': 'error text',
@@ -479,19 +491,22 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Does not run main with --start-paused', () async {
-    final ResidentRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentRunner residentWebRunner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
     _setupMocks();
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
@@ -505,12 +520,15 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Can hot reload after attaching', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(
+      mockFlutterDevice,
+      logger: logger,
+      systemClock: SystemClock.fixed(DateTime(2001, 1, 1)),
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
@@ -528,7 +546,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(GoogleChromeDevice(
       fileSystem: fileSystem,
       chromiumLauncher: chromiumLauncher,
-      logger: globals.logger,
+      logger: BufferLogger.test(),
       platform: FakePlatform(operatingSystem: 'linux'),
       processManager: FakeProcessManager.any(),
     ));
@@ -561,7 +579,7 @@ void main() {
 
     final OperationResult result = await residentWebRunner.restart(fullRestart: false);
 
-    expect(testLogger.statusText, contains('Restarted application in'));
+    expect(logger.statusText, contains('Restarted application in'));
     expect(result.code, 0);
     verify(mockResidentCompiler.accept()).called(2);
 
@@ -576,13 +594,15 @@ void main() {
     Usage: () => testUsage,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
-    SystemClock: () => SystemClock.fixed(DateTime(2001, 1, 1))
   });
 
   testUsingContext('Can hot restart after attaching', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(
+      mockFlutterDevice,
+      logger: logger,
+      systemClock: SystemClock.fixed(DateTime(2001, 1, 1)),
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
@@ -600,7 +620,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(GoogleChromeDevice(
       fileSystem: fileSystem,
       chromiumLauncher: chromiumLauncher,
-      logger: globals.logger,
+      logger: BufferLogger.test(),
       platform: FakePlatform(operatingSystem: 'linux'),
       processManager: FakeProcessManager.any(),
     ));
@@ -637,7 +657,7 @@ void main() {
     expect(entrypointContents, contains("import 'dart:ui' as ui;"));
     expect(entrypointContents, contains('await ui.webOnlyInitializePlatform();'));
 
-    expect(testLogger.statusText, contains('Restarted application in'));
+    expect(logger.statusText, contains('Restarted application in'));
     expect(result.code, 0);
     verify(mockResidentCompiler.accept()).called(2);
 
@@ -652,13 +672,15 @@ void main() {
     Usage: () => testUsage,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
-    SystemClock: () => SystemClock.fixed(DateTime(2001, 1, 1))
   });
 
   testUsingContext('Can hot restart after attaching with web-server device', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(
+      mockFlutterDevice,
+      logger: logger,
+      systemClock: SystemClock.fixed(DateTime(2001, 1, 1)),
+    );
     fakeVmServiceHost = FakeVmServiceHost(requests :kAttachExpectations);
     _setupMocks();
     when(mockFlutterDevice.device).thenReturn(mockWebServerDevice);
@@ -686,7 +708,7 @@ void main() {
     await connectionInfoCompleter.future;
     final OperationResult result = await residentWebRunner.restart(fullRestart: true);
 
-    expect(testLogger.statusText, contains('Restarted application in'));
+    expect(logger.statusText, contains('Restarted application in'));
     expect(result.code, 0);
     verify(mockResidentCompiler.accept()).called(2);
 
@@ -697,9 +719,6 @@ void main() {
     Usage: () => testUsage,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
-    SystemClock: () => SystemClock.fixed(DateTime(2001, 1, 1))
   });
 
   testUsingContext('web resident runner is debuggable', () {
@@ -710,9 +729,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
-    SystemClock: () => SystemClock.fixed(DateTime(2001, 1, 1))
   });
 
   testUsingContext('Exits when initial compile fails', () async {
@@ -748,12 +764,11 @@ void main() {
     Usage: () => testUsage,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Faithfully displays stdout messages with leading/trailing spaces', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
       FakeVmServiceStreamResponse(
@@ -775,14 +790,12 @@ void main() {
     ));
     await connectionInfoCompleter.future;
 
-    expect(testLogger.statusText,
+    expect(logger.statusText,
       contains('    This is a message with 4 leading and trailing spaces    '));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Fails on compilation errors in hot restart', () async {
@@ -822,8 +835,6 @@ void main() {
     Usage: () => testUsage,
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Fails non-fatally on vmservice response error for hot restart', () async {
@@ -850,8 +861,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Fails fatally on Vm Service error response', () async {
@@ -878,25 +887,23 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('printHelp without details shows hot restart help message', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     residentWebRunner.printHelp(details: false);
 
-    expect(testLogger.statusText, contains('To hot restart changes'));
+    expect(logger.statusText, contains('To hot restart changes'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugDumpApp', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
@@ -918,8 +925,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugDumpLayerTree', () async {
@@ -945,8 +950,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugDumpRenderTree', () async {
@@ -972,8 +975,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugDumpSemanticsTreeInTraversalOrder', () async {
@@ -999,8 +1000,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugDumpSemanticsTreeInInverseHitTestOrder', () async {
@@ -1027,8 +1026,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugToggleDebugPaintSizeEnabled', () async {
@@ -1068,8 +1065,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugTogglePerformanceOverlayOverride', () async {
@@ -1109,8 +1104,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugToggleInvertOversizedImagesOverride', () async {
@@ -1150,8 +1143,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugToggleWidgetInspector', () async {
@@ -1191,8 +1182,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugToggleProfileWidgetBuilds', () async {
@@ -1232,12 +1221,11 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugTogglePlatform', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
@@ -1269,18 +1257,17 @@ void main() {
 
     await residentWebRunner.debugTogglePlatform();
 
-    expect(testLogger.statusText,
+    expect(logger.statusText,
       contains('Switched operating system to fuchsia'));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('debugToggleBrightness', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
@@ -1312,14 +1299,12 @@ void main() {
 
     await residentWebRunner.debugToggleBrightness();
 
-    expect(testLogger.statusText,
+    expect(logger.statusText,
       contains('Changed brightness to Brightness.dark.'));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('cleanup of resources is safe to call multiple times', () async {
@@ -1350,8 +1335,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('cleans up Chrome if tab is closed', () async {
@@ -1376,12 +1359,11 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Prints target and device name on run', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
     ]);
@@ -1393,7 +1375,7 @@ void main() {
     ));
     await connectionInfoCompleter.future;
 
-    expect(testLogger.statusText, contains(
+    expect(logger.statusText, contains(
       'Launching ${fileSystem.path.join('lib', 'main.dart')} on '
       'Chromez in debug mode',
     ));
@@ -1401,11 +1383,10 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Sends launched app.webLaunchUrl event for Chrome device', () async {
+    final BufferLogger logger = BufferLogger.test();
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
       ...kAttachIsolateExpectations,
@@ -1419,7 +1400,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(GoogleChromeDevice(
       fileSystem: fileSystem,
       chromiumLauncher: chromiumLauncher,
-      logger: globals.logger,
+      logger: logger,
       platform: FakePlatform(operatingSystem: 'linux'),
       processManager: FakeProcessManager.any(),
     ));
@@ -1435,17 +1416,19 @@ void main() {
       return mockWipConnection;
     });
 
-    final FakeStatusLogger fakeStatusLogger = globals.logger as FakeStatusLogger;
-    final MockStatus mockStatus = MockStatus();
-    fakeStatusLogger.status = mockStatus;
-    final ResidentWebRunner runner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentWebRunner runner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: logger,
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(runner.run(
@@ -1454,7 +1437,7 @@ void main() {
     await connectionInfoCompleter.future;
 
     // Ensure we got the URL and that it was already launched.
-    expect(asLogger<BufferLogger>(fakeStatusLogger).eventText,
+    expect(logger.eventText,
       contains(json.encode(<String, Object>{
         'name': 'app.webLaunchUrl',
         'args': <String, Object>{
@@ -1468,31 +1451,32 @@ void main() {
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Sends unlaunched app.webLaunchUrl event for Web Server device', () async {
+    final BufferLogger logger = BufferLogger.test();
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     _setupMocks();
     when(mockFlutterDevice.device).thenReturn(WebServerDevice(
-      logger: globals.logger,
+      logger: logger,
     ));
     when(mockWebDevFS.create()).thenAnswer((Invocation invocation) async {
       return Uri.parse('http://localhost:8765/app/');
     });
 
-    final FakeStatusLogger fakeStatusLogger = globals.logger as FakeStatusLogger;
-    final MockStatus mockStatus = MockStatus();
-    fakeStatusLogger.status = mockStatus;
-    final ResidentWebRunner runner = DwdsWebRunnerFactory().createWebRunner(
+    final ResidentWebRunner runner = ResidentWebRunner(
       mockFlutterDevice,
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       ipv6: true,
       stayResident: true,
       urlTunneller: null,
-    ) as ResidentWebRunner;
+      fileSystem: fileSystem,
+      logger: logger,
+      usage: globals.flutterUsage,
+      featureFlags: TestFeatureFlags(),
+      systemClock: globals.systemClock,
+    );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(runner.run(
@@ -1501,7 +1485,7 @@ void main() {
     await connectionInfoCompleter.future;
 
     // Ensure we got the URL and that it was not already launched.
-    expect(asLogger<BufferLogger>(fakeStatusLogger).eventText,
+    expect(logger.eventText,
       contains(json.encode(<String, Object>{
         'name': 'app.webLaunchUrl',
         'args': <String, Object>{
@@ -1512,11 +1496,8 @@ void main() {
     )));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
-    Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Successfully turns WebSocketException into ToolExit', () async {
@@ -1532,8 +1513,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Successfully turns AppConnectionException into ToolExit', () async {
@@ -1549,8 +1528,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Successfully turns ChromeDebugError into ToolExit', () async {
@@ -1566,8 +1543,6 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Rethrows unknown Exception type from dwds', () async {
@@ -1581,15 +1556,14 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 
   testUsingContext('Rethrows unknown Error type from dwds tooling', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final FakeStatusLogger fakeStatusLogger = FakeStatusLogger(logger);
+    final ResidentRunner residentWebRunner = setUpResidentRunner(mockFlutterDevice, logger: fakeStatusLogger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     _setupMocks();
-    final FakeStatusLogger fakeStatusLogger = globals.logger as FakeStatusLogger;
     final MockStatus mockStatus = MockStatus();
     fakeStatusLogger.status = mockStatus;
 
@@ -1599,29 +1573,28 @@ void main() {
     verify(mockStatus.stop()).called(1);
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
-    Logger: () => FakeStatusLogger(BufferLogger(
-      terminal: AnsiTerminal(
-        stdio: null,
-        platform: const LocalPlatform(),
-      ),
-      outputPreferences: OutputPreferences.test(),
-    )),
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
-    Pub: () => FakePub(),
-    Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
   });
 }
 
-ResidentRunner setUpResidentRunner(FlutterDevice flutterDevice) {
-  return DwdsWebRunnerFactory().createWebRunner(
+ResidentRunner setUpResidentRunner(FlutterDevice flutterDevice, {
+  Logger logger,
+  SystemClock systemClock,
+}) {
+  return ResidentWebRunner(
     flutterDevice,
     flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
     debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
     ipv6: true,
     stayResident: true,
     urlTunneller: null,
-  ) as ResidentWebRunner;
+    usage: globals.flutterUsage,
+    systemClock: systemClock ?? SystemClock.fixed(DateTime.now()),
+    fileSystem: globals.fs,
+    logger: logger ?? BufferLogger.test(),
+    featureFlags: TestFeatureFlags(),
+  );
 }
 
 class MockChromeDevice extends Mock implements ChromiumDevice {}


### PR DESCRIPTION
Remove global variables from resident runner, and almost completely from its test. Performs some minor refactor to Logger to expose terminal and to a FSUtil method.

Deletes unneeded  injection of Pub and Platform classes in the resident_web_runner tests