### PR TITLE
Rename 'moduleName' to 'componentName'

### DIFF
--- a/packages/flutter/lib/src/services/deferred_component.dart
+++ b/packages/flutter/lib/src/services/deferred_component.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'system_channels.dart';
 
-/// Manages the installation and loading of deferred component modules.
+/// Manages the installation and loading of deferred components.
 ///
 /// Deferred components allow Flutter applications to download precompiled AOT
 /// dart code and assets at runtime, reducing the install size of apps and
@@ -25,12 +25,12 @@ class DeferredComponent {
   // prevents instantiation and extension.
   DeferredComponent._();
 
-  // TODO(garyq): We should eventually expand this to install modules by loadingUnitId
-  // as well as moduleName, but currently, loadingUnitId is opaque to the dart code
+  // TODO(garyq): We should eventually expand this to install components by loadingUnitId
+  // as well as componentName, but currently, loadingUnitId is opaque to the dart code
   // so this is not possible. The API has been left flexible to allow adding
   // loadingUnitId as a parameter.
 
-  /// Requests that an assets-only deferred component identified by the [moduleName]
+  /// Requests that an assets-only deferred component identified by the [componentName]
   /// be downloaded and installed.
   ///
   /// This method returns a Future<void> that will complete when the feature is
@@ -45,14 +45,14 @@ class DeferredComponent {
   /// library loading process. For example:
   ///
   /// ```dart
-  /// import 'split_module.dart' deferred as SplitModule;
+  /// import 'split_component.dart' deferred as SplitComponent;
   /// ...
-  /// SplitModule.loadLibrary();
+  /// SplitComponent.loadLibrary();
   /// ```
   ///
-  /// This method will not load associated dart libraries contained in the dynamic
-  /// feature module, though it will download the files necessary and subsequent
-  /// calls to `loadLibrary()` to load will complete faster.
+  /// This method will not load associated dart libraries contained in the component,
+  /// though it will download the files necessary and subsequent calls to `loadLibrary()`
+  /// to load will complete faster.
   ///
   /// Assets installed by this method may be accessed in the same way as any other
   /// local asset by providing a string path to the asset.
@@ -63,14 +63,14 @@ class DeferredComponent {
   ///  * [loadLibrary](https://api.dart.dev/dart-mirrors/LibraryDependencyMirror/loadLibrary.html),
   ///    the dart method to trigger the installation of the corresponding deferred component that
   ///    contains the dart library.
-  static Future<void> installDeferredComponent({required String moduleName}) async {
+  static Future<void> installDeferredComponent({required String componentName}) async {
     await SystemChannels.deferredComponent.invokeMethod<void>(
       'installDeferredComponent',
-      <String, dynamic>{ 'loadingUnitId': -1, 'moduleName': moduleName },
+      <String, dynamic>{ 'loadingUnitId': -1, 'componentName': componentName },
     );
   }
 
-  /// Requests that a deferred component identified by the [moduleName] be
+  /// Requests that a deferred component identified by the [componentName] be
   /// uninstalled.
   ///
   /// Since uninstallation typically requires significant disk i/o, this method only
@@ -91,10 +91,10 @@ class DeferredComponent {
   ///  * [loadLibrary](https://api.dart.dev/dart-mirrors/LibraryDependencyMirror/loadLibrary.html),
   ///    the dart method to trigger the installation of the corresponding deferred component that
   ///    contains the dart library.
-  static Future<void> uninstallDeferredComponent({required String moduleName}) async {
+  static Future<void> uninstallDeferredComponent({required String componentName}) async {
     await SystemChannels.deferredComponent.invokeMethod<void>(
       'uninstallDeferredComponent',
-      <String, dynamic>{ 'loadingUnitId': -1, 'moduleName': moduleName },
+      <String, dynamic>{ 'loadingUnitId': -1, 'componentName': componentName },
     );
   }
 }

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -324,17 +324,16 @@ class SystemChannels {
   /// [OptionalMethodChannel.invokeMethod]):
   ///
   ///  * `installDeferredComponent`: Requests that a deferred component identified by
-  ///    the provided loadingUnitId or moduleName be downloaded and installed.
-  ///    Providing a loadingUnitId with null moduleName will install a dynamic
-  ///    feature module that includes the desired loading unit. If a moduleName
-  ///    is provided, then the deferred component with the moduleName will be installed.
-  ///    This method returns a future that will not be completed until the
-  ///    feature is fully installed and ready to use. When an error occurs, the
-  ///    future will complete an error. Calling `loadLibrary()` on a deferred
-  ///    imported library is equivalent to calling this method with a
-  ///    loadingUnitId and null moduleName.
+  ///    the provided loadingUnitId or componentName be downloaded and installed.
+  ///    Providing a loadingUnitId with null componentName will install a component that
+  ///    includes the desired loading unit. If a componentName is provided, then the
+  ///    deferred component with the componentName will be installed. This method
+  ///    returns a future that will not be completed until the feature is fully installed
+  ///    and ready to use. When an error occurs, the future will complete an error.
+  ///    Calling `loadLibrary()` on a deferred imported library is equivalent to calling
+  ///    this method with a loadingUnitId and null componentName.
   ///  * `uninstallDeferredComponent`:  Requests that a deferred component identified by
-  ///    the provided loadingUnitId or moduleName be uninstalled. Since
+  ///    the provided loadingUnitId or componentName be uninstalled. Since
   ///    uninstallation typically requires significant disk i/o, this method only
   ///    signals the intent to uninstall. Actual uninstallation (eg, removal of
   ///    assets and files) may occur at a later time. However, once uninstallation

--- a/packages/flutter/test/services/deferred_component_test.dart
+++ b/packages/flutter/test/services/deferred_component_test.dart
@@ -15,12 +15,12 @@ void main() {
       log.add(methodCall);
     });
 
-    await DeferredComponent.installDeferredComponent(moduleName: 'testModuleName');
+    await DeferredComponent.installDeferredComponent(componentName: 'testComponentName');
 
     expect(log, hasLength(1));
     expect(log.single, isMethodCall(
       'installDeferredComponent',
-      arguments: <String, dynamic>{'loadingUnitId': -1, 'moduleName': 'testModuleName'},
+      arguments: <String, dynamic>{'loadingUnitId': -1, 'componentName': 'testComponentName'},
     ));
   });
 
@@ -31,12 +31,12 @@ void main() {
       log.add(methodCall);
     });
 
-    await DeferredComponent.uninstallDeferredComponent(moduleName: 'testModuleName');
+    await DeferredComponent.uninstallDeferredComponent(componentName: 'testComponentName');
 
     expect(log, hasLength(1));
     expect(log.single, isMethodCall(
       'uninstallDeferredComponent',
-      arguments: <String, dynamic>{'loadingUnitId': -1, 'moduleName': 'testModuleName'},
+      arguments: <String, dynamic>{'loadingUnitId': -1, 'componentName': 'testComponentName'},
     ));
   });
 }


### PR DESCRIPTION
Renames all instances of moduleName to componentName to avoid referencing android modules, which is play store implementation specific. Instead, we refer to it by componentName which is a flutter concept and is equivalent to the android module name in the default implementation.

Continued from engine-side: https://github.com/flutter/engine/pull/24906