### PR TITLE
Make LocalFileComparator.compare easier to override

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -91,16 +91,9 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
 
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-    final File goldenFile = _getGoldenFile(golden);
-    if (!goldenFile.existsSync()) {
-      throw test_package.TestFailure(
-        'Could not be compared against non-existent file: "$golden"'
-      );
-    }
-    final List<int> goldenBytes = await goldenFile.readAsBytes();
     final ComparisonResult result = await GoldenFileComparator.compareLists(
       imageBytes,
-      goldenBytes,
+      await getGoldenBytes(golden),
     );
 
     if (!result.passed) {
@@ -117,9 +110,22 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
     await goldenFile.writeAsBytes(imageBytes, flush: true);
   }
 
-  File _getGoldenFile(Uri golden) {
-    return File(_path.join(_path.fromUri(basedir), _path.fromUri(golden.path)));
+  /// Returns the bytes of the given [golden] file.
+  ///
+  /// If the file cannot be found, an error will be thrown.
+  @protected
+  Future<List<int>> getGoldenBytes(Uri golden) async {
+    final File goldenFile = _getGoldenFile(golden);
+    if (!goldenFile.existsSync()) {
+      throw test_package.TestFailure(
+        'Could not be compared against non-existent file: "$golden"'
+      );
+    }
+    final List<int> goldenBytes = await goldenFile.readAsBytes();
+    return goldenBytes;
   }
+
+  File _getGoldenFile(Uri golden) => File(_path.join(_path.fromUri(basedir), _path.fromUri(golden.path)));
 }
 
 /// A class for use in golden file comparators that run locally and provide


### PR DESCRIPTION
In setting up a custom comparator for flutter/cocoon, I realized it is not very easy to override the compare function.
This refactors things a bit to fix that.
Related to https://github.com/flutter/flutter/issues/76337

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
