### PR TITLE
[flutter_tools] remove mock processes from batch compile_test

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -175,10 +175,6 @@ List<String> buildModeOptions(BuildMode mode, List<String> dartDefines) {
   throw Exception('Unknown BuildMode: $mode');
 }
 
-StdoutHandler _defaultFactory(Logger logger) {
-  return StdoutHandler(logger: logger);
-}
-
 /// A compiler interface for producing single (non-incremental) kernel files.
 class KernelCompiler {
   KernelCompiler({
@@ -188,14 +184,14 @@ class KernelCompiler {
     @required Artifacts artifacts,
     @required List<String> fileSystemRoots,
     @required String fileSystemScheme,
-    @visibleForTesting StdoutHandler Function(Logger) stdoutHandlerFactory,
+    @visibleForTesting StdoutHandler stdoutHandler,
   }) : _logger = logger,
        _fileSystem = fileSystem,
        _artifacts = artifacts,
        _processManager = processManager,
        _fileSystemScheme = fileSystemScheme,
        _fileSystemRoots = fileSystemRoots,
-       _stdoutHandlerFactory = stdoutHandlerFactory ?? _defaultFactory;
+       _stdoutHandler = stdoutHandler ?? StdoutHandler(logger: logger);
 
   final FileSystem _fileSystem;
   final Artifacts _artifacts;
@@ -203,7 +199,7 @@ class KernelCompiler {
   final Logger _logger;
   final String _fileSystemScheme;
   final List<String> _fileSystemRoots;
-  final StdoutHandler Function(Logger) _stdoutHandlerFactory;
+  final StdoutHandler _stdoutHandler;
 
   Future<CompilerOutput> compile({
     String sdkRoot,
@@ -317,7 +313,6 @@ class KernelCompiler {
     _logger.printTrace(command.join(' '));
     final Process server = await _processManager.start(command);
 
-    final StdoutHandler _stdoutHandler = _stdoutHandlerFactory(_logger);
     server.stderr
       .transform<String>(utf8.decoder)
       .listen(_logger.printError);

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -175,6 +175,10 @@ List<String> buildModeOptions(BuildMode mode, List<String> dartDefines) {
   throw Exception('Unknown BuildMode: $mode');
 }
 
+StdoutHandler _defaultFactory(Logger logger) {
+  return StdoutHandler(logger: logger);
+}
+
 /// A compiler interface for producing single (non-incremental) kernel files.
 class KernelCompiler {
   KernelCompiler({
@@ -184,12 +188,14 @@ class KernelCompiler {
     @required Artifacts artifacts,
     @required List<String> fileSystemRoots,
     @required String fileSystemScheme,
+    @visibleForTesting StdoutHandler Function(Logger) stdoutHandlerFactory,
   }) : _logger = logger,
        _fileSystem = fileSystem,
        _artifacts = artifacts,
        _processManager = processManager,
        _fileSystemScheme = fileSystemScheme,
-       _fileSystemRoots = fileSystemRoots;
+       _fileSystemRoots = fileSystemRoots,
+       _stdoutHandlerFactory = stdoutHandlerFactory ?? _defaultFactory;
 
   final FileSystem _fileSystem;
   final Artifacts _artifacts;
@@ -197,6 +203,7 @@ class KernelCompiler {
   final Logger _logger;
   final String _fileSystemScheme;
   final List<String> _fileSystemRoots;
+  final StdoutHandler Function(Logger) _stdoutHandlerFactory;
 
   Future<CompilerOutput> compile({
     String sdkRoot,
@@ -310,7 +317,7 @@ class KernelCompiler {
     _logger.printTrace(command.join(' '));
     final Process server = await _processManager.start(command);
 
-    final StdoutHandler _stdoutHandler = StdoutHandler(logger: _logger);
+    final StdoutHandler _stdoutHandler = _stdoutHandlerFactory(_logger);
     server.stderr
       .transform<String>(utf8.decoder)
       .listen(_logger.printError);
@@ -540,11 +547,12 @@ class DefaultResidentCompiler implements ResidentCompiler {
     this.platformDill,
     List<String> dartDefines,
     this.librariesSpec,
+    @visibleForTesting StdoutHandler stdoutHandler,
   }) : assert(sdkRoot != null),
        _logger = logger,
        _processManager = processManager,
        _artifacts = artifacts,
-       _stdoutHandler = StdoutHandler(logger: logger),
+       _stdoutHandler = stdoutHandler ?? StdoutHandler(logger: logger),
        _platform = platform,
        dartDefines = dartDefines ?? const <String>[],
        // This is a URI, not a file path, so the forward slash is correct even on Windows.

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -8,64 +8,71 @@ import 'dart:async';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
-import 'package:flutter_tools/src/convert.dart';
-import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config.dart';
-import 'package:process/process.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/mocks.dart';
 
 void main() {
-  ProcessManager mockProcessManager;
-  MockProcess mockFrontendServer;
-  MockStdIn mockFrontendServerStdIn;
-  MockStream mockFrontendServerStdErr;
+  testWithoutContext('StdoutHandler can parse output for successful batch compilation', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
 
-  List<String> latestCommand;
+    stdoutHandler.reset();
+    'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'.split('\n').forEach(stdoutHandler.handler);
+    final CompilerOutput output = await  stdoutHandler.compilerOutput.future;
 
-  setUp(() {
-    mockProcessManager = MockProcessManager();
-    mockFrontendServer = MockProcess();
-    mockFrontendServerStdIn = MockStdIn();
-    mockFrontendServerStdErr = MockStream();
-
-    when(mockFrontendServer.stderr)
-        .thenAnswer((Invocation invocation) => mockFrontendServerStdErr);
-    final StreamController<String> stdErrStreamController = StreamController<String>();
-    when(mockFrontendServerStdErr.transform<String>(any)).thenAnswer((_) => stdErrStreamController.stream);
-    when(mockFrontendServer.stdin).thenReturn(mockFrontendServerStdIn);
-    when(mockProcessManager.canRun(any)).thenReturn(true);
-    when(mockProcessManager.start(any)).thenAnswer(
-        (Invocation invocation) {
-          latestCommand = invocation.positionalArguments.first as List<String>;
-          return Future<Process>.value(mockFrontendServer);
-        });
-    when(mockFrontendServer.exitCode).thenAnswer((_) async => 0);
+    expect(logger.errorText, equals('line1\nline2\n'));
+    expect(output.outputFilename, equals('/path/to/main.dart.dill'));
   });
 
-  testWithoutContext('batch compile single dart successful compilation', () async {
-    when(mockFrontendServer.stdout)
-        .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-          Future<List<int>>.value(utf8.encode(
-            'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'
-          ))
-        ));
+  testWithoutContext('StdoutHandler can parse output for failed batch compilation', () async {
     final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+
+    stdoutHandler.reset();
+    'result abc\nline1\nline2\nabc\nabc'.split('\n').forEach(stdoutHandler.handler);
+    final CompilerOutput output = await stdoutHandler.compilerOutput.future;
+
+    expect(logger.errorText, equals('line1\nline2\n'));
+    expect(output, equals(null));
+  });
+
+  testWithoutContext('KernelCompiler passes correct configuration to frontend server process', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
     final KernelCompiler kernelCompiler = KernelCompiler(
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
       fileSystemRoots: <String>[],
       fileSystemScheme: '',
       logger: logger,
-      processManager: mockProcessManager
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+         'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=false',
+          '--enable-asserts',
+          '--no-link-platform',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart'
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
     );
-    final CompilerOutput output = await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
       buildMode: BuildMode.debug,
       trackWidgetCreation: false,
@@ -73,28 +80,135 @@ void main() {
       packageConfig: PackageConfig.empty,
       packagesPath: '.packages',
     );
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
 
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    expect(logger.errorText, equals('line1\nline2\n'));
-    expect(output.outputFilename, equals('/path/to/main.dart.dill'));
+    expect((await output).outputFilename, '');
   });
 
-  testWithoutContext('passes correct AOT config to kernel compiler in aot/profile mode', () async {
-    when(mockFrontendServer.stdout)
-      .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-        Future<List<int>>.value(utf8.encode(
-          'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'
-        ))
-      ));
+  testWithoutContext('KernelCompiler returns null if StdoutHandler returns null', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
     final KernelCompiler kernelCompiler = KernelCompiler(
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
       fileSystemRoots: <String>[],
       fileSystemScheme: '',
-      logger: BufferLogger.test(),
-      processManager: mockProcessManager
+      logger: logger,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+         'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=false',
+          '--enable-asserts',
+          '--no-link-platform',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart'
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
     );
-    await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+      mainPath: '/path/to/main.dart',
+      buildMode: BuildMode.debug,
+      trackWidgetCreation: false,
+      dartDefines: const <String>[],
+      packageConfig: PackageConfig.empty,
+      packagesPath: '.packages',
+    );
+    stdoutHandler.compilerOutput.complete(null);
+    completer.complete();
+
+    expect(await output, null);
+  });
+
+  testWithoutContext('KernelCompiler returns null if frontend_server process exits with non-zero code', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
+    final KernelCompiler kernelCompiler = KernelCompiler(
+      artifacts: Artifacts.test(),
+      fileSystem: MemoryFileSystem.test(),
+      fileSystemRoots: <String>[],
+      fileSystemScheme: '',
+      logger: logger,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+         'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=false',
+          '--enable-asserts',
+          '--no-link-platform',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart'
+        ], completer: completer, exitCode: 127),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+    );
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+      mainPath: '/path/to/main.dart',
+      buildMode: BuildMode.debug,
+      trackWidgetCreation: false,
+      dartDefines: const <String>[],
+      packageConfig: PackageConfig.empty,
+      packagesPath: '.packages',
+    );
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
+
+    expect(await output, null);
+  });
+
+  testWithoutContext('KernelCompiler passes correct AOT config to frontend_server in aot/profile mode', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
+    final KernelCompiler kernelCompiler = KernelCompiler(
+      artifacts: Artifacts.test(),
+      fileSystem: MemoryFileSystem.test(),
+      fileSystemRoots: <String>[],
+      fileSystemScheme: '',
+      logger: logger,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+          'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=true',
+          '-Ddart.vm.product=false',
+          '--no-link-platform',
+          '--aot',
+          '--tfa',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart'
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+    );
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
       buildMode: BuildMode.profile,
       trackWidgetCreation: false,
@@ -103,33 +217,45 @@ void main() {
       packageConfig: PackageConfig.empty,
       packagesPath: '.packages',
     );
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
 
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
-    expect(argVerification.captured.single, containsAll(<String>[
-      '--aot',
-      '--tfa',
-      '-Ddart.vm.profile=true',
-      '-Ddart.vm.product=false',
-    ]));
+    expect((await output).outputFilename, '');
   });
 
   testWithoutContext('passes correct AOT config to kernel compiler in aot/release mode', () async {
-    when(mockFrontendServer.stdout)
-      .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-        Future<List<int>>.value(utf8.encode(
-          'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'
-        ))
-      ));
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
     final KernelCompiler kernelCompiler = KernelCompiler(
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
       fileSystemRoots: <String>[],
       fileSystemScheme: '',
-      logger: BufferLogger.test(),
-      processManager: mockProcessManager
+      logger: logger,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+          'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=true',
+          '--no-link-platform',
+          '--aot',
+          '--tfa',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart'
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
     );
-    await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
       buildMode: BuildMode.release,
       trackWidgetCreation: false,
@@ -138,93 +264,47 @@ void main() {
       packageConfig: PackageConfig.empty,
       packagesPath: '.packages',
     );
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
 
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
-    expect(argVerification.captured.single, containsAll(<String>[
-      '--aot',
-      '--tfa',
-      '-Ddart.vm.profile=false',
-      '-Ddart.vm.product=true',
-    ]));
+    expect((await output).outputFilename, '');
   });
 
-  testWithoutContext('batch compile single dart failed compilation', () async {
-    when(mockFrontendServer.stdout)
-        .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-          Future<List<int>>.value(utf8.encode(
-            'result abc\nline1\nline2\nabc\nabc'
-          ))
-        ));
+  testWithoutContext('KernelCompiler passes dartDefines to the frontend_server', () async {
     final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
     final KernelCompiler kernelCompiler = KernelCompiler(
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
       fileSystemRoots: <String>[],
       fileSystemScheme: '',
       logger: logger,
-      processManager: mockProcessManager
-    );
-    final CompilerOutput output = await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
-      mainPath: '/path/to/main.dart',
-      buildMode: BuildMode.debug,
-      trackWidgetCreation: false,
-      dartDefines: const <String>[],
-      packageConfig: PackageConfig.empty,
-      packagesPath: '.packages',
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+          'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-DFOO=bar',
+          '-DBAZ=qux',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=false',
+          '--enable-asserts',
+          '--no-link-platform',
+          '--packages',
+          '.packages',
+          'file:///path/to/main.dart',
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
     );
 
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    expect(logger.errorText, equals('line1\nline2\n'));
-    expect(output, equals(null));
-  });
-
-  testWithoutContext('batch compile single dart abnormal compiler termination', () async {
-    when(mockFrontendServer.exitCode).thenAnswer((_) async => 255);
-    when(mockFrontendServer.stdout)
-        .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-        Future<List<int>>.value(utf8.encode(
-            'result abc\nline1\nline2\nabc\nabc'
-        ))
-    ));
-    final BufferLogger logger = BufferLogger.test();
-    final KernelCompiler kernelCompiler = KernelCompiler(
-      artifacts: Artifacts.test(),
-      fileSystem: MemoryFileSystem.test(),
-      fileSystemRoots: <String>[],
-      fileSystemScheme: '',
-      logger: logger,
-      processManager: mockProcessManager
-    );
-    final CompilerOutput output = await kernelCompiler.compile(
-      sdkRoot: '/path/to/sdkroot',
-      mainPath: '/path/to/main.dart',
-      buildMode: BuildMode.debug,
-      trackWidgetCreation: false,
-      dartDefines: const <String>[],
-      packageConfig: PackageConfig.empty,
-      packagesPath: '.packages',
-    );
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    expect(logger.errorText, equals('line1\nline2\n'));
-    expect(output, equals(null));
-  });
-
-  testWithoutContext('passes dartDefines to the kernel compiler', () async {
-    // Use unsuccessful result because it's easier to setup in test. We only care about arguments passed to the compiler.
-    when(mockFrontendServer.exitCode).thenAnswer((_) async => 255);
-    when(mockFrontendServer.stdout).thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-      Future<List<int>>.value(<int>[])
-    ));
-    final KernelCompiler kernelCompiler = KernelCompiler(
-      artifacts: Artifacts.test(),
-      fileSystem: MemoryFileSystem.test(),
-      fileSystemRoots: <String>[],
-      fileSystemScheme: '',
-      logger: BufferLogger.test(),
-      processManager: mockProcessManager
-    );
-    await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
       buildMode: BuildMode.debug,
       trackWidgetCreation: false,
@@ -233,15 +313,17 @@ void main() {
       packagesPath: '.packages',
     );
 
-    expect(latestCommand, containsAllInOrder(<String>['-DFOO=bar', '-DBAZ=qux']));
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
+
+    expect((await output).outputFilename, '');
   });
 
-  testWithoutContext('maps a file to a multiroot scheme if provided', () async {
-    // Use unsuccessful result because it's easier to setup in test. We only care about arguments passed to the compiler.
-    when(mockFrontendServer.exitCode).thenAnswer((_) async => 255);
-    when(mockFrontendServer.stdout).thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-      Future<List<int>>.value(<int>[])
-    ));
+  testWithoutContext('KernelCompiler maps a file to a multi-root scheme if provided', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final StdoutHandler stdoutHandler = StdoutHandler(logger: logger);
+    final Completer<void> completer = Completer<void>();
+
     final KernelCompiler kernelCompiler = KernelCompiler(
       artifacts: Artifacts.test(),
       fileSystem: MemoryFileSystem.test(),
@@ -249,10 +331,29 @@ void main() {
         '/foo/bar/fizz',
       ],
       fileSystemScheme: 'scheme',
-      logger: BufferLogger.test(),
-      processManager: mockProcessManager
+      logger: logger,
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+          'Artifact.engineDartBinary',
+          '--disable-dart-dev',
+          'Artifact.frontendServerSnapshotForEngineDartSdk',
+          '--sdk-root',
+          '/path/to/sdkroot/',
+          '--target=flutter',
+          '--no-print-incremental-dependencies',
+          '-Ddart.vm.profile=false',
+          '-Ddart.vm.product=false',
+          '--enable-asserts',
+          '--no-link-platform',
+          '--packages',
+          '.packages',
+          'scheme:///main.dart',
+        ], completer: completer),
+      ]),
+      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
     );
-    await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+
+    final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/foo/bar/fizz/main.dart',
       buildMode: BuildMode.debug,
       trackWidgetCreation: false,
@@ -261,9 +362,9 @@ void main() {
       packagesPath: '.packages',
     );
 
-    expect(latestCommand, containsAll(<String>['scheme:///main.dart']));
+    stdoutHandler.compilerOutput.complete(const CompilerOutput('', 0, <Uri>[]));
+    completer.complete();
+
+    expect((await output).outputFilename, '');
   });
 }
-
-class MockProcess extends Mock implements Process {}
-class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -70,7 +70,7 @@ void main() {
           'file:///path/to/main.dart'
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
@@ -115,7 +115,7 @@ void main() {
           'file:///path/to/main.dart'
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
@@ -160,7 +160,7 @@ void main() {
           'file:///path/to/main.dart'
         ], completer: completer, exitCode: 127),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
@@ -206,7 +206,7 @@ void main() {
           'file:///path/to/main.dart'
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
@@ -253,7 +253,7 @@ void main() {
           'file:///path/to/main.dart'
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
       mainPath: '/path/to/main.dart',
@@ -301,7 +301,7 @@ void main() {
           'file:///path/to/main.dart',
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
 
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
@@ -350,7 +350,7 @@ void main() {
           'scheme:///main.dart',
         ], completer: completer),
       ]),
-      stdoutHandlerFactory: (Logger logger) => stdoutHandler,
+      stdoutHandler: stdoutHandler,
     );
 
     final Future<CompilerOutput> output = kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',


### PR DESCRIPTION
We had previously discussed separating the kernel compilation and the stdout handler by some sort of stream or command interface. After investigating a bit more, I didn't find that to be necessary since we could also inject the stdout handler.

* For tests of the stdout handler, just test the stdout handler directly
* For tests of the kernel compiler, test that the process is started correctly and use the injected stdout handler to ensure the compile finishes.

Removes mocks

https://github.com/flutter/flutter/issues/71511
