### PR TITLE
Removed PaginatedDataTable accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -488,7 +488,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                     // These typographic styles aren't quite the regular ones. We pick the closest ones from the regular
                     // list and then tweak them appropriately.
                     // See https://material.io/design/components/data-tables.html#tables-within-cards
-                    style: _selectedRowCount > 0 ? themeData.textTheme.subtitle1!.copyWith(color: themeData.accentColor)
+                    style: _selectedRowCount > 0 ? themeData.textTheme.subtitle1!.copyWith(color: themeData.colorScheme.secondary)
                                                  : themeData.textTheme.headline6!.copyWith(fontWeight: FontWeight.w400),
                     child: IconTheme.merge(
                       data: const IconThemeData(


### PR DESCRIPTION
This PR removes the PaginatedDataTable widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

The reference in question was used to set the '# items selected' text color when selection is supported.

## Breaking change

This is a breaking change, although most apps will not notice the change from `theme.accentColor` to `theme.colorScheme.secondary`, because they are typically the same color. For apps that do need a
specific color for the item selection text, you can wrap your `PaginatedDataTable` with something like:

```dart
final ThemeData theme = Theme.of(context);
...
Theme(
  data: theme.copyWith(colorScheme: theme.colorScheme.copyWith(secondary: Colors.red)),
  child: PaginatedDataTable(
    ...
  ),
),
```
Which will force the selected items header text color red.

A new test was added to verify the selected text header used the secondary color.

This PR was tested against internal Google apps in cl/360773810

