### PR TITLE
Fix UNNECESSARY_TYPE_CHECK_TRUE hints.

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -126,7 +126,6 @@ class PaintingContext extends ClipContext {
       // layer for repaint boundaries.
       child._layer = childLayer = OffsetLayer();
     } else {
-      assert(childLayer is OffsetLayer);
       assert(debugAlsoPaintedParent || childLayer.attached);
       childLayer.removeAllChildren();
     }

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -465,9 +465,8 @@ class SliverConstraints extends Constraints {
       return true;
     if (other is! SliverConstraints)
       return false;
-    assert(other is SliverConstraints && other.debugAssertIsValid());
-    return other is SliverConstraints
-        && other.axisDirection == axisDirection
+    assert(other.debugAssertIsValid());
+    return other.axisDirection == axisDirection
         && other.growthDirection == growthDirection
         && other.scrollOffset == scrollOffset
         && other.overlap == overlap

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3965,7 +3965,6 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     assert(_debugCheckStateIsActiveForAncestorLookup());
     final InheritedElement? ancestor = _inheritedWidgets == null ? null : _inheritedWidgets![T];
     if (ancestor != null) {
-      assert(ancestor is InheritedElement);
       return dependOnInheritedElement(ancestor, aspect: aspect) as T;
     }
     _hadUnsatisfiedDependencies = true;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1328,7 +1328,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     final TapGestureRecognizer? tap = recognizers[TapGestureRecognizer] as TapGestureRecognizer?;
     if (tap == null)
       return null;
-    assert(tap is TapGestureRecognizer);
 
     return () {
       assert(tap != null);
@@ -1347,7 +1346,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
       return null;
 
     return () {
-      assert(longPress is LongPressGestureRecognizer);
       if (longPress.onLongPressStart != null)
         longPress.onLongPressStart!(const LongPressStartDetails());
       if (longPress.onLongPress != null)
@@ -1366,7 +1364,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     final GestureDragUpdateCallback? horizontalHandler = horizontal == null ?
       null :
       (DragUpdateDetails details) {
-        assert(horizontal is HorizontalDragGestureRecognizer);
         if (horizontal.onDown != null)
           horizontal.onDown!(DragDownDetails());
         if (horizontal.onStart != null)
@@ -1380,7 +1377,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     final GestureDragUpdateCallback? panHandler = pan == null ?
       null :
       (DragUpdateDetails details) {
-        assert(pan is PanGestureRecognizer);
         if (pan.onDown != null)
           pan.onDown!(DragDownDetails());
         if (pan.onStart != null)
@@ -1408,7 +1404,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     final GestureDragUpdateCallback? verticalHandler = vertical == null ?
       null :
       (DragUpdateDetails details) {
-        assert(vertical is VerticalDragGestureRecognizer);
         if (vertical.onDown != null)
           vertical.onDown!(DragDownDetails());
         if (vertical.onStart != null)
@@ -1422,7 +1417,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
     final GestureDragUpdateCallback? panHandler = pan == null ?
       null :
       (DragUpdateDetails details) {
-        assert(pan is PanGestureRecognizer);
         if (pan.onDown != null)
           pan.onDown!(DragDownDetails());
         if (pan.onStart != null)

--- a/packages/flutter/test/services/message_codecs_test.dart
+++ b/packages/flutter/test/services/message_codecs_test.dart
@@ -55,7 +55,6 @@ void main() {
       expect(
           () => method.decodeEnvelope(errorData),
           throwsA(predicate((PlatformException e) =>
-              e is PlatformException &&
               e.code == 'errorCode' &&
               e.message == 'errorMessage' &&
               e.details == 'errorDetails')));
@@ -71,7 +70,7 @@ void main() {
       expect(
           () => method.decodeEnvelope(errorData),
           throwsA(predicate((PlatformException e) =>
-              e is PlatformException && e.stacktrace == 'errorStacktrace')));
+              e.stacktrace == 'errorStacktrace')));
     });
 
     test('should allow null error message,', () {
@@ -84,8 +83,7 @@ void main() {
         () => method.decodeEnvelope(errorData),
         throwsA(
           predicate((PlatformException e) {
-            return e is PlatformException &&
-              e.code == 'errorCode' &&
+            return e.code == 'errorCode' &&
               e.message == null &&
               e.details == 'errorDetails';
           }),
@@ -106,7 +104,6 @@ void main() {
       expect(
           () => jsonMethodCodec.decodeEnvelope(errorData),
           throwsA(predicate((PlatformException e) =>
-              e is PlatformException &&
               e.code == 'errorCode' &&
               e.message == 'errorMessage' &&
               e.details == 'errorDetails')));
@@ -122,7 +119,7 @@ void main() {
       expect(
           () => jsonMethodCodec.decodeEnvelope(errorData!),
           throwsA(predicate((PlatformException e) =>
-              e is PlatformException && e.stacktrace == 'errorStacktrace')));
+              e.stacktrace == 'errorStacktrace')));
     });
   });
   group('JSON message codec', () {


### PR DESCRIPTION
Dart analyzer is going to start reporting `UNNECESSARY_TYPE_CHECK_TRUE` in null safe code.
https://dart-review.googlesource.com/c/sdk/+/190360

So, we need to fix existing violations in Flutter.