### PR TITLE
Implement iOS app install deltas

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -414,6 +414,10 @@ abstract class IOSApp extends ApplicationPackage {
   String get simulatorBundlePath;
 
   String get deviceBundlePath;
+
+  /// Directory used by ios-deploy to store incremental installation metadata for
+  /// faster second installs.
+  Directory get appDeltaDirectory;
 }
 
 class BuildableIOSApp extends IOSApp {
@@ -439,6 +443,9 @@ class BuildableIOSApp extends IOSApp {
 
   @override
   String get deviceBundlePath => _buildAppPath('iphoneos');
+
+  @override
+  Directory get appDeltaDirectory => globals.fs.directory(globals.fs.path.join(getIosBuildDirectory(), 'app-delta'));
 
   // Xcode uses this path for the final archive bundle location,
   // not a top-level output directory.
@@ -467,6 +474,9 @@ class PrebuiltIOSApp extends IOSApp {
 
   final Directory bundleDir;
   final String bundleName;
+
+  @override
+  final Directory appDeltaDirectory = null;
 
   @override
   String get name => bundleName;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -258,6 +258,7 @@ class IOSDevice extends Device {
       installationResult = await _iosDeploy.installApp(
         deviceId: id,
         bundlePath: bundle.path,
+        appDeltaDirectory: app.appDeltaDirectory,
         launchArguments: <String>[],
         interfaceType: interfaceType,
       );
@@ -384,6 +385,7 @@ class IOSDevice extends Device {
           iosDeployDebugger = _iosDeploy.prepareDebuggerForLaunch(
             deviceId: id,
             bundlePath: bundle.path,
+            appDeltaDirectory: package.appDeltaDirectory,
             launchArguments: launchArguments,
             interfaceType: interfaceType,
           );
@@ -404,6 +406,7 @@ class IOSDevice extends Device {
         installationResult = await _iosDeploy.launchApp(
           deviceId: id,
           bundlePath: bundle.path,
+          appDeltaDirectory: package.appDeltaDirectory,
           launchArguments: launchArguments,
           interfaceType: interfaceType,
         );

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -11,6 +11,7 @@ import 'package:process/process.dart';
 
 import '../artifacts.dart';
 import '../base/common.dart';
+import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
@@ -89,15 +90,21 @@ class IOSDeploy {
   Future<int> installApp({
     @required String deviceId,
     @required String bundlePath,
+    @required Directory appDeltaDirectory,
     @required List<String>launchArguments,
     @required IOSDeviceInterface interfaceType,
   }) async {
+    appDeltaDirectory?.createSync(recursive: true);
     final List<String> launchCommand = <String>[
       _binaryPath,
       '--id',
       deviceId,
       '--bundle',
       bundlePath,
+      if (appDeltaDirectory != null) ...<String>[
+        '--app_deltas',
+        appDeltaDirectory.path,
+      ],
       if (interfaceType != IOSDeviceInterface.network)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
@@ -121,9 +128,11 @@ class IOSDeploy {
   IOSDeployDebugger prepareDebuggerForLaunch({
     @required String deviceId,
     @required String bundlePath,
+    @required Directory appDeltaDirectory,
     @required List<String> launchArguments,
     @required IOSDeviceInterface interfaceType,
   }) {
+    appDeltaDirectory?.createSync(recursive: true);
     // Interactive debug session to support sending the lldb detach command.
     final List<String> launchCommand = <String>[
       'script',
@@ -135,6 +144,10 @@ class IOSDeploy {
       deviceId,
       '--bundle',
       bundlePath,
+      if (appDeltaDirectory != null) ...<String>[
+        '--app_deltas',
+        appDeltaDirectory.path,
+      ],
       '--debug',
       if (interfaceType != IOSDeviceInterface.network)
         '--no-wifi',
@@ -157,15 +170,21 @@ class IOSDeploy {
   Future<int> launchApp({
     @required String deviceId,
     @required String bundlePath,
+    @required Directory appDeltaDirectory,
     @required List<String> launchArguments,
     @required IOSDeviceInterface interfaceType,
   }) async {
+    appDeltaDirectory?.createSync(recursive: true);
     final List<String> launchCommand = <String>[
       _binaryPath,
       '--id',
       deviceId,
       '--bundle',
       bundlePath,
+      if (appDeltaDirectory != null) ...<String>[
+        '--app_deltas',
+        appDeltaDirectory.path,
+      ],
       if (interfaceType != IOSDeviceInterface.network)
         '--no-wifi',
       '--justlaunch',

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -426,18 +426,24 @@ Future<XcodeBuildResult> buildXcodeProject({
         targetBuildDir,
         buildSettings['WRAPPER_NAME'],
       );
-      if (globals.fs.isDirectorySync(expectedOutputDirectory)) {
+      if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
         // Copy app folder to a place where other tools can find it without knowing
         // the BuildInfo.
-        outputDir = expectedOutputDirectory.replaceFirst('/$configuration-', '/');
-        if (globals.fs.isDirectorySync(outputDir)) {
-          // Previous output directory might have incompatible artifacts
-          // (for example, kernel binary files produced from previous run).
-          globals.fs.directory(outputDir).deleteSync(recursive: true);
-        }
-        copyDirectory(
-          globals.fs.directory(expectedOutputDirectory),
-          globals.fs.directory(outputDir),
+        outputDir = targetBuildDir.replaceFirst('/$configuration-', '/');
+        globals.fs.directory(outputDir).createSync(recursive: true);
+
+        // rsync instead of copy to maintain timestamps to support incremental
+        // app install deltas. Use --delete to remove incompatible artifacts
+        // (for example, kernel binary files produced from previous run).
+        await globals.processUtils.run(
+          <String>[
+            'rsync',
+            '-av',
+            '--delete',
+            expectedOutputDirectory,
+            outputDir,
+          ],
+          throwOnError: true,
         );
       } else {
         globals.printError('Build succeeded but the expected app at $expectedOutputDirectory not found');


### PR DESCRIPTION
Incremental iOS installs (app-deltas) are an Xcode feature exposed by ios-deploy in https://github.com/ios-control/ios-deploy/pull/434 that saves a representation of the app to a place on disk, then only copies the deltas over when installing.  Only implemented for `BuildableIOSApp` at `build/ios/app-deltas`, not `PrebuiltIOSApp` since I wasn't sure where the app deltas directory should live.

The app delta calculations are based on time stamp changes, not on file content hashes, so instead of deleting `build/ios/iphoneos` and copying the app bundle on every build, instead `rsync` the bundle so it only updates changed files, thus preserving the timestamps of unchanged files.

I ran some numbers (on my machine an an iPhone 6s) building and installing the new non-trivial [gallery app](https://github.com/flutter/gallery) after a `flutter clean`
The first number is the amount of time `flutter run` takes where I force an exit as soon as the app is launched.  The second number is the same, run a second time with no `clean`.

|   | stable      | master |  this PR |
| ----------- | ----------- | ----------- | ----------- |
| 1st | 1:15.08      | 1:14.95       | 1:17.53 |
| 2nd | 48.379   |   45.479      |31.096 |

So the improvements with thinning (https://github.com/flutter/flutter/pull/76834 and https://github.com/flutter/flutter/pull/77007), bitcode stripping (https://github.com/flutter/flutter/pull/77329), and codesigning (https://github.com/flutter/flutter/pull/77664) improved matters by ~3 seconds.  App deltas gave us another ~14 seconds.  It also cost us ~3 seconds on a first run, presumably to build the initial app-delta disk representation.

Note as long as `flutter clean` isn't run this will also be an improvement if any dart code changes and the `App.framework` needs to be recompiled, since the large `Flutter.framework` and plugin frameworks won't be copied over on subsequent installs.

`BuildableIOSApp` part of https://github.com/flutter/flutter/issues/67580.