### PR TITLE
Enable prefer_mixin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -171,7 +171,7 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    - prefer_mixin
     - prefer_null_aware_operators
     # - prefer_relative_imports # incompatible with sub-package imports
     - prefer_single_quotes

--- a/dev/benchmarks/microbenchmarks/lib/foundation/change_notifier_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/change_notifier_bench.dart
@@ -111,6 +111,6 @@ void main() {
   printer.printToStdout();
 }
 
-class _Notifier extends ChangeNotifier {
+class _Notifier with ChangeNotifier {
   void notify() => notifyListeners();
 }

--- a/dev/benchmarks/test_apps/stocks/lib/stock_data.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_data.dart
@@ -38,7 +38,7 @@ class Stock {
   double percentChange;
 }
 
-class StockData extends ChangeNotifier {
+class StockData with ChangeNotifier {
   StockData() {
     if (actuallyFetchData) {
       _httpClient = http.Client();

--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_board.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_board.dart
@@ -11,7 +11,7 @@ import 'package:vector_math/vector_math_64.dart' show Vector3;
 // The entire state of the hex board and abstraction to get information about
 // it. Iterable so that all BoardPoints on the board can be iterated over.
 @immutable
-class Board extends Object with IterableMixin<BoardPoint?> {
+class Board extends IterableMixin<BoardPoint?> {
   Board({
     required this.boardRadius,
     required this.hexagonRadius,

--- a/dev/integration_tests/flutter_gallery/test_memory/back_button.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/back_button.dart
@@ -17,7 +17,7 @@ Future<void> endOfAnimation() async {
 
 int iteration = 0;
 
-class LifecycleObserver extends WidgetsBindingObserver {
+class LifecycleObserver with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     debugPrint('==== MEMORY BENCHMARK ==== $state ====');

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -44,7 +44,7 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => _MyHomePageState();
 }
 
-class OptionModel extends ChangeNotifier {
+class OptionModel with ChangeNotifier {
   double get size => _size;
   double _size = 1.0;
   set size(double size) {

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -62,7 +62,7 @@ import 'theme.dart';
 ///    controlled by a [CupertinoTabController].
 ///  * [RestorableCupertinoTabController], which is a restorable version
 ///    of this controller.
-class CupertinoTabController extends ChangeNotifier {
+class CupertinoTabController with ChangeNotifier {
   /// Creates a [CupertinoTabController] to control the tab index of [CupertinoTabScaffold]
   /// and [CupertinoTabBar].
   ///

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -99,8 +99,8 @@ class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
   final VoidCallback listener;
 }
 
-/// A class that can be extended or mixed in that provides a change notification
-/// API using [VoidCallback] for notifications.
+/// A mixin that provides a change notification API using [VoidCallback] for
+/// notifications.
 ///
 /// It is O(1) for adding listeners and O(N) for removing listeners and dispatching
 /// notifications (where N is the number of listeners).
@@ -108,7 +108,7 @@ class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
 /// See also:
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
-class ChangeNotifier implements Listenable {
+mixin ChangeNotifier implements Listenable {
   LinkedList<_ListenerEntry>? _listeners = LinkedList<_ListenerEntry>();
 
   bool _debugAssertNotDisposed() {
@@ -290,7 +290,7 @@ class _MergingListenable extends Listenable {
 /// When [value] is replaced with something that is not equal to the old
 /// value as evaluated by the equality operator ==, this class notifies its
 /// listeners.
-class ValueNotifier<T> extends ChangeNotifier implements ValueListenable<T> {
+class ValueNotifier<T> with ChangeNotifier implements ValueListenable<T>  {
   /// Creates a [ChangeNotifier] that wraps this value.
   ValueNotifier(this._value);
 

--- a/packages/flutter/lib/src/material/data_table_source.dart
+++ b/packages/flutter/lib/src/material/data_table_source.dart
@@ -18,7 +18,7 @@ import 'data_table.dart';
 ///
 /// DataTableSource objects are expected to be long-lived, not recreated with
 /// each build.
-abstract class DataTableSource extends ChangeNotifier {
+abstract class DataTableSource with ChangeNotifier {
   /// Called to obtain the data about a particular row.
   ///
   /// The [new DataRow.byIndex] constructor provides a convenient way to construct

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -21,7 +21,7 @@ const double _kFinalLabelScale = 0.75;
 
 // Defines the gap in the InputDecorator's outline border where the
 // floating label will appear.
-class _InputBorderGap extends ChangeNotifier {
+class _InputBorderGap with ChangeNotifier {
   double? _start;
   double? get start => _start;
   set start(double? value) {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -698,7 +698,7 @@ class ScaffoldGeometry {
   }
 }
 
-class _ScaffoldGeometryNotifier extends ChangeNotifier implements ValueListenable<ScaffoldGeometry> {
+class _ScaffoldGeometryNotifier with ChangeNotifier implements ValueListenable<ScaffoldGeometry> {
   _ScaffoldGeometryNotifier(this.geometry, this.context)
     : assert (context != null);
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1423,7 +1423,7 @@ abstract class RangeSliderTrackShape {
 ///    rectangular edges
 ///  * [RoundedRectSliderTrackShape], which is a track shape with round
 ///    stadium-like edges.
-abstract class BaseSliderTrackShape {
+mixin BaseSliderTrackShape {
   /// Returns a rect that represents the track bounds that fits within the
   /// [Slider].
   ///

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -136,7 +136,7 @@ import 'constants.dart';
 /// ```
 /// {@end-tool}
 ///
-class TabController extends ChangeNotifier {
+class TabController with ChangeNotifier {
   /// Creates an object that manages the state required by [TabBar] and a
   /// [TabBarView].
   ///

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -341,7 +341,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
 /// Subclasses must implement the [paint] method to draw the actual visuals of
 /// the Toggleable. In their [paint] method subclasses may call
 /// [paintRadialReaction] to draw a radial ink reaction for this control.
-abstract class ToggleablePainter extends ChangeNotifier implements CustomPainter  {
+abstract class ToggleablePainter with ChangeNotifier implements CustomPainter  {
   /// The visual value of the control.
   ///
   /// Usually set to [ToggleableStateMixin.position].

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2457,7 +2457,7 @@ class _RenderEditableCustomPaint extends RenderBox {
 ///  * [RenderEditable.painter], which takes a [RenderEditablePainter]
 ///    and sets it as the background painter of the [RenderEditable].
 ///  * [CustomPainter] a similar class which paints within a [RenderCustomPaint].
-abstract class RenderEditablePainter extends ChangeNotifier {
+abstract class RenderEditablePainter with ChangeNotifier {
 
   /// Determines whether repaint is needed when a new [RenderEditablePainter]
   /// is provided to a [RenderEditable].

--- a/packages/flutter/lib/src/rendering/mouse_tracking.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracking.dart
@@ -278,7 +278,7 @@ class MouseTrackerUpdateDetails with Diagnosticable {
 ///     of how to process mouse event callbacks and mouse cursors.
 ///   * [MouseTrackerCursorMixin], which is a mixin for [BaseMouseTracker] that
 ///     defines how to process mouse cursors.
-abstract class BaseMouseTracker extends ChangeNotifier {
+abstract class BaseMouseTracker with ChangeNotifier {
   /// Whether or not at least one mouse is connected and has produced events.
   bool get mouseIsConnected => _mouseStates.isNotEmpty;
 

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1597,8 +1597,7 @@ abstract class RenderSliver extends RenderObject {
 }
 
 /// Mixin for [RenderSliver] subclasses that provides some utility functions.
-abstract class RenderSliverHelpers implements RenderSliver {
-
+mixin RenderSliverHelpers implements RenderSliver {
   bool _getRightWayUp(SliverConstraints constraints) {
     assert(constraints != null);
     assert(constraints.axisDirection != null);

--- a/packages/flutter/lib/src/rendering/viewport_offset.dart
+++ b/packages/flutter/lib/src/rendering/viewport_offset.dart
@@ -63,7 +63,7 @@ ScrollDirection flipScrollDirection(ScrollDirection direction) {
 ///  * [ScrollPosition], which is a commonly used concrete subclass.
 ///  * [RenderViewportBase], which is a render object that uses viewport
 ///    offsets.
-abstract class ViewportOffset extends ChangeNotifier {
+abstract class ViewportOffset with ChangeNotifier {
   /// Default constructor.
   ///
   /// Allows subclasses to construct this object directly.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2592,7 +2592,7 @@ class _TraversalSortNode implements Comparable<_TraversalSortNode> {
 /// To listen for semantic updates, call [PipelineOwner.ensureSemantics] to
 /// obtain a [SemanticsHandle]. This will create a [SemanticsOwner] if
 /// necessary.
-class SemanticsOwner extends ChangeNotifier {
+class SemanticsOwner with ChangeNotifier {
   final Set<SemanticsNode> _dirtyNodes = <SemanticsNode>{};
   final Map<int, SemanticsNode> _nodes = <int, SemanticsNode>{};
   final Set<SemanticsNode> _detachedNodes = <SemanticsNode>{};

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -167,7 +167,7 @@ abstract class KeyHelper {
 }
 
 /// Helper class that uses GLFW-specific key mappings.
-class GLFWKeyHelper with KeyHelper {
+class GLFWKeyHelper implements KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the CAPS LOCK modifier key is on.
   ///
@@ -304,7 +304,7 @@ class GLFWKeyHelper with KeyHelper {
 }
 
 /// Helper class that uses GTK-specific key mappings.
-class GtkKeyHelper with KeyHelper {
+class GtkKeyHelper implements KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the SHIFT modifier keys is pressed.
   ///

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -150,7 +150,7 @@ typedef _BucketVisitor = void Function(RestorationBucket bucket);
 ///  * [RestorationBucket], which make up the restoration data hierarchy.
 ///  * [RestorationMixin], which uses [RestorationBucket]s behind the scenes
 ///    to make [State] objects of [StatefulWidget]s restorable.
-class RestorationManager extends ChangeNotifier {
+class RestorationManager with ChangeNotifier {
   /// Construct the restoration manager and set up the communications channels
   /// with the engine to get restoration messages (by calling [initChannels]).
   RestorationManager() {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -791,9 +791,9 @@ enum SelectionChangedCause {
   drag,
 }
 
-/// An interface for manipulating the selection, to be used by the implementor
+/// A mixin for manipulating the selection, to be used by the implementor
 /// of the toolbar widget.
-abstract class TextSelectionDelegate {
+mixin TextSelectionDelegate {
   /// Gets the current text input.
   TextEditingValue get textEditingValue;
 

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -316,7 +316,7 @@ class KeepAliveNotification extends Notification {
 /// For a more convenient way to interact with [AutomaticKeepAlive] widgets,
 /// consider using [AutomaticKeepAliveClientMixin], which uses a
 /// [KeepAliveHandle] internally.
-class KeepAliveHandle extends ChangeNotifier {
+class KeepAliveHandle with ChangeNotifier {
   /// Trigger the listeners to indicate that the widget
   /// no longer needs to be kept alive.
   void release() {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -23,11 +23,9 @@ export 'dart:ui' show AppLifecycleState, Locale;
 
 /// Interface for classes that register with the Widgets layer binding.
 ///
-/// When used as a mixin, provides no-op method implementations.
-///
 /// See [WidgetsBinding.addObserver] and [WidgetsBinding.removeObserver].
 ///
-/// This class can be extended directly, to get default behaviors for all of the
+/// This class can be mixed in directly, to get default behaviors for all of the
 /// handlers, or can used with the `implements` keyword, in which case all the
 /// handlers must be implemented (and the analyzer will list those that have
 /// been omitted).
@@ -76,7 +74,7 @@ export 'dart:ui' show AppLifecycleState, Locale;
 ///
 /// To respond to other notifications, replace the [didChangeAppLifecycleState]
 /// method above with other methods from this class.
-abstract class WidgetsBindingObserver {
+mixin WidgetsBindingObserver {
   /// Called when the system tells the app to pop the current route.
   /// For example, on Android, this is called when the user presses
   /// the back button.

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -558,7 +558,7 @@ class DraggableScrollableActuator extends StatelessWidget {
 
 /// A [ChangeNotifier] to use with [InheritedResetNotifier] to notify
 /// descendants that they should reset to initial state.
-class _ResetNotifier extends ChangeNotifier {
+class _ResetNotifier with ChangeNotifier {
   /// Whether someone called [sendReset] or not.
   ///
   /// This flag should be reset after checking it.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1727,7 +1727,7 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
 ///  * [NestedScrollView], which uses a [NestedScrollViewViewport] and a
 ///    [SliverOverlapAbsorber] to align its children, and which shows sample
 ///    usage for this class.
-class SliverOverlapAbsorberHandle extends ChangeNotifier {
+class SliverOverlapAbsorberHandle with ChangeNotifier {
   // Incremented when a RenderSliverOverlapAbsorber takes ownership of this
   // object, decremented when it releases it. This allows us to find cases where
   // the same handle is being passed to two render objects.

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -55,7 +55,7 @@ import 'ticker_provider.dart';
 ///  * [OverlayState]
 ///  * [WidgetsApp]
 ///  * [MaterialApp]
-class OverlayEntry extends ChangeNotifier {
+class OverlayEntry with ChangeNotifier {
   /// Creates an overlay entry.
   ///
   /// To insert the entry into an [Overlay], first find the overlay using

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -348,7 +348,7 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
 
 enum _GlowState { idle, absorb, pull, recede }
 
-class _GlowController extends ChangeNotifier {
+class _GlowController with ChangeNotifier {
   _GlowController({
     required TickerProvider vsync,
     required Color color,

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -400,7 +400,7 @@ class _RootRestorationScopeState extends State<RootRestorationScope> {
 ///  * [RestorationMixin], to which a [RestorableProperty] must be registered.
 ///  * [RestorationManager], which describes how state restoration works in
 ///    Flutter.
-abstract class RestorableProperty<T> extends ChangeNotifier {
+abstract class RestorableProperty<T> with ChangeNotifier {
   /// Called by the [RestorationMixin] if no restoration data is available to
   /// restore the value of the property from to obtain the default value for the
   /// property.

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -41,7 +41,7 @@ import 'scroll_position_with_single_context.dart';
 ///    scrolling widget.
 ///  * [ScrollNotification] and [NotificationListener], which can be used to watch
 ///    the scroll position without using a [ScrollController].
-class ScrollController extends ChangeNotifier {
+class ScrollController with ChangeNotifier {
   /// Creates a controller for a scrollable widget.
   ///
   /// The values of `initialScrollOffset` and `keepScrollOffset` must not be null.

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -31,7 +31,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [FixedScrollMetrics], which is an immutable object that implements this
 ///    interface.
-abstract class ScrollMetrics {
+mixin ScrollMetrics {
   /// Creates a [ScrollMetrics] that has the same properties as this object.
   ///
   /// This is useful if this object is mutable, but you want to get a snapshot
@@ -129,7 +129,7 @@ abstract class ScrollMetrics {
 /// An immutable snapshot of values associated with a [Scrollable] viewport.
 ///
 /// For details, see [ScrollMetrics], which defines this object's interfaces.
-class FixedScrollMetrics extends ScrollMetrics {
+class FixedScrollMetrics with ScrollMetrics {
   /// Creates an immutable snapshot of values associated with a [Scrollable] viewport.
   FixedScrollMetrics({
     required double? minScrollExtent,

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -57,7 +57,7 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///    Material Design style.
 ///  * [CupertinoScrollbar] for a widget showing a scrollbar around a
 ///    [Scrollable] in the iOS style.
-class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
+class ScrollbarPainter with ChangeNotifier implements CustomPainter {
   /// Creates a scrollbar with customizations given by construction arguments.
   ScrollbarPainter({
     required Color color,

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -181,7 +181,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
   }
 }
 
-class _SemanticsClient extends ChangeNotifier {
+class _SemanticsClient with ChangeNotifier {
   _SemanticsClient(PipelineOwner pipelineOwner) {
     _semanticsHandle = pipelineOwner.ensureSemantics(
       listener: _didUpdateSemantics

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -252,7 +252,7 @@ class ShortcutMapProperty extends DiagnosticsProperty<Map<LogicalKeySet, Intent>
 ///
 /// A [ShortcutManager] is obtained by calling [Shortcuts.of] on the context of
 /// the widget that you want to find a manager for.
-class ShortcutManager extends ChangeNotifier with Diagnosticable {
+class ShortcutManager with ChangeNotifier, Diagnosticable {
   /// Constructs a [ShortcutManager].
   ///
   /// The [shortcuts] argument must not  be null.

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestNotifier extends ChangeNotifier {
+class TestNotifier with ChangeNotifier {
   void notify() {
     notifyListeners();
   }

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -54,7 +54,7 @@ class _GestureBindingSpy extends AutomatedTestWidgetsFlutterBinding {
   PointerRouter get pointerRouter => _testPointerRouter;
 }
 
-class FakeEditableTextState extends TextSelectionDelegate with Fake { }
+class FakeEditableTextState extends Fake implements TextSelectionDelegate  { }
 
 class _PointerRouterSpy extends PointerRouter {
   int routeCount = 0;

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -598,7 +598,7 @@ class AlwaysKeepAliveRenderBoxState extends State<_AlwaysKeepAlive> with Automat
   }
 }
 
-abstract class KeepAliveParentDataMixinAlt implements KeepAliveParentDataMixin {
+mixin KeepAliveParentDataMixinAlt implements KeepAliveParentDataMixin {
   @override
   bool keptAlive = false;
 

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -440,7 +440,7 @@ void main() {
 
   testWidgets('InheritedNotifier', (WidgetTester tester) async {
     int buildCount = 0;
-    final ChangeNotifier notifier = ChangeNotifier();
+    final TestChangeNotifier notifier = TestChangeNotifier();
 
     final Widget builder = Builder(
       builder: (BuildContext context) {
@@ -477,3 +477,5 @@ void main() {
     expect(buildCount, equals(3));
   });
 }
+
+class TestChangeNotifier with ChangeNotifier { }

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -122,9 +122,9 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
   }
 }
 
-/// A class for use in golden file comparators that run locally and provide
+/// A mixin for use in golden file comparators that run locally and provide
 /// output.
-class LocalComparisonOutput {
+mixin LocalComparisonOutput {
   /// Writes out diffs from the [ComparisonResult] of a golden file test.
   ///
   /// Will throw an error if a null result is provided.

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -150,7 +150,7 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
 
 class ErrorHandlingFile
     extends ForwardingFileSystemEntity<File, io.File>
-    with ForwardingFile {
+    with ForwardingFile { // ignore: prefer_mixin
   ErrorHandlingFile({
     @required Platform platform,
     @required this.fileSystem,
@@ -352,7 +352,7 @@ class ErrorHandlingFile
 
 class ErrorHandlingDirectory
     extends ForwardingFileSystemEntity<Directory, io.Directory>
-    with ForwardingDirectory<Directory> {
+    with ForwardingDirectory<Directory> { // ignore: prefer_mixin
   ErrorHandlingDirectory({
     @required Platform platform,
     @required this.fileSystem,
@@ -483,7 +483,7 @@ class ErrorHandlingDirectory
 
 class ErrorHandlingLink
     extends ForwardingFileSystemEntity<Link, io.Link>
-    with ForwardingLink {
+    with ForwardingLink { // ignore: prefer_mixin
   ErrorHandlingLink({
     @required Platform platform,
     @required this.fileSystem,


### PR DESCRIPTION
Experiment to see what breaks when enabling `prefer_mixin` lint after fixing up warnings in the framework.

The following classes were turned into mixins:

* ChangeNotifier
* WidgetsBindingObserver
* BaseSliderTrackShape
* RenderSliverHelpers
* TextSelectionDelegate
* ScrollMetrics
* LocalComparisonOutput (from package:flutter_test)

Of those, only the ChangeNotifier and the WidgetsBindingObserver are breaking as defined in our breaking change policy:

* ChangeNotifier requires the following changes for our customers:
  * 216 changes in google3
  * 7 changes in https://github.com/flutter/cocoon
  * 3 code changes + 2 changes in documentation in https://github.com/rrousselGit/provider
  * 6 changes in https://github.com/jocosocial/rainbowmonkey
* WidgetsBindingObserver
  * 6 changes in google3

All of these changes are easy to do (mostly replace `extends ChangeNotifier` by `with ChangeNotifier`). However, given the number of breakages, turning the ChangeNotifier into a mixin is non-starter. Alternatives to satisfy the `prefer_mixin` lint:

* Leave `ChangeNotifier` as a class and add a separate `ChangeNotifierMixin` mixin. The class could be marked as deprecated.
* Mark the `ChangeNotifier` (with e.g. an annotation) as an old-school mixin and teach the `prefer_mixin` lint to ignore it if a class with that marking is used in a `with` clause.

To a lesser extend the above also applies to the `WidgetsBindingObserver`. However, since that one is less breaking we could just change it into a mixin, write a migration guide, and migrate the breakages in google3.