### PR TITLE
Spelling standardization: implementer

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -791,7 +791,7 @@ enum SelectionChangedCause {
   drag,
 }
 
-/// An interface for manipulating the selection, to be used by the implementor
+/// An interface for manipulating the selection, to be used by the implementer
 /// of the toolbar widget.
 abstract class TextSelectionDelegate {
   /// Gets the current text input.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -106,7 +106,7 @@ class ToolbarItemsParentData extends ContainerBoxParentData<RenderBox> {
 }
 
 /// An interface for building the selection UI, to be provided by the
-/// implementor of the toolbar widget.
+/// implementer of the toolbar widget.
 ///
 /// Override text operations such as [handleCut] if needed.
 abstract class TextSelectionControls {


### PR DESCRIPTION
I noticed that we had both spellings "implementor" and "implementer" in our docs.  This PR standardizes it to "implementer", which seems to be the correct one.

No tests, just a docs change.