### PR TITLE
[DatePicker] Don't jump to the current month

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -531,7 +531,7 @@ class _MonthPickerState extends State<_MonthPicker> {
   @override
   void didUpdateWidget(_MonthPicker oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.initialMonth != oldWidget.initialMonth) {
+    if (widget.initialMonth != oldWidget.initialMonth && widget.initialMonth != _currentMonth) {
       // We can't interrupt this widget build with a scroll, so do it next frame
       WidgetsBinding.instance!.addPostFrameCallback(
         (Duration timeStamp) => _showMonth(widget.initialMonth, jump: true)

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -431,6 +431,24 @@ void main() {
       expect(find.text('2016'), findsNothing); // 2016 in year grid
     });
 
+    testWidgets('Dragging more than half the width should not cause a jump', (
+        WidgetTester tester) async {
+      await tester.pumpWidget(calendarDatePicker());
+      await tester.pumpAndSettle();
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(PageView)));
+      // This initial drag is required for the PageView to recognize the gesture, as it uses DragStartBehavior.start.
+      // It does not count towards the drag distance.
+      await gesture.moveBy(const Offset(100, 0));
+      // Dragging for a bit less than half the width should reveal the previous month.
+      await gesture.moveBy(const Offset(800 / 2 - 1, 0));
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsNWidgets(2));
+      // Dragging a bit over the half should still show both.
+      await gesture.moveBy(const Offset(2, 0));
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsNWidgets(2));
+    });
+
     group('Keyboard navigation', () {
       testWidgets('Can toggle to year mode', (WidgetTester tester) async {
         await tester.pumpWidget(calendarDatePicker());

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -442,10 +442,12 @@ void main() {
       // Dragging for a bit less than half the width should reveal the previous month.
       await gesture.moveBy(const Offset(800 / 2 - 1, 0));
       await tester.pumpAndSettle();
+      expect(find.text('January 2016'), findsOneWidget);
       expect(find.text('1'), findsNWidgets(2));
       // Dragging a bit over the half should still show both.
       await gesture.moveBy(const Offset(2, 0));
       await tester.pumpAndSettle();
+      expect(find.text('December 2015'), findsOneWidget);
       expect(find.text('1'), findsNWidgets(2));
     });
 


### PR DESCRIPTION
When the currently selected month of a `_MonthPicker` changes (this happens when the underlying `PageView` is dragged more than halfway), the parent `CalendarDatePicker` rebuilds and passes the new month back to the `_MonthPicker`. The month picker then unconditionally jumped to the new month. Since the `PageView` was only dragged halfway at this point, this caused a jump under the finger of the user (or skipped a part of the fling animation).
This patch updates `didUpdateWidget` to not jump to the month that is currently selected anyways.
Before:
https://user-images.githubusercontent.com/44171190/110478375-9378d300-80e4-11eb-8934-3fed4d333393.mp4
After:
https://user-images.githubusercontent.com/44171190/110538143-ee7dea80-8123-11eb-9ce1-b20c3bb7003d.mp4

Closes #77705.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
