### PR TITLE
[flutter_tools] simplify platform null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/platform.dart
+++ b/packages/flutter_tools/lib/src/base/platform.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io' as io show Platform, stdin, stdout;
 
 /// Provides API parity with the `Platform` class in `dart:io`, but using
@@ -103,7 +101,7 @@ abstract class Platform {
   /// specifies how Dart packages are looked up.
   ///
   /// If there is no `--packages` flag, `null` is returned.
-  String get packageConfig;
+  String? get packageConfig;
 
   /// The version of the current Dart runtime.
   ///
@@ -158,7 +156,7 @@ class LocalPlatform extends Platform {
   List<String> get executableArguments => io.Platform.executableArguments;
 
   @override
-  String get packageConfig => io.Platform.packageConfig;
+  String? get packageConfig => io.Platform.packageConfig;
 
   @override
   String get version => io.Platform.version;
@@ -173,29 +171,30 @@ class LocalPlatform extends Platform {
   String get localeName => io.Platform.localeName;
 }
 
+final Uri _empty = Uri.parse('');
+
 /// Provides a mutable implementation of the [Platform] interface.
 class FakePlatform extends Platform {
   /// Creates a new [FakePlatform] with the specified properties.
   ///
-  /// Unspecified properties will *not* be assigned default values (they will
-  /// remain `null`).
+  /// Unspecified properties will default to a 'linux' OS.
   FakePlatform({
-    this.numberOfProcessors,
-    this.pathSeparator,
-    this.operatingSystem,
-    this.operatingSystemVersion,
-    this.localHostname,
-    this.environment,
-    this.executable,
-    this.resolvedExecutable,
-    this.script,
-    this.executableArguments,
+    this.numberOfProcessors = 1,
+    this.pathSeparator = '/',
+    this.operatingSystem = 'linux',
+    this.operatingSystemVersion = '',
+    this.localHostname = '',
+    this.environment = const <String, String>{},
+    this.executable = '',
+    this.resolvedExecutable = '',
+    Uri? script,
+    this.executableArguments = const <String>[],
     this.packageConfig,
-    this.version,
-    this.stdinSupportsAnsi,
-    this.stdoutSupportsAnsi,
-    this.localeName,
-  });
+    this.version = '',
+    this.stdinSupportsAnsi = false,
+    this.stdoutSupportsAnsi = false,
+    this.localeName = '',
+  }) : script = script ?? _empty;
 
   /// Creates a new [FakePlatform] with properties whose initial values mirror
   /// the specified [platform].
@@ -248,7 +247,7 @@ class FakePlatform extends Platform {
   List<String> executableArguments;
 
   @override
-  String packageConfig;
+  String? packageConfig;
 
   @override
   String version;

--- a/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(message(macPlatform), contains('https://flutter.dev/docs/get-started/install/macos#android-setup'));
     expect(message(linuxPlatform), contains('https://flutter.dev/docs/get-started/install/linux#android-setup'));
     expect(message(windowsPlatform), contains('https://flutter.dev/docs/get-started/install/windows#android-setup'));
-    expect(message(FakePlatform()), contains('https://flutter.dev/docs/get-started/install '));
+    expect(message(FakePlatform(operatingSystem: '')), contains('https://flutter.dev/docs/get-started/install '));
   }
 
   testWithoutContext('Android installation instructions', () {


### PR DESCRIPTION
Redo of https://github.com/flutter/flutter/pull/77309, with much simplified logic.

Test properties can no longer be null, set them to some reasonable defaults.

Part of #71511