### PR TITLE
[fuchsia] remove no devices found from ffx parsing

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -395,7 +395,6 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
     final Map<String, HealthCheckResult> results = <String, HealthCheckResult>{};
     for (final String deviceId in await discoverDevices()) {
       try {
-        StringBuffer stderr;
         final int resolveResult = await exec(
           _ffx,
           <String>[
@@ -404,11 +403,9 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
             '--format',
             'a',
             deviceId,
-          ],
-          stderr: stderr
+          ]
         );
-        final String stderrOutput = stderr.toString().trim();
-        if (resolveResult == 0 && ! stderrOutput.contains('No devices found')) {
+        if (resolveResult == 0) {
           results['fuchsia-device-$deviceId'] = HealthCheckResult.success();
         } else {
           results['fuchsia-device-$deviceId'] = HealthCheckResult.failure('Cannot resolve device $deviceId');

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -322,7 +322,6 @@ Future<int> exec(
   List<String> arguments, {
   Map<String, String> environment,
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
-  StringBuffer stderr, // if not null, the stderr will be written here
   String workingDirectory,
 }) async {
   return _execute(
@@ -330,7 +329,6 @@ Future<int> exec(
     arguments,
     environment: environment,
     canFail : canFail,
-    stderr: stderr,
     workingDirectory: workingDirectory,
   );
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
@@ -93,9 +93,6 @@ class FuchsiaFfx {
       _logger.printError('ffx failed: ${result.stderr}');
       return null;
     }
-    if (result.stderr.contains('No devices found')) {
-      return null;
-    }
     return result.stdout.trim();
   }
 }


### PR DESCRIPTION
Ffx will now return an exit code of 2 if it tries resolving to a target and fails. 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.