### PR TITLE
[FloatingActionButtonLocation] Add spacing between placement entries in documentation

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -66,73 +66,91 @@ const double kMiniButtonOffsetAdjustment = 4.0;
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_center_docked.png)
 ///
+///
 /// * [FloatingActionButtonLocation.centerFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_center_float.png)
+///
 ///
 /// * [FloatingActionButtonLocation.centerTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_center_top.png)
 ///
+///
 /// * [FloatingActionButtonLocation.endDocked]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_end_docked.png)
+///
 ///
 /// * [FloatingActionButtonLocation.endFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_end_float.png)
 ///
+///
 /// * [FloatingActionButtonLocation.endTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_end_top.png)
+///
 ///
 /// * [FloatingActionButtonLocation.startDocked]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_start_docked.png)
 ///
+///
 /// * [FloatingActionButtonLocation.startFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_start_float.png)
+///
 ///
 /// * [FloatingActionButtonLocation.startTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_start_top.png)
 ///
+///
 /// * [FloatingActionButtonLocation.miniCenterDocked]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_center_docked.png)
+///
 ///
 /// * [FloatingActionButtonLocation.miniCenterFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_center_float.png)
 ///
+///
 /// * [FloatingActionButtonLocation.miniCenterTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_center_top.png)
+///
 ///
 /// * [FloatingActionButtonLocation.miniEndDocked]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_end_docked.png)
 ///
+///
 /// * [FloatingActionButtonLocation.miniEndFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_end_float.png)
+///
 ///
 /// * [FloatingActionButtonLocation.miniEndTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_end_top.png)
 ///
+///
 /// * [FloatingActionButtonLocation.miniStartDocked]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_start_docked.png)
+///
 ///
 /// * [FloatingActionButtonLocation.miniStartFloat]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_start_float.png)
 ///
+///
 /// * [FloatingActionButtonLocation.miniStartTop]:
 ///
 ///   ![](https://flutter.github.io/assets-for-api-docs/assets/material/floating_action_button_location_mini_start_top.png)
+///
 ///
 /// See also:
 ///


### PR DESCRIPTION
This PR adds a bunch of newlines to make the placement entries of the `FloatingActionButtonLocation` docs a bit separated for better readability.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
