### PR TITLE
Increase activated devtools version to 2.0

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1413,7 +1413,6 @@ class DevToolsMemoryTest {
       'global',
       'activate',
       'devtools',
-      '0.2.5',
     ]);
     _devToolsProcess = await startProcess(
       pubBin,

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1413,6 +1413,7 @@ class DevToolsMemoryTest {
       'global',
       'activate',
       'devtools',
+      '2.0.0',
     ]);
     _devToolsProcess = await startProcess(
       pubBin,


### PR DESCRIPTION
`devtools` was pinned to `0.2.5` in https://github.com/flutter/flutter/pull/57340.  Up the version to 2.0.

https://github.com/flutter/flutter/issues/77619