### PR TITLE
Fix linux build

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.sh
+++ b/packages/flutter_tools/bin/tool_backend.sh
@@ -6,4 +6,4 @@
 readonly flutter_bin_dir="${FLUTTER_ROOT}/bin"
 readonly dart_bin_dir="${flutter_bin_dir}/cache/dart-sdk/bin"
 
-exec "${dart_bin_dir}/dart" "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.dart" "${@:1}"
+exec "${dart_bin_dir}/dart" "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.dart" linux "${@:1}"

--- a/packages/flutter_tools/bin/tool_backend.sh
+++ b/packages/flutter_tools/bin/tool_backend.sh
@@ -6,4 +6,4 @@
 readonly flutter_bin_dir="${FLUTTER_ROOT}/bin"
 readonly dart_bin_dir="${flutter_bin_dir}/cache/dart-sdk/bin"
 
-exec "${dart_bin_dir}/dart" "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.dart" linux "${@:1}"
+exec "${dart_bin_dir}/dart" "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.dart" "${@:1}"

--- a/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
@@ -82,7 +82,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+      "${FLUTTER_TARGET_PLATFORM}" "${CMAKE_BUILD_TYPE}"
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
`tool_backend.dart` requests 2 arguments: the target platform and the build type.
"${@:1}" is the build type only.
this PR just adds "linux" as the first argument.
