### PR TITLE
Removed MaterialApp accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -678,7 +678,7 @@ class _MaterialScrollBehavior extends ScrollBehavior {
         return GlowingOverscrollIndicator(
           child: child,
           axisDirection: axisDirection,
-          color: Theme.of(context).accentColor,
+          color: Theme.of(context).colorScheme.secondary,
         );
     }
   }

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+import '../rendering/mock_canvas.dart';
+
 class StateMarker extends StatefulWidget {
   const StateMarker({ Key? key, this.child }) : super(key: key);
 
@@ -880,6 +882,37 @@ void main() {
 
     expect(themeBeforeBrightnessChange!.brightness, Brightness.light);
     expect(themeAfterBrightnessChange!.brightness, Brightness.dark);
+  });
+
+  testWidgets('MaterialApp provides default overscroll color', (WidgetTester tester) async {
+    Future<void> slowDrag(WidgetTester tester, Offset start, Offset offset) async {
+      final TestGesture gesture = await tester.startGesture(start);
+      for (int index = 0; index < 10; index += 1) {
+        await gesture.moveBy(offset);
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+      await gesture.up();
+    }
+
+    // The overscroll color should be a transparent version of the colorScheme's
+    // secondary color.
+    const Color secondaryColor = Color(0xff008800);
+    final Color glowSecondaryColor = secondaryColor.withOpacity(0.05);
+    final ThemeData theme = ThemeData.from(
+      colorScheme: const ColorScheme.light().copyWith(secondary: secondaryColor),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const SingleChildScrollView(
+          child: SizedBox(height: 2000.0),
+        ),
+      ),
+    );
+
+    final RenderObject painter = tester.renderObject(find.byType(CustomPaint).first);
+    await slowDrag(tester, const Offset(200.0, 200.0), const Offset(0.0, 5.0));
+    expect(painter, paints..circle(color: glowSecondaryColor));
   });
 
   testWidgets('MaterialApp can customize initial routes', (WidgetTester tester) async {


### PR DESCRIPTION
This PR removes the MaterialApp widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

The reference in question was used to set the `GlowingOverscrollIndicator`'s color that is created for Material viewports. This PR updates this to now use the `colorScheme.secondary` for the overscroll indicator instead.

## Breaking change

This is a breaking change, although most apps will not notice the change from theme.accentColor to theme.colorScheme.secondary, because they are typically the same color. For apps that do need a
specific color for the glow indicator, you can wrap your scrollable with something like:

```dart
    ScrollConfiguration(
      behavior: const ScrollBehavior(),
      child: GlowingOverscrollIndicator(
        axisDirection: AxisDirection.down,
        color: Colors.yellow,
        child: ListView.builder(
          ...
        ),
      ),
    ),
```

Which will force the glow color to yellow.

A new test was added to check verify the overscroll indicator color for Material apps.

This PR was tested against internal Google apps in cl/360771909
