### PR TITLE
[docs] added flutter-fix and dart-fix public links

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# TODO(Piinks): Add link to public user guide when available.
+# For details regarding *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
 
 # Please add new fixes to the top of the file, separated by one blank line
 # from other fixes. In a comment, include a link to the PR where the change

--- a/packages/flutter/test_fixes/README.md
+++ b/packages/flutter/test_fixes/README.md
@@ -1,9 +1,7 @@
 ## Directory contents
 
 The Dart files and golden master `.expect` files in this directory are used to
-test the `dart fix` framework refactorings used by the Flutter framework.
-
-<!-- TODO(devoncarew): Add link to public user guide when available. -->
+test the [`dart fix` framework](https://dart.dev/tools/dart-fix) refactorings used by the Flutter framework.
 
 See the flutter/packages/flutter/lib/fix_data.yaml file for the current package:flutter
 data driven fixes.


### PR DESCRIPTION
Added public link for [`dart fix`](https://dart.dev/tools/dart-fix) in the doc. `TODO` label for it was added.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- ~~I listed at least one issue that this PR fixes in the description above.~~
- ~~I updated/added relevant documentation (doc comments with `///`).~~
- ~~I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.~~
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
