### PR TITLE
[FloatingActionButtonLocation] Avoid docked FAB to be clipped by the software keyboard

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -584,7 +584,13 @@ mixin FabDockedOffsetY on StandardFabLocation {
     final double bottomSheetHeight = scaffoldGeometry.bottomSheetSize.height;
     final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
     final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
-    final double safeMargin = bottomViewPadding > contentMargin ? bottomViewPadding : 0.0;
+    final double bottomMinInset = scaffoldGeometry.minInsets.bottom;
+
+    final double safeMargin = bottomMinInset + fabHeight / 2.0 < contentMargin
+        ? 0.0
+        : bottomMinInset == 0.0
+            ? bottomViewPadding
+            : fabHeight / 2.0 + kFloatingActionButtonMargin;
 
     double fabY = contentBottom - fabHeight / 2.0 - safeMargin;
     // The FAB should sit with a margin between it and the snack bar.

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -586,11 +586,21 @@ mixin FabDockedOffsetY on StandardFabLocation {
     final double snackBarHeight = scaffoldGeometry.snackBarSize.height;
     final double bottomMinInset = scaffoldGeometry.minInsets.bottom;
 
-    final double safeMargin = bottomMinInset + fabHeight / 2.0 < contentMargin
-        ? 0.0
-        : bottomMinInset == 0.0
-            ? bottomViewPadding
-            : fabHeight / 2.0 + kFloatingActionButtonMargin;
+    double safeMargin;
+
+    if (contentMargin > bottomMinInset + fabHeight / 2.0) {
+      // If contentMargin is higher than bottomMinInset enough to display the
+      // FAB without clipping, don't provide a margin
+      safeMargin = 0.0;
+    } else if (bottomMinInset == 0.0) {
+      // If bottomMinInset is zero(the software keyboard is not on the screen)
+      // provide bottomViewPadding as margin
+      safeMargin = bottomViewPadding;
+    } else {
+      // Provide a margin that would shift the FAB enough so that it stays away
+      // from the keyboard
+      safeMargin = fabHeight / 2.0 + kFloatingActionButtonMargin;
+    }
 
     double fabY = contentBottom - fabHeight / 2.0 - safeMargin;
     // The FAB should sit with a margin between it and the snack bar.

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -1037,7 +1037,9 @@ void main() {
       );
     });
 
-    // Test docked locations, for each (6), keyboard presented or not:
+    // Test docked locations, for each (6), keyboard presented or not.
+    // If keyboard is presented and resizeToAvoidBottomInset: true, test whether
+    // the FAB is away from the keyboard(and thus not clipped):
     //  - Default
     //  - Default with resizeToAvoidBottomInset: false
     //  - docked with BottomNavigationBar
@@ -1057,6 +1059,7 @@ void main() {
       const double keyboardHeight = 200.0;
       const double viewPadding = 50.0;
       const double bottomNavHeight = 106.0;
+      const double scaffoldHeight = 600.0;
       final Key floatingActionButton = UniqueKey();
       final double fabHeight = mini ? 48.0 : 56.0;
       // Default
@@ -1086,6 +1089,11 @@ void main() {
           0.0,
           viewPadding - keyboardHeight - kFloatingActionButtonMargin,
         )),
+      );
+      // The FAB should be away from the keyboard
+      expect(
+        tester.getRect(find.byKey(floatingActionButton)).bottom,
+        lessThan(scaffoldHeight - keyboardHeight),
       );
 
       // With resizeToAvoidBottomInset: false
@@ -1138,6 +1146,11 @@ void main() {
           0.0,
           bottomNavHeight + fabHeight / 2.0 - keyboardHeight - kFloatingActionButtonMargin - fabHeight,
         )),
+      );
+      // The FAB should be away from the keyboard
+      expect(
+        tester.getRect(find.byKey(floatingActionButton)).bottom,
+        lessThan(scaffoldHeight - keyboardHeight),
       );
 
       // BottomNavigationBar with resizeToAvoidBottomInset: false
@@ -1194,6 +1207,11 @@ void main() {
           0.0,
           -keyboardHeight + bottomNavHeight,
         )),
+      );
+      // The FAB should be away from the keyboard
+      expect(
+        tester.getRect(find.byKey(floatingActionButton)).bottom,
+        lessThan(scaffoldHeight - keyboardHeight),
       );
 
       // BottomNavigationBar + BottomSheet with resizeToAvoidBottomInset: false
@@ -1263,6 +1281,11 @@ void main() {
       expect(
         tester.getRect(find.byKey(floatingActionButton)),
         rectMoreOrLessEquals(snackBarRect.translate(0.0, -keyboardHeight)),
+      );
+      // The FAB should be away from the keyboard
+      expect(
+        tester.getRect(find.byKey(floatingActionButton)).bottom,
+        lessThan(scaffoldHeight - keyboardHeight),
       );
     }
 

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -1084,7 +1084,7 @@ void main() {
         tester.getRect(find.byKey(floatingActionButton)),
         rectMoreOrLessEquals(defaultRect.translate(
           0.0,
-          viewPadding - keyboardHeight + fabHeight / 2.0,
+          viewPadding - keyboardHeight - kFloatingActionButtonMargin,
         )),
       );
 
@@ -1136,7 +1136,7 @@ void main() {
         tester.getRect(find.byKey(floatingActionButton)),
         rectMoreOrLessEquals(bottomNavigationBarRect.translate(
           0.0,
-          -keyboardHeight + bottomNavHeight,
+          bottomNavHeight + fabHeight / 2.0 - keyboardHeight - kFloatingActionButtonMargin - fabHeight,
         )),
       );
 


### PR DESCRIPTION
This PR adjusts the margin applied to a docked `FloatingActionButton` to avoid the software keyboard when invoked.

The docked FAB would detach from `Scaffold.bottomNavigationBar` and behave like a floating FAB placed above the keyboard with a margin of `kFloatingActionButtonMargin`.

|Before|After|
|-------|------|
|![before](https://user-images.githubusercontent.com/44899587/110581022-bf9d5e00-818f-11eb-9a5a-4859622765d8.gif)|![after](https://user-images.githubusercontent.com/44899587/110581039-caf08980-818f-11eb-9949-d0d7771521bb.gif)|

## Related Issues

Fixes #26100.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
