### PR TITLE
Fix some issues flagged by unawaited_futures lint

### DIFF
--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -791,7 +791,7 @@ void main() {
       expect(repeating.animationBehavior, AnimationBehavior.preserve);
     });
 
-    test('AnimationBehavior.preserve runs at normal speed when animatingTo', () async {
+    test('AnimationBehavior.preserve runs at normal speed when animatingTo', () {
       debugSemanticsDisableAnimations = true;
       final AnimationController controller = AnimationController(
         vsync: const TestVSync(),
@@ -816,7 +816,7 @@ void main() {
       debugSemanticsDisableAnimations = false;
     });
 
-    test('AnimationBehavior.normal runs at 20x speed when animatingTo', () async {
+    test('AnimationBehavior.normal runs at 20x speed when animatingTo', () {
       debugSemanticsDisableAnimations = true;
       final AnimationController controller = AnimationController(
         vsync: const TestVSync(),

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1193,7 +1193,7 @@ void main() {
     await tester.pumpWidget(buildCheckbox(false));
     expect(find.byType(Checkbox), findsNothing);
     // Release pointer after widget disappeared.
-    gesture.up();
+    await gesture.up();
   });
 }
 

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -106,7 +106,7 @@ void main() {
     final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect(color: hoverColor));
 
-    gesture.removePointer();
+    await gesture.removePointer();
   });
 
   testWidgets('OutlineButton changes mouse cursor when hovered', (WidgetTester tester) async {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -187,7 +187,7 @@ void main() {
     final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect(color: hoverColor));
 
-    gesture.removePointer();
+    await gesture.removePointer();
   });
 
   testWidgets('Does OutlinedButton work with focus', (WidgetTester tester) async {

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -1101,6 +1101,6 @@ void main() {
     await tester.pumpWidget(buildRadio(false));
     expect(find.byKey(key), findsNothing);
     // Release pointer after widget disappeared.
-    gesture.up();
+    await gesture.up();
   });
 }

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1631,6 +1631,6 @@ void main() {
     await tester.pumpWidget(buildSwitch(false));
     expect(find.byType(Switch), findsNothing);
     // Release pointer after widget disappeared.
-    gesture.up();
+    await gesture.up();
   });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8802,14 +8802,14 @@ void main() {
         // Regression test for https://github.com/flutter/flutter/issues/54729
         // If the intrinsic height does not match that of the height after
         // performLayout, this will fail.
-        tester.pumpWidget(_buildTest(isDense: false));
+        await tester.pumpWidget(_buildTest(isDense: false));
       });
 
       testWidgets('When isDense, intrinsic height can go below kMinInteractiveDimension height', (WidgetTester tester) async {
         // Regression test for https://github.com/flutter/flutter/issues/54729
         // If the intrinsic height does not match that of the height after
         // performLayout, this will fail.
-        tester.pumpWidget(_buildTest(isDense: true));
+        await tester.pumpWidget(_buildTest(isDense: true));
       });
     });
   });

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -857,7 +857,7 @@ void main() {
     // keep holding the long press, should still show tooltip
     await tester.pump(kLongPressTimeout);
     expect(find.text(tooltipText), findsOneWidget);
-    gesture.up();
+    await gesture.up();
   });
 
   testWidgets('Tooltip shows/hides when hovered', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -303,7 +303,7 @@ void main() {
     }
 
     testWidgets('layoutChild on non existent child', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         tester: tester,
         delegate: ZeroAndOneIdLayoutDelegate(),
         message:
@@ -315,7 +315,7 @@ void main() {
     });
 
     testWidgets('layoutChild more than once', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
           tester: tester,
           delegate: DuplicateLayoutDelegate(),
           message:
@@ -327,7 +327,7 @@ void main() {
     });
 
     testWidgets('layoutChild on invalid size constraint', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         tester: tester,
         delegate: InvalidConstraintsChildLayoutDelegate(),
         message:
@@ -346,7 +346,7 @@ void main() {
     });
 
     testWidgets('positionChild on non existent child', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         tester: tester,
         delegate: NonExistentPositionDelegate(),
         message:
@@ -358,7 +358,7 @@ void main() {
     });
 
     testWidgets("_callPerformLayout on child that doesn't have id", (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         widget: Center(
           child: CustomMultiChildLayout(
             children: <Widget>[LayoutWithMissingId(child: Container(width: 100))],
@@ -381,7 +381,7 @@ void main() {
     });
 
     testWidgets('performLayout did not layout a child', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         widget: Center(
           child: CustomMultiChildLayout(
             children: <Widget>[
@@ -403,7 +403,7 @@ void main() {
     });
 
     testWidgets('performLayout did not layout multiple child', (WidgetTester tester) async {
-      expectFlutterErrorMessage(
+      await expectFlutterErrorMessage(
         widget: Center(
           child: CustomMultiChildLayout(
             children: <Widget>[


### PR DESCRIPTION
Fixes some issues uncovered by the unawaited_futures lint.

The lint itself flags a lot of other instances as well (mainly in tests) where awaiting the future is not the right thing and `unawaited` kinda litters the code...