### PR TITLE
Explain why devtools in pinned

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1409,6 +1409,11 @@ class DevToolsMemoryTest {
   }
 
   Future<void> _launchDevTools() async {
+    // The version of devtools is pinned. If we pub global activate devtools and an
+    // upstream devtools release breaks our CI, it will manifest on an unrelated
+    // commit, making it more difficult to determine the cause.
+    //
+    // Also, for release branches, all external test dependencies need to be pinned.
     await exec(pubBin, <String>[
       'global',
       'activate',


### PR DESCRIPTION
See discussion on https://github.com/flutter/flutter/pull/77637

Are there any other instances where this is pinned? @jonahwilliams @kenzieschmoll 