### PR TITLE
[flutter_tools] simplify fake imports for FakeProcessManager

### DIFF
--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -6,14 +6,12 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io show ProcessSignal;
+import 'dart:io' as io show ProcessSignal, Process, ProcessStartMode, ProcessResult, systemEncoding;
 
-import 'package:flutter_tools/src/base/io.dart';
+import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
-import 'common.dart';
-import 'context.dart';
-
+import 'package:test/test.dart';
 export 'package:process/process.dart' show ProcessManager;
 
 typedef VoidCallback = void Function();
@@ -120,7 +118,7 @@ class FakeCommand {
   }
 }
 
-class _FakeProcess implements Process {
+class _FakeProcess implements io.Process {
   _FakeProcess(
     this._exitCode,
     Duration duration,
@@ -251,37 +249,37 @@ abstract class FakeProcessManager implements ProcessManager {
   }
 
   @override
-  Future<Process> start(
+  Future<io.Process> start(
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
-    ProcessStartMode mode = ProcessStartMode.normal, // ignored
+    io.ProcessStartMode mode = io.ProcessStartMode.normal, // ignored
   }) {
-    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, systemEncoding);
+    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, io.systemEncoding);
     if (process._completer != null) {
       _fakeRunningProcesses[process.pid] = process;
       process.exitCode.whenComplete(() {
         _fakeRunningProcesses.remove(process.pid);
       });
     }
-    return Future<Process>.value(process);
+    return Future<io.Process>.value(process);
   }
 
   @override
-  Future<ProcessResult> run(
+  Future<io.ProcessResult> run(
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
-    Encoding stdoutEncoding = systemEncoding,
-    Encoding stderrEncoding = systemEncoding,
+    Encoding stdoutEncoding = io.systemEncoding,
+    Encoding stderrEncoding = io.systemEncoding,
   }) async {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     await process.exitCode;
-    return ProcessResult(
+    return io.ProcessResult(
       process.pid,
       process._exitCode,
       stdoutEncoding == null ? process.stdout : await stdoutEncoding.decodeStream(process.stdout),
@@ -290,17 +288,17 @@ abstract class FakeProcessManager implements ProcessManager {
   }
 
   @override
-  ProcessResult runSync(
+  io.ProcessResult runSync(
     List<dynamic> command, {
     String workingDirectory,
     Map<String, String> environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
-    Encoding stdoutEncoding = systemEncoding, // actual encoder is ignored
-    Encoding stderrEncoding = systemEncoding, // actual encoder is ignored
+    Encoding stdoutEncoding = io.systemEncoding, // actual encoder is ignored
+    Encoding stderrEncoding = io.systemEncoding, // actual encoder is ignored
   }) {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
-    return ProcessResult(
+    return io.ProcessResult(
       process.pid,
       process._exitCode,
       stdoutEncoding == null ? utf8.encode(process._stdout) : process._stdout,

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -11,7 +11,9 @@ import 'dart:io' as io show ProcessSignal, Process, ProcessStartMode, ProcessRes
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
-import 'package:test/test.dart';
+
+import 'test_wrapper.dart';
+
 export 'package:process/process.dart' show ProcessManager;
 
 typedef VoidCallback = void Function();

--- a/packages/flutter_tools/test/src/test_wrapper.dart
+++ b/packages/flutter_tools/test/src/test_wrapper.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:test_api/test_api.dart' as test_package show TypeMatcher; // ignore: deprecated_member_use
+import 'package:test_api/test_api.dart' hide TypeMatcher, isInstanceOf; // ignore: deprecated_member_use
+// ignore: deprecated_member_use
+export 'package:test_core/test_core.dart' hide TypeMatcher, isInstanceOf, test; // Defines a 'package:test' shim.
+
+/// A matcher that compares the type of the actual value to the type argument T.
+// TODO(ianh): Remove this once https://github.com/dart-lang/matcher/issues/98 is fixed
+test_package.TypeMatcher<T> isInstanceOf<T>() => isA<T>();


### PR DESCRIPTION
To allow replacing the mocks used in dev/** without requiring they depend on the entire flutter tool
