### PR TITLE
ShaderMask on web for CupertinoContextMenu

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -510,9 +510,6 @@ class _DecoyChildState extends State<_DecoyChild> with TickerProviderStateMixin 
       : _mask.value;
     return Positioned.fromRect(
       rect: _rect.value!,
-      // TODO(justinmc): When ShaderMask is supported on web, remove this
-      // conditional and use ShaderMask everywhere.
-      // https://github.com/flutter/flutter/issues/52967.
       child: ShaderMask(
         key: _childGlobalKey,
         shaderCallback: (Rect bounds) {

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -514,19 +513,17 @@ class _DecoyChildState extends State<_DecoyChild> with TickerProviderStateMixin 
       // TODO(justinmc): When ShaderMask is supported on web, remove this
       // conditional and use ShaderMask everywhere.
       // https://github.com/flutter/flutter/issues/52967.
-      child: kIsWeb
-          ? Container(key: _childGlobalKey, child: widget.child)
-          : ShaderMask(
-            key: _childGlobalKey,
-            shaderCallback: (Rect bounds) {
-              return LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: <Color>[color, color],
-              ).createShader(bounds);
-            },
-            child: widget.child,
-          ),
+      child: ShaderMask(
+        key: _childGlobalKey,
+        shaderCallback: (Rect bounds) {
+          return LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: <Color>[color, color],
+          ).createShader(bounds);
+        },
+        child: widget.child,
+      ),
     );
   }
 

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -121,7 +121,7 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
       expect(_findStatic(), findsOneWidget);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
   });
 
   group('CupertinoContextMenu when open', () {
@@ -141,7 +141,7 @@ void main() {
       await tester.tapAt(const Offset(1.0, 1.0));
       await tester.pumpAndSettle();
       expect(_findStatic(), findsNothing);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
 
     testWidgets('Can close CupertinoContextMenu by dragging down', (WidgetTester tester) async {
       final Widget child = _getChild();
@@ -183,7 +183,7 @@ void main() {
       await swipeGesture.up();
       await tester.pumpAndSettle();
       expect(_findStatic(), findsNothing);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
 
     testWidgets('Can close CupertinoContextMenu by flinging down', (WidgetTester tester) async {
       final Widget child = _getChild();
@@ -208,7 +208,7 @@ void main() {
       await tester.fling(_findStaticChild(child), const Offset(0.0, 100.0), 1000.0);
       await tester.pumpAndSettle();
       expect(_findStatic(), findsNothing);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
 
     testWidgets("Backdrop is added using ModalRoute's filter parameter", (WidgetTester tester) async {
       final Widget child = _getChild();
@@ -223,7 +223,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(_findStatic(), findsOneWidget);
       expect(find.byType(BackdropFilter), findsOneWidget);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
   });
 
   group("Open layout differs depending on child's position on screen", () {
@@ -298,7 +298,7 @@ void main() {
 
       // Set the screen back to its normal size.
       await binding.setSurfaceSize(const Size(800.0, 600.0));
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
 
     testWidgets('Landscape', (WidgetTester tester) async {
       // Pump a CupertinoContextMenu in the center of the screen and open it.
@@ -363,6 +363,6 @@ void main() {
       expect(find.byType(CupertinoContextMenuAction), findsOneWidget);
       final Offset right = tester.getTopLeft(find.byType(CupertinoContextMenuAction));
       expect(right.dx, lessThan(left.dx));
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+    });
   });
 }

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 void main() {
   final TestWidgetsFlutterBinding binding =
@@ -104,10 +103,7 @@ void main() {
       Rect decoyChildRect = tester.getRect(_findDecoyChild(child));
       expect(childRect, equals(decoyChildRect));
 
-      // TODO(justinmc): When ShaderMask is supported on web, remove this
-      // conditional and just check for ShaderMask.
-      // https://github.com/flutter/flutter/issues/52967.
-      expect(find.byType(ShaderMask), kIsWeb ? findsNothing : findsOneWidget);
+      expect(find.byType(ShaderMask), findsOneWidget);
 
       // After a small delay, the _DecoyChild has begun to animate.
       await tester.pump(const Duration(milliseconds: 100));

--- a/packages/flutter/test/widgets/shader_mask_test.dart
+++ b/packages/flutter/test/widgets/shader_mask_test.dart
@@ -19,7 +19,7 @@ void main() {
   testWidgets('Can be constructed', (WidgetTester tester) async {
     const Widget child = SizedBox(width: 100.0, height: 100.0);
     await tester.pumpWidget(const ShaderMask(child: child, shaderCallback: createShader));
-  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+  });
 
   testWidgets('Bounds rect includes offset', (WidgetTester tester) async {
     late Rect shaderBounds;
@@ -43,7 +43,7 @@ void main() {
 
     // The shader bounds rectangle should reflect the position of the centered SizedBox.
     expect(shaderBounds, equals(const Rect.fromLTWH(0.0, 0.0, 400.0, 400.0)));
-  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+  });
 
 
   testWidgets('Bounds rect includes offset visual inspection', (WidgetTester tester) async {
@@ -106,5 +106,5 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('shader_mask.bounds.matches_top_left.png'),
     );
-  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44152
+  });
 }


### PR DESCRIPTION
I'm [told](https://github.com/flutter/flutter/issues/52967#issuecomment-785506069) that web now supports ShaderMask, so we can remove this workaround that was put into CupertinoContextMenu to simplify it so it didn't need ShaderMask on web.

Also unskips ShaderMask tests on web.

Closes https://github.com/flutter/flutter/issues/52967

