### PR TITLE
allow golden tests to specify epsilon tolerance

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -236,7 +236,7 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
   }
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) async {
     golden = _addPrefix(golden);
     await update(golden, imageBytes);
     final File goldenFile = getGoldenFile(golden);
@@ -322,7 +322,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
     }
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) async {
     golden = _addPrefix(golden);
     await update(golden, imageBytes);
     final File goldenFile = getGoldenFile(golden);
@@ -388,7 +388,7 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
   }
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) async {
     print(
       'Skipping "$golden" test : $reason'
     );
@@ -500,7 +500,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
   }
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) async {
     golden = _addPrefix(golden);
     final String testName = skiaClient.cleanTestName(golden.path);
     late String? testExpectation;
@@ -523,6 +523,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     result = await GoldenFileComparator.compareLists(
       imageBytes,
       goldenBytes,
+      epsilon,
     );
 
     if (result.passed)

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -577,6 +577,7 @@ void main() {
           await comparator.compare(
             Uint8List.fromList(_kTestPngBytes),
             Uri.parse('flutter.golden_test.1.png'),
+            0.0,
           ),
           isTrue,
         );
@@ -587,6 +588,7 @@ void main() {
           await comparator.compare(
             Uint8List.fromList(_kFailPngBytes),
             Uri.parse('flutter.new_golden_test.1'),
+            0.0,
           ),
           isTrue,
         );
@@ -600,6 +602,7 @@ void main() {
           await comparator.compare(
             Uint8List.fromList(_kFailPngBytes),
             Uri.parse('flutter.new_golden_test.2'),
+            0.0,
           ),
           isTrue,
         );
@@ -613,6 +616,7 @@ void main() {
         final Future<bool> result = comparator.compare(
           Uint8List.fromList(_kFailPngBytes),
           Uri.parse('flutter.golden_test.1.png'),
+          0.0,
         );
         bool shouldThrow = true;
         result.then((_) {

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -28,7 +28,7 @@ class LocalFileComparator extends GoldenFileComparator {
 ///
 /// This method is not supported on the web and throws an [UnsupportedError]
 /// when called.
-Future<ComparisonResult> compareLists(List<int> test, List<int> master) async {
+Future<ComparisonResult> compareLists(List<int> test, List<int> master, double epsilon) async {
   throw UnsupportedError('Golden testing is not supported on the web.');
 }
 

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -14,7 +14,7 @@ import 'goldens.dart';
 /// An unsupported [GoldenFileComparator] that exists for API compatibility.
 class LocalFileComparator extends GoldenFileComparator {
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) {
     throw UnsupportedError('LocalFileComparator is not supported on the web.');
   }
 

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -36,16 +36,19 @@ Future<ui.Image> captureImage(Element element) {
 /// test is running on a VM using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, this.epsilon);
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, this.epsilon) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// The acceptable golden diff tolerance.
+  final double epsilon;
 
   @override
   Future<String?> matchAsync(dynamic item) async {
@@ -82,7 +85,7 @@ class MatchesGoldenFile extends AsyncMatcher {
         return null;
       }
       try {
-        final bool success = await goldenFileComparator.compare(bytes.buffer.asUint8List(), testNameUri);
+        final bool success = await goldenFileComparator.compare(bytes.buffer.asUint8List(), testNameUri, epsilon);
         return success ? null : 'does not match';
       } on TestFailure catch (ex) {
         return ex.message;

--- a/packages/flutter_test/lib/src/_matchers_web.dart
+++ b/packages/flutter_test/lib/src/_matchers_web.dart
@@ -23,16 +23,19 @@ Future<ui.Image> captureImage(Element element) {
 /// test is running in a web browser using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, this.epsilon);
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, this.epsilon) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// The acceptable golden diff tolerance.
+  final double epsilon;
 
   @override
   Future<String?> matchAsync(dynamic item) async {

--- a/packages/flutter_test/lib/src/buffer_matcher.dart
+++ b/packages/flutter_test/lib/src/buffer_matcher.dart
@@ -13,13 +13,16 @@ import 'goldens.dart';
 /// Matcher created by [bufferMatchesGoldenFile].
 class _BufferGoldenMatcher extends AsyncMatcher {
   /// Creates an instance of [BufferGoldenMatcher]. Called by [bufferMatchesGoldenFile].
-  const _BufferGoldenMatcher(this.key, this.version);
+  const _BufferGoldenMatcher(this.key, this.version, this.epsilon);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// The acceptable golden diff tolerance.
+  final double epsilon;
 
   @override
   Future<String?> matchAsync(dynamic item) async {
@@ -37,7 +40,7 @@ class _BufferGoldenMatcher extends AsyncMatcher {
       return null;
     }
     try {
-      final bool success = await goldenFileComparator.compare(buffer, testNameUri);
+      final bool success = await goldenFileComparator.compare(buffer, testNameUri, epsilon);
       return success ? null : 'does not match';
     } on TestFailure catch (ex) {
       return ex.message;
@@ -69,6 +72,6 @@ class _BufferGoldenMatcher extends AsyncMatcher {
 /// );
 /// ```
 /// {@end-tool}
-AsyncMatcher bufferMatchesGoldenFile(String key, {int? version}) {
-   return _BufferGoldenMatcher(Uri.parse(key), version);
+AsyncMatcher bufferMatchesGoldenFile(String key, {int? version, double epsilon = 0.0}) {
+   return _BufferGoldenMatcher(Uri.parse(key), version, epsilon);
 }

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -60,7 +60,7 @@ abstract class GoldenFileComparator {
   /// is left up to the implementation class. For instance, some implementations
   /// may load files from the local file system, whereas others may load files
   /// over the network or from a remote repository.
-  Future<bool> compare(Uint8List imageBytes, Uri golden);
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon);
 
   /// Updates the golden file identified by [golden] with [imageBytes].
   ///
@@ -94,8 +94,8 @@ abstract class GoldenFileComparator {
 
   /// Returns a [ComparisonResult] to describe the pixel differential of the
   /// [test] and [master] image bytes provided.
-  static Future<ComparisonResult> compareLists(List<int> test, List<int> master) {
-    return _goldens.compareLists(test, master);
+  static Future<ComparisonResult> compareLists(List<int> test, List<int> master, double epsilon) {
+    return _goldens.compareLists(test, master, epsilon);
   }
 }
 
@@ -274,7 +274,7 @@ class TrivialComparator implements GoldenFileComparator {
   const TrivialComparator._();
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) {
     print('Golden file comparison requested for "$golden"; skipping...');
     return Future<bool>.value(true);
   }
@@ -320,6 +320,7 @@ class ComparisonResult {
   ComparisonResult({
     required this.passed,
     required this.diffPercent,
+    required this.epsilon,
     this.error,
     this.diffs,
   });
@@ -339,4 +340,7 @@ class ComparisonResult {
 
   /// The calculated percentage of pixel difference between two images.
   final double diffPercent;
+
+  /// The acceptable golden diff tolerance.
+  final double epsilon;
 }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -364,11 +364,11 @@ Matcher coversSameAreaAs(Path expectedPath, { required Rect areaToCompare, int s
 ///    verify that two different code paths create identical images.
 ///  * [flutter_test] for a discussion of test configurations, whereby callers
 ///    may swap out the backend for this matcher.
-AsyncMatcher matchesGoldenFile(Object key, {int? version}) {
+AsyncMatcher matchesGoldenFile(Object key, {int? version, double epsilon = 0.0}) {
   if (key is Uri) {
-    return MatchesGoldenFile(key, version);
+    return MatchesGoldenFile(key, version, epsilon);
   } else if (key is String) {
-    return MatchesGoldenFile.forStringPath(key, version);
+    return MatchesGoldenFile.forStringPath(key, version, epsilon);
   }
   throw ArgumentError('Unexpected type for golden file: ${key.runtimeType}');
 }

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -104,7 +104,7 @@ void main() {
     test('throws if local output is not awaited', () {
       try {
         comparator.generateFailureOutput(
-          ComparisonResult(passed: false, diffPercent: 1.0),
+          ComparisonResult(passed: false, diffPercent: 1.0, epsilon: 0.0),
           Uri.parse('foo_test.dart'),
           Uri.parse('/foo/bar/'),
         );
@@ -132,11 +132,12 @@ void main() {
     });
 
     group('compare', () {
-      Future<bool> doComparison([ String golden = 'golden.png' ]) {
+      Future<bool> doComparison([ String golden = 'golden.png' , double epsilon = 0.0]) {
         final Uri uri = fs.file(fix(golden)).uri;
         return comparator.compare(
           Uint8List.fromList(_kExpectedPngBytes),
           uri,
+          epsilon,
         );
       }
 
@@ -263,6 +264,13 @@ void main() {
           } on FlutterError catch (error) {
             expect(error.message, contains('% diff detected'));
           }
+        });
+
+        test('when pixels do not match but are within epsilon tolerance', () async{
+          await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
+
+          final bool didPass = await doComparison('golden.png', 100.0);
+          expect(didPass, isTrue);
         });
 
         test('when golden bytes are empty', () async {

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -669,7 +669,7 @@ class _FakeComparator implements GoldenFileComparator {
   Uri? golden;
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, double epsilon) {
     invocation = _ComparatorInvocation.compare;
     this.imageBytes = imageBytes;
     this.golden = golden;


### PR DESCRIPTION
This PR adds the ability to specify an epsilon tolerance on any golden test.

Closes issues:
https://github.com/flutter/flutter/issues/76337

May close issue:
https://github.com/flutter/flutter/issues/56383#issuecomment-793829114

Related PR:
https://github.com/flutter/flutter/pull/76545

No migration steps are necessary.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
