### PR TITLE
Making renderTree and renderObjectDiagnostics available in profile builds

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1562,7 +1562,7 @@ abstract class DiagnosticsNode {
   @mustCallSuper
   Map<String, Object?> toJsonMap(DiagnosticsSerializationDelegate delegate) {
     Map<String, Object?> result = <String, Object?>{};
-    assert(() {
+    if (!kReleaseMode) {
       final bool hasChildren = getChildren().isNotEmpty;
       result = <String, Object?>{
         'description': toDescription(),
@@ -1603,8 +1603,7 @@ abstract class DiagnosticsNode {
             delegate,
           ),
       };
-      return true;
-    }());
+    }
     return result;
   }
 
@@ -1655,7 +1654,7 @@ abstract class DiagnosticsNode {
     String result = super.toString();
     assert(style != null);
     assert(minLevel != null);
-    assert(() {
+    if (!kReleaseMode) {
       if (_isSingleLine(style)) {
         result = toStringDeep(
             parentConfiguration: parentConfiguration, minLevel: minLevel);
@@ -1669,8 +1668,7 @@ abstract class DiagnosticsNode {
               : '$name$_separator $description';
         }
       }
-      return true;
-    }());
+    }
     return result;
   }
 
@@ -1736,7 +1734,7 @@ abstract class DiagnosticsNode {
     DiagnosticLevel minLevel = DiagnosticLevel.debug,
   }) {
     String result = '';
-    assert(() {
+    if (!kReleaseMode) {
       result = TextTreeRenderer(
         minLevel: minLevel,
         wrapWidth: 65,
@@ -1747,8 +1745,7 @@ abstract class DiagnosticsNode {
         prefixOtherLines: prefixOtherLines,
         parentConfiguration: parentConfiguration,
       );
-      return true;
-    }());
+    }
     return result;
   }
 }
@@ -2939,13 +2936,10 @@ class DiagnosticableNode<T extends Diagnosticable> extends DiagnosticsNode {
     if (kReleaseMode) {
       return null;
     } else {
-      assert(() {
-        if (_cachedBuilder == null) {
-          _cachedBuilder = DiagnosticPropertiesBuilder();
-          value.debugFillProperties(_cachedBuilder!);
-        }
-        return true;
-      }());
+      if (_cachedBuilder == null) {
+        _cachedBuilder = DiagnosticPropertiesBuilder();
+        value.debugFillProperties(_cachedBuilder!);
+      }
       return _cachedBuilder;
     }
   }
@@ -2956,10 +2950,10 @@ class DiagnosticableNode<T extends Diagnosticable> extends DiagnosticsNode {
   }
 
   @override
-  String? get emptyBodyDescription => (kReleaseMode || kProfileMode) ? '' : builder!.emptyBodyDescription;
+  String? get emptyBodyDescription => (kReleaseMode) ? '' : builder!.emptyBodyDescription;
 
   @override
-  List<DiagnosticsNode> getProperties() => (kReleaseMode || kProfileMode) ? const <DiagnosticsNode>[] : builder!.properties;
+  List<DiagnosticsNode> getProperties() => (kReleaseMode) ? const <DiagnosticsNode>[] : builder!.properties;
 
   @override
   List<DiagnosticsNode> getChildren() {
@@ -2969,10 +2963,9 @@ class DiagnosticableNode<T extends Diagnosticable> extends DiagnosticsNode {
   @override
   String toDescription({ TextTreeConfiguration? parentConfiguration }) {
     String result = '';
-    assert(() {
+    if (!kReleaseMode) {
       result = value.toStringShort();
-      return true;
-    }());
+    }
     return result;
   }
 }
@@ -3051,10 +3044,9 @@ class DiagnosticPropertiesBuilder {
 
   /// Add a property to the list of properties.
   void add(DiagnosticsNode property) {
-    assert(() {
+    if (!kReleaseMode) {
       properties.add(property);
-      return true;
-    }());
+    }
   }
 
   /// List of properties accumulated so far.
@@ -3106,10 +3098,9 @@ mixin Diagnosticable {
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
     String? fullString;
-    assert(() {
+    if (!kReleaseMode) {
       fullString = toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
-      return true;
-    }());
+    }
     return fullString ?? toStringShort();
   }
 
@@ -3382,7 +3373,7 @@ abstract class DiagnosticableTree with Diagnosticable {
     DiagnosticLevel minLevel = DiagnosticLevel.debug,
   }) {
     String? shallowString;
-    assert(() {
+    if (!kReleaseMode) {
       final StringBuffer result = StringBuffer();
       result.write(toString());
       result.write(joiner);
@@ -3393,8 +3384,7 @@ abstract class DiagnosticableTree with Diagnosticable {
             .join(joiner),
       );
       shallowString = result.toString();
-      return true;
-    }());
+    }
     return shallowString ?? toString();
   }
 
@@ -3472,7 +3462,7 @@ mixin DiagnosticableTreeMixin implements DiagnosticableTree {
     DiagnosticLevel minLevel = DiagnosticLevel.debug,
   }) {
     String? shallowString;
-    assert(() {
+    if (!kReleaseMode) {
       final StringBuffer result = StringBuffer();
       result.write(toStringShort());
       result.write(joiner);
@@ -3483,8 +3473,7 @@ mixin DiagnosticableTreeMixin implements DiagnosticableTree {
             .join(joiner),
       );
       shallowString = result.toString();
-      return true;
-    }());
+    }
     return shallowString ?? toString();
   }
 

--- a/packages/flutter/lib/src/foundation/object.dart
+++ b/packages/flutter/lib/src/foundation/object.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'constants.dart';
+
 /// Framework code should use this method in favor of calling `toString` on
 /// [Object.runtimeType].
 ///
@@ -10,9 +12,8 @@
 /// return `object.runtimeType.toString()`; otherwise, it will return the
 /// [optimizedValue], which must be a simple constant string.
 String objectRuntimeType(Object? object, String optimizedValue) {
-  assert(() {
+  if (!kReleaseMode) {
     optimizedValue = object.runtimeType.toString();
-    return true;
-  }());
+  }
   return optimizedValue;
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3147,9 +3147,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    bool inReleaseMode = true;
-    assert(() {
-      inReleaseMode = false;
+    if (!kReleaseMode) {
       if (debugSymmetricPaintCount + debugAsymmetricPaintCount == 0) {
         properties.add(MessageProperty('usefulness ratio', 'no metrics collected yet (never painted)'));
       } else {
@@ -3173,10 +3171,9 @@ class RenderRepaintBoundary extends RenderProxyBox {
         properties.add(PercentProperty('metrics', fraction, unit: 'useful', tooltip: '$debugSymmetricPaintCount bad vs $debugAsymmetricPaintCount good'));
         properties.add(MessageProperty('diagnosis', diagnosis));
       }
-      return true;
-    }());
-    if (inReleaseMode)
+    } else {
       properties.add(DiagnosticsNode.message('(run in checked mode to collect repaint boundary statistics)'));
+    }
   }
 }
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -313,10 +313,9 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     // call to ${super.debugFillProperties(description)} is omitted because the
     // root superclasses don't include any interesting information for this
     // class
-    assert(() {
-      properties.add(DiagnosticsNode.message('debug mode enabled - ${kIsWeb ? 'Web' :  Platform.operatingSystem}'));
-      return true;
-    }());
+    if (!kReleaseMode) {
+      properties.add(DiagnosticsNode.message('${kDebugMode ? 'debug' : 'profile'} mode enabled - ${kIsWeb ? 'Web' :  Platform.operatingSystem}'));
+    }
     properties.add(DiagnosticsProperty<Size>('window size', _window.physicalSize, tooltip: 'in physical pixels'));
     properties.add(DoubleProperty('device pixel ratio', _window.devicePixelRatio, tooltip: 'physical pixels per logical pixel'));
     properties.add(DiagnosticsProperty<ViewConfiguration>('configuration', configuration, tooltip: 'in logical pixels'));

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5425,10 +5425,9 @@ abstract class RenderObjectElement extends Element {
       _debugDoingBuild = false;
       return true;
     }());
-    assert(() {
+    if (!kReleaseMode) {
       _debugUpdateRenderObjectOwner();
-      return true;
-    }());
+    }
     assert(_slot == newSlot);
     attachRenderObject(newSlot);
     _dirty = false;
@@ -5438,10 +5437,9 @@ abstract class RenderObjectElement extends Element {
   void update(covariant RenderObjectWidget newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    assert(() {
+    if (!kReleaseMode) {
       _debugUpdateRenderObjectOwner();
-      return true;
-    }());
+    }
     assert(() {
       _debugDoingBuild = true;
       return true;
@@ -5455,10 +5453,9 @@ abstract class RenderObjectElement extends Element {
   }
 
   void _debugUpdateRenderObjectOwner() {
-    assert(() {
+    if (!kReleaseMode) {
       renderObject.debugCreator = DebugCreator(this);
-      return true;
-    }());
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

I replaced `assert` blocks of code with `if (!kReleaseMode)` blocks to allow profile builds access to type, properties, and diagnostics of render objects.  I also removed `kProfileMode` condition in `emptyBodyDescription` and `getProperties` methods of `diagnostics.dart` file for the same reasons.

## Related Issues

Fixes [#70772](https://github.com/flutter/flutter/issues/70772)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat