### PR TITLE
non-breaking changes recommended by prefer_mixin lint

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_board.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_board.dart
@@ -11,7 +11,7 @@ import 'package:vector_math/vector_math_64.dart' show Vector3;
 // The entire state of the hex board and abstraction to get information about
 // it. Iterable so that all BoardPoints on the board can be iterated over.
 @immutable
-class Board extends Object with IterableMixin<BoardPoint?> {
+class Board extends IterableMixin<BoardPoint?> {
   Board({
     required this.boardRadius,
     required this.hexagonRadius,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1423,7 +1423,7 @@ abstract class RangeSliderTrackShape {
 ///    rectangular edges
 ///  * [RoundedRectSliderTrackShape], which is a track shape with round
 ///    stadium-like edges.
-abstract class BaseSliderTrackShape {
+mixin BaseSliderTrackShape {
   /// Returns a rect that represents the track bounds that fits within the
   /// [Slider].
   ///

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1596,8 +1596,7 @@ abstract class RenderSliver extends RenderObject {
 }
 
 /// Mixin for [RenderSliver] subclasses that provides some utility functions.
-abstract class RenderSliverHelpers implements RenderSliver {
-
+mixin RenderSliverHelpers implements RenderSliver {
   bool _getRightWayUp(SliverConstraints constraints) {
     assert(constraints != null);
     assert(constraints.axisDirection != null);

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -167,7 +167,7 @@ abstract class KeyHelper {
 }
 
 /// Helper class that uses GLFW-specific key mappings.
-class GLFWKeyHelper with KeyHelper {
+class GLFWKeyHelper implements KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether the CAPS LOCK modifier key is on.
   ///
@@ -304,7 +304,7 @@ class GLFWKeyHelper with KeyHelper {
 }
 
 /// Helper class that uses GTK-specific key mappings.
-class GtkKeyHelper with KeyHelper {
+class GtkKeyHelper implements KeyHelper {
   /// This mask is used to check the [RawKeyEventDataLinux.modifiers] field to
   /// test whether one of the SHIFT modifier keys is pressed.
   ///

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -791,9 +791,9 @@ enum SelectionChangedCause {
   drag,
 }
 
-/// An interface for manipulating the selection, to be used by the implementer
+/// A mixin for manipulating the selection, to be used by the implementer
 /// of the toolbar widget.
-abstract class TextSelectionDelegate {
+mixin TextSelectionDelegate {
   /// Gets the current text input.
   TextEditingValue get textEditingValue;
 

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -31,7 +31,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [FixedScrollMetrics], which is an immutable object that implements this
 ///    interface.
-abstract class ScrollMetrics {
+mixin ScrollMetrics {
   /// Creates a [ScrollMetrics] that has the same properties as this object.
   ///
   /// This is useful if this object is mutable, but you want to get a snapshot
@@ -129,7 +129,7 @@ abstract class ScrollMetrics {
 /// An immutable snapshot of values associated with a [Scrollable] viewport.
 ///
 /// For details, see [ScrollMetrics], which defines this object's interfaces.
-class FixedScrollMetrics extends ScrollMetrics {
+class FixedScrollMetrics with ScrollMetrics {
   /// Creates an immutable snapshot of values associated with a [Scrollable] viewport.
   FixedScrollMetrics({
     required double? minScrollExtent,

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -54,7 +54,7 @@ class _GestureBindingSpy extends AutomatedTestWidgetsFlutterBinding {
   PointerRouter get pointerRouter => _testPointerRouter;
 }
 
-class FakeEditableTextState extends TextSelectionDelegate with Fake { }
+class FakeEditableTextState extends Fake implements TextSelectionDelegate  { }
 
 class _PointerRouterSpy extends PointerRouter {
   int routeCount = 0;

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -598,7 +598,7 @@ class AlwaysKeepAliveRenderBoxState extends State<_AlwaysKeepAlive> with Automat
   }
 }
 
-abstract class KeepAliveParentDataMixinAlt implements KeepAliveParentDataMixin {
+mixin KeepAliveParentDataMixinAlt implements KeepAliveParentDataMixin {
   @override
   bool keptAlive = false;
 

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -128,9 +128,9 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
   File _getGoldenFile(Uri golden) => File(_path.join(_path.fromUri(basedir), _path.fromUri(golden.path)));
 }
 
-/// A class for use in golden file comparators that run locally and provide
+/// A mixin for use in golden file comparators that run locally and provide
 /// output.
-class LocalComparisonOutput {
+mixin LocalComparisonOutput {
   /// Writes out diffs from the [ComparisonResult] of a golden file test.
   ///
   /// Will throw an error if a null result is provided.


### PR DESCRIPTION
This PR contains the non-breaking changes recommended by the `prefer_mixin` lint (see also https://github.com/flutter/flutter/pull/77826 for context). We cannot turn on the lint right now because the `ChangeNotifier` class is extensively used as base class (with the `extends` keyword) as well as as mixin (with the `with` keyword). To a lesser extend this is also true for the `WidgetsBindingObserver` class. Changing them to mixins would break a lot of customers as outlined in https://github.com/flutter/flutter/pull/77826. The changes included in this PR do not break customers and therefore do not constitute breaking changes as defined by our breaking change policy.