### PR TITLE
Update samples to use repo analysis options, Fix sample templates and a ton of analyzer issues

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -464,7 +464,7 @@ class SampleChecker {
       }
     }
     if (!silent)
-      print('Found ${sections.length} snippet code blocks and $sampleCount sample code sections, and $dartpadCount dartpad sections.');
+      print('Found ${sections.length} snippet code blocks, $sampleCount sample code sections, and $dartpadCount dartpad sections.');
     for (final Section section in sections) {
       final String path = _writeSection(section).path;
       if (sectionMap != null)

--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -327,6 +327,8 @@ class SampleChecker {
   void _extractSamples(List<File> files, {Map<String, Section> sectionMap, Map<String, Sample> sampleMap, bool silent = false}) {
     final List<Section> sections = <Section>[];
     final List<Sample> samples = <Sample>[];
+    int dartpadCount = 0;
+    int sampleCount = 0;
 
     for (final File file in files) {
       final String relativeFilePath = path.relative(file.path, from: _flutterPackage.path);
@@ -431,6 +433,12 @@ class SampleChecker {
           } else if (sampleMatch != null) {
             inSnippet = sampleMatch != null && (sampleMatch[1] == 'sample' || sampleMatch[1] == 'dartpad');
             if (inSnippet) {
+              if (sampleMatch[1] == 'sample') {
+                sampleCount++;
+              }
+              if (sampleMatch[1] == 'dartpad') {
+                dartpadCount++;
+              }
               startLine = Line(
                 '',
                 filename: relativeFilePath,
@@ -456,7 +464,7 @@ class SampleChecker {
       }
     }
     if (!silent)
-      print('Found ${sections.length} snippet code blocks and ${samples.length} sample code sections.');
+      print('Found ${sections.length} snippet code blocks and $sampleCount sample code sections, and $dartpadCount dartpad sections.');
     for (final Section section in sections) {
       final String path = _writeSection(section).path;
       if (sectionMap != null)

--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -7,6 +7,7 @@
 // To run this, from the root of the Flutter repository:
 //   bin/cache/dart-sdk/bin/dart dev/bots/analyze_sample_code.dart
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -41,7 +42,7 @@ void main(List<String> arguments) {
   argParser.addOption(
     'interactive',
     abbr: 'i',
-    help: 'Analyzes the sample code in the specified file interactivly.',
+    help: 'Analyzes the sample code in the specified file interactively.',
   );
 
   final ArgResults parsedArguments = argParser.parse(arguments);
@@ -455,7 +456,7 @@ class SampleChecker {
       }
     }
     if (!silent)
-      print('Found ${sections.length} sample code sections.');
+      print('Found ${sections.length} snippet code blocks and ${samples.length} sample code sections.');
     for (final Section section in sections) {
       final String path = _writeSection(section).path;
       if (sectionMap != null)
@@ -510,10 +511,10 @@ class SampleChecker {
   }
 
   /// Creates the configuration files necessary for the analyzer to consider
-  /// the temporary director a package, and sets which lint rules to enforce.
+  /// the temporary directory a package, and sets which lint rules to enforce.
   void _createConfigurationFiles(Directory directory) {
     final File pubSpec = File(path.join(directory.path, 'pubspec.yaml'))..createSync(recursive: true);
-    final File analysisOptions = File(path.join(directory.path, 'analysis_options.yaml'))..createSync(recursive: true);
+
     pubSpec.writeAsStringSync('''
 name: analyze_sample_code
 environment:
@@ -524,12 +525,9 @@ dependencies:
   flutter_test:
     sdk: flutter
 ''');
-    analysisOptions.writeAsStringSync('''
-linter:
-  rules:
-    - unnecessary_const
-    - unnecessary_new
-''');
+
+    // Copy in the analysis options from the Flutter root.
+    File(path.join(_flutterRoot,'analysis_options.yaml')).copySync(path.join(directory.path, 'analysis_options.yaml'));
   }
 
   /// Writes out a sample section to the disk and returns the file.
@@ -606,107 +604,107 @@ linter:
     final String kBullet = Platform.isWindows ? ' - ' : ' • ';
     // RegExp to match an error output line of the analyzer.
     final RegExp errorPattern = RegExp(
-      '^ +([a-z]+)$kBullet(.+)$kBullet(.+):([0-9]+):([0-9]+)$kBullet([-a-z_]+)\$',
+      '^ +(?<type>[a-z]+)'
+      '$kBullet(?<description>.+)'
+      '$kBullet(?<file>.+):(?<line>[0-9]+):(?<column>[0-9]+)'
+      '$kBullet(?<code>[-a-z_]+)\$',
       caseSensitive: false,
     );
     bool unknownAnalyzerErrors = false;
     final int headerLength = headers.length + 3;
     for (final String error in errors) {
-      final Match parts = errorPattern.matchAsPrefix(error);
-      if (parts != null) {
-        final String message = parts[2];
-        final File file = File(path.join(_tempDirectory.path, parts[3]));
-        final List<String> fileContents = file.readAsLinesSync();
-        final bool isSnippet = path.basename(file.path).startsWith('snippet.');
-        final bool isSample = path.basename(file.path).startsWith('sample.');
-        final String line = parts[4];
-        final String column = parts[5];
-        final String errorCode = parts[6];
-        final int lineNumber = int.parse(line, radix: 10) - (isSnippet ? headerLength : 0);
-        final int columnNumber = int.parse(column, radix: 10);
+      final RegExpMatch match = errorPattern.firstMatch(error);
+      if (match == null) {
+        stderr.writeln('Analyzer output: $error');
+        unknownAnalyzerErrors = true;
+        continue;
+      }
+      final String type = match.namedGroup('type');
+      final String message = match.namedGroup('description');
+      final File file = File(path.join(_tempDirectory.path, match.namedGroup('file')));
+      final List<String> fileContents = file.readAsLinesSync();
+      final bool isSnippet = path.basename(file.path).startsWith('snippet.');
+      final bool isSample = path.basename(file.path).startsWith('sample.');
+      final String line = match.namedGroup('line');
+      final String column = match.namedGroup('column');
+      final String errorCode = match.namedGroup('code');
+      final int lineNumber = int.parse(line, radix: 10) - (isSnippet ? headerLength : 0);
+      final int columnNumber = int.parse(column, radix: 10);
 
-        // For when errors occur outside of the things we're trying to analyze.
-        if (!isSnippet && !isSample) {
+      // For when errors occur outside of the things we're trying to analyze.
+      if (!isSnippet && !isSample) {
+        addAnalysisError(
+          file,
+          AnalysisError(
+            type,
+            lineNumber,
+            columnNumber,
+            message,
+            errorCode,
+            Line(
+              '',
+              filename: file.path,
+              line: lineNumber,
+            ),
+          ),
+        );
+        throw SampleCheckerException(
+          'Cannot analyze dartdocs; analysis errors exist: $error',
+          file: file.path,
+          line: lineNumber,
+        );
+      }
+
+      if (isSample) {
+        addAnalysisError(
+          file,
+          AnalysisError(
+            type,
+            lineNumber,
+            columnNumber,
+            message,
+            errorCode,
+            null,
+            sample: samples[file.path],
+          ),
+        );
+      } else {
+        if (lineNumber < 1 || lineNumber > fileContents.length) {
           addAnalysisError(
             file,
             AnalysisError(
+              type,
               lineNumber,
               columnNumber,
               message,
               errorCode,
-              Line(
-                '',
-                filename: file.path,
-                line: lineNumber,
-              ),
+              Line('', filename: file.path, line: lineNumber),
             ),
           );
+          throw SampleCheckerException('Failed to parse error message: $error', file: file.path, line: lineNumber);
+        }
+
+        final Section actualSection = sections[file.path];
+        if (actualSection == null) {
           throw SampleCheckerException(
-            'Cannot analyze dartdocs; analysis errors exist: $error',
+            "Unknown section for ${file.path}. Maybe the temporary directory wasn't empty?",
             file: file.path,
             line: lineNumber,
           );
         }
+        final Line actualLine = actualSection.code[lineNumber - 1];
 
-        if (isSample) {
-          addAnalysisError(
-            file,
-            AnalysisError(
-              lineNumber,
-              columnNumber,
-              message,
-              errorCode,
-              null,
-              sample: samples[file.path],
-            ),
-          );
-        } else {
-          if (lineNumber < 1 || lineNumber > fileContents.length) {
-            addAnalysisError(
-              file,
-              AnalysisError(
-                lineNumber,
-                columnNumber,
-                message,
-                errorCode,
-                Line('', filename: file.path, line: lineNumber),
-              ),
-            );
-            throw SampleCheckerException('Failed to parse error message: $error', file: file.path, line: lineNumber);
-          }
-
-          final Section actualSection = sections[file.path];
-          if (actualSection == null) {
-            throw SampleCheckerException(
-              "Unknown section for ${file.path}. Maybe the temporary directory wasn't empty?",
-              file: file.path,
-              line: lineNumber,
-            );
-          }
-          final Line actualLine = actualSection.code[lineNumber - 1];
-
-          if (actualLine?.filename == null) {
-            if (errorCode == 'missing_identifier' && lineNumber > 1) {
-              if (fileContents[lineNumber - 2].endsWith(',')) {
-                final Line actualLine = sections[file.path].code[lineNumber - 2];
-                addAnalysisError(
-                  file,
-                  AnalysisError(
-                    actualLine.line,
-                    actualLine.indent + fileContents[lineNumber - 2].length - 1,
-                    'Unexpected comma at end of sample code.',
-                    errorCode,
-                    actualLine,
-                  ),
-                );
-              }
-            } else {
+        if (actualLine?.filename == null) {
+          if (errorCode == 'missing_identifier' && lineNumber > 1) {
+            if (fileContents[lineNumber - 2].endsWith(',')) {
+              final Line actualLine = sections[file.path].code[lineNumber - 2];
               addAnalysisError(
                 file,
                 AnalysisError(
-                  lineNumber - 1,
-                  columnNumber,
-                  message,
+                  type,
+                  actualLine.line,
+                  actualLine.indent + fileContents[lineNumber - 2].length - 1,
+                  'Unexpected comma at end of sample code.',
                   errorCode,
                   actualLine,
                 ),
@@ -716,18 +714,28 @@ linter:
             addAnalysisError(
               file,
               AnalysisError(
-                actualLine.line,
-                actualLine.indent + columnNumber,
+                type,
+                lineNumber - 1,
+                columnNumber,
                 message,
                 errorCode,
                 actualLine,
               ),
             );
           }
+        } else {
+          addAnalysisError(
+            file,
+            AnalysisError(
+              type,
+              actualLine.line,
+              actualLine.indent + columnNumber,
+              message,
+              errorCode,
+              actualLine,
+            ),
+          );
         }
-      } else {
-        stderr.writeln('Analyzer output: $error');
-        unknownAnalyzerErrors = true;
       }
     }
     if (_exitCode == 1 && analysisErrors.isEmpty && !unknownAnalyzerErrors) {
@@ -906,6 +914,7 @@ class Sample {
 /// Changes how it converts to a string based on the source of the error.
 class AnalysisError {
   const AnalysisError(
+    this.type,
     this.line,
     this.column,
     this.message,
@@ -914,6 +923,7 @@ class AnalysisError {
     this.sample,
   });
 
+  final String type;
   final int line;
   final int column;
   final String message;
@@ -924,19 +934,18 @@ class AnalysisError {
   @override
   String toString() {
     if (source != null) {
-      return '${source.toStringWithColumn(column)}\n>>> $message ($errorCode)';
+      return '${source.toStringWithColumn(column)}\n>>> $type: $message ($errorCode)';
     } else if (sample != null) {
       return 'In sample starting at '
           '${sample.start.filename}:${sample.start.line}:${sample.contents[line - 1]}\n'
-          '>>> $message ($errorCode)';
+          '>>> $type: $message ($errorCode)';
     } else {
-      return '<source unknown>:$line:$column\n>>> $message ($errorCode)';
+      return '<source unknown>:$line:$column\n>>> $type: $message ($errorCode)';
     }
   }
 }
 
 Future<void> _runInteractive(Directory tempDir, Directory flutterPackage, String filePath) async {
-  print('Starting up in interactive mode...');
   filePath = path.isAbsolute(filePath) ? filePath : path.join(path.current, filePath);
   final File file = File(filePath);
   if (!file.existsSync()) {
@@ -955,6 +964,7 @@ Future<void> _runInteractive(Directory tempDir, Directory flutterPackage, String
     });
     print('Using temp dir ${tempDir.path}');
   }
+  print('Starting up in interactive mode on ${path.relative(filePath, from: _flutterRoot)} ...');
 
   void analyze(SampleChecker checker, File file) {
     final Map<String, Section> sections = <String, Section>{};
@@ -976,8 +986,32 @@ Future<void> _runInteractive(Directory tempDir, Directory flutterPackage, String
     .._createConfigurationFiles(tempDir);
   analyze(checker, file);
 
-  Watcher(file.absolute.path).events.listen((_) {
+  print('Type "q" to quit, or "r" to delete temp dir and manually reload.');
+
+  void rerun() {
     print('\n\nRerunning...');
-    analyze(checker, file);
+    try {
+      analyze(checker, file);
+    } on SampleCheckerException catch (e) {
+      print('Caught Exception (${e.runtimeType}), press "r" to retry:\n$e');
+    }
+  }
+
+  stdin.lineMode = false;
+  stdin.echoMode = false;
+  stdin.transform(utf8.decoder).listen((String input) {
+    switch (input) {
+      case 'q':
+        print('Exiting...');
+        exit(0);
+        break;
+      case 'r':
+        print('Deleting temp files...');
+        tempDir.deleteSync(recursive: true);
+        rerun();
+        break;
+    }
   });
+
+  Watcher(file.absolute.path).events.listen((_) => rerun());
 }

--- a/dev/bots/test/analyze_sample_code_test.dart
+++ b/dev/bots/test/analyze_sample_code_test.dart
@@ -17,20 +17,32 @@ void main() {
       ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
+      'In sample starting at known_broken_documentation.dart:117:bool? _visible = true;',
+      '>>> info: Use late for private members with non-nullable type (use_late_for_private_fields_and_variables)',
       'In sample starting at known_broken_documentation.dart:117:      child: Text(title),',
-      '>>> The final variable \'title\' can\'t be read because it is potentially unassigned at this point (read_potentially_unassigned_final)',
+      '>>> error: The final variable \'title\' can\'t be read because it is potentially unassigned at this point (read_potentially_unassigned_final)',
       'known_broken_documentation.dart:30:9: new Opacity(',
-      '>>> Unnecessary new keyword (unnecessary_new)',
+      '>>> info: Unnecessary new keyword (unnecessary_new)',
       'known_broken_documentation.dart:62:9: new Opacity(',
-      '>>> Unnecessary new keyword (unnecessary_new)',
+      '>>> info: Unnecessary new keyword (unnecessary_new)',
+      'known_broken_documentation.dart:95:9: const text0 = Text(\'Poor wandering ones!\');',
+      '>>> info: Specify type annotations (always_specify_types)',
+      'known_broken_documentation.dart:103:9: const text1 = _Text(\'Poor wandering ones!\');',
+      '>>> info: Specify type annotations (always_specify_types)',
+      'known_broken_documentation.dart:111:9: final String? bar = \'Hello\';',
+      '>>> info: Prefer const over final for declarations (prefer_const_declarations)',
+      'known_broken_documentation.dart:111:23: final String? bar = \'Hello\';',
+      '>>> info: Use a non-nullable type for a final variable initialized with a non-nullable value (unnecessary_nullable_for_final_variable_declarations)',
+      'known_broken_documentation.dart:112:9: final int foo = null;',
+      '>>> info: Prefer const over final for declarations (prefer_const_declarations)',
       'known_broken_documentation.dart:112:25: final int foo = null;',
-      '>>> A value of type \'Null\' can\'t be assigned to a variable of type \'int\' (invalid_assignment)',
+      '>>> error: A value of type \'Null\' can\'t be assigned to a variable of type \'int\' (invalid_assignment)',
       '',
       'Found 2 sample code errors.',
       ''
     ]);
     expect(stdoutLines, <String>[
-      'Found 8 sample code sections.',
+      'Found 8 snippet code blocks and 0 sample code sections, and 2 dartpad sections.',
       'Starting analysis of code samples.',
       '',
     ]);

--- a/dev/bots/test/analyze_sample_code_test.dart
+++ b/dev/bots/test/analyze_sample_code_test.dart
@@ -42,7 +42,7 @@ void main() {
       ''
     ]);
     expect(stdoutLines, <String>[
-      'Found 8 snippet code blocks and 0 sample code sections, and 2 dartpad sections.',
+      'Found 8 snippet code blocks, 0 sample code sections, and 2 dartpad sections.',
       'Starting analysis of code samples.',
       '',
     ]);

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -28,7 +28,12 @@ Future<String> capture(AsyncVoidCallback callback, { int exitCode = 0 }) async {
   } finally {
     print = oldPrint;
   }
-  return buffer.toString();
+  if (stdout.supportsAnsiEscapes) {
+    // Remove ANSI escapes when this test is running on a terminal.
+    return buffer.toString().replaceAll(RegExp(r'(\x9B|\x1B\[)[0-?]{1,3}[ -/]*[@-~]'), '');
+  } else {
+    return buffer.toString();
+  }
 }
 
 void main() {

--- a/dev/snippets/config/templates/freeform.tmpl
+++ b/dev/snippets/config/templates/freeform.tmpl
@@ -2,6 +2,7 @@
 
 {{description}}
 
+{{code-dartImports}}
 {{code-imports}}
 
 {{code-main}}

--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -2,20 +2,23 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+{{code-dartImports}}
 
+import 'package:flutter/widgets.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
+    return const WidgetsApp(
       title: 'Flutter Code Sample',
       home: MyStatefulWidget(),
-      color: const Color(0xffffffff),
+      color: Color(0xffffffff),
     );
   }
 }
@@ -24,7 +27,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/cupertino.dart';
+{{code-dartImports}}
 
+import 'package:flutter/cupertino.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp(
+    return const CupertinoApp(
       title: _title,
       home: MyStatefulWidget(),
     );
@@ -25,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/cupertino.dart';
+{{code-dartImports}}
 
+import 'package:flutter/cupertino.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp(
+    return const CupertinoApp(
       title: _title,
       home: CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(middle: const Text(_title)),
@@ -28,7 +31,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/cupertino.dart';
+{{code-dartImports}}
 
+import 'package:flutter/cupertino.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp(
+    return const CupertinoApp(
       title: _title,
       home: MyStatefulWidget(),
     );
@@ -25,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       title: _title,
       home: MyStatefulWidget(),
     );
@@ -25,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       title: _title,
       home: MyStatefulWidget(),
     );
@@ -25,7 +28,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_restoration.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return WidgetsApp(
       title: 'Flutter Code Sample',
-      home: Center(
+      home: const Center(
         child: MyStatefulWidget(restorationId: 'main'),
       ),
       color: const Color(0xffffffff),
@@ -26,7 +29,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key, this.restorationId}) : super(key: key);
+  const MyStatefulWidget({Key? key, this.restorationId}) : super(key: key);
 
   final String? restorationId;
 

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -2,14 +2,17 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
@@ -18,7 +21,7 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: MyStatefulWidget(),
+        body: const MyStatefulWidget(),
       ),
     );
   }
@@ -28,7 +31,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
@@ -2,14 +2,17 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
@@ -18,7 +21,7 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: Center(
+        body: const Center(
           child: MyStatefulWidget(),
         ),
       ),
@@ -30,7 +33,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
@@ -2,14 +2,17 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
@@ -18,7 +21,7 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: Center(
+        body: const Center(
           child: MyStatefulWidget(),
         ),
       ),
@@ -30,7 +33,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateful_widget_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_ticker.tmpl
@@ -2,20 +2,23 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+{{code-dartImports}}
 
+import 'package:flutter/widgets.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return WidgetsApp(
+    return const WidgetsApp(
       title: 'Flutter Code Sample',
       home: MyStatefulWidget(),
-      color: const Color(0xffffffff),
+      color: Color(0xffffffff),
     );
   }
 }
@@ -24,7 +27,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateful widget that the main application instantiates.
 class MyStatefulWidget extends StatefulWidget {
-  MyStatefulWidget({Key? key}) : super(key: key);
+  const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();

--- a/dev/snippets/config/templates/stateless_widget.tmpl
+++ b/dev/snippets/config/templates/stateless_widget.tmpl
@@ -2,21 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/widgets.dart';
+{{code-dartImports}}
 
+import 'package:flutter/widgets.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return WidgetsApp(
       title: 'Flutter Code Sample',
-      builder: (BuildContext context, Widget navigator) {
-        return MyStatelessWidget();
-      },
+      builder: (BuildContext context, Widget? navigator) => const MyStatelessWidget(),
       color: const Color(0xffffffff),
     );
   }
@@ -26,7 +27,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/cupertino.dart';
+{{code-dartImports}}
 
+import 'package:flutter/cupertino.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp(
+    return const CupertinoApp(
       title: _title,
       home: MyStatelessWidget(),
     );
@@ -26,7 +29,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_cupertino_page_scaffold.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/cupertino.dart';
+{{code-dartImports}}
 
+import 'package:flutter/cupertino.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoApp(
+    return const CupertinoApp(
       title: _title,
       home: CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(middle: const Text(_title)),
@@ -29,7 +32,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material.tmpl
@@ -2,19 +2,22 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       title: _title,
       home: MyStatelessWidget(),
     );
@@ -26,7 +29,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold.tmpl
@@ -2,14 +2,17 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
@@ -18,7 +21,7 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: MyStatelessWidget(),
+        body: const MyStatelessWidget(),
       ),
     );
   }
@@ -29,7 +32,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_scaffold_center.tmpl
@@ -2,14 +2,17 @@
 
 {{description}}
 
-import 'package:flutter/material.dart';
+{{code-dartImports}}
 
+import 'package:flutter/material.dart';
 {{code-imports}}
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 /// This is the main application widget.
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   static const String _title = 'Flutter Code Sample';
 
   @override
@@ -18,7 +21,7 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: Center(
+        body: const Center(
           child: MyStatelessWidget(),
         ),
       ),
@@ -31,7 +34,7 @@ class MyApp extends StatelessWidget {
 
 /// This is the stateless widget that the main application instantiates.
 class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({Key? key}) : super(key: key);
 
   @override
   {{code}}

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -138,7 +138,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// final Animatable<Alignment> _tween = AlignmentTween(begin: Alignment.topLeft, end: Alignment.topRight)
   ///   .chain(CurveTween(curve: Curves.easeIn));
   /// // ...
-  /// Animation<Alignment> _alignment2 = _controller.drive(_tween);
+  /// final Animation<Alignment> _alignment2 = _controller.drive(_tween);
   /// ```
   /// {@end-tool}
   /// {@tool snippet}

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -136,7 +136,7 @@ enum AnimationBehavior {
 ///
 /// ```dart
 /// class Foo extends StatefulWidget {
-///   Foo({ Key? key, required this.duration }) : super(key: key);
+///   const Foo({ Key? key, required this.duration }) : super(key: key);
 ///
 ///   final Duration duration;
 ///

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -339,8 +339,8 @@ class Cubic extends Curve {
 ///     Offset(0.93, 0.93),
 ///     Offset(0.05, 0.75),
 ///   ],
-///   startHandle: Offset(0.93, 0.93),
-///   endHandle: Offset(0.18, 0.23),
+///   startHandle: const Offset(0.93, 0.93),
+///   endHandle: const Offset(0.18, 0.23),
 ///   tension: 0.0,
 /// );
 ///
@@ -389,7 +389,7 @@ class Cubic extends Curve {
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     // Scale the path values to match the -1.0 to 1.0 domain of the Alignment widget.
-///     final Offset position = widget.path.transform(animation.value) * 2.0 - Offset(1.0, 1.0);
+///     final Offset position = widget.path.transform(animation.value) * 2.0 - const Offset(1.0, 1.0);
 ///     return Align(
 ///       alignment: Alignment(position.dx, position.dy),
 ///       child: widget.child,
@@ -411,7 +411,7 @@ class Cubic extends Curve {
 ///           backgroundColor: Colors.yellow,
 ///           child: DefaultTextStyle(
 ///             style: Theme.of(context).textTheme.headline6!,
-///             child: Text("B"), // Buzz, buzz!
+///             child: const Text('B'), // Buzz, buzz!
 ///           ),
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/animation/tween_sequence.dart
+++ b/packages/flutter/lib/src/animation/tween_sequence.dart
@@ -22,7 +22,7 @@ import 'tween.dart';
 /// for the next 20%, and then returns to 5.0 for the final 40%.
 ///
 /// ```dart
-/// final Animation<double> animation = TweenSequence(
+/// final Animation<double> animation = TweenSequence<double>(
 ///   <TweenSequenceItem<double>>[
 ///     TweenSequenceItem<double>(
 ///       tween: Tween<double>(begin: 5.0, end: 10.0)

--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -105,6 +105,8 @@ const double _kDividerThickness = 1.0;
 ///
 /// ```dart
 /// class MyStatefulWidget extends StatefulWidget {
+///   const MyStatefulWidget({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
 /// }
@@ -116,12 +118,12 @@ const double _kDividerThickness = 1.0;
 ///       child: Center(
 ///         child: CupertinoButton(
 ///           onPressed: () {
-///             showCupertinoModalPopup(
+///             showCupertinoModalPopup<void>(
 ///               context: context,
 ///               builder: (BuildContext context) => CupertinoActionSheet(
 ///                 title: const Text('Title'),
 ///                 message: const Text('Message'),
-///                 actions: [
+///                 actions: <CupertinoActionSheetAction>[
 ///                   CupertinoActionSheetAction(
 ///                     child: const Text('Action One'),
 ///                     onPressed: () {
@@ -138,7 +140,7 @@ const double _kDividerThickness = 1.0;
 ///               ),
 ///             );
 ///           },
-///           child: Text('CupertinoActionSheet'),
+///           child: const Text('CupertinoActionSheet'),
 ///         ),
 ///       ),
 ///     );

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -57,10 +57,10 @@ import 'theme.dart';
 /// ![The CupertinoApp displays a CupertinoPageScaffold](https://flutter.github.io/assets-for-api-docs/assets/cupertino/basic_cupertino_app.png)
 ///
 /// ```dart
-/// CupertinoApp(
+/// const CupertinoApp(
 ///   home: CupertinoPageScaffold(
 ///     navigationBar: CupertinoNavigationBar(
-///       middle: const Text('Home'),
+///       middle: Text('Home'),
 ///     ),
 ///     child: Center(child: Icon(CupertinoIcons.share)),
 ///   ),
@@ -77,17 +77,17 @@ import 'theme.dart';
 /// CupertinoApp(
 ///   routes: <String, WidgetBuilder>{
 ///     '/': (BuildContext context) {
-///       return CupertinoPageScaffold(
+///       return const CupertinoPageScaffold(
 ///         navigationBar: CupertinoNavigationBar(
-///           middle: const Text('Home Route'),
+///           middle: Text('Home Route'),
 ///         ),
 ///         child: Center(child: Icon(CupertinoIcons.share)),
 ///       );
 ///     },
 ///     '/about': (BuildContext context) {
-///       return CupertinoPageScaffold(
+///       return const CupertinoPageScaffold(
 ///         navigationBar: CupertinoNavigationBar(
-///           middle: const Text('About Route'),
+///           middle: Text('About Route'),
 ///         ),
 ///         child: Center(child: Icon(CupertinoIcons.share)),
 ///       );
@@ -104,14 +104,14 @@ import 'theme.dart';
 /// ![The CupertinoApp displays a CupertinoPageScaffold with orange-colored icons](https://flutter.github.io/assets-for-api-docs/assets/cupertino/theme_cupertino_app.png)
 ///
 /// ```dart
-/// CupertinoApp(
+/// const CupertinoApp(
 ///   theme: CupertinoThemeData(
 ///     brightness: Brightness.dark,
 ///     primaryColor: CupertinoColors.systemOrange,
 ///   ),
 ///   home: CupertinoPageScaffold(
 ///     navigationBar: CupertinoNavigationBar(
-///       middle: const Text('CupertinoApp Theme'),
+///       middle: Text('CupertinoApp Theme'),
 ///     ),
 ///     child: Center(child: Icon(CupertinoIcons.share)),
 ///   ),
@@ -372,7 +372,7 @@ class CupertinoApp extends StatefulWidget {
   ///   return WidgetsApp(
   ///     actions: <Type, Action<Intent>>{
   ///       ... WidgetsApp.defaultActions,
-  ///       ActivateAction: CallbackAction(
+  ///       ActivateAction: CallbackAction<Intent>(
   ///         onInvoke: (Intent intent) {
   ///           // Do something here...
   ///           return null;

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -601,7 +601,7 @@ class CupertinoColors {
 /// CupertinoButton(
 ///   child: child,
 ///   // CupertinoDynamicColor works out of box in a CupertinoButton.
-///   color: CupertinoDynamicColor.withBrightness(
+///   color: const CupertinoDynamicColor.withBrightness(
 ///     color: CupertinoColors.white,
 ///     darkColor: CupertinoColors.black,
 ///   ),

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -86,7 +86,7 @@ enum _ContextMenuLocation {
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Center(
-///       child: Container(
+///       child: SizedBox(
 ///         width: 100,
 ///         height: 100,
 ///         child: CupertinoContextMenu(

--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -41,7 +41,7 @@ const EdgeInsetsGeometry _kDefaultPadding =
 ///
 /// ```dart
 /// class FlutterDemo extends StatefulWidget {
-///   FlutterDemo({Key? key}) : super(key: key);
+///   const FlutterDemo({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   _FlutterDemoState createState() => _FlutterDemoState();
@@ -55,20 +55,20 @@ const EdgeInsetsGeometry _kDefaultPadding =
 ///     return CupertinoPageScaffold(
 ///       child: Center(
 ///         child: CupertinoFormSection(
-///           header: Text('SECTION 1'),
+///           header: const Text('SECTION 1'),
 ///           children: <Widget>[
 ///             CupertinoFormRow(
 ///               child: CupertinoSwitch(
-///                 value: this.toggleValue,
-///                 onChanged: (value) {
+///                 value: toggleValue,
+///                 onChanged: (bool value) {
 ///                   setState(() {
-///                     this.toggleValue = value;
+///                     toggleValue = value;
 ///                   });
 ///                 },
 ///               ),
-///               prefix: Text('Toggle'),
-///               helper: Text('Use your instincts'),
-///               error: toggleValue ? Text('Cannot be true') : null,
+///               prefix: const Text('Toggle'),
+///               helper: const Text('Use your instincts'),
+///               error: toggleValue ? const Text('Cannot be true') : null,
 ///             ),
 ///           ],
 ///         ),

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -189,6 +189,7 @@ bool _isTransitionable(BuildContext context) {
 ///
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return CupertinoPageScaffold(
 ///     navigationBar: CupertinoNavigationBar(
@@ -197,7 +198,7 @@ bool _isTransitionable(BuildContext context) {
 ///       middle: const Text('Sample Code'),
 ///     ),
 ///     child: Column(
-///       children: [
+///       children: <Widget>[
 ///         Container(height: 50, color: CupertinoColors.systemRed),
 ///         Container(height: 50, color: CupertinoColors.systemGreen),
 ///         Container(height: 50, color: CupertinoColors.systemBlue),

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -26,15 +26,16 @@ import 'theme.dart';
 /// ```dart
 /// int _count = 0;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return CupertinoPageScaffold(
 ///     // Uncomment to change the background color
 ///     // backgroundColor: CupertinoColors.systemPink,
-///     navigationBar: CupertinoNavigationBar(
+///     navigationBar: const CupertinoNavigationBar(
 ///       middle: const Text('Sample Code'),
 ///     ),
 ///     child: ListView(
-///       children: [
+///       children: <Widget>[
 ///         CupertinoButton(
 ///           onPressed: () => setState(() => _count++),
 ///           child: const Icon(CupertinoIcons.add),

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -273,12 +273,12 @@ typedef RefreshCallback = Future<void> Function();
 /// adds a new item to the top of the list view.
 ///
 /// ```dart
-/// List<Color> colors = [
+/// List<Color> colors = <Color>[
 ///   CupertinoColors.systemYellow,
 ///   CupertinoColors.systemOrange,
 ///   CupertinoColors.systemPink
 /// ];
-/// List<Widget> items = [
+/// List<Widget> items = <Widget>[
 ///   Container(color: CupertinoColors.systemPink, height: 100.0),
 ///   Container(color: CupertinoColors.systemOrange, height: 100.0),
 ///   Container(color: CupertinoColors.systemYellow, height: 100.0),
@@ -296,7 +296,7 @@ typedef RefreshCallback = Future<void> Function();
 ///             refreshTriggerPullDistance: 100.0,
 ///             refreshIndicatorExtent: 60.0,
 ///             onRefresh: () async {
-///               await Future.delayed(Duration(milliseconds: 1000));
+///               await Future<void>.delayed(const Duration(milliseconds: 1000));
 ///               setState(() {
 ///                 items.insert(0, Container(color: colors[items.length % 3], height: 100.0));
 ///               });

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -1144,13 +1144,15 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 ///
 /// ```dart
 /// void main() {
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return CupertinoApp(
+///     return const CupertinoApp(
 ///       restorationScopeId: 'app',
 ///       home: MyHomePage(),
 ///     );
@@ -1158,13 +1160,15 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 /// }
 ///
 /// class MyHomePage extends StatelessWidget {
-///   static Route _modalBuilder(BuildContext context, Object? arguments) {
-///     return CupertinoModalPopupRoute(
+///   const MyHomePage({Key? key}) : super(key: key);
+///
+///   static Route<void> _modalBuilder(BuildContext context, Object? arguments) {
+///     return CupertinoModalPopupRoute<void>(
 ///       builder: (BuildContext context) {
 ///         return CupertinoActionSheet(
 ///           title: const Text('Title'),
 ///           message: const Text('Message'),
-///           actions: [
+///           actions: <CupertinoActionSheetAction>[
 ///             CupertinoActionSheetAction(
 ///               child: const Text('Action One'),
 ///               onPressed: () {
@@ -1306,13 +1310,15 @@ Widget _buildCupertinoDialogTransitions(BuildContext context, Animation<double> 
 ///
 /// ```dart
 /// void main() {
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return CupertinoApp(
+///     return const CupertinoApp(
 ///       restorationScopeId: 'app',
 ///       home: MyHomePage(),
 ///     );
@@ -1320,6 +1326,8 @@ Widget _buildCupertinoDialogTransitions(BuildContext context, Animation<double> 
 /// }
 ///
 /// class MyHomePage extends StatelessWidget {
+///   const MyHomePage({Key? key}) : super(key: key);
+///
 ///   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
 ///     return CupertinoDialogRoute<void>(
 ///       context: context,

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -25,6 +25,8 @@ import 'text_field.dart';
 ///
 /// ```dart
 /// class MyPrefilledSearch extends StatefulWidget {
+///   const MyPrefilledSearch({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyPrefilledSearchState createState() => _MyPrefilledSearchState();
 /// }
@@ -54,6 +56,8 @@ import 'text_field.dart';
 ///
 /// ```dart
 /// class MyPrefilledSearch extends StatefulWidget {
+///   const MyPrefilledSearch({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyPrefilledSearchState createState() => _MyPrefilledSearchState();
 /// }
@@ -62,11 +66,11 @@ import 'text_field.dart';
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return CupertinoSearchTextField(
-///       onChanged: (value) {
-///         print("The text has changed to: " + value);
+///       onChanged: (String value) {
+///         print('The text has changed to: ' + value);
 ///       },
-///       onSubmitted: (value) {
-///         print("Submitted text: " + value);
+///       onSubmitted: (String value) {
+///         print('Submitted text: ' + value);
 ///       },
 ///     );
 ///   }

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -67,10 +67,10 @@ import 'text_field.dart';
 ///   Widget build(BuildContext context) {
 ///     return CupertinoSearchTextField(
 ///       onChanged: (String value) {
-///         print('The text has changed to: ' + value);
+///         print('The text has changed to: $value');
 ///       },
 ///       onSubmitted: (String value) {
-///         print('Submitted text: ' + value);
+///         print('Submitted text: $value');
 ///       },
 ///     );
 ///   }

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -127,12 +127,14 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   ///
   /// ```dart
   /// class SegmentedControlExample extends StatefulWidget {
+  ///   const SegmentedControlExample({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State createState() => SegmentedControlExampleState();
   /// }
   ///
   /// class SegmentedControlExampleState extends State<SegmentedControlExample> {
-  ///   final Map<int, Widget> children = const {
+  ///   final Map<int, Widget> children = const <int, Widget>{
   ///     0: Text('Child 1'),
   ///     1: Text('Child 2'),
   ///   };
@@ -141,16 +143,14 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   ///
   ///   @override
   ///   Widget build(BuildContext context) {
-  ///     return Container(
-  ///       child: CupertinoSegmentedControl<int>(
-  ///         children: children,
-  ///         onValueChanged: (int newValue) {
-  ///           setState(() {
-  ///             currentValue = newValue;
-  ///           });
-  ///         },
-  ///         groupValue: currentValue,
-  ///       ),
+  ///     return CupertinoSegmentedControl<int>(
+  ///       children: children,
+  ///       onValueChanged: (int newValue) {
+  ///         setState(() {
+  ///           currentValue = newValue;
+  ///         });
+  ///       },
+  ///       groupValue: currentValue,
   ///     );
   ///   }
   /// }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -352,12 +352,14 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   ///
   /// ```dart
   /// class SegmentedControlExample extends StatefulWidget {
+  ///   const SegmentedControlExample({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State createState() => SegmentedControlExampleState();
   /// }
   ///
   /// class SegmentedControlExampleState extends State<SegmentedControlExample> {
-  ///   final Map<int, Widget> children = const {
+  ///   final Map<int, Widget> children = const <int, Widget>{
   ///     0: Text('Child 1'),
   ///     1: Text('Child 2'),
   ///   };
@@ -366,16 +368,14 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   ///
   ///   @override
   ///   Widget build(BuildContext context) {
-  ///     return Container(
-  ///       child: CupertinoSlidingSegmentedControl<int>(
-  ///         children: children,
-  ///         onValueChanged: (int? newValue) {
-  ///           setState(() {
-  ///             currentValue = newValue;
-  ///           });
-  ///         },
-  ///         groupValue: currentValue,
-  ///       ),
+  ///     return CupertinoSlidingSegmentedControl<int>(
+  ///       children: children,
+  ///       onValueChanged: (int? newValue) {
+  ///         setState(() {
+  ///           currentValue = newValue;
+  ///         });
+  ///       },
+  ///       groupValue: currentValue,
   ///     );
   ///   }
   /// }

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -35,7 +35,7 @@ import 'thumb_painter.dart';
 /// ```dart
 /// MergeSemantics(
 ///   child: ListTile(
-///     title: Text('Lights'),
+///     title: const Text('Lights'),
 ///     trailing: CupertinoSwitch(
 ///       value: _lights,
 ///       onChanged: (bool value) { setState(() { _lights = value; }); },

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -20,6 +20,8 @@ import 'theme.dart';
 ///
 /// ```dart
 /// class MyCupertinoTabScaffoldPage extends StatefulWidget {
+///   const MyCupertinoTabScaffoldPage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _CupertinoTabScaffoldPageState createState() => _CupertinoTabScaffoldPageState();
 /// }
@@ -31,7 +33,7 @@ import 'theme.dart';
 ///   Widget build(BuildContext context) {
 ///     return CupertinoTabScaffold(
 ///       tabBar: CupertinoTabBar(
-///         items: <BottomNavigationBarItem> [
+///         items: const <BottomNavigationBarItem> [
 ///           // ...
 ///         ],
 ///       ),
@@ -143,7 +145,7 @@ class CupertinoTabController extends ChangeNotifier {
 /// ```dart
 /// CupertinoTabScaffold(
 ///   tabBar: CupertinoTabBar(
-///     items: <BottomNavigationBarItem> [
+///     items: const <BottomNavigationBarItem> [
 ///       // ...
 ///     ],
 ///   ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -149,6 +149,8 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
 ///
 /// ```dart
 /// class MyPrefilledText extends StatefulWidget {
+///   const MyPrefilledText({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyPrefilledTextState createState() => _MyPrefilledTextState();
 /// }

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -58,7 +58,7 @@ import 'text_field.dart';
 ///
 /// ```dart
 /// CupertinoTextFormFieldRow(
-///   prefix: Text('Username'),
+///   prefix: const Text('Username'),
 ///   onSaved: (String? value) {
 ///     // This optional block of code can be used to run
 ///     // code when the user saves the form.
@@ -79,6 +79,7 @@ import 'text_field.dart';
 /// ```
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return CupertinoPageScaffold(
 ///     child: Center(
@@ -88,12 +89,12 @@ import 'text_field.dart';
 ///           Form.of(primaryFocus!.context!)?.save();
 ///         },
 ///         child: CupertinoFormSection.insetGrouped(
-///           header: Text('SECTION 1'),
+///           header: const Text('SECTION 1'),
 ///           children: List<Widget>.generate(5, (int index) {
 ///             return CupertinoTextFormFieldRow(
-///               prefix: Text('Enter text'),
+///               prefix: const Text('Enter text'),
 ///               placeholder: 'Enter text',
-///               validator: (value) {
+///               validator: (String? value) {
 ///                 if (value == null || value.isEmpty) {
 ///                   return 'Please enter a value';
 ///                 }

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1763,8 +1763,8 @@ abstract class DiagnosticsNode {
 /// of an actual property of the object:
 ///
 /// ```dart
-/// var table = MessageProperty('table size', '$columns\u00D7$rows');
-/// var usefulness = MessageProperty('usefulness ratio', 'no metrics collected yet (never painted)');
+/// MessageProperty table = MessageProperty('table size', '$columns\u00D7$rows');
+/// MessageProperty usefulness = MessageProperty('usefulness ratio', 'no metrics collected yet (never painted)');
 /// ```
 /// {@end-tool}
 /// {@tool snippet}
@@ -1773,7 +1773,7 @@ abstract class DiagnosticsNode {
 /// concrete value that is a string:
 ///
 /// ```dart
-/// var name = StringProperty('name', _name);
+/// StringProperty name = StringProperty('name', _name);
 /// ```
 /// {@end-tool}
 ///
@@ -3068,7 +3068,7 @@ class DiagnosticPropertiesBuilder {
 }
 
 // Examples can assume:
-// class ExampleSuperclass with Diagnosticable { late String message; late double stepWidth; late double scale; late double paintExtent; late double hitTestExtent; late double paintExtend; late double maxWidth; late bool primary; late double progress; late int maxLines; late Duration duration; late int depth; late dynamic boxShadow; late dynamic style; late bool hasSize; late Matrix4 transform; Map<Listenable, VoidCallback>? handles; late Color color; late bool obscureText; late ImageRepeat repeat; late Size size; late Widget widget; late bool isCurrent; late bool keepAlive; late TextAlign textAlign; }
+// class ExampleSuperclass with Diagnosticable { late String message; late double stepWidth; late double scale; late double paintExtent; late double hitTestExtent; late double paintExtend; late double maxWidth; late bool primary; late double progress; late int maxLines; late Duration duration; late int depth; Iterable<BoxShadow>? boxShadow; late DiagnosticsTreeStyle style; late bool hasSize; late Matrix4 transform; Map<Listenable, VoidCallback>? handles; late Color color; late bool obscureText; late ImageRepeat repeat; late Size size; late Widget widget; late bool isCurrent; late bool keepAlive; late TextAlign textAlign; }
 
 /// A mixin class for providing string and [DiagnosticsNode] debug
 /// representations describing the properties of an object.

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -71,7 +71,7 @@ enum _LicenseEntryWithLineBreaksParserState {
 /// ```dart
 /// void initMyLibrary() {
 ///   LicenseRegistry.addLicense(() async* {
-///     yield LicenseEntryWithLineBreaks(<String>['my_library'], '''
+///     yield const LicenseEntryWithLineBreaks(<String>['my_library'], '''
 /// Copyright 2016 The Sample Authors. All rights reserved.
 ///
 /// Redistribution and use in source and binary forms, with or without

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -52,7 +52,7 @@ import 'theme.dart';
 ///  Widget build(BuildContext context) {
 ///    final TextStyle textStyle = Theme.of(context).textTheme.bodyText2!;
 ///    final List<Widget> aboutBoxChildren = <Widget>[
-///      SizedBox(height: 24),
+///      const SizedBox(height: 24),
 ///      RichText(
 ///        text: TextSpan(
 ///          children: <TextSpan>[
@@ -77,14 +77,14 @@ import 'theme.dart';
 ///
 ///    return Scaffold(
 ///      appBar: AppBar(
-///        title: Text('Show About Example'),
+///        title: const Text('Show About Example'),
 ///      ),
 ///      drawer: Drawer(
 ///        child: SingleChildScrollView(
 ///          child: SafeArea(
 ///            child: AboutListTile(
-///              icon: Icon(Icons.info),
-///              applicationIcon: FlutterLogo(),
+///              icon: const Icon(Icons.info),
+///              applicationIcon: const FlutterLogo(),
 ///              applicationName: 'Show About Example',
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '\u{a9} 2014 The Flutter Authors',
@@ -95,11 +95,11 @@ import 'theme.dart';
 ///      ),
 ///      body: Center(
 ///        child: ElevatedButton(
-///          child: Text('Show About Example'),
+///          child: const Text('Show About Example'),
 ///          onPressed: () {
 ///            showAboutDialog(
 ///              context: context,
-///              applicationIcon: FlutterLogo(),
+///              applicationIcon: const FlutterLogo(),
 ///              applicationName: 'Show About Example',
 ///              applicationVersion: 'August 2019',
 ///              applicationLegalese: '\u{a9} 2014 The Flutter Authors',

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -611,7 +611,7 @@ class MaterialApp extends StatefulWidget {
   ///   return WidgetsApp(
   ///     actions: <Type, Action<Intent>>{
   ///       ... WidgetsApp.defaultActions,
-  ///       ActivateAction: CallbackAction(
+  ///       ActivateAction: CallbackAction<Intent>(
   ///         onInvoke: (Intent intent) {
   ///           // Do something here...
   ///           return null;

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -115,7 +115,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 ///           icon: const Icon(Icons.navigate_next),
 ///           tooltip: 'Go to the next page',
 ///           onPressed: () {
-///             Navigator.push(context, MaterialPageRoute(
+///             Navigator.push(context, MaterialPageRoute<void>(
 ///               builder: (BuildContext context) {
 ///                 return Scaffold(
 ///                   appBar: AppBar(
@@ -317,10 +317,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///     primary: true,
   ///     slivers: <Widget>[
   ///       SliverAppBar(
-  ///         title: Text('Hello World'),
+  ///         title: const Text('Hello World'),
   ///         actions: <Widget>[
   ///           IconButton(
-  ///             icon: Icon(Icons.shopping_cart),
+  ///             icon: const Icon(Icons.shopping_cart),
   ///             tooltip: 'Open shopping cart',
   ///             onPressed: () {
   ///               // handle the press
@@ -1273,7 +1273,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// ```
 ///
 /// ```dart
-/// void main() => runApp(MyApp());
+/// void main() => runApp(const MyApp());
 ///
 /// class MyApp extends StatefulWidget {
 ///   const MyApp({Key? key}) : super(key: key);
@@ -1296,20 +1296,20 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///         body: CustomScrollView(
 ///           slivers: <Widget>[
 ///             SliverAppBar(
-///               pinned: this._pinned,
-///               snap: this._snap,
-///               floating: this._floating,
+///               pinned: _pinned,
+///               snap: _snap,
+///               floating: _floating,
 ///               expandedHeight: 160.0,
-///               flexibleSpace: FlexibleSpaceBar(
-///                 title: const Text("SliverAppBar"),
+///               flexibleSpace: const FlexibleSpaceBar(
+///                 title: Text('SliverAppBar'),
 ///                 background: FlutterLogo(),
 ///               ),
 ///             ),
-///             SliverToBoxAdapter(
+///             const SliverToBoxAdapter(
 ///               child: Center(
-///                 child: Container(
+///                 child: SizedBox(
 ///                   height: 2000,
-///                   child: const Text("Scroll to see SliverAppBar in effect ."),
+///                   child: const Text('Scroll to see SliverAppBar in effect .'),
 ///                 ),
 ///               ),
 ///             ),
@@ -1325,10 +1325,10 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                   Switch(
 ///                     onChanged: (bool val) {
 ///                       setState(() {
-///                         this._pinned = val;
+///                         _pinned = val;
 ///                       });
 ///                     },
-///                     value: this._pinned,
+///                     value: _pinned,
 ///                   ),
 ///                 ],
 ///               ),
@@ -1338,12 +1338,12 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                   Switch(
 ///                     onChanged: (bool val) {
 ///                       setState(() {
-///                         this._snap = val;
+///                         _snap = val;
 ///                         //Snapping only applies when the app bar is floating.
-///                         this._floating = this._floating || val;
+///                         _floating = _floating || val;
 ///                       });
 ///                     },
-///                     value: this._snap,
+///                     value: _snap,
 ///                   ),
 ///                 ],
 ///               ),
@@ -1353,15 +1353,15 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                   Switch(
 ///                     onChanged: (bool val) {
 ///                       setState(() {
-///                         this._floating = val;
-///                         if (this._snap == true) {
-///                           if (this._floating != true) {
-///                             this._snap = false;
+///                         _floating = val;
+///                         if (_snap == true) {
+///                           if (_floating != true) {
+///                             _snap = false;
 ///                           }
 ///                         }
 ///                       });
 ///                     },
-///                     value: this._floating,
+///                     value: _floating,
 ///                   ),
 ///                 ],
 ///               ),

--- a/packages/flutter/lib/src/material/autocomplete.dart
+++ b/packages/flutter/lib/src/material/autocomplete.dart
@@ -57,6 +57,7 @@ import 'text_form_field.dart';
 /// ```
 ///
 /// ```dart
+/// @immutable
 /// class User {
 ///   const User({
 ///     required this.email,
@@ -73,8 +74,9 @@ import 'text_form_field.dart';
 ///
 ///   @override
 ///   bool operator ==(Object other) {
-///     if (other.runtimeType != runtimeType)
+///     if (other.runtimeType != runtimeType) {
 ///       return false;
+///     }
 ///     return other is User
 ///         && other.name == name
 ///         && other.email == email;
@@ -85,9 +87,9 @@ import 'text_form_field.dart';
 /// }
 ///
 /// class AutocompleteBasicUserExample extends StatelessWidget {
-///   AutocompleteBasicUserExample({Key? key}) : super(key: key);
+///   const AutocompleteBasicUserExample({Key? key}) : super(key: key);
 ///
-///   static final List<User> _userOptions = <User>[
+///   static const List<User> _userOptions = <User>[
 ///     User(name: 'Alice', email: 'alice@example.com'),
 ///     User(name: 'Bob', email: 'bob@example.com'),
 ///     User(name: 'Charlie', email: 'charlie123@gmail.com'),

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///     color: Colors.white,
 ///     child: bottomAppBarContents,
 ///   ),
-///   floatingActionButton: FloatingActionButton(onPressed: null),
+///   floatingActionButton: const FloatingActionButton(onPressed: null),
 /// )
 /// ```
 /// {@end-tool}
@@ -42,20 +42,20 @@ import 'theme.dart';
 ///
 /// ```dart
 /// void main() {
-///   runApp(BottomAppBarDemo());
+///   runApp(const BottomAppBarDemo());
 /// }
 ///
 /// class BottomAppBarDemo extends StatefulWidget {
-///   const BottomAppBarDemo();
+///   const BottomAppBarDemo({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   State createState() => _BottomAppBarDemoState();
 /// }
 ///
 /// class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
-///   var _showFab = true;
-///   var _showNotch = true;
-///   var _fabLocation = FloatingActionButtonLocation.endDocked;
+///   bool _showFab = true;
+///   bool _showNotch = true;
+///   FloatingActionButtonLocation _fabLocation = FloatingActionButtonLocation.endDocked;
 ///
 ///   void _onShowNotchChanged(bool value) {
 ///     setState(() {
@@ -69,9 +69,9 @@ import 'theme.dart';
 ///     });
 ///   }
 ///
-///   void _onFabLocationChanged(dynamic value) {
+///   void _onFabLocationChanged(FloatingActionButtonLocation? value) {
 ///     setState(() {
-///       _fabLocation = value;
+///       _fabLocation = value ?? FloatingActionButtonLocation.endDocked;
 ///     });
 ///   }
 ///
@@ -81,55 +81,47 @@ import 'theme.dart';
 ///       home: Scaffold(
 ///         appBar: AppBar(
 ///           automaticallyImplyLeading: false,
-///           title: Text("Bottom App Bar Demo"),
+///           title: const Text('Bottom App Bar Demo'),
 ///         ),
 ///         body: ListView(
 ///           padding: const EdgeInsets.only(bottom: 88),
-///           children: [
+///           children: <Widget>[
 ///             SwitchListTile(
-///               title: Text(
-///                 "Floating Action Button",
+///               title: const Text(
+///                 'Floating Action Button',
 ///               ),
 ///               value: _showFab,
 ///               onChanged: _onShowFabChanged,
 ///             ),
 ///             SwitchListTile(
-///               title: Text("Notch"),
+///               title: const Text('Notch'),
 ///               value: _showNotch,
 ///               onChanged: _onShowNotchChanged,
 ///             ),
-///             Padding(
-///               padding: const EdgeInsets.all(16),
-///               child: Text("Floating action button position"),
+///             const Padding(
+///               padding: EdgeInsets.all(16),
+///               child: Text('Floating action button position'),
 ///             ),
 ///             RadioListTile<FloatingActionButtonLocation>(
-///               title: Text(
-///                 "Docked - End",
-///               ),
+///               title: const Text('Docked - End'),
 ///               value: FloatingActionButtonLocation.endDocked,
 ///               groupValue: _fabLocation,
 ///               onChanged: _onFabLocationChanged,
 ///             ),
 ///             RadioListTile<FloatingActionButtonLocation>(
-///               title: Text(
-///                 "Docked - Center",
-///               ),
+///               title: const Text('Docked - Center'),
 ///               value: FloatingActionButtonLocation.centerDocked,
 ///               groupValue: _fabLocation,
 ///               onChanged: _onFabLocationChanged,
 ///             ),
 ///             RadioListTile<FloatingActionButtonLocation>(
-///               title: Text(
-///                 "Floating - End",
-///               ),
+///               title: const Text('Floating - End'),
 ///               value: FloatingActionButtonLocation.endFloat,
 ///               groupValue: _fabLocation,
 ///               onChanged: _onFabLocationChanged,
 ///             ),
 ///             RadioListTile<FloatingActionButtonLocation>(
-///               title: Text(
-///                 "Floating - Center",
-///               ),
+///               title: const Text('Floating - Center'),
 ///               value: FloatingActionButtonLocation.centerFloat,
 ///               groupValue: _fabLocation,
 ///               onChanged: _onFabLocationChanged,
@@ -140,7 +132,7 @@ import 'theme.dart';
 ///             ? FloatingActionButton(
 ///                 onPressed: () {},
 ///                 child: const Icon(Icons.add),
-///                 tooltip: "Create",
+///                 tooltip: 'Create',
 ///               )
 ///             : null,
 ///         floatingActionButtonLocation: _fabLocation,
@@ -160,9 +152,9 @@ import 'theme.dart';
 ///   });
 ///
 ///   final FloatingActionButtonLocation fabLocation;
-///   final dynamic shape;
+///   final NotchedShape? shape;
 ///
-///   static final centerLocations = <FloatingActionButtonLocation>[
+///   static final List<FloatingActionButtonLocation> centerLocations = <FloatingActionButtonLocation>[
 ///     FloatingActionButtonLocation.centerDocked,
 ///     FloatingActionButtonLocation.centerFloat,
 ///   ];
@@ -175,7 +167,7 @@ import 'theme.dart';
 ///       child: IconTheme(
 ///         data: IconThemeData(color: Theme.of(context).colorScheme.onPrimary),
 ///         child: Row(
-///           children: [
+///           children: <Widget>[
 ///             IconButton(
 ///               tooltip: 'Open navigation menu',
 ///               icon: const Icon(Icons.menu),
@@ -183,12 +175,12 @@ import 'theme.dart';
 ///             ),
 ///             if (centerLocations.contains(fabLocation)) const Spacer(),
 ///             IconButton(
-///               tooltip: "Search",
+///               tooltip: 'Search',
 ///               icon: const Icon(Icons.search),
 ///               onPressed: () {},
 ///             ),
 ///             IconButton(
-///               tooltip: "Favorite",
+///               tooltip: 'Favorite',
 ///               icon: const Icon(Icons.favorite),
 ///               onPressed: () {},
 ///             ),

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -78,7 +78,7 @@ import 'theme.dart';
 ///         onTap: () {
 ///           print('Card tapped.');
 ///         },
-///         child: Container(
+///         child: const SizedBox(
 ///           width: 300,
 ///           height: 100,
 ///           child: Text('A card that can be tapped'),

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -39,6 +39,8 @@ import 'toggleable.dart';
 ///
 /// ```dart
 /// bool isChecked = false;
+///
+/// @override
 /// Widget build(BuildContext context) {
 ///   Color getColor(Set<MaterialState> states) {
 ///     const Set<MaterialState> interactiveStates = <MaterialState>{
@@ -55,9 +57,9 @@ import 'toggleable.dart';
 ///     checkColor: Colors.white,
 ///     fillColor: MaterialStateProperty.resolveWith(getColor),
 ///     value: isChecked,
-///     onChanged: (val) {
+///     onChanged: (bool? value) {
 ///       setState(() {
-///         isChecked = !isChecked;
+///         isChecked = value!;
 ///       });
 ///     },
 ///   );

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -99,11 +99,12 @@ import 'theme_data.dart';
 /// ```dart preamble
 /// class LinkedLabelCheckbox extends StatelessWidget {
 ///   const LinkedLabelCheckbox({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;
@@ -120,7 +121,7 @@ import 'theme_data.dart';
 ///             child: RichText(
 ///               text: TextSpan(
 ///                 text: label,
-///                 style: TextStyle(
+///                 style: const TextStyle(
 ///                   color: Colors.blueAccent,
 ///                   decoration: TextDecoration.underline,
 ///                 ),
@@ -179,11 +180,12 @@ import 'theme_data.dart';
 /// ```dart preamble
 /// class LabeledCheckbox extends StatelessWidget {
 ///   const LabeledCheckbox({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -232,6 +232,8 @@ abstract class DeletableChipAttributes {
   /// }
   ///
   /// class CastList extends StatefulWidget {
+  ///   const CastList({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State createState() => CastListState();
   /// }
@@ -275,7 +277,7 @@ abstract class DeletableChipAttributes {
   /// ```dart
   /// @override
   /// Widget build(BuildContext context) {
-  ///   return CastList();
+  ///   return const CastList();
   /// }
   /// ```
   /// {@end-tool}
@@ -383,6 +385,8 @@ abstract class SelectableChipAttributes {
   ///
   /// ```dart
   /// class Wood extends StatefulWidget {
+  ///   const Wood({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State<StatefulWidget> createState() => WoodState();
   /// }
@@ -519,6 +523,8 @@ abstract class TappableChipAttributes {
   ///
   /// ```dart
   /// class Blacksmith extends StatelessWidget {
+  ///   const Blacksmith({Key? key}) : super(key: key);
+  ///
   ///   void startHammering() {
   ///     print('bang bang bang');
   ///   }
@@ -567,9 +573,9 @@ abstract class TappableChipAttributes {
 /// Chip(
 ///   avatar: CircleAvatar(
 ///     backgroundColor: Colors.grey.shade800,
-///     child: Text('AB'),
+///     child: const Text('AB'),
 ///   ),
-///   label: Text('Aaron Burr'),
+///   label: const Text('Aaron Burr'),
 /// )
 /// ```
 /// {@end-tool}
@@ -716,9 +722,9 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
 /// InputChip(
 ///   avatar: CircleAvatar(
 ///     backgroundColor: Colors.grey.shade800,
-///     child: Text('AB'),
+///     child: const Text('AB'),
 ///   ),
-///   label: Text('Aaron Burr'),
+///   label: const Text('Aaron Burr'),
 ///   onPressed: () {
 ///     print('I am the one thing in life.');
 ///   }
@@ -916,6 +922,8 @@ class InputChip extends StatelessWidget
 ///
 /// ```dart
 /// class MyThreeOptions extends StatefulWidget {
+///   const MyThreeOptions({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyThreeOptionsState createState() => _MyThreeOptionsState();
 /// }
@@ -1106,6 +1114,8 @@ class ChoiceChip extends StatelessWidget
 /// }
 ///
 /// class CastFilter extends StatefulWidget {
+///   const CastFilter({Key? key}) : super(key: key);
+///
 ///   @override
 ///   State createState() => CastFilterState();
 /// }
@@ -1117,7 +1127,7 @@ class ChoiceChip extends StatelessWidget
 ///     const ActorFilterEntry('Eliza Hamilton', 'EH'),
 ///     const ActorFilterEntry('James Madison', 'JM'),
 ///   ];
-///   List<String> _filters = <String>[];
+///   final List<String> _filters = <String>[];
 ///
 ///   Iterable<Widget> get actorWidgets sync* {
 ///     for (final ActorFilterEntry actor in _cast) {
@@ -1331,11 +1341,11 @@ class FilterChip extends StatelessWidget
 /// ActionChip(
 ///   avatar: CircleAvatar(
 ///     backgroundColor: Colors.grey.shade800,
-///     child: Text('AB'),
+///     child: const Text('AB'),
 ///   ),
-///   label: Text('Aaron Burr'),
+///   label: const Text('Aaron Burr'),
 ///   onPressed: () {
-///     print("If you stand for nothing, Burr, what’ll you fall for?");
+///     print('If you stand for nothing, Burr, what’ll you fall for?');
 ///   }
 /// )
 /// ```

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -65,6 +65,8 @@ class ChipTheme extends InheritedTheme {
   ///
   /// ```dart
   /// class Spaceship extends StatelessWidget {
+  ///   const Spaceship({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     return ChipTheme(
@@ -122,6 +124,8 @@ class ChipTheme extends InheritedTheme {
 ///
 /// ```dart
 /// class CarColor extends StatefulWidget {
+///   const CarColor({Key? key}) : super(key: key);
+///
 ///   @override
 ///   State createState() => _CarColorState();
 /// }
@@ -134,7 +138,7 @@ class ChipTheme extends InheritedTheme {
 ///     return ChipTheme(
 ///       data: ChipTheme.of(context).copyWith(backgroundColor: Colors.lightBlue),
 ///       child: ChoiceChip(
-///         label: Text('Light Blue'),
+///         label: const Text('Light Blue'),
 ///         onSelected: (bool value) {
 ///           setState(() {
 ///             _color = value ? Colors.lightBlue : Colors.red;

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -46,7 +46,7 @@ import 'theme.dart';
 /// ```dart
 /// CircleAvatar(
 ///   backgroundColor: Colors.brown.shade800,
-///   child: Text('AH'),
+///   child: const Text('AH'),
 /// )
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -373,7 +373,7 @@ class DataCell {
 ///
 /// ```dart
 /// static const int numItems = 10;
-/// List<bool> selected = List<bool>.generate(numItems, (index) => false);
+/// List<bool> selected = List<bool>.generate(numItems, (int index) => false);
 ///
 /// @override
 /// Widget build(BuildContext context) {
@@ -387,17 +387,18 @@ class DataCell {
 ///       ],
 ///       rows: List<DataRow>.generate(
 ///         numItems,
-///         (index) => DataRow(
+///         (int index) => DataRow(
 ///           color: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
 ///             // All rows will have the same selected color.
 ///             if (states.contains(MaterialState.selected))
 ///               return Theme.of(context).colorScheme.primary.withOpacity(0.08);
 ///             // Even rows will have a grey color.
-///             if (index % 2 == 0)
+///             if (index.isEven) {
 ///               return Colors.grey.withOpacity(0.3);
+///             }
 ///             return null;  // Use default value for other states and odd rows.
 ///           }),
-///           cells: [DataCell(Text('Row $index'))],
+///           cells: <DataCell>[ DataCell(Text('Row $index')) ],
 ///           selected: selected[index],
 ///           onSelectChanged: (bool? value) {
 ///             setState(() {

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -194,10 +194,10 @@ class Dialog extends StatelessWidget {
 ///     barrierDismissible: false, // user must tap button!
 ///     builder: (BuildContext context) {
 ///       return AlertDialog(
-///         title: Text('AlertDialog Title'),
+///         title: const Text('AlertDialog Title'),
 ///         content: SingleChildScrollView(
 ///           child: ListBody(
-///             children: <Widget>[
+///             children: const <Widget>[
 ///               Text('This is a demo alert dialog.'),
 ///               Text('Would you like to approve of this message?'),
 ///             ],
@@ -205,7 +205,7 @@ class Dialog extends StatelessWidget {
 ///         ),
 ///         actions: <Widget>[
 ///           TextButton(
-///             child: Text('Approve'),
+///             child: const Text('Approve'),
 ///             onPressed: () {
 ///               Navigator.of(context).pop();
 ///             },
@@ -232,7 +232,7 @@ class Dialog extends StatelessWidget {
 ///       builder: (BuildContext context) => AlertDialog(
 ///         title: const Text('AlertDialog Tilte'),
 ///         content: const Text('AlertDialog description'),
-///         actions: [
+///         actions: <Widget>[
 ///           TextButton(
 ///             onPressed: () => Navigator.pop(context, 'Cancel'),
 ///             child: const Text('Cancel'),
@@ -244,7 +244,7 @@ class Dialog extends StatelessWidget {
 ///         ],
 ///       ),
 ///     ),
-///     child: Text('Show Dialog'),
+///     child: const Text('Show Dialog'),
 ///   );
 /// }
 ///
@@ -367,13 +367,13 @@ class AlertDialog extends StatelessWidget {
   /// This is an example of a set of actions aligned with the content widget.
   /// ```dart
   /// AlertDialog(
-  ///   title: Text('Title'),
+  ///   title: const Text('Title'),
   ///   content: Container(width: 200, height: 200, color: Colors.green),
   ///   actions: <Widget>[
-  ///     ElevatedButton(onPressed: () {}, child: Text('Button 1')),
-  ///     ElevatedButton(onPressed: () {}, child: Text('Button 2')),
+  ///     ElevatedButton(onPressed: () {}, child: const Text('Button 1')),
+  ///     ElevatedButton(onPressed: () {}, child: const Text('Button 2')),
   ///   ],
-  ///   actionsPadding: EdgeInsets.symmetric(horizontal: 8.0),
+  ///   actionsPadding: const EdgeInsets.symmetric(horizontal: 8.0),
   /// )
   /// ```
   /// {@end-tool}
@@ -1009,13 +1009,15 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 ///
 /// ```dart
 /// void main() {
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return MaterialApp(
+///     return const MaterialApp(
 ///       restorationScopeId: 'app',
 ///       title: 'Restorable Routes Demo',
 ///       home: MyHomePage(),
@@ -1024,6 +1026,8 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// }
 ///
 /// class MyHomePage extends StatelessWidget {
+///   const MyHomePage({Key? key}) : super(key: key);
+///
 ///   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
 ///     return DialogRoute<void>(
 ///       context: context,

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -140,7 +140,7 @@ class Divider extends StatelessWidget {
   /// {@tool snippet}
   ///
   /// ```dart
-  /// Divider(
+  /// const Divider(
   ///   color: Colors.deepOrange,
   /// )
   /// ```
@@ -332,7 +332,7 @@ class VerticalDivider extends StatelessWidget {
   /// {@tool snippet}
   ///
   /// ```dart
-  /// Divider(
+  /// const Divider(
   ///   color: Colors.deepOrange,
   /// )
   /// ```

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -760,10 +760,10 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// Widget build(BuildContext context) {
 ///   return DropdownButton<String>(
 ///     value: dropdownValue,
-///     icon: Icon(Icons.arrow_downward),
+///     icon: const Icon(Icons.arrow_downward),
 ///     iconSize: 24,
 ///     elevation: 16,
-///     style: TextStyle(
+///     style: const TextStyle(
 ///       color: Colors.deepPurple
 ///     ),
 ///     underline: Container(
@@ -1002,12 +1002,12 @@ class DropdownButton<T> extends StatefulWidget {
   ///           dropdownValue = newValue!;
   ///         });
   ///       },
-  ///       style: TextStyle(color: Colors.blue),
+  ///       style: const TextStyle(color: Colors.blue),
   ///       selectedItemBuilder: (BuildContext context) {
   ///         return options.map((String value) {
   ///           return Text(
   ///             dropdownValue,
-  ///             style: TextStyle(color: Colors.white),
+  ///             style: const TextStyle(color: Colors.white),
   ///           );
   ///         }).toList();
   ///       },

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -52,9 +52,10 @@ import 'theme_data.dart';
 /// This sample produces an enabled and a disabled ElevatedButton.
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   final ButtonStyle style =
-///     ElevatedButton.styleFrom(textStyle: TextStyle(fontSize: 20));
+///     ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
 ///
 ///   return Center(
 ///     child: Column(

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -166,7 +166,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
 /// }
 ///
 /// List<Item> generateItems(int numberOfItems) {
-///   return List.generate(numberOfItems, (int index) {
+///   return List<Item>.generate(numberOfItems, (int index) {
 ///     return Item(
 ///       headerValue: 'Panel $index',
 ///       expandedValue: 'This is item number $index',
@@ -176,7 +176,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
 /// ```
 ///
 /// ```dart
-/// List<Item> _data = generateItems(8);
+/// final List<Item> _data = generateItems(8);
 ///
 /// @override
 /// Widget build(BuildContext context) {
@@ -203,11 +203,11 @@ class ExpansionPanelRadio extends ExpansionPanel {
 ///         },
 ///         body: ListTile(
 ///           title: Text(item.expandedValue),
-///           subtitle: Text('To delete this panel, tap the trash can icon'),
-///           trailing: Icon(Icons.delete),
+///           subtitle: const Text('To delete this panel, tap the trash can icon'),
+///           trailing: const Icon(Icons.delete),
 ///           onTap: () {
 ///             setState(() {
-///               _data.removeWhere((currentItem) => item == currentItem);
+///               _data.removeWhere((Item currentItem) => item == currentItem);
 ///             });
 ///           }
 ///         ),
@@ -270,7 +270,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// }
   ///
   /// List<Item> generateItems(int numberOfItems) {
-  ///   return List.generate(numberOfItems, (int index) {
+  ///   return List<Item>.generate(numberOfItems, (int index) {
   ///     return Item(
   ///       id: index,
   ///       headerValue: 'Panel $index',
@@ -281,7 +281,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// ```
   ///
   /// ```dart
-  /// List<Item> _data = generateItems(8);
+  /// final List<Item> _data = generateItems(8);
   ///
   /// @override
   /// Widget build(BuildContext context) {
@@ -305,11 +305,11 @@ class ExpansionPanelList extends StatefulWidget {
   ///         },
   ///         body: ListTile(
   ///           title: Text(item.expandedValue),
-  ///           subtitle: Text('To delete this panel, tap the trash can icon'),
-  ///           trailing: Icon(Icons.delete),
+  ///           subtitle: const Text('To delete this panel, tap the trash can icon'),
+  ///           trailing: const Icon(Icons.delete),
   ///           onTap: () {
   ///             setState(() {
-  ///               _data.removeWhere((currentItem) => item == currentItem);
+  ///               _data.removeWhere((Item currentItem) => item == currentItem);
   ///             });
   ///           }
   ///         )

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -32,6 +32,8 @@ import 'theme.dart';
 ///
 /// ```dart
 /// class WidgetWithWrappedHandler extends StatelessWidget {
+///   const WidgetWithWrappedHandler({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return GestureDetector(
@@ -58,6 +60,8 @@ import 'theme.dart';
 ///
 /// ```dart
 /// class WidgetWithExplicitCall extends StatelessWidget {
+///   const WidgetWithExplicitCall({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return GestureDetector(

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -66,9 +66,11 @@ enum StretchMode {
 /// import 'package:flutter/material.dart';
 /// ```
 /// ```dart
-/// void main() => runApp(MaterialApp(home: MyApp()));
+/// void main() => runApp(const MaterialApp(home: MyApp()));
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
@@ -79,11 +81,11 @@ enum StretchMode {
 ///             stretch: true,
 ///             onStretchTrigger: () {
 ///               // Function callback for stretch
-///               return Future.value();
+///               return Future<void>.value();
 ///             },
 ///             expandedHeight: 300.0,
 ///             flexibleSpace: FlexibleSpaceBar(
-///               stretchModes: <StretchMode>[
+///               stretchModes: const <StretchMode>[
 ///                 StretchMode.zoomBackground,
 ///                 StretchMode.blurBackground,
 ///                 StretchMode.fadeTitle,
@@ -92,7 +94,7 @@ enum StretchMode {
 ///               title: const Text('Flight Report'),
 ///               background: Stack(
 ///                 fit: StackFit.expand,
-///                 children: [
+///                 children: <Widget>[
 ///                   Image.network(
 ///                     'https://flutter.github.io/assets-for-api-docs/assets/widgets/owl-2.jpg',
 ///                     fit: BoxFit.cover,
@@ -114,19 +116,21 @@ enum StretchMode {
 ///             ),
 ///           ),
 ///           SliverList(
-///             delegate: SliverChildListDelegate([
-///               ListTile(
-///                 leading: Icon(Icons.wb_sunny),
-///                 title: Text('Sunday'),
-///                 subtitle: Text('sunny, h: 80, l: 65'),
-///               ),
-///               ListTile(
-///                 leading: Icon(Icons.wb_sunny),
-///                 title: Text('Monday'),
-///                 subtitle: Text('sunny, h: 80, l: 65'),
-///               ),
-///               // ListTiles++
-///             ]),
+///             delegate: SliverChildListDelegate(
+///               const <Widget>[
+///                 ListTile(
+///                   leading: Icon(Icons.wb_sunny),
+///                   title: Text('Sunday'),
+///                   subtitle: Text('sunny, h: 80, l: 65'),
+///                 ),
+///                 ListTile(
+///                   leading: Icon(Icons.wb_sunny),
+///                   title: Text('Monday'),
+///                   subtitle: Text('sunny, h: 80, l: 65'),
+///                 ),
+///                 // ListTiles++
+///               ],
+///             ),
 ///           ),
 ///         ],
 ///       ),

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -69,14 +69,14 @@ class _DefaultHeroTag {
 ///     appBar: AppBar(
 ///       title: const Text('Floating Action Button'),
 ///     ),
-///     body: Center(
-///       child: const Text('Press the button below!')
+///     body: const Center(
+///       child: Text('Press the button below!')
 ///     ),
 ///     floatingActionButton: FloatingActionButton(
 ///       onPressed: () {
 ///         // Add your onPressed code here!
 ///       },
-///       child: Icon(Icons.navigation),
+///       child: const Icon(Icons.navigation),
 ///       backgroundColor: Colors.green,
 ///     ),
 ///   );
@@ -97,15 +97,15 @@ class _DefaultHeroTag {
 ///     appBar: AppBar(
 ///       title: const Text('Floating Action Button Label'),
 ///     ),
-///     body: Center(
-///       child: const Text('Press the button with a label below!'),
+///     body: const Center(
+///       child: Text('Press the button with a label below!'),
 ///     ),
 ///     floatingActionButton: FloatingActionButton.extended(
 ///       onPressed: () {
 ///         // Add your onPressed code here!
 ///       },
-///       label: Text('Approve'),
-///       icon: Icon(Icons.thumb_up),
+///       label: const Text('Approve'),
+///       icon: const Icon(Icons.thumb_up),
 ///       backgroundColor: Colors.pink,
 ///     ),
 ///   );

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -461,12 +461,12 @@ abstract class FloatingActionButtonLocation {
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
-///       title: Text('Home page'),
+///       title: const Text('Home page'),
 ///     ),
 ///     floatingActionButton: FloatingActionButton(
 ///       onPressed: () { print('FAB pressed.'); },
 ///       tooltip: 'Increment',
-///       child: Icon(Icons.add),
+///       child: const Icon(Icons.add),
 ///     ),
 ///     floatingActionButtonLocation: AlmostEndFloatFabLocation(),
 ///   );

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -52,12 +52,13 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// ```
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Column(
 ///     mainAxisSize: MainAxisSize.min,
 ///     children: <Widget>[
 ///       IconButton(
-///         icon: Icon(Icons.volume_up),
+///         icon: const Icon(Icons.volume_up),
 ///         tooltip: 'Increase volume by 10',
 ///         onPressed: () {
 ///           setState(() {
@@ -94,6 +95,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/icon_button_background.png)
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Material(
 ///     color: Colors.white,
@@ -104,7 +106,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 ///           shape: CircleBorder(),
 ///         ),
 ///         child: IconButton(
-///           icon: Icon(Icons.android),
+///           icon: const Icon(Icons.android),
 ///           color: Colors.white,
 ///           onPressed: () {},
 ///         ),

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -59,7 +59,7 @@ import 'material.dart';
 ///       height: 100.0,
 ///       child: InkWell(
 ///         onTap: () { /* ... */ },
-///         child: Center(
+///         child: const Center(
 ///           child: Text('YELLOW'),
 ///         )
 ///       ),
@@ -78,17 +78,23 @@ import 'material.dart';
 ///   color: Colors.grey[800],
 ///   child: Center(
 ///     child: Ink.image(
-///       image: AssetImage('cat.jpeg'),
+///       image: const AssetImage('cat.jpeg'),
 ///       fit: BoxFit.cover,
 ///       width: 300.0,
 ///       height: 200.0,
 ///       child: InkWell(
 ///         onTap: () { /* ... */ },
-///         child: Align(
+///         child: const Align(
 ///           alignment: Alignment.topLeft,
 ///           child: Padding(
-///             padding: const EdgeInsets.all(10.0),
-///             child: Text('KITTEN', style: TextStyle(fontWeight: FontWeight.w900, color: Colors.white)),
+///             padding: EdgeInsets.all(10.0),
+///             child: Text(
+///               'KITTEN',
+///               style: TextStyle(
+///                 fontWeight: FontWeight.w900,
+///                 color: Colors.white,
+///               ),
+///             ),
 ///           ),
 ///         )
 ///       ),

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1182,11 +1182,12 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 /// ```dart
 /// double sideLength = 50;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return AnimatedContainer(
 ///     height: sideLength,
 ///     width: sideLength,
-///     duration: Duration(seconds: 2),
+///     duration: const Duration(seconds: 2),
 ///     curve: Curves.easeIn,
 ///     child: Material(
 ///       color: Colors.yellow,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2415,7 +2415,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return TextField(
+///   return const TextField(
 ///     decoration: InputDecoration(
 ///       icon: Icon(Icons.send),
 ///       hintText: 'Hint Text',
@@ -2438,7 +2438,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return TextField(
+///   return const TextField(
 ///     decoration: InputDecoration.collapsed(
 ///       hintText: 'Hint Text',
 ///       border: OutlineInputBorder(),
@@ -2458,7 +2458,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return TextField(
+///   return const TextField(
 ///     decoration: InputDecoration(
 ///       hintText: 'Hint Text',
 ///       errorText: 'Error Text',
@@ -2875,7 +2875,7 @@ class InputDecoration {
   ///     padding: const EdgeInsets.symmetric(horizontal: 8.0),
   ///     child: Column(
   ///       mainAxisAlignment: MainAxisAlignment.center,
-  ///       children: <Widget>[
+  ///       children: const <Widget>[
   ///         TextField(
   ///           decoration: InputDecoration(
   ///             hintText: 'Normal Icon Constraints',
@@ -3043,7 +3043,7 @@ class InputDecoration {
   ///     padding: const EdgeInsets.symmetric(horizontal: 8.0),
   ///     child: Column(
   ///       mainAxisAlignment: MainAxisAlignment.center,
-  ///       children: <Widget>[
+  ///       children: const <Widget>[
   ///         TextField(
   ///           decoration: InputDecoration(
   ///             hintText: 'Normal Icon Constraints',

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -399,12 +399,12 @@ enum ListTileControlAffinity {
 ///     child: Container(
 ///       width: 48,
 ///       height: 48,
-///       padding: EdgeInsets.symmetric(vertical: 4.0),
+///       padding: const EdgeInsets.symmetric(vertical: 4.0),
 ///       alignment: Alignment.center,
-///       child: CircleAvatar(),
+///       child: const CircleAvatar(),
 ///     ),
 ///   ),
-///   title: Text('title'),
+///   title: const Text('title'),
 ///   dense: false,
 /// ),
 /// ```
@@ -426,11 +426,12 @@ enum ListTileControlAffinity {
 /// ```dart preamble
 /// class CustomListItem extends StatelessWidget {
 ///   const CustomListItem({
+///     Key? key,
 ///     required this.thumbnail,
 ///     required this.title,
 ///     required this.user,
 ///     required this.viewCount,
-///   });
+///   }) : super(key: key);
 ///
 ///   final Widget thumbnail;
 ///   final String title;
@@ -547,7 +548,7 @@ enum ListTileControlAffinity {
 ///
 /// ```dart preamble
 /// class _ArticleDescription extends StatelessWidget {
-///   _ArticleDescription({
+///   const _ArticleDescription({
 ///     Key? key,
 ///     required this.title,
 ///     required this.subtitle,
@@ -573,7 +574,7 @@ enum ListTileControlAffinity {
 ///             crossAxisAlignment: CrossAxisAlignment.start,
 ///             children: <Widget>[
 ///               Text(
-///                 '$title',
+///                 title,
 ///                 maxLines: 2,
 ///                 overflow: TextOverflow.ellipsis,
 ///                 style: const TextStyle(
@@ -582,7 +583,7 @@ enum ListTileControlAffinity {
 ///               ),
 ///               const Padding(padding: EdgeInsets.only(bottom: 2.0)),
 ///               Text(
-///                 '$subtitle',
+///                 subtitle,
 ///                 maxLines: 2,
 ///                 overflow: TextOverflow.ellipsis,
 ///                 style: const TextStyle(
@@ -600,7 +601,7 @@ enum ListTileControlAffinity {
 ///             mainAxisAlignment: MainAxisAlignment.end,
 ///             children: <Widget>[
 ///               Text(
-///                 '$author',
+///                 author,
 ///                 style: const TextStyle(
 ///                   fontSize: 12.0,
 ///                   color: Colors.black87,
@@ -622,7 +623,7 @@ enum ListTileControlAffinity {
 /// }
 ///
 /// class CustomListItemTwo extends StatelessWidget {
-///   CustomListItemTwo({
+///   const CustomListItemTwo({
 ///     Key? key,
 ///     required this.thumbnail,
 ///     required this.title,
@@ -683,7 +684,7 @@ enum ListTileControlAffinity {
 ///         ),
 ///         title: 'Flutter 1.0 Launch',
 ///         subtitle:
-///           'Flutter continues to improve and expand its horizons.'
+///           'Flutter continues to improve and expand its horizons. '
 ///           'This text should max out at two lines and clip',
 ///         author: 'Dash',
 ///         publishDate: 'Dec 28',

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -109,10 +109,10 @@ typedef MaterialPropertyResolver<T> = T Function(Set<MaterialState> states);
 ///
 /// ```dart
 /// class MyColor extends MaterialStateColor {
+///   const MyColor() : super(_defaultColor);
+///
 ///   static const int _defaultColor = 0xcafefeed;
 ///   static const int _pressedColor = 0xdeadbeef;
-///
-///   const MyColor() : super(_defaultColor);
 ///
 ///   @override
 ///   Color resolve(Set<MaterialState> states) {
@@ -204,7 +204,7 @@ class _MaterialStateColor extends MaterialStateColor {
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return ListTile(
-///     title: Text('Disabled ListTile'),
+///     title: const Text('Disabled ListTile'),
 ///     enabled: false,
 ///     mouseCursor: ListTileCursor(),
 ///   );
@@ -304,7 +304,7 @@ class _EnabledAndDisabledMouseCursor extends MaterialStateMouseCursor {
 ///   @override
 ///   BorderSide? resolve(Set<MaterialState> states) {
 ///     if (states.contains(MaterialState.selected)) {
-///       return BorderSide(
+///       return const BorderSide(
 ///         width: 1,
 ///         color: Colors.red,
 ///       );
@@ -317,9 +317,10 @@ class _EnabledAndDisabledMouseCursor extends MaterialStateMouseCursor {
 /// ```dart
 /// bool isSelected = true;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return FilterChip(
-///     label: Text('Select chip'),
+///     label: const Text('Select chip'),
 ///     selected: isSelected,
 ///     onSelected: (bool value) {
 ///       setState(() {
@@ -364,7 +365,7 @@ abstract class MaterialStateBorderSide extends BorderSide implements MaterialSta
 ///   @override
 ///   OutlinedBorder? resolve(Set<MaterialState> states) {
 ///     if (states.contains(MaterialState.selected)) {
-///       return RoundedRectangleBorder();
+///       return const RoundedRectangleBorder();
 ///     }
 ///     return null;  // Defer to default value on the theme or widget.
 ///   }
@@ -374,9 +375,10 @@ abstract class MaterialStateBorderSide extends BorderSide implements MaterialSta
 /// ```dart
 /// bool isSelected = true;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return FilterChip(
-///     label: Text('Select chip'),
+///     label: const Text('Select chip'),
 ///     selected: isSelected,
 ///     onSelected: (bool value) {
 ///       setState(() {
@@ -451,7 +453,7 @@ abstract class MaterialStateOutlinedBorder extends OutlinedBorder implements Mat
 ///       foregroundColor: MaterialStateProperty.resolveWith(getColor),
 ///     ),
 ///     onPressed: () {},
-///     child: Text('TextButton'),
+///     child: const Text('TextButton'),
 ///   );
 /// }
 /// ```

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -58,7 +58,7 @@ import 'theme.dart';
 ///              });
 ///            },
 ///            labelType: NavigationRailLabelType.selected,
-///            destinations: [
+///            destinations: const <NavigationRailDestination>[
 ///              NavigationRailDestination(
 ///                icon: Icon(Icons.favorite_border),
 ///                selectedIcon: Icon(Icons.favorite),
@@ -76,7 +76,7 @@ import 'theme.dart';
 ///              ),
 ///            ],
 ///          ),
-///          VerticalDivider(thickness: 1, width: 1),
+///          const VerticalDivider(thickness: 1, width: 1),
 ///          // This is the main content.
 ///          Expanded(
 ///            child: Center(
@@ -329,7 +329,7 @@ class NavigationRail extends StatefulWidget {
   /// This can be used to synchronize animations in the [leading] or [trailing]
   /// widget, such as an animated menu or a [FloatingActionButton] animation.
   ///
-  /// {@tool snippet}
+  /// {@tool dartpad --template=stateless_widget_material}
   ///
   /// This example shows how to use this animation to create a
   /// [FloatingActionButton] that animates itself between the normal and
@@ -338,10 +338,11 @@ class NavigationRail extends StatefulWidget {
   /// An instance of `ExtendableFab` would be created for
   /// [NavigationRail.leading].
   ///
-  /// ```dart
+  /// ```dart dartImports
   /// import 'dart:ui';
+  /// ```
   ///
-  /// @override
+  /// ```dart
   /// Widget build(BuildContext context) {
   ///   final Animation<double> animation = NavigationRail.extendedAnimation(context);
   ///   return AnimatedBuilder(
@@ -355,7 +356,7 @@ class NavigationRail extends StatefulWidget {
   ///         ),
   ///         child: animation.value == 0
   ///           ? FloatingActionButton(
-  ///               child: Icon(Icons.add),
+  ///               child: const Icon(Icons.add),
   ///               onPressed: () {},
   ///             )
   ///           : Align(
@@ -364,8 +365,8 @@ class NavigationRail extends StatefulWidget {
   ///               child: Padding(
   ///                 padding: const EdgeInsetsDirectional.only(start: 8),
   ///                 child: FloatingActionButton.extended(
-  ///                   icon: Icon(Icons.add),
-  ///                   label: Text('CREATE'),
+  ///                   icon: const Icon(Icons.add),
+  ///                   label: const Text('CREATE'),
   ///                   onPressed: () {},
   ///                 ),
   ///               ),

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -22,8 +22,8 @@ import 'tooltip.dart';
 
 // Examples can assume:
 // enum Commands { heroAndScholar, hurricaneCame }
-// dynamic _heroAndScholar;
-// dynamic _selection;
+// late bool _heroAndScholar;
+// late dynamic _selection;
 // late BuildContext context;
 // void setState(VoidCallback fn) { }
 

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -267,14 +267,15 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 ///   super.dispose();
 /// }
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Padding(
 ///       padding: const EdgeInsets.all(20.0),
 ///       child: Column(
 ///         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-///         children: [
-///           Text(
+///         children: <Widget>[
+///           const Text(
 ///             'Linear progress indicator with a fixed color',
 ///             style: const TextStyle(fontSize: 20),
 ///           ),
@@ -505,13 +506,14 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 ///   super.dispose();
 /// }
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Padding(
 ///       padding: const EdgeInsets.all(20.0),
 ///       child: Column(
 ///         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-///         children: [
+///         children: <Widget>[
 ///           Text(
 ///             'Linear progress indicator with a fixed color',
 ///             style: Theme.of(context).textTheme.headline6,

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -52,12 +52,13 @@ const double _kInnerRadius = 4.5;
 /// ```dart
 /// SingingCharacter? _character = SingingCharacter.lafayette;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Column(
 ///     children: <Widget>[
 ///       ListTile(
 ///         title: const Text('Lafayette'),
-///         leading: Radio(
+///         leading: Radio<SingingCharacter>(
 ///           value: SingingCharacter.lafayette,
 ///           groupValue: _character,
 ///           onChanged: (SingingCharacter? value) {
@@ -67,7 +68,7 @@ const double _kInnerRadius = 4.5;
 ///       ),
 ///       ListTile(
 ///         title: const Text('Thomas Jefferson'),
-///         leading: Radio(
+///         leading: Radio<SingingCharacter>(
 ///           value: SingingCharacter.jefferson,
 ///           groupValue: _character,
 ///           onChanged: (SingingCharacter? value) {
@@ -218,7 +219,7 @@ class Radio<T> extends StatefulWidget {
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     body: ListView.builder(
-  ///       itemBuilder: (context, index) {
+  ///       itemBuilder: (BuildContext context, int index) {
   ///         return Row(
   ///           mainAxisSize: MainAxisSize.min,
   ///           crossAxisAlignment: CrossAxisAlignment.center,

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -108,12 +108,13 @@ import 'theme_data.dart';
 /// ```dart preamble
 /// class LinkedLabelRadio extends StatelessWidget {
 ///   const LinkedLabelRadio({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.groupValue,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) :super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;
@@ -137,7 +138,7 @@ import 'theme_data.dart';
 ///           RichText(
 ///             text: TextSpan(
 ///               text: label,
-///               style: TextStyle(
+///               style: const TextStyle(
 ///                 color: Colors.blueAccent,
 ///                 decoration: TextDecoration.underline,
 ///               ),
@@ -164,7 +165,7 @@ import 'theme_data.dart';
 ///       children: <Widget>[
 ///         LinkedLabelRadio(
 ///           label: 'First tappable label text',
-///           padding: EdgeInsets.symmetric(horizontal: 5.0),
+///           padding: const EdgeInsets.symmetric(horizontal: 5.0),
 ///           value: true,
 ///           groupValue: _isRadioSelected,
 ///           onChanged: (bool newValue) {
@@ -175,7 +176,7 @@ import 'theme_data.dart';
 ///         ),
 ///         LinkedLabelRadio(
 ///           label: 'Second tappable label text',
-///           padding: EdgeInsets.symmetric(horizontal: 5.0),
+///           padding: const EdgeInsets.symmetric(horizontal: 5.0),
 ///           value: false,
 ///           groupValue: _isRadioSelected,
 ///           onChanged: (bool newValue) {
@@ -208,12 +209,13 @@ import 'theme_data.dart';
 /// ```dart preamble
 /// class LabeledRadio extends StatelessWidget {
 ///   const LabeledRadio({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.groupValue,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;
@@ -225,8 +227,9 @@ import 'theme_data.dart';
 ///   Widget build(BuildContext context) {
 ///     return InkWell(
 ///       onTap: () {
-///         if (value != groupValue)
+///         if (value != groupValue) {
 ///           onChanged(value);
+///         }
 ///       },
 ///       child: Padding(
 ///         padding: padding,
@@ -406,7 +409,7 @@ class RadioListTile<T> extends StatelessWidget {
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     body: ListView.builder(
-  ///       itemBuilder: (context, index) {
+  ///       itemBuilder: (BuildContext context, int index) {
   ///         return RadioListTile<int>(
   ///           value: index,
   ///           groupValue: groupValue,

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -18,8 +18,8 @@ import 'slider_theme.dart';
 import 'theme.dart';
 
 // Examples can assume:
-// RangeValues _rangeValues = RangeValues(0.3, 0.7);
-// RangeValues _dollarsRange = RangeValues(50, 100);
+// RangeValues _rangeValues = const RangeValues(0.3, 0.7);
+// RangeValues _dollarsRange = const RangeValues(50, 100);
 // void setState(VoidCallback fn) { }
 
 /// [RangeSlider] uses this callback to paint the value indicator on the overlay.

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -34,10 +34,11 @@ import 'theme.dart';
 /// ```dart
 /// final List<int> _items = List<int>.generate(50, (int index) => index);
 ///
+/// @override
 /// Widget build(BuildContext context){
 ///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
-///   final oddItemColor = colorScheme.primary.withOpacity(0.05);
-///   final evenItemColor = colorScheme.primary.withOpacity(0.15);
+///   final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
+///   final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
 ///
 ///   return ReorderableListView(
 ///     padding: const EdgeInsets.symmetric(horizontal: 40),
@@ -186,10 +187,11 @@ class ReorderableListView extends StatefulWidget {
   /// ```dart
   /// final List<int> _items = List<int>.generate(50, (int index) => index);
   ///
+  /// @override
   /// Widget build(BuildContext context){
   ///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
-  ///   final oddItemColor = colorScheme.primary.withOpacity(0.05);
-  ///   final evenItemColor = colorScheme.primary.withOpacity(0.15);
+  ///   final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
+  ///   final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
   ///
   ///   return ReorderableListView(
   ///     buildDefaultDragHandles: false,
@@ -217,7 +219,7 @@ class ReorderableListView extends StatefulWidget {
   ///           ),
   ///         ),
   ///     ],
-  ///     onReorder: (oldIndex, newIndex) {
+  ///     onReorder: (int oldIndex, int newIndex) {
   ///       setState(() {
   ///         if (oldIndex < newIndex) {
   ///           newIndex -= 1;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -152,9 +152,11 @@ class ScaffoldMessenger extends StatefulWidget {
   /// import 'package:flutter/material.dart';
   /// ```
   /// ```dart
-  /// void main() => runApp(MyApp());
+  /// void main() => runApp(const MyApp());
   ///
   /// class MyApp extends StatefulWidget {
+  ///   const MyApp({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///  _MyAppState createState() => _MyAppState();
   /// }
@@ -179,12 +181,12 @@ class ScaffoldMessenger extends StatefulWidget {
   ///     return MaterialApp(
   ///       scaffoldMessengerKey: _scaffoldMessengerKey,
   ///       home: Scaffold(
-  ///         appBar: AppBar(title: Text('ScaffoldMessenger Demo')),
+  ///         appBar: AppBar(title: const Text('ScaffoldMessenger Demo')),
   ///         body: Center(
   ///           child: Column(
   ///             mainAxisAlignment: MainAxisAlignment.center,
   ///             children: <Widget>[
-  ///               Text(
+  ///               const Text(
   ///                 'You have pushed the button this many times:',
   ///               ),
   ///               Text(
@@ -197,7 +199,7 @@ class ScaffoldMessenger extends StatefulWidget {
   ///         floatingActionButton: FloatingActionButton(
   ///           onPressed: _incrementCounter,
   ///           tooltip: 'Increment',
-  ///           child: Icon(Icons.add),
+  ///           child: const Icon(Icons.add),
   ///         ),
   ///       ),
   ///     );
@@ -1291,6 +1293,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```dart
 /// int _count = 0;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
@@ -1320,6 +1323,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```dart
 /// int _count = 0;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
@@ -1352,6 +1356,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 /// ```dart
 /// int _count = 0;
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
@@ -1369,7 +1374,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 ///         _count++;
 ///       }),
 ///       tooltip: 'Increment Counter',
-///       child: Icon(Icons.add),
+///       child: const Icon(Icons.add),
 ///     ),
 ///     floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
 ///   );
@@ -1665,11 +1670,11 @@ class Scaffold extends StatefulWidget {
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     key: _scaffoldKey,
-  ///     appBar: AppBar(title: Text('Drawer Demo')),
+  ///     appBar: AppBar(title: const Text('Drawer Demo')),
   ///     body: Center(
   ///       child: ElevatedButton(
   ///         onPressed: _openEndDrawer,
-  ///         child: Text('Open End Drawer'),
+  ///         child: const Text('Open End Drawer'),
   ///       ),
   ///     ),
   ///     endDrawer: Drawer(
@@ -1822,11 +1827,13 @@ class Scaffold extends StatefulWidget {
   /// ```
   ///
   /// ```dart main
-  /// void main() => runApp(MyApp());
+  /// void main() => runApp(const MyApp());
   /// ```
   ///
   /// ```dart preamble
   /// class MyApp extends StatelessWidget {
+  ///   const MyApp({Key? key}) : super(key: key);
+  ///
   ///   // This widget is the root of your application.
   ///   @override
   ///   Widget build(BuildContext context) {
@@ -1836,7 +1843,7 @@ class Scaffold extends StatefulWidget {
   ///         primarySwatch: Colors.blue,
   ///       ),
   ///       home: Scaffold(
-  ///         body: MyScaffoldBody(),
+  ///         body: const MyScaffoldBody(),
   ///         appBar: AppBar(title: const Text('Scaffold.of Example')),
   ///       ),
   ///       color: Colors.white,
@@ -1847,6 +1854,8 @@ class Scaffold extends StatefulWidget {
   ///
   /// ```dart
   /// class MyScaffoldBody extends StatelessWidget {
+  ///   const MyScaffoldBody({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     return Center(
@@ -2213,8 +2222,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   ///     return OutlinedButton(
   ///       onPressed: () {
   ///         ScaffoldMessenger.of(context).showSnackBar(
-  ///           SnackBar(
-  ///             content: const Text('A SnackBar has been shown.'),
+  ///           const SnackBar(
+  ///             content: Text('A SnackBar has been shown.'),
   ///           ),
   ///         );
   ///       },

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -101,7 +101,7 @@ abstract class SearchDelegate<T> {
   ///
   /// {@tool snippet}
   /// ```dart
-  /// class CustomSearchHintDelegate extends SearchDelegate {
+  /// class CustomSearchHintDelegate extends SearchDelegate<String> {
   ///   CustomSearchHintDelegate({
   ///     required String hintText,
   ///   }) : super(
@@ -111,22 +111,23 @@ abstract class SearchDelegate<T> {
   ///   );
   ///
   ///   @override
-  ///   Widget buildLeading(BuildContext context) => Text("leading");
+  ///   Widget buildLeading(BuildContext context) => const Text('leading');
   ///
+  ///   @override
   ///   PreferredSizeWidget buildBottom(BuildContext context) {
-  ///     return PreferredSize(
+  ///     return const PreferredSize(
   ///        preferredSize: Size.fromHeight(56.0),
-  ///        child: Text("bottom"));
+  ///        child: Text('bottom'));
   ///   }
   ///
   ///   @override
-  ///   Widget buildSuggestions(BuildContext context) => Text("suggestions");
+  ///   Widget buildSuggestions(BuildContext context) => const Text('suggestions');
   ///
   ///   @override
-  ///   Widget buildResults(BuildContext context) => Text('results');
+  ///   Widget buildResults(BuildContext context) => const Text('results');
   ///
   ///   @override
-  ///   List<Widget> buildActions(BuildContext context) => [];
+  ///   List<Widget> buildActions(BuildContext context) => <Widget>[];
   /// }
   /// ```
   /// {@end-tool}

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -125,7 +125,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// {@tool snippet}
 ///
 /// ```dart
-/// SelectableText(
+/// const SelectableText(
 ///   'Hello! How are you?',
 ///   textAlign: TextAlign.center,
 ///   style: TextStyle(fontWeight: FontWeight.bold),

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -84,6 +84,8 @@ class SliderTheme extends InheritedTheme {
   ///
   /// ```dart
   /// class Launch extends StatefulWidget {
+  ///   const Launch({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State createState() => LaunchState();
   /// }
@@ -244,6 +246,8 @@ class SliderThemeData with Diagnosticable {
   ///
   /// ```dart
   /// class Blissful extends StatefulWidget {
+  ///   const Blissful({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   State createState() => BlissfulState();
   /// }

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -165,13 +165,13 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return ElevatedButton(
-///     child: Text("Show Snackbar"),
+///     child: const Text('Show Snackbar'),
 ///     onPressed: () {
 ///       ScaffoldMessenger.of(context).showSnackBar(
 ///         SnackBar(
-///           content: Text("Awesome Snackbar!"),
+///           content: const Text('Awesome Snackbar!'),
 ///           action: SnackBarAction(
-///             label: "Action",
+///             label: 'Action',
 ///             onPressed: () {
 ///               // Code to execute.
 ///             },
@@ -193,21 +193,22 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return ElevatedButton(
-///     child: Text("Show Snackbar"),
+///     child: const Text('Show Snackbar'),
 ///     onPressed: () {
 ///       ScaffoldMessenger.of(context).showSnackBar(
 ///         SnackBar(
 ///           action: SnackBarAction(
-///             label: "Action",
+///             label: 'Action',
 ///             onPressed: () {
 ///               // Code to execute.
 ///             },
 ///           ),
-///           content: Text("Awesome SnackBar!"),
-///           duration: Duration(milliseconds: 1500),
+///           content: const Text('Awesome SnackBar!'),
+///           duration: const Duration(milliseconds: 1500),
 ///           width: 280.0, // Width of the SnackBar.
-///           padding: EdgeInsets.symmetric(
-///             horizontal: 8.0), // Inner padding for SnackBar content.
+///           padding: const EdgeInsets.symmetric(
+///             horizontal: 8.0,  // Inner padding for SnackBar content.
+///           ),
 ///           behavior: SnackBarBehavior.floating,
 ///           shape: RoundedRectangleBorder(
 ///             borderRadius: BorderRadius.circular(10.0),

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -126,29 +126,33 @@ class Step {
 ///
 /// ```dart
 /// int _index = 0;
+///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Stepper(
 ///     currentStep: _index,
 ///     onStepCancel: () {
-///       if (_index > 0)
+///       if (_index > 0) {
 ///         setState(() { _index -= 1; });
+///       }
 ///     },
 ///     onStepContinue: () {
-///       if (_index <= 0)
+///       if (_index <= 0) {
 ///         setState(() { _index += 1; });
+///       }
 ///     },
-///     onStepTapped: (index) {
+///     onStepTapped: (int index) {
 ///       setState(() { _index = index; });
 ///     },
 ///     steps: <Step>[
 ///       Step(
-///         title: Text('Step 1 title'),
+///         title: const Text('Step 1 title'),
 ///         content: Container(
 ///           alignment: Alignment.centerLeft,
-///           child: Text('Content for Step 1')
+///           child: const Text('Content for Step 1')
 ///         ),
 ///       ),
-///       Step(
+///       const Step(
 ///         title: Text('Step 2 title'),
 ///         content: Text('Content for Step 2'),
 ///       ),

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -102,11 +102,12 @@ enum _SwitchListTileType { material, adaptive }
 /// ```dart preamble
 /// class LinkedLabelSwitch extends StatelessWidget {
 ///   const LinkedLabelSwitch({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;
@@ -123,7 +124,7 @@ enum _SwitchListTileType { material, adaptive }
 ///             child: RichText(
 ///               text: TextSpan(
 ///                 text: label,
-///                 style: TextStyle(
+///                 style: const TextStyle(
 ///                   color: Colors.blueAccent,
 ///                   decoration: TextDecoration.underline,
 ///                 ),
@@ -182,11 +183,12 @@ enum _SwitchListTileType { material, adaptive }
 /// ```dart preamble
 /// class LabeledSwitch extends StatelessWidget {
 ///   const LabeledSwitch({
+///     Key? key,
 ///     required this.label,
 ///     required this.padding,
 ///     required this.value,
 ///     required this.onChanged,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String label;
 ///   final EdgeInsets padding;

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -38,7 +38,7 @@ import 'constants.dart';
 /// }
 ///
 /// class _MyTabbedPageState extends State<MyTabbedPage> with SingleTickerProviderStateMixin {
-///   final List<Tab> myTabs = <Tab>[
+///   static const List<Tab> myTabs = <Tab>[
 ///     Tab(text: 'LEFT'),
 ///     Tab(text: 'RIGHT'),
 ///   ];
@@ -90,7 +90,7 @@ import 'constants.dart';
 /// when using [DefaultTabController].
 ///
 /// ```dart preamble
-/// final List<Tab> tabs = <Tab>[
+/// const List<Tab> tabs = <Tab>[
 ///   Tab(text: 'Zeroth'),
 ///   Tab(text: 'First'),
 ///   Tab(text: 'Second'),
@@ -114,7 +114,7 @@ import 'constants.dart';
 ///         });
 ///         return Scaffold(
 ///           appBar: AppBar(
-///             bottom: TabBar(
+///             bottom: const TabBar(
 ///               tabs: tabs,
 ///             ),
 ///           ),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -579,8 +579,8 @@ class _TabBarScrollController extends ScrollController {
 ///      length: 3,
 ///      child: Scaffold(
 ///        appBar: AppBar(
-///          title: Text('TabBar Widget'),
-///          bottom: TabBar(
+///          title: const Text('TabBar Widget'),
+///          bottom: const TabBar(
 ///            tabs: <Widget>[
 ///              Tab(
 ///                icon: Icon(Icons.cloud_outlined),
@@ -594,7 +594,7 @@ class _TabBarScrollController extends ScrollController {
 ///            ],
 ///          ),
 ///        ),
-///        body: TabBarView(
+///        body: const TabBarView(
 ///          children: <Widget>[
 ///            Center(
 ///              child: Text('It\'s cloudy here'),
@@ -628,13 +628,14 @@ class _TabBarScrollController extends ScrollController {
 ///    _tabController = TabController(length: 3, vsync: this);
 ///  }
 ///
+///  @override
 ///  Widget build(BuildContext context) {
 ///    return Scaffold(
 ///      appBar: AppBar(
-///        title: Text('TabBar Widget'),
+///        title: const Text('TabBar Widget'),
 ///        bottom: TabBar(
 ///          controller: _tabController,
-///          tabs: <Widget>[
+///          tabs: const <Widget>[
 ///            Tab(
 ///              icon: Icon(Icons.cloud_outlined),
 ///            ),
@@ -649,7 +650,7 @@ class _TabBarScrollController extends ScrollController {
 ///      ),
 ///      body: TabBarView(
 ///        controller: _tabController,
-///        children: <Widget>[
+///        children: const <Widget>[
 ///          Center(
 ///            child: Text('It\'s cloudy here'),
 ///          ),

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -64,7 +64,7 @@ import 'theme_data.dart';
 ///       children: <Widget>[
 ///         TextButton(
 ///            style: TextButton.styleFrom(
-///              textStyle: TextStyle(fontSize: 20),
+///              textStyle: const TextStyle(fontSize: 20),
 ///            ),
 ///            onPressed: null,
 ///            child: const Text('Disabled'),
@@ -72,7 +72,7 @@ import 'theme_data.dart';
 ///         const SizedBox(height: 30),
 ///         TextButton(
 ///           style: TextButton.styleFrom(
-///             textStyle: TextStyle(fontSize: 20),
+///             textStyle: const TextStyle(fontSize: 20),
 ///           ),
 ///           onPressed: () {},
 ///           child: const Text('Enabled'),
@@ -99,7 +99,7 @@ import 'theme_data.dart';
 ///                 style: TextButton.styleFrom(
 ///                   padding: const EdgeInsets.all(16.0),
 ///                   primary: Colors.white,
-///                   textStyle: TextStyle(fontSize: 20),
+///                   textStyle: const TextStyle(fontSize: 20),
 ///                 ),
 ///                 onPressed: () {},
 ///                  child: const Text('Gradient'),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -181,7 +181,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/text_field.png)
 ///
 /// ```dart
-/// TextField(
+/// const TextField(
 ///   obscureText: true,
 ///   decoration: InputDecoration(
 ///     border: OutlineInputBorder(),
@@ -205,16 +205,19 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// ```dart
 /// late TextEditingController _controller;
 ///
+/// @override
 /// void initState() {
 ///   super.initState();
 ///   _controller = TextEditingController();
 /// }
 ///
+/// @override
 /// void dispose() {
 ///   _controller.dispose();
 ///   super.dispose();
 /// }
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Center(

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -76,6 +76,7 @@ export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 /// ```
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Material(
 ///     child: Center(

--- a/packages/flutter/lib/src/material/text_selection_theme.dart
+++ b/packages/flutter/lib/src/material/text_selection_theme.dart
@@ -118,7 +118,7 @@ class TextSelectionThemeData with Diagnosticable {
 /// color with light blue selection handles to the child text field.
 ///
 /// ```dart
-/// TextSelectionTheme(
+/// const TextSelectionTheme(
 ///   data: TextSelectionThemeData(
 ///     cursorColor: Colors.blue,
 ///     selectionHandleColor: Colors.lightBlue,

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -353,7 +353,7 @@ class TextTheme with Diagnosticable {
   /// /// A Widget that sets the ambient theme's title text color for its
   /// /// descendants, while leaving other ambient theme attributes alone.
   /// class TitleColorThemeCopy extends StatelessWidget {
-  ///   TitleColorThemeCopy({Key? key, required this.child, required this.titleColor}) : super(key: key);
+  ///   const TitleColorThemeCopy({Key? key, required this.child, required this.titleColor}) : super(key: key);
   ///
   ///   final Color titleColor;
   ///   final Widget child;
@@ -494,7 +494,7 @@ class TextTheme with Diagnosticable {
   /// /// A Widget that sets the ambient theme's title text color for its
   /// /// descendants, while leaving other ambient theme attributes alone.
   /// class TitleColorTheme extends StatelessWidget {
-  ///   TitleColorTheme({Key? key, required this.child, required this.titleColor}) : super(key: key);
+  ///   const TitleColorTheme({Key? key, required this.child, required this.titleColor}) : super(key: key);
   ///
   ///   final Color titleColor;
   ///   final Widget child;
@@ -507,7 +507,7 @@ class TextTheme with Diagnosticable {
   ///     // set the title, but everything else would be null. This isn't very
   ///     // useful, so merge it with the existing theme to keep all of the
   ///     // preexisting definitions for the other styles.
-  ///     TextTheme partialTheme = TextTheme(headline6: TextStyle(color: titleColor));
+  ///     final TextTheme partialTheme = TextTheme(headline6: TextStyle(color: titleColor));
   ///     theme = theme.copyWith(textTheme: theme.textTheme.merge(partialTheme));
   ///     return Theme(data: theme, child: child);
   ///   }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -164,7 +164,7 @@ enum MaterialTapTargetSize {
 ///   theme: ThemeData(
 ///     primaryColor: Colors.blue,
 ///     accentColor: Colors.green,
-///     textTheme: TextTheme(bodyText2: TextStyle(color: Colors.purple)),
+///     textTheme: const TextTheme(bodyText2: TextStyle(color: Colors.purple)),
 ///   ),
 ///   home: Scaffold(
 ///     appBar: AppBar(
@@ -174,10 +174,8 @@ enum MaterialTapTargetSize {
 ///       child: const Icon(Icons.add),
 ///       onPressed: () {},
 ///     ),
-///     body: Center(
-///       child: Text(
-///         'Button pressed 0 times',
-///       ),
+///     body: const Center(
+///       child: Text('Button pressed 0 times'),
 ///     ),
 ///   ),
 /// )
@@ -722,8 +720,8 @@ class ThemeData with Diagnosticable {
   ///
   /// ```dart
   /// MaterialApp(
-  ///   theme: ThemeData.from(colorScheme: ColorScheme.light()),
-  ///   darkTheme: ThemeData.from(colorScheme: ColorScheme.dark()),
+  ///   theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+  ///   darkTheme: ThemeData.from(colorScheme: const ColorScheme.dark()),
   /// )
   /// ```
   /// {@end-tool}

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -31,7 +31,7 @@ enum DayPeriod {
 ///
 /// ```dart
 /// TimeOfDay now = TimeOfDay.now();
-/// TimeOfDay releaseTime = TimeOfDay(hour: 15, minute: 0); // 3:00pm
+/// const TimeOfDay releaseTime = TimeOfDay(hour: 15, minute: 0); // 3:00pm
 /// TimeOfDay roomBooked = TimeOfDay.fromDateTime(DateTime.parse('2018-10-20 16:30:04Z')); // 4:30pm
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2174,7 +2174,7 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 /// ```dart
 /// Future<TimeOfDay?> selectedTime24Hour = showTimePicker(
 ///   context: context,
-///   initialTime: TimeOfDay(hour: 10, minute: 47),
+///   initialTime: const TimeOfDay(hour: 10, minute: 47),
 ///   builder: (BuildContext context, Widget? child) {
 ///     return MediaQuery(
 ///       data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -38,9 +38,9 @@ import 'tooltip_theme.dart';
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   return Tooltip(
-///     message: "I am a Tooltip",
-///     child: Text("Hover over the text to show a tooltip."),
+///   return const Tooltip(
+///     message: 'I am a Tooltip',
+///     child: Text('Hover over the text to show a tooltip.'),
 ///   );
 /// }
 /// ```
@@ -63,20 +63,20 @@ import 'tooltip_theme.dart';
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return Tooltip(
-///     message: "I am a Tooltip",
-///     child: Text("Tap this text and hold down to show a tooltip."),
+///     message: 'I am a Tooltip',
+///     child: const Text('Tap this text and hold down to show a tooltip.'),
 ///     decoration: BoxDecoration(
 ///       borderRadius: BorderRadius.circular(25),
-///       gradient: LinearGradient(colors: [Colors.amber, Colors.red]),
+///       gradient: const LinearGradient(colors: <Color>[Colors.amber, Colors.red]),
 ///     ),
 ///     height: 50,
-///     padding: EdgeInsets.all(8.0),
+///     padding: const EdgeInsets.all(8.0),
 ///     preferBelow: false,
-///     textStyle: TextStyle(
+///     textStyle: const TextStyle(
 ///       fontSize: 24,
 ///     ),
-///     showDuration: Duration(seconds: 2),
-///     waitDuration: Duration(seconds: 1),
+///     showDuration: const Duration(seconds: 2),
+///     waitDuration: const Duration(seconds: 1),
 ///   );
 /// }
 /// ```

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -207,7 +207,7 @@ class TooltipThemeData with Diagnosticable {
 ///     message: 'Example tooltip',
 ///     child: IconButton(
 ///       iconSize: 36.0,
-///       icon: Icon(Icons.touch_app),
+///       icon: const Icon(Icons.touch_app),
 ///       onPressed: () {},
 ///     ),
 ///   ),

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -38,14 +38,14 @@ enum BorderStyle {
 ///
 /// ```dart
 /// Container(
-///   padding: EdgeInsets.all(8.0),
+///   padding: const EdgeInsets.all(8.0),
 ///   decoration: BoxDecoration(
 ///     border: Border(
 ///       top: BorderSide(width: 16.0, color: Colors.lightBlue.shade50),
 ///       bottom: BorderSide(width: 16.0, color: Colors.lightBlue.shade900),
 ///     ),
 ///   ),
-///   child: Text('Flutter in the sky', textAlign: TextAlign.center),
+///   child: const Text('Flutter in the sky', textAlign: TextAlign.center),
 /// )
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -267,20 +267,20 @@ abstract class BoxBorder extends ShapeBorder {
 /// Container(
 ///   decoration: const BoxDecoration(
 ///     border: Border(
-///       top: BorderSide(width: 1.0, color: Color(0xFFFFFFFFFF)),
-///       left: BorderSide(width: 1.0, color: Color(0xFFFFFFFFFF)),
-///       right: BorderSide(width: 1.0, color: Color(0xFFFF000000)),
-///       bottom: BorderSide(width: 1.0, color: Color(0xFFFF000000)),
+///       top: BorderSide(width: 1.0, color: Color(0xFFFFFFFF)),
+///       left: BorderSide(width: 1.0, color: Color(0xFFFFFFFF)),
+///       right: BorderSide(width: 1.0, color: Color(0xFF000000)),
+///       bottom: BorderSide(width: 1.0, color: Color(0xFF000000)),
 ///     ),
 ///   ),
 ///   child: Container(
 ///     padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 2.0),
 ///     decoration: const BoxDecoration(
 ///       border: Border(
-///         top: BorderSide(width: 1.0, color: Color(0xFFFFDFDFDF)),
-///         left: BorderSide(width: 1.0, color: Color(0xFFFFDFDFDF)),
-///         right: BorderSide(width: 1.0, color: Color(0xFFFF7F7F7F)),
-///         bottom: BorderSide(width: 1.0, color: Color(0xFFFF7F7F7F)),
+///         top: BorderSide(width: 1.0, color: Color(0xFFDFDFDF)),
+///         left: BorderSide(width: 1.0, color: Color(0xFFDFDFDF)),
+///         right: BorderSide(width: 1.0, color: Color(0xFF7F7F7F)),
+///         bottom: BorderSide(width: 1.0, color: Color(0xFF7F7F7F)),
 ///       ),
 ///       color: Color(0xFFBFBFBF),
 ///     ),

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -338,11 +338,11 @@ abstract class Gradient {
 /// ```dart
 ///  Widget build(BuildContext context) {
 ///    return Container(
-///      decoration: BoxDecoration(
-///        gradient: LinearGradient(
+///      decoration: const BoxDecoration(
+///        gradient: const LinearGradient(
 ///          begin: Alignment.topLeft,
 ///          end: Alignment(0.8, 0.0), // 10% of the width, so there are ten blinds.
-///          colors: [const Color(0xffee0000), const Color(0xffeeee00)], // red to yellow
+///          colors: const <Color>[Color(0xffee0000), Color(0xffeeee00)], // red to yellow
 ///          tileMode: TileMode.repeated, // repeats the gradient over the canvas
 ///        ),
 ///      ),
@@ -562,17 +562,17 @@ class LinearGradient extends Gradient {
 ///
 /// ```dart
 /// void paintSky(Canvas canvas, Rect rect) {
-///   var gradient = RadialGradient(
-///     center: const Alignment(0.7, -0.6), // near the top right
+///   const RadialGradient gradient = RadialGradient(
+///     center: Alignment(0.7, -0.6), // near the top right
 ///     radius: 0.2,
-///     colors: [
-///       const Color(0xFFFFFF00), // yellow sun
-///       const Color(0xFF0099FF), // blue sky
+///     colors: <Color>[
+///       Color(0xFFFFFF00), // yellow sun
+///       Color(0xFF0099FF), // blue sky
 ///     ],
-///     stops: [0.4, 1.0],
+///     stops: <double>[0.4, 1.0],
 ///   );
 ///   // rect is the area we are painting over
-///   var paint = Paint()
+///   final Paint paint = Paint()
 ///     ..shader = gradient.createShader(rect);
 ///   canvas.drawRect(rect, paint);
 /// }
@@ -810,19 +810,19 @@ class RadialGradient extends Gradient {
 ///
 /// ```dart
 /// Container(
-///   decoration: BoxDecoration(
+///   decoration: const BoxDecoration(
 ///     gradient: SweepGradient(
 ///       center: FractionalOffset.center,
 ///       startAngle: 0.0,
 ///       endAngle: math.pi * 2,
-///       colors: const <Color>[
+///       colors: <Color>[
 ///         Color(0xFF4285F4), // blue
 ///         Color(0xFF34A853), // green
 ///         Color(0xFFFBBC05), // yellow
 ///         Color(0xFFEA4335), // red
 ///         Color(0xFF4285F4), // blue again to seamlessly transition to the start
 ///       ],
-///       stops: const <double>[0.0, 0.25, 0.5, 0.75, 1.0],
+///       stops: <double>[0.0, 0.25, 0.5, 0.75, 1.0],
 ///     ),
 ///   )
 /// )
@@ -836,19 +836,19 @@ class RadialGradient extends Gradient {
 ///
 /// ```dart
 /// Container(
-///   decoration: BoxDecoration(
+///   decoration: const BoxDecoration(
 ///     gradient: SweepGradient(
 ///       center: FractionalOffset.center,
 ///       startAngle: 0.0,
 ///       endAngle: math.pi * 2,
-///       colors: const <Color>[
+///       colors: <Color>[
 ///         Color(0xFF4285F4), // blue
 ///         Color(0xFF34A853), // green
 ///         Color(0xFFFBBC05), // yellow
 ///         Color(0xFFEA4335), // red
 ///         Color(0xFF4285F4), // blue again to seamlessly transition to the start
 ///       ],
-///       stops: const <double>[0.0, 0.25, 0.5, 0.75, 1.0],
+///       stops: <double>[0.0, 0.25, 0.5, 0.75, 1.0],
 ///       transform: GradientRotation(math.pi/4),
 ///     ),
 ///   ),

--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -19,7 +19,7 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// MB. The maximum size can be adjusted using [maximumSize] and
 /// [maximumSizeBytes].
 ///
-/// The cache also holds a list of "live" references. An image is considered
+/// The cache also holds a list of 'live' references. An image is considered
 /// live if its [ImageStreamCompleter]'s listener count has never dropped to
 /// zero after adding at least one listener. The cache uses
 /// [ImageStreamCompleter.addOnLastListenerRemovedCallback] to determine when
@@ -28,7 +28,7 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// The [putIfAbsent] method is the main entry-point to the cache API. It
 /// returns the previously cached [ImageStreamCompleter] for the given key, if
 /// available; if not, it calls the given callback to obtain it first. In either
-/// case, the key is moved to the "most recently used" position.
+/// case, the key is moved to the 'most recently used' position.
 ///
 /// A caller can determine whether an image is already in the cache by using
 /// [containsKey], which will return true if the image is tracked by the cache
@@ -52,7 +52,7 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// class MyImageCache extends ImageCache {
 ///   @override
 ///   void clear() {
-///     print("Clearing cache!");
+///     print('Clearing cache!');
 ///     super.clear();
 ///   }
 /// }
@@ -65,10 +65,12 @@ const int _kDefaultSizeBytes = 100 << 20; // 100 MiB
 /// void main() {
 ///   // The constructor sets global variables.
 ///   MyWidgetsBinding();
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Container();
@@ -309,7 +311,7 @@ class ImageCache {
 
   /// Returns the previously cached [ImageStream] for the given key, if available;
   /// if not, calls the given callback to obtain it first. In either case, the
-  /// key is moved to the "most recently used" position.
+  /// key is moved to the 'most recently used' position.
   ///
   /// The arguments must not be null. The `loader` cannot return null.
   ///

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -529,7 +529,12 @@ abstract class ImageProvider<T extends Object> {
   ///
   /// ```dart
   /// class MyWidget extends StatelessWidget {
-  ///   final String url = '...';
+  ///   const MyWidget({
+  ///     Key? key,
+  ///     this.url = ' ... ',
+  ///   }) : super(key: key);
+  ///
+  ///   final String url;
   ///
   ///   @override
   ///   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -119,17 +119,17 @@ class InlineSpanSemanticsInformation {
 /// Text.rich(
 ///   TextSpan(
 ///     text: 'My name is ',
-///     style: TextStyle(color: Colors.black),
+///     style: const TextStyle(color: Colors.black),
 ///     children: <InlineSpan>[
 ///       WidgetSpan(
 ///         alignment: PlaceholderAlignment.baseline,
 ///         baseline: TextBaseline.alphabetic,
 ///         child: ConstrainedBox(
-///           constraints: BoxConstraints(maxWidth: 100),
-///           child: TextField(),
+///           constraints: const BoxConstraints(maxWidth: 100),
+///           child: const TextField(),
 ///         )
 ///       ),
-///       TextSpan(
+///       const TextSpan(
 ///         text: '.',
 ///       ),
 ///     ],

--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -239,7 +239,7 @@ import 'text_style.dart';
 /// ![The result of the example below.](https://flutter.github.io/assets-for-api-docs/assets/painting/strut_force_example_2.png)
 ///
 /// ```dart
-/// Text.rich(
+/// const Text.rich(
 ///   TextSpan(
 ///     text: '       he candle flickered\n',
 ///     style: TextStyle(

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -35,7 +35,7 @@ import 'text_style.dart';
 /// The text "Hello world!", in black:
 ///
 /// ```dart
-/// TextSpan(
+/// const TextSpan(
 ///   text: 'Hello world!',
 ///   style: TextStyle(color: Colors.black),
 /// )
@@ -119,6 +119,8 @@ class TextSpan extends InlineSpan {
   ///
   /// ```dart
   /// class BuzzingText extends StatefulWidget {
+  ///   const BuzzingText({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   _BuzzingTextState createState() => _BuzzingTextState();
   /// }
@@ -148,18 +150,18 @@ class TextSpan extends InlineSpan {
   ///     return Text.rich(
   ///       TextSpan(
   ///         text: 'Can you ',
-  ///         style: TextStyle(color: Colors.black),
+  ///         style: const TextStyle(color: Colors.black),
   ///         children: <InlineSpan>[
   ///           TextSpan(
   ///             text: 'find the',
-  ///             style: TextStyle(
+  ///             style: const TextStyle(
   ///               color: Colors.green,
   ///               decoration: TextDecoration.underline,
   ///               decorationStyle: TextDecorationStyle.wavy,
   ///             ),
   ///             recognizer: _longPressRecognizer,
   ///           ),
-  ///           TextSpan(
+  ///           const TextSpan(
   ///             text: ' secret?',
   ///           ),
   ///         ],

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -39,7 +39,7 @@ const double _kDefaultFontSize = 14.0;
 /// ![Applying the style in this way creates bold text.](https://flutter.github.io/assets-for-api-docs/assets/painting/text_style_bold.png)
 ///
 /// ```dart
-/// Text(
+/// const Text(
 ///   'No, we need bold strokes. We need this plan.',
 ///   style: TextStyle(fontWeight: FontWeight.bold),
 /// )
@@ -55,7 +55,7 @@ const double _kDefaultFontSize = 14.0;
 /// ![This results in italicized text.](https://flutter.github.io/assets-for-api-docs/assets/painting/text_style_italics.png)
 ///
 /// ```dart
-/// Text(
+/// const Text(
 ///   "Welcome to the present, we're running a real nation.",
 ///   style: TextStyle(fontStyle: FontStyle.italic),
 /// )
@@ -137,7 +137,7 @@ const double _kDefaultFontSize = 14.0;
 /// 50 pixels.
 ///
 /// ```dart
-/// Text(
+/// const Text(
 ///   'Ladies and gentlemen, you coulda been anywhere in the world tonight, but you’re here with us in New York City.',
 ///   style: TextStyle(height: 5, fontSize: 10),
 /// )
@@ -163,7 +163,7 @@ const double _kDefaultFontSize = 14.0;
 ///
 /// ```dart
 /// RichText(
-///   text: TextSpan(
+///   text: const TextSpan(
 ///     text: "Don't tax the South ",
 ///     children: <TextSpan>[
 ///       TextSpan(
@@ -654,7 +654,7 @@ class TextStyle with Diagnosticable {
   /// decoration.
   ///
   /// ```dart
-  /// Text(
+  /// const Text(
   ///   'This has a very BOLD strike through!',
   ///   style: TextStyle(
   ///     decoration: TextDecoration.lineThrough,
@@ -669,7 +669,7 @@ class TextStyle with Diagnosticable {
   /// are misspelled) by using a [decorationThickness] < 1.0.
   ///
   /// ```dart
-  /// Text(
+  /// const Text(
   ///   'oopsIforgottousespaces!',
   ///   style: TextStyle(
   ///     decoration: TextDecoration.underline,

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -19,7 +19,7 @@ import 'view.dart';
 export 'package:flutter/gestures.dart' show HitTestResult;
 
 // Examples can assume:
-// dynamic context;
+// late BuildContext context;
 
 /// The glue between the render tree and the Flutter engine.
 mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureBinding, SemanticsBinding, HitTestable {

--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -73,12 +73,12 @@ typedef SemanticsBuilderCallback = List<CustomPainterSemantics> Function(Size si
 /// class Sky extends CustomPainter {
 ///   @override
 ///   void paint(Canvas canvas, Size size) {
-///     var rect = Offset.zero & size;
-///     var gradient = RadialGradient(
-///       center: const Alignment(0.7, -0.6),
+///     final Rect rect = Offset.zero & size;
+///     const RadialGradient gradient = RadialGradient(
+///       center: Alignment(0.7, -0.6),
 ///       radius: 0.2,
-///       colors: [const Color(0xFFFFFF00), const Color(0xFF0099FF)],
-///       stops: [0.4, 1.0],
+///       colors: <Color>[Color(0xFFFFFF00), Color(0xFF0099FF)],
+///       stops: <double>[0.4, 1.0],
 ///     );
 ///     canvas.drawRect(
 ///       rect,
@@ -93,13 +93,13 @@ typedef SemanticsBuilderCallback = List<CustomPainterSemantics> Function(Size si
 ///       // with the label "Sun". When text to speech feature is enabled on the
 ///       // device, a user will be able to locate the sun on this picture by
 ///       // touch.
-///       var rect = Offset.zero & size;
-///       var width = size.shortestSide * 0.4;
+///       Rect rect = Offset.zero & size;
+///       final double width = size.shortestSide * 0.4;
 ///       rect = const Alignment(0.8, -0.9).inscribe(Size(width, width), rect);
-///       return [
+///       return <CustomPainterSemantics>[
 ///         CustomPainterSemantics(
 ///           rect: rect,
-///           properties: SemanticsProperties(
+///           properties: const SemanticsProperties(
 ///             label: 'Sun',
 ///             textDirection: TextDirection.ltr,
 ///           ),

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3047,7 +3047,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   ///
   /// ```dart
   /// class PngHome extends StatefulWidget {
-  ///   PngHome({Key? key}) : super(key: key);
+  ///   const PngHome({Key? key}) : super(key: key);
   ///
   ///   @override
   ///   _PngHomeState createState() => _PngHomeState();
@@ -3057,10 +3057,10 @@ class RenderRepaintBoundary extends RenderProxyBox {
   ///   GlobalKey globalKey = GlobalKey();
   ///
   ///   Future<void> _capturePng() async {
-  ///     RenderRepaintBoundary boundary = globalKey.currentContext!.findRenderObject()! as RenderRepaintBoundary;
-  ///     ui.Image image = await boundary.toImage();
-  ///     ByteData? byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-  ///     Uint8List pngBytes = byteData!.buffer.asUint8List();
+  ///     final RenderRepaintBoundary boundary = globalKey.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  ///     final ui.Image image = await boundary.toImage();
+  ///     final ByteData? byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+  ///     final Uint8List pngBytes = byteData!.buffer.asUint8List();
   ///     print(pngBytes);
   ///   }
   ///
@@ -3070,7 +3070,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   ///       key: globalKey,
   ///       child: Center(
   ///         child: TextButton(
-  ///           child: Text('Hello World', textDirection: TextDirection.ltr),
+  ///           child: const Text('Hello World', textDirection: TextDirection.ltr),
   ///           onPressed: _capturePng,
   ///         ),
   ///       ),

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -290,9 +290,7 @@ abstract class SliverGridDelegate {
 ///     ),
 ///     children: List<Widget>.generate(20, (int i) {
 ///       return Builder(builder: (BuildContext context) {
-///         return Container(
-///           child: Text('$i'),
-///         );
+///         return Text('$i');
 ///       });
 ///     }),
 ///   );
@@ -315,9 +313,7 @@ abstract class SliverGridDelegate {
 ///     ),
 ///     children: List<Widget>.generate(20, (int i) {
 ///       return Builder(builder: (BuildContext context) {
-///         return Container(
-///           child: Text('$i'),
-///         );
+///         return Text('$i');
 ///       });
 ///     }),
 ///   );

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1716,7 +1716,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   ///   elevation: 0.0,
   ///   child: Semantics(
   ///     explicitChildNodes: true,
-  ///     child: PhysicalModel( // B
+  ///     child: const PhysicalModel( // B
   ///       color: Colors.brown,
   ///       elevation: 5.0,
   ///       child: PhysicalModel( // C

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -2040,7 +2040,7 @@ class LogicalKeyboardKey extends KeyboardKey {
 ///                 onTap: () {
 ///                   FocusScope.of(context).requestFocus(_focusNode);
 ///                 },
-///                 child: Text('Tap to focus'),
+///                 child: const Text('Tap to focus'),
 ///               );
 ///             }
 ///             return Text(_message ?? 'Press a key');

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -203,8 +203,8 @@ class MethodChannel {
   ///     // code thus cannot assume e.g. List<Map<String, String>> even though
   ///     // the actual values involved would support such a typed container.
   ///     // The correct type cannot be inferred with any value of `T`.
-  ///     final List<dynamic> songs = await _channel.invokeMethod('getSongs');
-  ///     return songs.map(Song.fromJson).toList();
+  ///     final List<dynamic>? songs = await _channel.invokeMethod<List<dynamic>>('getSongs');
+  ///     return songs?.map(Song.fromJson).toList() ?? <Song>[];
   ///   }
   ///
   ///   static Future<void> play(Song song, double volume) async {
@@ -229,7 +229,7 @@ class MethodChannel {
   ///   final String artist;
   ///
   ///   static Song fromJson(dynamic json) {
-  ///     return Song(json['id'], json['title'], json['artist']);
+  ///     return Song(json['id'] as String, json['title'] as String, json['artist'] as String);
   ///   }
   /// }
   /// ```

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -331,7 +331,7 @@ class SystemChrome {
   /// @override
   /// Widget build(BuildContext context) {
   ///   SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
-  ///   return Placeholder();
+  ///   return const Placeholder();
   /// }
   /// ```
   /// {@end-tool}
@@ -348,17 +348,20 @@ class SystemChrome {
   /// The following example creates a widget that changes the status bar color
   /// to a random value on Android.
   ///
-  /// ```dart imports
-  /// import 'package:flutter/services.dart';
+  /// ```dart dartImports
   /// import 'dart:math' as math;
   /// ```
   ///
+  /// ```dart imports
+  /// import 'package:flutter/services.dart';
+  /// ```
+  ///
   /// ```dart
-  /// final _random = math.Random();
+  /// final math.Random _random = math.Random();
   /// SystemUiOverlayStyle _currentStyle = SystemUiOverlayStyle.light;
   ///
   /// void _changeColor() {
-  ///   final color = Color.fromRGBO(
+  ///   final Color color = Color.fromRGBO(
   ///     _random.nextInt(255),
   ///     _random.nextInt(255),
   ///     _random.nextInt(255),
@@ -373,7 +376,7 @@ class SystemChrome {
   ///
   /// @override
   /// Widget build(BuildContext context) {
-  ///   return AnnotatedRegion(
+  ///   return AnnotatedRegion<SystemUiOverlayStyle>(
   ///     value: _currentStyle,
   ///     child: Center(
   ///       child: ElevatedButton(

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -190,7 +190,7 @@ class FilteringTextInputFormatter extends TextInputFormatter {
   /// Typically the pattern is a regular expression, as in:
   ///
   /// ```dart
-  /// var onlyDigits = FilteringTextInputFormatter.allow(RegExp(r'[0-9]'));
+  /// FilteringTextInputFormatter onlyDigits = FilteringTextInputFormatter.allow(RegExp(r'[0-9]'));
   /// ```
   /// {@end-tool}
   ///
@@ -199,7 +199,7 @@ class FilteringTextInputFormatter extends TextInputFormatter {
   /// [String] can be used:
   ///
   /// ```dart
-  /// var noTabs = FilteringTextInputFormatter.deny('\t');
+  /// FilteringTextInputFormatter noTabs = FilteringTextInputFormatter.deny('\t');
   /// ```
   /// {@end-tool}
   final Pattern filterPattern;

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -253,6 +253,8 @@ abstract class Action<T extends Intent> with Diagnosticable {
 ///
 /// ```dart preamble
 /// class ActionListenerExample extends StatefulWidget {
+///   const ActionListenerExample({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _ActionListenerExampleState createState() => _ActionListenerExampleState();
 /// }
@@ -286,26 +288,26 @@ abstract class Action<T extends Intent> with Diagnosticable {
 ///             child: Text(_on ? 'Disable' : 'Enable'),
 ///           ),
 ///         ),
-///         _on
-///             ? Padding(
-///                 padding: const EdgeInsets.all(8.0),
-///                 child: ActionListener(
-///                   listener: (Action<Intent> action) {
-///                     if (action.intentType == MyIntent) {
-///                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-///                           content: const Text('Action Listener Called'),
-///                       ));
-///                     }
-///                   },
-///                   action: _myAction,
-///                   child: ElevatedButton(
-///                     onPressed: () =>
-///                         ActionDispatcher().invokeAction(_myAction, MyIntent()),
-///                     child: const Text('Call Action Listener'),
-///                   ),
-///                 ),
-///               )
-///             : Container(),
+///         if (_on)
+///           Padding(
+///             padding: const EdgeInsets.all(8.0),
+///             child: ActionListener(
+///               listener: (Action<Intent> action) {
+///                 if (action.intentType == MyIntent) {
+///                   ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+///                     content: Text('Action Listener Called'),
+///                   ));
+///                 }
+///               },
+///               action: _myAction,
+///               child: ElevatedButton(
+///                 onPressed: () => const ActionDispatcher()
+///                     .invokeAction(_myAction, const MyIntent()),
+///                 child: const Text('Call Action Listener'),
+///               ),
+///             ),
+///           ),
+///         if (!_on) Container(),
 ///       ],
 ///     );
 ///   }
@@ -313,13 +315,13 @@ abstract class Action<T extends Intent> with Diagnosticable {
 ///
 /// class MyAction extends Action<MyIntent> {
 ///   @override
-///   void addActionListener(listener) {
+///   void addActionListener(ActionListenerCallback listener) {
 ///     super.addActionListener(listener);
 ///     print('Action Listener was added');
 ///   }
 ///
 ///   @override
-///   void removeActionListener(listener) {
+///   void removeActionListener(ActionListenerCallback listener) {
 ///     super.removeActionListener(listener);
 ///     print('Action Listener was removed');
 ///   }
@@ -336,8 +338,9 @@ abstract class Action<T extends Intent> with Diagnosticable {
 /// ```
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
-///   return ActionListenerExample();
+///   return const ActionListenerExample();
 /// }
 /// ```
 /// {@end-tool}
@@ -596,7 +599,7 @@ class ActionDispatcher with Diagnosticable {
 /// }
 ///
 /// class SaveButton extends StatefulWidget {
-///   const SaveButton(this.valueNotifier);
+///   const SaveButton(this.valueNotifier, {Key? key}) : super(key: key);
 ///
 ///   final ValueNotifier<bool> valueNotifier;
 ///
@@ -622,7 +625,7 @@ class ActionDispatcher with Diagnosticable {
 ///           ),
 ///           onPressed: () {
 ///             setState(() {
-///               savedValue = Actions.invoke(context, const SaveIntent()) as int;
+///               savedValue = Actions.invoke(context, const SaveIntent())! as int;
 ///             });
 ///           },
 ///         );
@@ -1135,7 +1138,7 @@ class _ActionsMarker extends InheritedWidget {
 ///   void initState() {
 ///     super.initState();
 ///     _actionMap = <Type, Action<Intent>>{
-///       ActivateIntent: CallbackAction(
+///       ActivateIntent: CallbackAction<Intent>(
 ///         onInvoke: (Intent intent) => _toggleState(),
 ///       ),
 ///     };
@@ -1185,14 +1188,14 @@ class _ActionsMarker extends InheritedWidget {
 ///         child: Row(
 ///           children: <Widget>[
 ///             Container(
-///               padding: EdgeInsets.all(10.0),
+///               padding: const EdgeInsets.all(10.0),
 ///               color: color,
 ///               child: widget.child,
 ///             ),
 ///             Container(
 ///               width: 30,
 ///               height: 30,
-///               margin: EdgeInsets.all(10.0),
+///               margin: const EdgeInsets.all(10.0),
 ///               color: _on ? Colors.red : Colors.transparent,
 ///             ),
 ///           ],
@@ -1204,10 +1207,11 @@ class _ActionsMarker extends InheritedWidget {
 /// ```
 ///
 /// ```dart
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
-///       title: Text('FocusableActionDetector Example'),
+///       title: const Text('FocusableActionDetector Example'),
 ///     ),
 ///     body: Center(
 ///       child: Row(
@@ -1215,11 +1219,11 @@ class _ActionsMarker extends InheritedWidget {
 ///         children: <Widget>[
 ///           Padding(
 ///             padding: const EdgeInsets.all(8.0),
-///             child: TextButton(onPressed: () {}, child: Text('Press Me')),
+///             child: TextButton(onPressed: () {}, child: const Text('Press Me')),
 ///           ),
 ///           Padding(
 ///             padding: const EdgeInsets.all(8.0),
-///             child: FadButton(onPressed: () {}, child: Text('And Me')),
+///             child: FadButton(onPressed: () {}, child: const Text('And Me')),
 ///           ),
 ///         ],
 ///       ),

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -57,7 +57,13 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 /// ```
 ///
 /// ```dart
+/// void main() {
+///   runApp(const AnimatedListSample());
+/// }
+///
 /// class AnimatedListSample extends StatefulWidget {
+///   const AnimatedListSample({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _AnimatedListSampleState createState() => _AnimatedListSampleState();
 /// }
@@ -156,6 +162,8 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///   }
 /// }
 ///
+/// typedef RemovedItemBuilder = Widget Function(int item, BuildContext context, Animation<double> animation);
+///
 /// /// Keeps a Dart [List] in sync with an [AnimatedList].
 /// ///
 /// /// The [insert] and [removeAt] methods apply to both the internal list and
@@ -173,7 +181,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///   }) : _items = List<E>.from(initialItems ?? <E>[]);
 ///
 ///   final GlobalKey<AnimatedListState> listKey;
-///   final dynamic removedItemBuilder;
+///   final RemovedItemBuilder removedItemBuilder;
 ///   final List<E> _items;
 ///
 ///   AnimatedListState? get _animatedList => listKey.currentState;
@@ -189,7 +197,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///       _animatedList!.removeItem(
 ///         index,
 ///         (BuildContext context, Animation<double> animation) {
-///           return removedItemBuilder(removedItem, context, animation);
+///           return removedItemBuilder(index, context, animation);
 ///         },
 ///       );
 ///     }
@@ -250,10 +258,6 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///       ),
 ///     );
 ///   }
-/// }
-///
-/// void main() {
-///   runApp(AnimatedListSample());
 /// }
 /// ```
 /// {@end-tool}
@@ -531,9 +535,11 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 /// ```
 ///
 /// ```dart
-/// void main() => runApp(SliverAnimatedListSample());
+/// void main() => runApp(const SliverAnimatedListSample());
 ///
 /// class SliverAnimatedListSample extends StatefulWidget {
+///   const SliverAnimatedListSample({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _SliverAnimatedListSampleState createState() => _SliverAnimatedListSampleState();
 /// }
@@ -599,7 +605,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///         _selectedItem = null;
 ///       });
 ///     } else {
-///       _scaffoldMessengerKey.currentState!.showSnackBar(SnackBar(
+///       _scaffoldMessengerKey.currentState!.showSnackBar(const SnackBar(
 ///         content: Text(
 ///           'Select an item to remove from the list.',
 ///           style: TextStyle(fontSize: 20),
@@ -617,7 +623,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///         body: CustomScrollView(
 ///           slivers: <Widget>[
 ///             SliverAppBar(
-///               title: Text(
+///               title: const Text(
 ///                 'SliverAnimatedList',
 ///                 style: TextStyle(fontSize: 30),
 ///               ),
@@ -630,7 +636,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///                 tooltip: 'Insert a new item.',
 ///                 iconSize: 32,
 ///               ),
-///               actions: [
+///               actions: <Widget>[
 ///                 IconButton(
 ///                   icon: const Icon(Icons.remove_circle),
 ///                   onPressed: _remove,
@@ -651,6 +657,8 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///   }
 /// }
 ///
+/// typedef RemovedItemBuilder = Widget Function(int item, BuildContext context, Animation<double> animation);
+///
 /// // Keeps a Dart [List] in sync with an [AnimatedList].
 /// //
 /// // The [insert] and [removeAt] methods apply to both the internal list and
@@ -668,7 +676,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///   }) : _items = List<E>.from(initialItems ?? <E>[]);
 ///
 ///   final GlobalKey<SliverAnimatedListState> listKey;
-///   final dynamic removedItemBuilder;
+///   final RemovedItemBuilder removedItemBuilder;
 ///   final List<E> _items;
 ///
 ///   SliverAnimatedListState get _animatedList => listKey.currentState!;
@@ -683,7 +691,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///     if (removedItem != null) {
 ///       _animatedList.removeItem(
 ///         index,
-///         (BuildContext context, Animation<double> animation) => removedItemBuilder(removedItem, context, animation),
+///         (BuildContext context, Animation<double> animation) => removedItemBuilder(index, context, animation),
 ///       );
 ///     }
 ///     return removedItem;

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -36,7 +36,7 @@ import 'framework.dart';
 ///         child: AnimatedSize(
 ///           curve: Curves.easeIn,
 ///           vsync: this,
-///           duration: Duration(seconds: 1),
+///           duration: const Duration(seconds: 1),
 ///           child: FlutterLogo(size: _size),
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -926,7 +926,7 @@ class WidgetsApp extends StatefulWidget {
   ///   return WidgetsApp(
   ///     actions: <Type, Action<Intent>>{
   ///       ... WidgetsApp.defaultActions,
-  ///       ActivateAction: CallbackAction(
+  ///       ActivateAction: CallbackAction<Intent>(
   ///         onInvoke: (Intent intent) {
   ///           // Do something here...
   ///           return null;

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -375,12 +375,13 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 /// emitting bids, the final price is displayed.
 ///
 /// ```dart
-/// Stream<int> _bids = (() async* {
-///   await Future<void>.delayed(Duration(seconds: 1));
+/// final Stream<int> _bids = (() async* {
+///   await Future<void>.delayed(const Duration(seconds: 1));
 ///   yield 1;
-///   await Future<void>.delayed(Duration(seconds: 1));
+///   await Future<void>.delayed(const Duration(seconds: 1));
 /// })();
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return DefaultTextStyle(
 ///     style: Theme.of(context).textTheme.headline2!,
@@ -394,7 +395,7 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 ///           List<Widget> children;
 ///           if (snapshot.hasError) {
 ///             children = <Widget>[
-///               Icon(
+///               const Icon(
 ///                 Icons.error_outline,
 ///                 color: Colors.red,
 ///                 size: 60,
@@ -411,26 +412,26 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 ///           } else {
 ///             switch (snapshot.connectionState) {
 ///               case ConnectionState.none:
-///                 children = <Widget>[
+///                 children = const <Widget>[
 ///                   Icon(
 ///                     Icons.info,
 ///                     color: Colors.blue,
 ///                     size: 60,
 ///                   ),
-///                   const Padding(
+///                   Padding(
 ///                     padding: EdgeInsets.only(top: 16),
 ///                     child: Text('Select a lot'),
 ///                   )
 ///                 ];
 ///                 break;
 ///               case ConnectionState.waiting:
-///                 children = <Widget>[
+///                 children = const <Widget>[
 ///                   SizedBox(
-///                     child: const CircularProgressIndicator(),
+///                     child: CircularProgressIndicator(),
 ///                     width: 60,
 ///                     height: 60,
 ///                   ),
-///                   const Padding(
+///                   Padding(
 ///                     padding: EdgeInsets.only(top: 16),
 ///                     child: Text('Awaiting bids...'),
 ///                   )
@@ -438,7 +439,7 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 ///                 break;
 ///               case ConnectionState.active:
 ///                 children = <Widget>[
-///                   Icon(
+///                   const Icon(
 ///                     Icons.check_circle_outline,
 ///                     color: Colors.green,
 ///                     size: 60,
@@ -451,7 +452,7 @@ typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, AsyncSnaps
 ///                 break;
 ///               case ConnectionState.done:
 ///                 children = <Widget>[
-///                   Icon(
+///                   const Icon(
 ///                     Icons.info,
 ///                     color: Colors.blue,
 ///                     size: 60,
@@ -618,11 +619,12 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 /// in the UI.
 ///
 /// ```dart
-/// Future<String> _calculation = Future<String>.delayed(
-///   Duration(seconds: 2),
+/// final Future<String> _calculation = Future<String>.delayed(
+///   const Duration(seconds: 2),
 ///   () => 'Data Loaded',
 /// );
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return DefaultTextStyle(
 ///     style: Theme.of(context).textTheme.headline2!,
@@ -633,7 +635,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 ///         List<Widget> children;
 ///         if (snapshot.hasData) {
 ///           children = <Widget>[
-///             Icon(
+///             const Icon(
 ///               Icons.check_circle_outline,
 ///               color: Colors.green,
 ///               size: 60,
@@ -645,7 +647,7 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 ///           ];
 ///         } else if (snapshot.hasError) {
 ///           children = <Widget>[
-///             Icon(
+///             const Icon(
 ///               Icons.error_outline,
 ///               color: Colors.red,
 ///               size: 60,
@@ -656,13 +658,13 @@ class StreamBuilder<T> extends StreamBuilderBase<T, AsyncSnapshot<T>> {
 ///             )
 ///           ];
 ///         } else {
-///           children = <Widget>[
+///           children = const <Widget>[
 ///             SizedBox(
 ///               child: CircularProgressIndicator(),
 ///               width: 60,
 ///               height: 60,
 ///             ),
-///             const Padding(
+///             Padding(
 ///               padding: EdgeInsets.only(top: 16),
 ///               child: Text('Awaiting result...'),
 ///             )

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -85,9 +85,9 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///
 /// ```dart
 /// class AutocompleteBasicExample extends StatelessWidget {
-///   AutocompleteBasicExample({Key? key}) : super(key: key);
+///   const AutocompleteBasicExample({Key? key}) : super(key: key);
 ///
-///   static final List<String> _options = <String>[
+///   static const List<String> _options = <String>[
 ///     'aardvark',
 ///     'bobcat',
 ///     'chameleon',
@@ -115,10 +115,10 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///           alignment: Alignment.topLeft,
 ///           child: Material(
 ///             elevation: 4.0,
-///             child: Container(
+///             child: SizedBox(
 ///               height: 200.0,
 ///               child: ListView.builder(
-///                 padding: EdgeInsets.all(8.0),
+///                 padding: const EdgeInsets.all(8.0),
 ///                 itemCount: options.length,
 ///                 itemBuilder: (BuildContext context, int index) {
 ///                   final String option = options.elementAt(index);
@@ -159,6 +159,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///
 /// ```dart
 /// // An example of a type that someone might want to autocomplete a list of.
+/// @immutable
 /// class User {
 ///   const User({
 ///     required this.email,
@@ -175,8 +176,9 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///
 ///   @override
 ///   bool operator ==(Object other) {
-///     if (other.runtimeType != runtimeType)
+///     if (other.runtimeType != runtimeType) {
 ///       return false;
+///     }
 ///     return other is User
 ///         && other.name == name
 ///         && other.email == email;
@@ -187,9 +189,9 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 /// }
 ///
 /// class AutocompleteCustomTypeExample extends StatelessWidget {
-///   AutocompleteCustomTypeExample({Key? key}) : super(key: key);
+///   const AutocompleteCustomTypeExample({Key? key}) : super(key: key);
 ///
-///   static final List<User> _userOptions = <User>[
+///   static const List<User> _userOptions = <User>[
 ///     User(name: 'Alice', email: 'alice@example.com'),
 ///     User(name: 'Bob', email: 'bob@example.com'),
 ///     User(name: 'Charlie', email: 'charlie123@gmail.com'),
@@ -222,10 +224,10 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///           alignment: Alignment.topLeft,
 ///           child: Material(
 ///             elevation: 4.0,
-///             child: Container(
+///             child: SizedBox(
 ///               height: 200.0,
 ///               child: ListView.builder(
-///                 padding: EdgeInsets.all(8.0),
+///                 padding: const EdgeInsets.all(8.0),
 ///                 itemCount: options.length,
 ///                 itemBuilder: (BuildContext context, int index) {
 ///                   final User option = options.elementAt(index);
@@ -259,14 +261,14 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///
 /// ```dart
 /// class AutocompleteFormExamplePage extends StatefulWidget {
-///   AutocompleteFormExamplePage({Key? key}) : super(key: key);
+///   const AutocompleteFormExamplePage({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   AutocompleteFormExample createState() => AutocompleteFormExample();
 /// }
 ///
 /// class AutocompleteFormExample extends State<AutocompleteFormExamplePage> {
-///   final _formKey = GlobalKey<FormState>();
+///   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 ///   final TextEditingController _textEditingController = TextEditingController();
 ///   String? _dropdownValue;
 ///   String? _autocompleteSelection;
@@ -281,7 +283,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       appBar: AppBar(
-///         title: Text('Autocomplete Form Example'),
+///         title: const Text('Autocomplete Form Example'),
 ///       ),
 ///       body: Center(
 ///         child: Form(
@@ -290,11 +292,11 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///             children: <Widget>[
 ///               DropdownButtonFormField<String>(
 ///                 value: _dropdownValue,
-///                 icon: Icon(Icons.arrow_downward),
+///                 icon: const Icon(Icons.arrow_downward),
 ///                 hint: const Text('This is a regular DropdownButtonFormField'),
 ///                 iconSize: 24,
 ///                 elevation: 16,
-///                 style: TextStyle(color: Colors.deepPurple),
+///                 style: const TextStyle(color: Colors.deepPurple),
 ///                 onChanged: (String? newValue) {
 ///                   setState(() {
 ///                     _dropdownValue = newValue;
@@ -316,7 +318,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///               ),
 ///               TextFormField(
 ///                 controller: _textEditingController,
-///                 decoration: InputDecoration(
+///                 decoration: const InputDecoration(
 ///                   hintText: 'This is a regular TextFormField',
 ///                 ),
 ///                 validator: (String? value) {
@@ -340,7 +342,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///                 fieldViewBuilder: (BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
 ///                   return TextFormField(
 ///                     controller: textEditingController,
-///                     decoration: InputDecoration(
+///                     decoration: const InputDecoration(
 ///                       hintText: 'This is an RawAutocomplete!',
 ///                     ),
 ///                     focusNode: focusNode,
@@ -360,10 +362,10 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///                     alignment: Alignment.topLeft,
 ///                     child: Material(
 ///                       elevation: 4.0,
-///                       child: Container(
+///                       child: SizedBox(
 ///                         height: 200.0,
 ///                         child: ListView.builder(
-///                           padding: EdgeInsets.all(8.0),
+///                           padding: const EdgeInsets.all(8.0),
 ///                           itemCount: options.length,
 ///                           itemBuilder: (BuildContext context, int index) {
 ///                             final String option = options.elementAt(index);
@@ -392,7 +394,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///                     context: context,
 ///                     builder: (BuildContext context) {
 ///                       return AlertDialog(
-///                         title: Text('Successfully submitted'),
+///                         title: const Text('Successfully submitted'),
 ///                         content: SingleChildScrollView(
 ///                           child: ListBody(
 ///                             children: <Widget>[
@@ -404,7 +406,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///                         ),
 ///                         actions: <Widget>[
 ///                           TextButton(
-///                             child: Text('Ok'),
+///                             child: const Text('Ok'),
 ///                             onPressed: () {
 ///                               Navigator.of(context).pop();
 ///                             },
@@ -414,7 +416,7 @@ typedef AutocompleteOptionToString<T extends Object> = String Function(T option)
 ///                     },
 ///                   );
 ///                 },
-///                 child: Text('Submit'),
+///                 child: const Text('Submit'),
 ///               ),
 ///             ],
 ///           ),
@@ -494,8 +496,9 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
   /// ];
   ///
   /// class RawAutocompleteSplitPage extends StatefulWidget {
-  ///   RawAutocompleteSplitPage({Key? key}) : super(key: key);
+  ///   const RawAutocompleteSplitPage({Key? key}) : super(key: key);
   ///
+  ///   @override
   ///   RawAutocompleteSplitPageState createState() => RawAutocompleteSplitPageState();
   /// }
   ///
@@ -517,7 +520,7 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
   ///           title: TextFormField(
   ///             controller: _textEditingController,
   ///             focusNode: _focusNode,
-  ///             decoration: InputDecoration(
+  ///             decoration: const InputDecoration(
   ///               hintText: 'Split RawAutocomplete App',
   ///             ),
   ///             onFieldSubmitted: (String value) {

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -80,11 +80,11 @@ enum AutofillContextAction {
 ///            children: <Widget>[
 ///              TextField(
 ///                controller: shippingAddress1,
-///                autofillHints: <String>[AutofillHints.streetAddressLine1],
+///                autofillHints: const <String>[AutofillHints.streetAddressLine1],
 ///              ),
 ///              TextField(
 ///                controller: shippingAddress2,
-///                autofillHints: <String>[AutofillHints.streetAddressLine2],
+///                autofillHints: const <String>[AutofillHints.streetAddressLine2],
 ///              ),
 ///            ],
 ///          ),
@@ -104,11 +104,11 @@ enum AutofillContextAction {
 ///            children: <Widget>[
 ///              TextField(
 ///                controller: billingAddress1,
-///                autofillHints: <String>[AutofillHints.streetAddressLine1],
+///                autofillHints: const <String>[AutofillHints.streetAddressLine1],
 ///              ),
 ///              TextField(
 ///                controller: billingAddress2,
-///                autofillHints: <String>[AutofillHints.streetAddressLine2],
+///                autofillHints: const <String>[AutofillHints.streetAddressLine2],
 ///              ),
 ///            ],
 ///          ),
@@ -121,11 +121,11 @@ enum AutofillContextAction {
 ///            children: <Widget>[
 ///              TextField(
 ///                controller: creditCardNumber,
-///                autofillHints: <String>[AutofillHints.creditCardNumber],
+///                autofillHints: const <String>[AutofillHints.creditCardNumber],
 ///              ),
 ///              TextField(
 ///                controller: creditCardSecurityCode,
-///                autofillHints: <String>[AutofillHints.creditCardSecurityCode],
+///                autofillHints: const <String>[AutofillHints.creditCardSecurityCode],
 ///              ),
 ///            ],
 ///          ),
@@ -135,7 +135,7 @@ enum AutofillContextAction {
 ///        // `AutofillScope`.
 ///        TextField(
 ///          controller: phoneNumber,
-///          autofillHints: <String>[AutofillHints.telephoneNumber],
+///          autofillHints: const <String>[AutofillHints.telephoneNumber],
 ///        ),
 ///      ],
 ///    );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -66,12 +66,12 @@ export 'package:flutter/rendering.dart' show
   WrapCrossAlignment;
 
 // Examples can assume:
-// class TestWidget extends StatelessWidget { @override Widget build(BuildContext context) => const Placeholder(); }
+// class TestWidget extends StatelessWidget { const TestWidget({Key? key}) : super(key: key); @override Widget build(BuildContext context) => const Placeholder(); }
 // late WidgetTester tester;
 // late bool _visible;
-// class Sky extends CustomPainter { @override void paint(Canvas c, Size s) => null; @override bool shouldRepaint(Sky s) => false; }
+// class Sky extends CustomPainter { @override void paint(Canvas c, Size s) {} @override bool shouldRepaint(Sky s) => false; }
 // late BuildContext context;
-// dynamic userAvatarUrl;
+// String userAvatarUrl = '';
 
 // BIDIRECTIONAL TEXT SUPPORT
 
@@ -204,7 +204,7 @@ class Directionality extends InheritedWidget {
 /// ```dart
 /// Image.network(
 ///   'https://raw.githubusercontent.com/flutter/assets-for-api-docs/master/packages/diagrams/assets/blend_mode_destination.jpeg',
-///   color: Color.fromRGBO(255, 255, 255, 0.5),
+///   color: const Color.fromRGBO(255, 255, 255, 0.5),
 ///   colorBlendMode: BlendMode.modulate
 /// )
 /// ```
@@ -397,7 +397,7 @@ class ShaderMask extends SingleChildRenderObjectWidget {
 ///             alignment: Alignment.center,
 ///             width: 200.0,
 ///             height: 200.0,
-///             child: Text('Hello World'),
+///             child: const Text('Hello World'),
 ///           ),
 ///         ),
 ///       ),
@@ -485,10 +485,10 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
 /// ```dart
 /// CustomPaint(
 ///   painter: Sky(),
-///   child: Center(
+///   child: const Center(
 ///     child: Text(
 ///       'Once upon a time...',
-///       style: const TextStyle(
+///       style: TextStyle(
 ///         fontSize: 40.0,
 ///         fontWeight: FontWeight.w900,
 ///         color: Color(0xFFFFFFFF),
@@ -1482,7 +1482,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
 /// not happen normally without using FittedBox.
 ///
 /// ```dart
-/// Widget build(BuildContext) {
+/// Widget build(BuildContext context) {
 ///   return Container(
 ///     height: 400,
 ///     width: 300,
@@ -1634,9 +1634,9 @@ class FractionalTranslation extends SingleChildRenderObjectWidget {
 /// to top, like an axis label on a graph:
 ///
 /// ```dart
-/// RotatedBox(
+/// const RotatedBox(
 ///   quarterTurns: 3,
-///   child: const Text('Hello World!'),
+///   child: Text('Hello World!'),
 /// )
 /// ```
 /// {@end-tool}
@@ -1795,7 +1795,7 @@ class Padding extends SingleChildRenderObjectWidget {
 ///     height: 120.0,
 ///     width: 120.0,
 ///     color: Colors.blue[50],
-///     child: Align(
+///     child: const Align(
 ///       alignment: Alignment.topRight,
 ///       child: FlutterLogo(
 ///         size: 60,
@@ -1826,7 +1826,7 @@ class Padding extends SingleChildRenderObjectWidget {
 ///     height: 120.0,
 ///     width: 120.0,
 ///     color: Colors.blue[50],
-///     child: Align(
+///     child: const Align(
 ///       alignment: Alignment(0.2, 0.6),
 ///       child: FlutterLogo(
 ///         size: 60,
@@ -1864,7 +1864,7 @@ class Padding extends SingleChildRenderObjectWidget {
 ///     height: 120.0,
 ///     width: 120.0,
 ///     color: Colors.blue[50],
-///     child: Align(
+///     child: const Align(
 ///       alignment: FractionalOffset(0.2, 0.6),
 ///       child: FlutterLogo(
 ///         size: 60,
@@ -2150,10 +2150,10 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
 /// exact size 200x300, parental constraints permitting:
 ///
 /// ```dart
-/// SizedBox(
+/// const SizedBox(
 ///   width: 200.0,
 ///   height: 300.0,
-///   child: const Card(child: Text('Hello World!')),
+///   child: Card(child: Text('Hello World!')),
 /// )
 /// ```
 /// {@end-tool}
@@ -2768,7 +2768,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 /// displayed in a [SnackBar].
 ///
 /// ```dart
-/// GlobalKey _key = GlobalKey();
+/// final GlobalKey _key = GlobalKey();
 /// bool _offstage = true;
 ///
 /// Size _getFlutterLogoSize() {
@@ -2790,7 +2790,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///       ),
 ///       Text('Flutter logo is offstage: $_offstage'),
 ///       ElevatedButton(
-///         child: Text('Toggle Offstage Value'),
+///         child: const Text('Toggle Offstage Value'),
 ///         onPressed: () {
 ///           setState(() {
 ///             _offstage = !_offstage;
@@ -2799,7 +2799,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///       ),
 ///       if (_offstage)
 ///         ElevatedButton(
-///           child: Text('Get Flutter Logo size'),
+///           child: const Text('Get Flutter Logo size'),
 ///           onPressed: () {
 ///             ScaffoldMessenger.of(context).showSnackBar(
 ///               SnackBar(
@@ -3446,7 +3446,7 @@ class ListBody extends MultiChildRenderObjectWidget {
 ///         color: Colors.white,
 ///       ),
 ///       Container(
-///         padding: EdgeInsets.all(5.0),
+///         padding: const EdgeInsets.all(5.0),
 ///         alignment: Alignment.bottomCenter,
 ///         decoration: BoxDecoration(
 ///           gradient: LinearGradient(
@@ -3459,8 +3459,8 @@ class ListBody extends MultiChildRenderObjectWidget {
 ///             ],
 ///           ),
 ///         ),
-///         child: Text(
-///           "Foreground Text",
+///         child: const Text(
+///           'Foreground Text',
 ///           style: TextStyle(color: Colors.white, fontSize: 20.0),
 ///         ),
 ///       ),
@@ -4329,7 +4329,7 @@ class Flex extends MultiChildRenderObjectWidget {
 ///
 /// ```dart
 /// Row(
-///   children: <Widget>[
+///   children: const <Widget>[
 ///     Expanded(
 ///       child: Text('Deliver features faster', textAlign: TextAlign.center),
 ///     ),
@@ -4339,7 +4339,7 @@ class Flex extends MultiChildRenderObjectWidget {
 ///     Expanded(
 ///       child: FittedBox(
 ///         fit: BoxFit.contain, // otherwise the logo will be tiny
-///         child: const FlutterLogo(),
+///         child: FlutterLogo(),
 ///       ),
 ///     ),
 ///   ],
@@ -4540,13 +4540,13 @@ class Row extends Flex {
 ///
 /// ```dart
 /// Column(
-///   children: <Widget>[
+///   children: const <Widget>[
 ///     Text('Deliver features faster'),
 ///     Text('Craft beautiful UIs'),
 ///     Expanded(
 ///       child: FittedBox(
 ///         fit: BoxFit.contain, // otherwise the logo will be tiny
-///         child: const FlutterLogo(),
+///         child: FlutterLogo(),
 ///       ),
 ///     ),
 ///   ],
@@ -4568,12 +4568,12 @@ class Row extends Flex {
 ///   crossAxisAlignment: CrossAxisAlignment.start,
 ///   mainAxisSize: MainAxisSize.min,
 ///   children: <Widget>[
-///     Text('We move under cover and we move as one'),
-///     Text('Through the night, we have one shot to live another day'),
-///     Text('We cannot let a stray gunshot give us away'),
-///     Text('We will fight up close, seize the moment and stay in it'),
-///     Text('It’s either that or meet the business end of a bayonet'),
-///     Text('The code word is ‘Rochambeau,’ dig me?'),
+///     const Text('We move under cover and we move as one'),
+///     const Text('Through the night, we have one shot to live another day'),
+///     const Text('We cannot let a stray gunshot give us away'),
+///     const Text('We will fight up close, seize the moment and stay in it'),
+///     const Text('It’s either that or meet the business end of a bayonet'),
+///     const Text('The code word is ‘Rochambeau,’ dig me?'),
 ///     Text('Rochambeau!', style: DefaultTextStyle.of(context).style.apply(fontSizeFactor: 2.0)),
 ///   ],
 /// )
@@ -4821,7 +4821,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
-///       title: Text('Expanded Column Sample'),
+///       title: const Text('Expanded Column Sample'),
 ///     ),
 ///     body: Center(
 ///        child: Column(
@@ -4860,7 +4860,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     appBar: AppBar(
-///       title: Text('Expanded Row Sample'),
+///       title: const Text('Expanded Row Sample'),
 ///     ),
 ///     body: Center(
 ///       child: Row(
@@ -4935,20 +4935,20 @@ class Expanded extends Flexible {
 ///   runSpacing: 4.0, // gap between lines
 ///   children: <Widget>[
 ///     Chip(
-///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: Text('AH')),
-///       label: Text('Hamilton'),
+///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: const Text('AH')),
+///       label: const Text('Hamilton'),
 ///     ),
 ///     Chip(
-///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: Text('ML')),
-///       label: Text('Lafayette'),
+///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: const Text('ML')),
+///       label: const Text('Lafayette'),
 ///     ),
 ///     Chip(
-///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: Text('HM')),
-///       label: Text('Mulligan'),
+///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: const Text('HM')),
+///       label: const Text('Mulligan'),
 ///     ),
 ///     Chip(
-///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: Text('JL')),
-///       label: Text('Laurens'),
+///       avatar: CircleAvatar(backgroundColor: Colors.blue.shade900, child: const Text('JL')),
+///       label: const Text('Laurens'),
 ///     ),
 ///   ],
 /// )
@@ -5210,9 +5210,11 @@ class Wrap extends MultiChildRenderObjectWidget {
 /// ```dart main
 /// import 'package:flutter/material.dart';
 ///
-/// void main() => runApp(FlowApp());
+/// void main() => runApp(const FlowApp());
 ///
 /// class FlowApp extends StatelessWidget {
+///   const FlowApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
@@ -5220,13 +5222,15 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///         appBar: AppBar(
 ///           title: const Text('Flow Example'),
 ///         ),
-///         body: FlowMenu(),
+///         body: const FlowMenu(),
 ///       ),
 ///     );
 ///   }
 /// }
 ///
 /// class FlowMenu extends StatefulWidget {
+///   const FlowMenu({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _FlowMenuState createState() => _FlowMenuState();
 /// }
@@ -5243,8 +5247,9 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///   ];
 ///
 ///   void _updateMenu(IconData icon) {
-///     if (icon != Icons.menu)
+///     if (icon != Icons.menu) {
 ///       setState(() => lastTapped = icon);
+///     }
 ///   }
 ///
 ///   @override
@@ -5263,7 +5268,7 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///       child: RawMaterialButton(
 ///         fillColor: lastTapped == icon ? Colors.amber[700] : Colors.blue,
 ///         splashColor: Colors.amber[100],
-///         shape: CircleBorder(),
+///         shape: const CircleBorder(),
 ///         constraints: BoxConstraints.tight(Size(buttonDiameter, buttonDiameter)),
 ///         onPressed: () {
 ///           _updateMenu(icon);
@@ -5282,11 +5287,9 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return Container(
-///       child: Flow(
-///         delegate: FlowMenuDelegate(menuAnimation: menuAnimation),
-///         children: menuItems.map<Widget>((IconData icon) => flowMenuItem(icon)).toList(),
-///       ),
+///     return Flow(
+///       delegate: FlowMenuDelegate(menuAnimation: menuAnimation),
+///       children: menuItems.map<Widget>((IconData icon) => flowMenuItem(icon)).toList(),
 ///     );
 ///   }
 /// }
@@ -5405,7 +5408,7 @@ class Flow extends MultiChildRenderObjectWidget {
 ///   text: TextSpan(
 ///     text: 'Hello ',
 ///     style: DefaultTextStyle.of(context).style,
-///     children: <TextSpan>[
+///     children: const <TextSpan>[
 ///       TextSpan(text: 'bold', style: TextStyle(fontWeight: FontWeight.bold)),
 ///       TextSpan(text: ' world!'),
 ///     ],
@@ -5859,7 +5862,7 @@ class RawImage extends LeafRenderObjectWidget {
 ///   MaterialApp(
 ///     home: DefaultAssetBundle(
 ///       bundle: TestAssetBundle(),
-///       child: TestWidget(),
+///       child: const TestWidget(),
 ///     ),
 ///   ),
 /// );
@@ -6005,7 +6008,7 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 /// @override
 /// Widget build(BuildContext context) {
 ///   return ConstrainedBox(
-///     constraints: new BoxConstraints.tight(Size(300.0, 200.0)),
+///     constraints: BoxConstraints.tight(const Size(300.0, 200.0)),
 ///     child: Listener(
 ///       onPointerDown: _incrementDown,
 ///       onPointerMove: _updateLocation,
@@ -6015,7 +6018,7 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWidget {
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.center,
 ///           children: <Widget>[
-///             Text('You have pressed or released in this area this many times:'),
+///             const Text('You have pressed or released in this area this many times:'),
 ///             Text(
 ///               '$_downCounter presses\n$_upCounter releases',
 ///               style: Theme.of(context).textTheme.headline4,
@@ -6173,7 +6176,7 @@ class Listener extends SingleChildRenderObjectWidget {
 /// @override
 /// Widget build(BuildContext context) {
 ///   return ConstrainedBox(
-///     constraints: new BoxConstraints.tight(Size(300.0, 200.0)),
+///     constraints: BoxConstraints.tight(const Size(300.0, 200.0)),
 ///     child: MouseRegion(
 ///       onEnter: _incrementEnter,
 ///       onHover: _updateLocation,
@@ -6183,7 +6186,7 @@ class Listener extends SingleChildRenderObjectWidget {
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.center,
 ///           children: <Widget>[
-///             Text('You have entered or exited this box this many times:'),
+///             const Text('You have entered or exited this box this many times:'),
 ///             Text(
 ///               '$_enterCounter Entries\n$_exitCounter Exits',
 ///               style: Theme.of(context).textTheme.headline4,
@@ -6348,7 +6351,7 @@ class MouseRegion extends StatefulWidget {
   /// ```dart preamble
   /// // A region that hides its content one second after being hovered.
   /// class MyTimedButton extends StatefulWidget {
-  ///   MyTimedButton({ Key? key, required this.onEnterButton, required this.onExitButton })
+  ///   const MyTimedButton({ Key? key, required this.onEnterButton, required this.onExitButton })
   ///     : super(key: key);
   ///
   ///   final VoidCallback onEnterButton;
@@ -6362,21 +6365,22 @@ class MouseRegion extends StatefulWidget {
   ///   bool regionIsHidden = false;
   ///   bool hovered = false;
   ///
-  ///   void startCountdown() async {
-  ///     await Future.delayed(const Duration(seconds: 1));
+  ///   Future<void> startCountdown() async {
+  ///     await Future<void>.delayed(const Duration(seconds: 1));
   ///     hideButton();
   ///   }
   ///
   ///   void hideButton() {
   ///     setState(() { regionIsHidden = true; });
   ///     // This statement is necessary.
-  ///     if (hovered)
+  ///     if (hovered) {
   ///       widget.onExitButton();
+  ///     }
   ///   }
   ///
   ///   @override
   ///   Widget build(BuildContext context) {
-  ///     return Container(
+  ///     return SizedBox(
   ///       width: 100,
   ///       height: 100,
   ///       child: MouseRegion(
@@ -6410,9 +6414,10 @@ class MouseRegion extends StatefulWidget {
   ///           onPressed: () {
   ///             setState(() { key = UniqueKey(); });
   ///           },
-  ///           child: Text('Refresh'),
+  ///           child: const Text('Refresh'),
   ///         ),
-  ///         hovering ? Text('Hovering') : Text('Not hovering'),
+  ///         if (hovering) const Text('Hovering'),
+  ///         if (!hovering) const Text('Not hovering'),
   ///         MyTimedButton(
   ///           key: key,
   ///           onEnterButton: () {
@@ -6660,14 +6665,10 @@ class RepaintBoundary extends SingleChildRenderObjectWidget {
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
 ///           children: <Widget>[
-///             Text(
-///               'Ignoring: $ignoring',
-///             ),
+///             Text('Ignoring: $ignoring'),
 ///             ElevatedButton(
 ///               onPressed: () {},
-///               child: Text(
-///                 'Click me!',
-///               ),
+///               child: const Text('Click me!'),
 ///             ),
 ///           ],
 ///         ),
@@ -6750,7 +6751,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 /// Widget build(BuildContext context) {
 ///   return Stack(
 ///     alignment: AlignmentDirectional.center,
-///     children: [
+///     children: <Widget>[
 ///       SizedBox(
 ///         width: 200.0,
 ///         height: 100.0,
@@ -7255,7 +7256,7 @@ class Semantics extends SingleChildRenderObjectWidget {
 ///         value: true,
 ///         onChanged: (bool? value) {},
 ///       ),
-///       const Text("Settings"),
+///       const Text('Settings'),
 ///     ],
 ///   ),
 /// )

--- a/packages/flutter/lib/src/widgets/color_filter.dart
+++ b/packages/flutter/lib/src/widgets/color_filter.dart
@@ -26,9 +26,9 @@ import 'framework.dart';
 /// Widget build(BuildContext context) {
 ///   return SingleChildScrollView(
 ///     child: Column(
-///       children: [
+///       children: <Widget>[
 ///         ColorFiltered(
-///           colorFilter: ColorFilter.mode(
+///           colorFilter: const ColorFilter.mode(
 ///             Colors.red,
 ///             BlendMode.modulate,
 ///           ),
@@ -36,7 +36,7 @@ import 'framework.dart';
 ///               'https://flutter.github.io/assets-for-api-docs/assets/widgets/owl-2.jpg'),
 ///         ),
 ///         ColorFiltered(
-///           colorFilter: ColorFilter.mode(
+///           colorFilter: const ColorFilter.mode(
 ///             Colors.grey,
 ///             BlendMode.saturation,
 ///           ),

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -27,14 +27,14 @@ import 'image.dart';
 /// This sample shows a radial gradient that draws a moon on a night sky:
 ///
 /// ```dart
-/// DecoratedBox(
+/// const DecoratedBox(
 ///   decoration: BoxDecoration(
 ///     gradient: RadialGradient(
-///       center: const Alignment(-0.5, -0.6),
+///       center: Alignment(-0.5, -0.6),
 ///       radius: 0.15,
 ///       colors: <Color>[
-///         const Color(0xFFEEEEEE),
-///         const Color(0xFF111133),
+///         Color(0xFFEEEEEE),
+///         Color(0xFF111133),
 ///       ],
 ///       stops: <double>[0.9, 1.0],
 ///     ),

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -72,8 +72,9 @@ enum DismissDirection {
 /// tiles to the left or right to dismiss them from the [ListView].
 ///
 /// ```dart
-/// List<int> items = List<int>.generate(100, (index) => index);
+/// List<int> items = List<int>.generate(100, (int index) => index);
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return ListView.builder(
 ///     itemCount: items.length,
@@ -88,7 +89,7 @@ enum DismissDirection {
 ///         background: Container(
 ///           color: Colors.green,
 ///         ),
-///         key: ValueKey(items[index]),
+///         key: ValueKey<int>(items[index]),
 ///         onDismissed: (DismissDirection direction) {
 ///           setState(() {
 ///             items.remove(index);

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -113,10 +113,12 @@ enum DragAnchor {
 ///
 /// ```dart
 /// int acceptedData = 0;
+///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Row(
 ///     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-///     children: [
+///     children: <Widget>[
 ///       Draggable<int>(
 ///         // Data is the value this Draggable stores.
 ///         data: 10,
@@ -124,26 +126,26 @@ enum DragAnchor {
 ///           height: 100.0,
 ///           width: 100.0,
 ///           color: Colors.lightGreenAccent,
-///           child: Center(
-///             child: Text("Draggable"),
+///           child: const Center(
+///             child: Text('Draggable'),
 ///           ),
 ///         ),
 ///         feedback: Container(
 ///           color: Colors.deepOrange,
 ///           height: 100,
 ///           width: 100,
-///           child: Icon(Icons.directions_run),
+///           child: const Icon(Icons.directions_run),
 ///         ),
 ///         childWhenDragging: Container(
 ///           height: 100.0,
 ///           width: 100.0,
 ///           color: Colors.pinkAccent,
-///           child: Center(
-///             child: Text("Child When Dragging"),
+///           child: const Center(
+///             child: Text('Child When Dragging'),
 ///           ),
 ///         ),
 ///       ),
-///       DragTarget(
+///       DragTarget<int>(
 ///         builder: (
 ///           BuildContext context,
 ///           List<dynamic> accepted,
@@ -154,7 +156,7 @@ enum DragAnchor {
 ///             width: 100.0,
 ///             color: Colors.cyan,
 ///             child: Center(
-///               child: Text("Value is updated to: $acceptedData"),
+///               child: Text('Value is updated to: $acceptedData'),
 ///             ),
 ///           );
 ///         },

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -66,6 +66,8 @@ typedef ScrollableWidgetBuilder = Widget Function(
 ///
 /// ```dart
 /// class HomePage extends StatelessWidget {
+///   const HomePage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -101,12 +101,13 @@ final Map<LogicalKeySet, Intent> scrollShortcutOverrides = <LogicalKeySet, Inten
 /// cursor at the end of the input.
 ///
 /// ```dart
-/// final _controller = TextEditingController();
+/// final TextEditingController _controller = TextEditingController();
 ///
+/// @override
 /// void initState() {
 ///   super.initState();
 ///   _controller.addListener(() {
-///     final text = _controller.text.toLowerCase();
+///     final String text = _controller.text.toLowerCase();
 ///     _controller.value = _controller.value.copyWith(
 ///       text: text,
 ///       selection: TextSelection(baseOffset: text.length, extentOffset: text.length),
@@ -115,11 +116,13 @@ final Map<LogicalKeySet, Intent> scrollShortcutOverrides = <LogicalKeySet, Inten
 ///   });
 /// }
 ///
+/// @override
 /// void dispose() {
 ///   _controller.dispose();
 ///   super.dispose();
 /// }
 ///
+/// @override
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: Container(
@@ -127,7 +130,7 @@ final Map<LogicalKeySet, Intent> scrollShortcutOverrides = <LogicalKeySet, Inten
 ///       padding: const EdgeInsets.all(6),
 ///       child: TextFormField(
 ///         controller: _controller,
-///         decoration: InputDecoration(border: OutlineInputBorder()),
+///         decoration: const InputDecoration(border: OutlineInputBorder()),
 ///       ),
 ///     ),
 ///   );
@@ -957,11 +960,13 @@ class EditableText extends StatefulWidget {
   /// ```dart
   /// final TextEditingController _controller = TextEditingController();
   ///
+  /// @override
   /// void dispose() {
   ///   _controller.dispose();
   ///   super.dispose();
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     body: Column(
@@ -980,7 +985,7 @@ class EditableText extends StatefulWidget {
   ///               builder: (BuildContext context) {
   ///                 return AlertDialog(
   ///                   title: const Text('That is correct!'),
-  ///                   content: Text ('13 is the right answer.'),
+  ///                   content: const Text ('13 is the right answer.'),
   ///                   actions: <Widget>[
   ///                     TextButton(
   ///                       onPressed: () { Navigator.pop(context); },

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -58,7 +58,7 @@ import 'transitions.dart';
 /// FadeInImage(
 ///   // here `bytes` is a Uint8List containing the bytes for the in-memory image
 ///   placeholder: MemoryImage(bytes),
-///   image: NetworkImage('https://backend.example.com/image.png'),
+///   image: const NetworkImage('https://backend.example.com/image.png'),
 /// )
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -314,7 +314,7 @@ enum UnfocusDisposition {
 ///
 /// ```dart preamble
 /// class ColorfulButton extends StatefulWidget {
-///   ColorfulButton({Key? key}) : super(key: key);
+///   const ColorfulButton({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   _ColorfulButtonState createState() => _ColorfulButtonState();
@@ -407,7 +407,7 @@ enum UnfocusDisposition {
 ///   final TextTheme textTheme = Theme.of(context).textTheme;
 ///   return DefaultTextStyle(
 ///     style: textTheme.headline4!,
-///     child: ColorfulButton(),
+///     child: const ColorfulButton(),
 ///   );
 /// }
 /// ```
@@ -812,7 +812,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   ///         children: <Widget>[
   ///           Wrap(
   ///             children: List<Widget>.generate(4, (int index) {
-  ///               return SizedBox(
+  ///               return const SizedBox(
   ///                 width: 200,
   ///                 child: Padding(
   ///                   padding: const EdgeInsets.all(8.0),

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -163,7 +163,7 @@ import 'inherited_notifier.dart';
 ///         // would start looking for a Focus widget ancestor of the FocusableText
 ///         // instead of finding the one inside of its build function.
 ///         return Container(
-///           padding: EdgeInsets.all(8.0),
+///           padding: const EdgeInsets.all(8.0),
 ///           // Change the color based on whether or not this Container has focus.
 ///           color: Focus.of(context).hasPrimaryFocus ? Colors.black12 : null,
 ///           child: Text(data),
@@ -178,7 +178,7 @@ import 'inherited_notifier.dart';
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
 ///     body: ListView.builder(
-///       itemBuilder: (context, index) => FocusableText(
+///       itemBuilder: (BuildContext context, int index) => FocusableText(
 ///         'Item $index',
 ///         autofocus: index == 0,
 ///       ),
@@ -212,7 +212,9 @@ import 'inherited_notifier.dart';
 /// @override
 /// void dispose() {
 ///   super.dispose();
-///   childFocusNodes.forEach((FocusNode node) => node.dispose());
+///   for (final FocusNode node in childFocusNodes) {
+///     node.dispose();
+///   }
 /// }
 ///
 /// void _addChild() {
@@ -246,7 +248,7 @@ import 'inherited_notifier.dart';
 ///           _addChild();
 ///         });
 ///       },
-///       child: Icon(Icons.add),
+///       child: const Icon(Icons.add),
 ///     ),
 ///   );
 /// }
@@ -808,7 +810,7 @@ class _FocusState extends State<Focus> {
 ///   }
 ///
 ///   Widget _buildStack(BuildContext context, BoxConstraints constraints) {
-///     Size stackSize = constraints.biggest;
+///     final Size stackSize = constraints.biggest;
 ///     return Stack(
 ///       fit: StackFit.expand,
 ///       // The backdrop is behind the front widget in the Stack, but the widgets
@@ -827,7 +829,7 @@ class _FocusState extends State<Focus> {
 ///           // foreground pane semi-transparent to see it clearly.
 ///           canRequestFocus: backdropIsVisible,
 ///           child: Pane(
-///             icon: Icon(Icons.close),
+///             icon: const Icon(Icons.close),
 ///             focusNode: backdropNode,
 ///             backgroundColor: Colors.lightBlue,
 ///             onPressed: () => setState(() => backdropIsVisible = false),
@@ -838,11 +840,11 @@ class _FocusState extends State<Focus> {
 ///                 // the foreground pane without the FocusScope.
 ///                 ElevatedButton(
 ///                   onPressed: () => print('You pressed the other button!'),
-///                   child: Text('ANOTHER BUTTON TO FOCUS'),
+///                   child: const Text('ANOTHER BUTTON TO FOCUS'),
 ///                 ),
 ///                 DefaultTextStyle(
 ///                     style: Theme.of(context).textTheme.headline2!,
-///                     child: Text('BACKDROP')),
+///                     child: const Text('BACKDROP')),
 ///               ],
 ///             ),
 ///           ),
@@ -861,7 +863,7 @@ class _FocusState extends State<Focus> {
 ///             }
 ///           },
 ///           child: Pane(
-///             icon: Icon(Icons.menu),
+///             icon: const Icon(Icons.menu),
 ///             focusNode: foregroundNode,
 ///             // TRY THIS: Try changing this to Colors.green.withOpacity(0.8) to see for
 ///             // yourself that the hidden components do/don't get focus.
@@ -871,7 +873,7 @@ class _FocusState extends State<Focus> {
 ///                 : () => setState(() => backdropIsVisible = true),
 ///             child: DefaultTextStyle(
 ///                 style: Theme.of(context).textTheme.headline2!,
-///                 child: Text('FOREGROUND')),
+///                 child: const Text('FOREGROUND')),
 ///           ),
 ///         ),
 ///       ],

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1273,10 +1273,11 @@ class _OrderedFocusInfo {
 /// ```dart preamble
 /// class DemoButton extends StatelessWidget {
 ///   const DemoButton({
+///     Key? key,
 ///     required this.name,
 ///     this.autofocus = false,
 ///     required this.order,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String name;
 ///   final bool autofocus;
@@ -1493,11 +1494,12 @@ class FocusTraversalOrder extends InheritedWidget {
 /// /// the type of T.
 /// class OrderedButton<T> extends StatefulWidget {
 ///   const OrderedButton({
+///     Key? key,
 ///     required this.name,
 ///     this.canRequestFocus = true,
 ///     this.autofocus = false,
 ///     required this.order,
-///   });
+///   }) : super(key: key);
 ///
 ///   final String name;
 ///   final bool canRequestFocus;
@@ -1505,7 +1507,7 @@ class FocusTraversalOrder extends InheritedWidget {
 ///   final T order;
 ///
 ///   @override
-///   _OrderedButtonState createState() => _OrderedButtonState();
+///   _OrderedButtonState<T> createState() => _OrderedButtonState<T>();
 /// }
 ///
 /// class _OrderedButtonState<T> extends State<OrderedButton<T>> {
@@ -1614,7 +1616,7 @@ class FocusTraversalOrder extends InheritedWidget {
 ///               mainAxisAlignment: MainAxisAlignment.center,
 ///               children: List<Widget>.generate(3, (int index) {
 ///                 // Order as "C" "B", "A".
-///                 String order =
+///                 final String order =
 ///                     String.fromCharCode('A'.codeUnitAt(0) + (2 - index));
 ///                 return OrderedButton<String>(
 ///                   name: 'String: $order',

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -24,7 +24,7 @@ import 'will_pop_scope.dart';
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/widgets/form.png)
 ///
 /// ```dart
-/// final _formKey = GlobalKey<FormState>();
+/// final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 ///
 /// @override
 /// Widget build(BuildContext context) {
@@ -37,8 +37,8 @@ import 'will_pop_scope.dart';
 ///           decoration: const InputDecoration(
 ///             hintText: 'Enter your email',
 ///           ),
-///           validator: (value) {
-///             if (value!.isEmpty) {
+///           validator: (String? value) {
+///             if (value == null || value.isEmpty) {
 ///               return 'Please enter some text';
 ///             }
 ///             return null;
@@ -54,7 +54,7 @@ import 'will_pop_scope.dart';
 ///                 // Process data.
 ///               }
 ///             },
-///             child: Text('Submit'),
+///             child: const Text('Submit'),
 ///           ),
 ///         ),
 ///       ],

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -34,7 +34,7 @@ export 'package:flutter/rendering.dart' show RenderObject, RenderBox, debugDumpR
 // late BuildContext context;
 // void setState(VoidCallback fn) { }
 // abstract class RenderFrogJar extends RenderObject { }
-// abstract class FrogJar extends RenderObjectWidget { }
+// abstract class FrogJar extends RenderObjectWidget { const FrogJar({Key? key}) : super(key: key); }
 // abstract class FrogJarParentData extends ParentData { late Size size; }
 
 // KEYS
@@ -693,6 +693,7 @@ abstract class StatelessWidget extends Widget {
 ///   final Color color;
 ///   final Widget? child;
 ///
+///   @override
 ///   _BirdState createState() => _BirdState();
 /// }
 ///
@@ -1351,7 +1352,7 @@ abstract class ProxyWidget extends Widget {
 ///
 /// ```dart
 /// class FrogSize extends ParentDataWidget<FrogJarParentData> {
-///   FrogSize({
+///   const FrogSize({
 ///     Key? key,
 ///     required this.size,
 ///     required Widget child,
@@ -1554,6 +1555,8 @@ abstract class ParentDataWidget<T extends ParentData> extends ProxyWidget {
 ///
 /// ```dart
 /// class MyPage extends StatelessWidget {
+///   const MyPage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
@@ -1581,6 +1584,8 @@ abstract class ParentDataWidget<T extends ParentData> extends ProxyWidget {
 ///
 /// ```dart
 /// class MyOtherPage extends StatelessWidget {
+///   const MyOtherPage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
@@ -4328,14 +4333,15 @@ typedef ErrorWidgetBuilder = Widget Function(FlutterErrorDetails details);
 ///     assert(() { inDebug = true; return true; }());
 ///     // In debug mode, use the normal error widget which shows
 ///     // the error message:
-///     if (inDebug)
+///     if (inDebug) {
 ///       return ErrorWidget(details.exception);
+///     }
 ///     // In release builds, show a yellow-on-blue message instead:
 ///     return Container(
 ///       alignment: Alignment.center,
-///       child: Text(
+///       child: const Text(
 ///         'Error!',
-///         style: TextStyle(color: Colors.yellow),
+///         style: const TextStyle(color: Colors.yellow),
 ///         textDirection: TextDirection.ltr,
 ///       ),
 ///     );

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1044,9 +1044,10 @@ class RawGestureDetector extends StatefulWidget {
   /// ```dart
   /// class ForcePressGestureDetectorWithSemantics extends StatelessWidget {
   ///   const ForcePressGestureDetectorWithSemantics({
+  ///     Key? key,
   ///     required this.child,
   ///     required this.onForcePress,
-  ///   });
+  ///   }) : super(key: key);
   ///
   ///   final Widget child;
   ///   final VoidCallback onForcePress;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -124,7 +124,7 @@ enum HeroFlightDirection {
 ///        ListTile(
 ///          leading: Hero(
 ///            tag: 'hero-rectangle',
-///            child: _blueRectangle(Size(50,50)),
+///            child: _blueRectangle(const Size(50, 50)),
 ///          ),
 ///          onTap: () => _gotoDetailsPage(context),
 ///          title: const Text('Tap on the icon to view hero animation transition.'),
@@ -142,7 +142,7 @@ enum HeroFlightDirection {
 ///  }
 ///
 ///  void _gotoDetailsPage(BuildContext context) {
-///    Navigator.of(context).push(MaterialPageRoute(
+///    Navigator.of(context).push(MaterialPageRoute<void>(
 ///      builder: (BuildContext context) => Scaffold(
 ///        appBar: AppBar(
 ///          title: const Text('second Page'),
@@ -153,7 +153,7 @@ enum HeroFlightDirection {
 ///            children: <Widget>[
 ///              Hero(
 ///                tag: 'hero-rectangle',
-///                child: _blueRectangle(Size(200,200)),
+///                child: _blueRectangle(const Size(200, 200)),
 ///              ),
 ///            ],
 ///          ),

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -831,8 +831,9 @@ class Image extends StatefulWidget {
   ///     child: Image.network(
   ///       'https://example.com/image.jpg',
   ///       loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent? loadingProgress) {
-  ///         if (loadingProgress == null)
+  ///         if (loadingProgress == null) {
   ///           return child;
+  ///         }
   ///         return Center(
   ///           child: CircularProgressIndicator(
   ///             value: loadingProgress.expectedTotalBytes != null
@@ -882,7 +883,7 @@ class Image extends StatefulWidget {
   ///         //   exception,
   ///         //   stackTrace,
   ///         // );
-  ///         return Text('😢');
+  ///         return const Text('😢');
   ///       },
   ///     ),
   ///   );

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -18,8 +18,8 @@ import 'transitions.dart';
 
 // Examples can assume:
 // class MyWidget extends ImplicitlyAnimatedWidget {
-//   MyWidget() : super(duration: const Duration(seconds: 1));
-//   final Color targetColor = Colors.black;
+//   const MyWidget({Key? key, this.targetColor = Colors.black}) : super(key: key, duration: const Duration(seconds: 1));
+//   final Color targetColor;
 //   @override
 //   MyWidgetState createState() => MyWidgetState();
 // }
@@ -502,7 +502,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   ///       widget.targetColor,
   ///       // A function that takes a color value and returns a tween
   ///       // beginning at that value.
-  ///       (value) => ColorTween(begin: value),
+  ///       (dynamic value) => ColorTween(begin: value as Color?),
   ///     ) as ColorTween?;
   ///
   ///     // We could have more tweens than one by using the visitor
@@ -597,9 +597,9 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///         height: selected ? 100.0 : 200.0,
 ///         color: selected ? Colors.red : Colors.blue,
 ///         alignment: selected ? Alignment.center : AlignmentDirectional.topCenter,
-///         duration: Duration(seconds: 2),
+///         duration: const Duration(seconds: 2),
 ///         curve: Curves.fastOutSlowIn,
-///         child: FlutterLogo(size: 75),
+///         child: const FlutterLogo(size: 75),
 ///       ),
 ///     ),
 ///   );
@@ -820,7 +820,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 ///
 /// ```dart
 /// double padValue = 0.0;
-/// _updatePadding(double value) {
+/// void _updatePadding(double value) {
 ///   setState(() {
 ///     padValue = value;
 ///   });
@@ -830,7 +830,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 /// Widget build(BuildContext context) {
 ///   return Column(
 ///     mainAxisAlignment: MainAxisAlignment.center,
-///     children: [
+///     children: <Widget>[
 ///       AnimatedPadding(
 ///         padding: EdgeInsets.all(padValue),
 ///         duration: const Duration(seconds: 2),
@@ -843,7 +843,7 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 ///       ),
 ///       Text('Padding: $padValue'),
 ///       ElevatedButton(
-///         child: Text('Change padding'),
+///         child: const Text('Change padding'),
 ///         onPressed: () {
 ///           _updatePadding(padValue == 0.0 ? 100.0 : 0.0);
 ///         }
@@ -1110,16 +1110,16 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return Container(
+///   return SizedBox(
 ///     width: 200,
 ///     height: 350,
 ///     child: Stack(
-///       children: [
+///       children: <Widget>[
 ///         AnimatedPositioned(
 ///           width: selected ? 200.0 : 50.0,
 ///           height: selected ? 50.0 : 200.0,
 ///           top: selected ? 50.0 : 150.0,
-///           duration: Duration(seconds: 2),
+///           duration: const Duration(seconds: 2),
 ///           curve: Curves.fastOutSlowIn,
 ///           child: GestureDetector(
 ///             onTap: () {
@@ -1129,7 +1129,7 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 ///             },
 ///             child: Container(
 ///               color: Colors.blue,
-///               child: Center(child: Text('Tap me')),
+///               child: const Center(child: Text('Tap me')),
 ///             ),
 ///           ),
 ///         ),
@@ -1428,8 +1428,10 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///
 /// ```dart
 /// class LogoFade extends StatefulWidget {
+///   const LogoFade({Key? key}) : super(key: key);
+///
 ///   @override
-///   createState() => LogoFadeState();
+///   State<LogoFade> createState() => LogoFadeState();
 /// }
 ///
 /// class LogoFadeState extends State<LogoFade> {
@@ -1443,14 +1445,14 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///   Widget build(BuildContext context) {
 ///     return Column(
 ///       mainAxisAlignment: MainAxisAlignment.center,
-///       children: [
+///       children: <Widget>[
 ///         AnimatedOpacity(
 ///           opacity: opacityLevel,
-///           duration: Duration(seconds: 3),
-///           child: FlutterLogo(),
+///           duration: const Duration(seconds: 3),
+///           child: const FlutterLogo(),
 ///         ),
 ///         ElevatedButton(
-///           child: Text('Fade Logo'),
+///           child: const Text('Fade Logo'),
 ///           onPressed: _changeOpacity,
 ///         ),
 ///       ],
@@ -1559,18 +1561,19 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 /// class _MyStatefulWidgetState extends State<MyStatefulWidget> with SingleTickerProviderStateMixin {
 ///   bool _visible = true;
 ///
+///   @override
 ///   Widget build(BuildContext context) {
 ///     return CustomScrollView(
 ///       slivers: <Widget>[
 ///         SliverAnimatedOpacity(
 ///           opacity: _visible ? 1.0 : 0.0,
-///           duration: Duration(milliseconds: 500),
+///           duration: const Duration(milliseconds: 500),
 ///           sliver: SliverFixedExtentList(
 ///             itemExtent: 100.0,
 ///             delegate: SliverChildBuilderDelegate(
 ///               (BuildContext context, int index) {
 ///                 return Container(
-///                   color: index % 2 == 0
+///                   color: index.isEven
 ///                     ? Colors.indigo[200]
 ///                     : Colors.orange[200],
 ///                 );
@@ -1587,7 +1590,7 @@ class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacit
 ///               });
 ///             },
 ///             tooltip: 'Toggle opacity',
-///             child: Icon(Icons.flip),
+///             child: const Icon(Icons.flip),
 ///           )
 ///         ),
 ///       ]

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -43,13 +43,13 @@ import 'framework.dart';
 /// just need to know that there is one in their ancestry. This can help with
 /// decoupling widgets from their models.
 ///
-/// ```dart imports
+/// ```dart dartImports
 /// import 'dart:math' as math;
 /// ```
 ///
 /// ```dart preamble
 /// class SpinModel extends InheritedNotifier<AnimationController> {
-///   SpinModel({
+///   const SpinModel({
 ///     Key? key,
 ///     AnimationController? notifier,
 ///     required Widget child,
@@ -61,7 +61,7 @@ import 'framework.dart';
 /// }
 ///
 /// class Spinner extends StatelessWidget {
-///   const Spinner();
+///   const Spinner({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/inherited_theme.dart
+++ b/packages/flutter/lib/src/widgets/inherited_theme.dart
@@ -31,12 +31,14 @@ import 'framework.dart';
 ///
 /// ```dart main
 /// void main() {
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 /// ```
 ///
 /// ```dart
 /// class MyAppBody extends StatelessWidget {
+///   const MyAppBody({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     final NavigatorState navigator = Navigator.of(context);
@@ -51,28 +53,32 @@ import 'framework.dart';
 ///     return GestureDetector(
 ///       onTap: () {
 ///         Navigator.of(context).push(
-///           MaterialPageRoute(
+///           MaterialPageRoute<void>(
 ///             builder: (BuildContext _) {
 ///               // Wrap the actual child of the route in the previously
 ///               // captured themes.
-///               return themes.wrap(Container(
-///                 alignment: Alignment.center,
-///                 color: Colors.white,
-///                 child: Text('Hello World'),
-///               ));
+///               return themes.wrap(
+///                 Container(
+///                   alignment: Alignment.center,
+///                   color: Colors.white,
+///                   child: const Text('Hello World'),
+///                 ),
+///               );
 ///             },
 ///           ),
 ///         );
 ///       },
-///       child: Center(child: Text('Tap Here')),
+///       child: const Center(child: Text('Tap Here')),
 ///     );
 ///   }
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return MaterialApp(
+///     return const MaterialApp(
 ///       home: Scaffold(
 ///         // Override the DefaultTextStyle defined by the Scaffold.
 ///         // Descendant widgets will inherit this big blue text style.

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -45,11 +45,11 @@ import 'ticker_provider.dart';
 /// Widget build(BuildContext context) {
 ///   return Center(
 ///     child: InteractiveViewer(
-///       boundaryMargin: EdgeInsets.all(20.0),
+///       boundaryMargin: const EdgeInsets.all(20.0),
 ///       minScale: 0.1,
 ///       maxScale: 1.6,
 ///       child: Container(
-///         decoration: BoxDecoration(
+///         decoration: const BoxDecoration(
 ///           gradient: LinearGradient(
 ///             begin: Alignment.topCenter,
 ///             end: Alignment.bottomCenter,
@@ -386,13 +386,13 @@ class InteractiveViewer extends StatefulWidget {
   ///     ),
   ///     body: Center(
   ///       child: InteractiveViewer(
-  ///         boundaryMargin: EdgeInsets.all(double.infinity),
+  ///         boundaryMargin: const EdgeInsets.all(double.infinity),
   ///         transformationController: _transformationController,
   ///         minScale: 0.1,
   ///         maxScale: 1.0,
   ///         onInteractionStart: _onInteractionStart,
   ///         child: Container(
-  ///           decoration: BoxDecoration(
+  ///           decoration: const BoxDecoration(
   ///             gradient: LinearGradient(
   ///               begin: Alignment.topCenter,
   ///               end: Alignment.bottomCenter,
@@ -403,7 +403,7 @@ class InteractiveViewer extends StatefulWidget {
   ///         ),
   ///       ),
   ///     ),
-  ///     persistentFooterButtons: [
+  ///     persistentFooterButtons: <Widget>[
   ///       IconButton(
   ///         onPressed: _animateResetInitialize,
   ///         tooltip: 'Reset',

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -251,9 +251,9 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
-///     appBar: AppBar(title: Text("LayoutBuilder Example")),
+///     appBar: AppBar(title: const Text('LayoutBuilder Example')),
 ///     body: LayoutBuilder(
-///       builder: (context, constraints) {
+///       builder: (BuildContext context, BoxConstraints constraints) {
 ///         if (constraints.maxWidth > 600) {
 ///           return _buildWideContainers();
 ///         } else {

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -12,7 +12,7 @@ import 'framework.dart';
 
 // Examples can assume:
 // class Intl { static String message(String s, { String? name, String? locale }) => ''; }
-// Future<void> initializeMessages(String locale) => Future.value();
+// Future<void> initializeMessages(String locale) => Future<void>.value();
 
 // Used by loadAll() to record LocalizationsDelegate.load() futures we're
 // waiting for.

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -265,9 +265,9 @@ class MediaQueryData {
   ///
   /// @override
   /// Widget build(BuildContext context) {
-  ///   EdgeInsets systemGestureInsets = MediaQuery.of(context).systemGestureInsets;
+  ///   final EdgeInsets systemGestureInsets = MediaQuery.of(context).systemGestureInsets;
   ///   return Scaffold(
-  ///     appBar: AppBar(title: Text('Pad Slider to avoid systemGestureInsets')),
+  ///     appBar: AppBar(title: const Text('Pad Slider to avoid systemGestureInsets')),
   ///     body: Padding(
   ///       padding: EdgeInsets.only( // only left and right padding are needed here
   ///         left: systemGestureInsets.left,

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -26,8 +26,8 @@ import 'routes.dart';
 import 'ticker_provider.dart';
 
 // Examples can assume:
-// class MyPage extends Placeholder { MyPage({String? title}); }
-// class MyHomePage extends Placeholder { }
+// class MyPage extends Placeholder { const MyPage({Key? key}) : super(key: key); }
+// class MyHomePage extends Placeholder { const MyHomePage({Key? key}) : super(key: key); }
 // late NavigatorState navigator;
 // late BuildContext context;
 
@@ -1302,26 +1302,30 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// ```
 ///
 /// ```dart main
-/// void main() => runApp(MyApp());
+/// void main() => runApp(const MyApp());
 /// ```
 ///
 /// ```dart
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
 ///       title: 'Flutter Code Sample for Navigator',
 ///       // MaterialApp contains our top-level Navigator
 ///       initialRoute: '/',
-///       routes: {
-///         '/': (BuildContext context) => HomePage(),
-///         '/signup': (BuildContext context) => SignUpPage(),
+///       routes: <String, WidgetBuilder>{
+///         '/': (BuildContext context) => const HomePage(),
+///         '/signup': (BuildContext context) => const SignUpPage(),
 ///       },
 ///     );
 ///   }
 /// }
 ///
 /// class HomePage extends StatelessWidget {
+///   const HomePage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return DefaultTextStyle(
@@ -1329,13 +1333,15 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///       child: Container(
 ///         color: Colors.white,
 ///         alignment: Alignment.center,
-///         child: Text('Home Page'),
+///         child: const Text('Home Page'),
 ///       ),
 ///     );
 ///   }
 /// }
 ///
 /// class CollectPersonalInfoPage extends StatelessWidget {
+///   const CollectPersonalInfoPage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return DefaultTextStyle(
@@ -1350,7 +1356,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///         child: Container(
 ///           color: Colors.lightBlue,
 ///           alignment: Alignment.center,
-///           child: Text('Collect Personal Info Page'),
+///           child: const Text('Collect Personal Info Page'),
 ///         ),
 ///       ),
 ///     );
@@ -1359,8 +1365,9 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///
 /// class ChooseCredentialsPage extends StatelessWidget {
 ///   const ChooseCredentialsPage({
+///     Key? key,
 ///     required this.onSignupComplete,
-///   });
+///   }) : super(key: key);
 ///
 ///   final VoidCallback onSignupComplete;
 ///
@@ -1373,7 +1380,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///         child: Container(
 ///           color: Colors.pinkAccent,
 ///           alignment: Alignment.center,
-///           child: Text('Choose Credentials Page'),
+///           child: const Text('Choose Credentials Page'),
 ///         ),
 ///       ),
 ///     );
@@ -1381,6 +1388,8 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 /// }
 ///
 /// class SignUpPage extends StatelessWidget {
+///   const SignUpPage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     // SignUpPage builds its own Navigator which ends up being a nested
@@ -1393,7 +1402,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///           case 'signup/personal_info':
 ///           // Assume CollectPersonalInfoPage collects personal info and then
 ///           // navigates to 'signup/choose_credentials'.
-///             builder = (BuildContext _) => CollectPersonalInfoPage();
+///             builder = (BuildContext context) => const CollectPersonalInfoPage();
 ///             break;
 ///           case 'signup/choose_credentials':
 ///           // Assume ChooseCredentialsPage collects new credentials and then
@@ -1412,7 +1421,7 @@ class DefaultTransitionDelegate<T> extends TransitionDelegate<T> {
 ///           default:
 ///             throw Exception('Invalid route: ${settings.name}');
 ///         }
-///         return MaterialPageRoute(builder: builder, settings: settings);
+///         return MaterialPageRoute<void>(builder: builder, settings: settings);
 ///       },
 ///     );
 ///   }
@@ -2102,7 +2111,12 @@ class Navigator extends StatefulWidget {
   ///
   /// ```dart
   /// void _openMyPage() {
-  ///   Navigator.push(context, MaterialPageRoute(builder: (BuildContext context) => MyPage()));
+  ///   Navigator.push<void>(
+  ///     context,
+  ///     MaterialPageRoute<void>(
+  ///       builder: (BuildContext context) => const MyPage(),
+  ///     ),
+  ///   );
   /// }
   /// ```
   /// {@end-tool}
@@ -2145,12 +2159,13 @@ class Navigator extends StatefulWidget {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -2204,8 +2219,12 @@ class Navigator extends StatefulWidget {
   ///
   /// ```dart
   /// void _completeLogin() {
-  ///   Navigator.pushReplacement(
-  ///       context, MaterialPageRoute(builder: (BuildContext context) => MyHomePage()));
+  ///   Navigator.pushReplacement<void, void>(
+  ///     context,
+  ///     MaterialPageRoute<void>(
+  ///       builder: (BuildContext context) => const MyHomePage(),
+  ///     ),
+  ///   );
   /// }
   /// ```
   /// {@end-tool}
@@ -2240,12 +2259,13 @@ class Navigator extends StatefulWidget {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -2306,9 +2326,9 @@ class Navigator extends StatefulWidget {
   ///
   /// ```dart
   /// void _finishAccountCreation() {
-  ///   Navigator.pushAndRemoveUntil(
+  ///   Navigator.pushAndRemoveUntil<void>(
   ///     context,
-  ///     MaterialPageRoute(builder: (BuildContext context) => MyHomePage()),
+  ///     MaterialPageRoute<void>(builder: (BuildContext context) => const MyHomePage()),
   ///     ModalRoute.withName('/'),
   ///   );
   /// }
@@ -2345,12 +2365,13 @@ class Navigator extends StatefulWidget {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -4439,7 +4460,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// ```dart
   /// void _openPage() {
-  ///   navigator.push(MaterialPageRoute(builder: (BuildContext context) => MyPage()));
+  ///   navigator.push<void>(
+  ///     MaterialPageRoute<void>(
+  ///       builder: (BuildContext context) => const MyPage(),
+  ///     ),
+  ///   );
   /// }
   /// ```
   /// {@end-tool}
@@ -4499,12 +4524,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -4602,8 +4628,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// ```dart
   /// void _doOpenPage() {
-  ///   navigator.pushReplacement(
-  ///       MaterialPageRoute(builder: (BuildContext context) => MyHomePage()));
+  ///   navigator.pushReplacement<void, void>(
+  ///     MaterialPageRoute<void>(
+  ///       builder: (BuildContext context) => const MyHomePage(),
+  ///     ),
+  ///   );
   /// }
   /// ```
   /// {@end-tool}
@@ -4638,12 +4667,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -4706,8 +4736,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///
   /// ```dart
   /// void _resetAndOpenPage() {
-  ///   navigator.pushAndRemoveUntil(
-  ///     MaterialPageRoute(builder: (BuildContext context) => MyHomePage()),
+  ///   navigator.pushAndRemoveUntil<void>(
+  ///     MaterialPageRoute<void>(builder: (BuildContext context) => const MyHomePage()),
   ///     ModalRoute.withName('/'),
   ///   );
   /// }
@@ -4745,12 +4775,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// static Route _myRouteBuilder(BuildContext context, Object? arguments) {
-  ///   return MaterialPageRoute(
-  ///     builder: (BuildContext context) => MyStatefulWidget(),
+  /// static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
+  ///   return MaterialPageRoute<void>(
+  ///     builder: (BuildContext context) => const MyStatefulWidget(),
   ///   );
   /// }
   ///
+  /// @override
   /// Widget build(BuildContext context) {
   ///   return Scaffold(
   ///     appBar: AppBar(
@@ -5669,18 +5700,20 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 /// ```
 ///
 /// ```dart main
-/// void main() => runApp(MyApp());
+/// void main() => runApp(const MyApp());
 /// ```
 ///
 /// ```dart preamble
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
 ///       restorationScopeId: 'app',
 ///       home: Scaffold(
-///         appBar: AppBar(title: Text('RestorableRouteFuture Example')),
-///         body: MyHome(),
+///         appBar: AppBar(title: const Text('RestorableRouteFuture Example')),
+///         body: const MyHome(),
 ///       ),
 ///     );
 ///   }
@@ -5702,6 +5735,7 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 ///   @override
 ///   String get restorationId => 'home';
 ///
+///   @override
 ///   void initState() {
 ///     super.initState();
 ///     _counterRoute = RestorableRouteFuture<int>(
@@ -5740,9 +5774,9 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 ///   // A static `RestorableRouteBuilder` that can re-create the route during
 ///   // state restoration.
 ///   static Route<int> _counterRouteBuilder(BuildContext context, Object? arguments) {
-///     return MaterialPageRoute(
+///     return MaterialPageRoute<int>(
 ///       builder: (BuildContext context) => MyCounter(
-///         title: arguments as String,
+///         title: arguments!.toString(),
 ///       ),
 ///     );
 ///   }
@@ -5759,7 +5793,7 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 ///               // Show the route defined by the `RestorableRouteFuture`.
 ///               _counterRoute.present('Awesome Counter');
 ///             },
-///             child: Text('Open Counter'),
+///             child: const Text('Open Counter'),
 ///           ),
 ///         ],
 ///       ),
@@ -5810,7 +5844,7 @@ typedef RouteCompletionCallback<T> = void Function(T result);
 ///         child: Text('Count: ${_count.value}'),
 ///       ),
 ///       floatingActionButton: FloatingActionButton(
-///         child: Icon(Icons.add),
+///         child: const Icon(Icons.add),
 ///         onPressed: () {
 ///           setState(() {
 ///             _count.value++;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -66,7 +66,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   final List<String> _tabs = ['Tab 1', 'Tab 2'];
+///   final List<String> _tabs = <String>['Tab 1', 'Tab 2'];
 ///   return DefaultTabController(
 ///     length: _tabs.length, // This is the number of tabs.
 ///     child: Scaffold(
@@ -244,7 +244,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 ///         padding: const EdgeInsets.all(8),
 ///         itemCount: 30,
 ///         itemBuilder: (BuildContext context, int index) {
-///           return Container(
+///           return SizedBox(
 ///             height: 50,
 ///             child: Center(child: Text('Item $index')),
 ///           );
@@ -510,13 +510,13 @@ class NestedScrollView extends StatefulWidget {
 ///   return NestedScrollView(
 ///     key: globalKey,
 ///     headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-///       return <Widget>[
+///       return const <Widget>[
 ///         SliverAppBar(
 ///           title: Text('NestedScrollViewState Demo!'),
 ///         ),
 ///       ];
 ///     },
-///     body: CustomScrollView(
+///     body: const CustomScrollView(
 ///       // Body slivers go here!
 ///     ),
 ///   );

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -27,19 +27,19 @@ typedef NotificationListenerCallback<T extends Notification> = bool Function(T n
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-/// const List<String> _tabs = ["Months", "Days"];
-/// const List<String> _months = [ "January","February","March", ];
-/// const List<String> _days = [ "Sunday", "Monday","Tuesday", ];
+/// const List<String> _tabs = <String>['Months', 'Days'];
+/// const List<String> _months = <String>[ 'January','February','March', ];
+/// const List<String> _days = <String>[ 'Sunday', 'Monday','Tuesday', ];
 ///   return DefaultTabController(
 ///     length: _tabs.length,
 ///     child: Scaffold(
 ///       // Listens to the scroll events and returns the current position.
 ///       body: NotificationListener<ScrollNotification>(
-///         onNotification: (scrollNotification) {
+///         onNotification: (ScrollNotification scrollNotification) {
 ///           if (scrollNotification is ScrollStartNotification) {
 ///             print('Scrolling has started');
 ///           } else if (scrollNotification is ScrollEndNotification) {
-///             print("Scrolling has ended");
+///             print('Scrolling has ended');
 ///           }
 ///           // Return true to cancel the notification bubbling.
 ///           return true;
@@ -49,26 +49,26 @@ typedef NotificationListenerCallback<T extends Notification> = bool Function(T n
 ///               (BuildContext context, bool innerBoxIsScrolled) {
 ///             return <Widget>[
 ///               SliverAppBar(
-///                 title: const Text("Flutter Code Sample"),
+///                 title: const Text('Flutter Code Sample'),
 ///                 pinned: true,
 ///                 floating: true,
 ///                 bottom: TabBar(
-///                   tabs: _tabs.map((name) => Tab(text: name)).toList(),
+///                   tabs: _tabs.map((String name) => Tab(text: name)).toList(),
 ///                 ),
 ///               ),
 ///             ];
 ///           },
 ///           body: TabBarView(
-///             children: [
+///             children: <Widget>[
 ///               ListView.builder(
 ///                 itemCount: _months.length,
-///                 itemBuilder: (context, index) {
+///                 itemBuilder: (BuildContext context, int index) {
 ///                   return ListTile(title: Text(_months[index]));
 ///                 },
 ///               ),
 ///               ListView.builder(
 ///                 itemCount: _days.length,
-///                 itemBuilder: (context, index) {
+///                 itemBuilder: (BuildContext context, int index) {
 ///                   return ListTile(title: Text(_days[index]));
 ///                 },
 ///               ),

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -56,31 +56,31 @@ enum OverflowBarAlignment {
 /// Widget build(BuildContext context) {
 ///   return Container(
 ///     alignment: Alignment.center,
-///     padding: EdgeInsets.all(16),
+///     padding: const EdgeInsets.all(16),
 ///     color: Colors.black.withOpacity(0.15),
 ///     child: Material(
 ///       color: Colors.white,
 ///       elevation: 24,
-///       shape: RoundedRectangleBorder(
+///       shape: const RoundedRectangleBorder(
 ///         borderRadius: BorderRadius.all(Radius.circular(4))
 ///       ),
 ///       child: Padding(
-///         padding: EdgeInsets.all(8),
+///         padding: const EdgeInsets.all(8),
 ///         child: SingleChildScrollView(
 ///           child: Column(
 ///             mainAxisSize: MainAxisSize.min,
 ///             crossAxisAlignment: CrossAxisAlignment.stretch,
 ///             children: <Widget>[
-///               Container(height: 128, child: Placeholder()),
+///               const SizedBox(height: 128, child: Placeholder()),
 ///               Align(
 ///                 alignment: AlignmentDirectional.centerEnd,
 ///                 child: OverflowBar(
 ///                   spacing: 8,
 ///                   overflowAlignment: OverflowBarAlignment.end,
 ///                   children: <Widget>[
-///                     TextButton(child: Text('Cancel'), onPressed: () { }),
-///                     TextButton(child: Text('Really Really Cancel'), onPressed: () { }),
-///                     OutlinedButton(child: Text('OK'), onPressed: () { }),
+///                     TextButton(child: const Text('Cancel'), onPressed: () { }),
+///                     TextButton(child: const Text('Really Really Cancel'), onPressed: () { }),
+///                     OutlinedButton(child: const Text('OK'), onPressed: () { }),
 ///                   ],
 ///                 ),
 ///               ),

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -54,25 +54,25 @@ import 'ticker_provider.dart';
 ///
 /// ```dart
 /// Widget build(BuildContext context) {
-///   double leadingPaintOffset = MediaQuery.of(context).padding.top + AppBar().preferredSize.height;
+///   final double leadingPaintOffset = MediaQuery.of(context).padding.top + AppBar().preferredSize.height;
 ///   return NotificationListener<OverscrollIndicatorNotification>(
-///     onNotification: (notification) {
+///     onNotification: (OverscrollIndicatorNotification notification) {
 ///       if (notification.leading) {
 ///         notification.paintOffset = leadingPaintOffset;
 ///       }
 ///       return false;
 ///     },
 ///     child: CustomScrollView(
-///       slivers: [
-///         SliverAppBar(title: Text('Custom PaintOffset')),
+///       slivers: <Widget>[
+///         const SliverAppBar(title: Text('Custom PaintOffset')),
 ///         SliverToBoxAdapter(
 ///           child: Container(
 ///             color: Colors.amberAccent,
 ///             height: 100,
-///             child: Center(child: Text('Glow all day!')),
+///             child: const Center(child: Text('Glow all day!')),
 ///           ),
 ///         ),
-///         SliverFillRemaining(child: FlutterLogo()),
+///         const SliverFillRemaining(child: FlutterLogo()),
 ///       ],
 ///     ),
 ///   );
@@ -91,7 +91,7 @@ import 'ticker_provider.dart';
 /// Widget build(BuildContext context) {
 ///   return NestedScrollView(
 ///     headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-///       return <Widget>[
+///       return const <Widget>[
 ///         SliverAppBar(title: Text('Custom NestedScrollViews')),
 ///       ];
 ///     },
@@ -101,10 +101,10 @@ import 'ticker_provider.dart';
 ///           child: Container(
 ///             color: Colors.amberAccent,
 ///             height: 100,
-///             child: Center(child: Text('Glow all day!')),
+///             child: const Center(child: Text('Glow all day!')),
 ///           ),
 ///         ),
-///         SliverFillRemaining(child: FlutterLogo()),
+///         const SliverFillRemaining(child: FlutterLogo()),
 ///       ],
 ///     ),
 ///   );

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -148,31 +148,35 @@ class PageStorageBucket {
 /// ```
 ///
 /// ```dart main
-/// void main() => runApp(MyApp());
+/// void main() => runApp(const MyApp());
 /// ```
 ///
 /// ```dart
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return MaterialApp(
+///     return const MaterialApp(
 ///       home: MyHomePage(),
 ///     );
 ///   }
 /// }
 ///
 /// class MyHomePage extends StatefulWidget {
+///   const MyHomePage({Key? key}) : super(key: key);
+///
 ///   @override
 ///   _MyHomePageState createState() => _MyHomePageState();
 /// }
 ///
 /// class _MyHomePageState extends State<MyHomePage> {
-///   final List<Widget> pages = <Widget>[
+///   final List<Widget> pages = const <Widget>[
 ///     ColorBoxPage(
-///       key: PageStorageKey('pageOne'),
+///       key: PageStorageKey<String>('pageOne'),
 ///     ),
 ///     ColorBoxPage(
-///       key: PageStorageKey('pageTwo'),
+///       key: PageStorageKey<String>('pageTwo'),
 ///     )
 ///   ];
 ///   int currentTab = 0;
@@ -182,7 +186,7 @@ class PageStorageBucket {
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       appBar: AppBar(
-///         title: Text("Persistence Example"),
+///         title: const Text('Persistence Example'),
 ///       ),
 ///       body: PageStorage(
 ///         child: pages[currentTab],
@@ -195,7 +199,7 @@ class PageStorageBucket {
 ///             currentTab = index;
 ///           });
 ///         },
-///         items: <BottomNavigationBarItem>[
+///         items: const <BottomNavigationBarItem>[
 ///           BottomNavigationBarItem(
 ///             icon: Icon(Icons.home),
 ///             label: 'page 1',
@@ -211,18 +215,16 @@ class PageStorageBucket {
 /// }
 ///
 /// class ColorBoxPage extends StatelessWidget {
-///   ColorBoxPage({
-///     Key? key,
-///   }) : super(key: key);
+///   const ColorBoxPage({Key? key}) : super(key: key);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return ListView.builder(
 ///       itemExtent: 250.0,
-///       itemBuilder: (context, index) => Container(
-///         padding: EdgeInsets.all(10.0),
+///       itemBuilder: (BuildContext context, int index) => Container(
+///         padding: const EdgeInsets.all(10.0),
 ///         child: Material(
-///           color: index % 2 == 0 ? Colors.cyan : Colors.deepOrange,
+///           color: index.isEven ? Colors.cyan : Colors.deepOrange,
 ///           child: Center(
 ///             child: Text(index.toString()),
 ///           ),

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -45,13 +45,14 @@ import 'viewport.dart';
 ///
 /// ```dart
 /// class MyPageView extends StatefulWidget {
-///   MyPageView({Key? key}) : super(key: key);
+///   const MyPageView({Key? key}) : super(key: key);
 ///
+///   @override
 ///   _MyPageViewState createState() => _MyPageViewState();
 /// }
 ///
 /// class _MyPageViewState extends State<MyPageView> {
-///   PageController _pageController = PageController();
+///   final PageController _pageController = PageController();
 ///
 ///   @override
 ///   void dispose() {
@@ -65,7 +66,7 @@ import 'viewport.dart';
 ///       home: Scaffold(
 ///         body: PageView(
 ///           controller: _pageController,
-///           children: [
+///           children: <Widget>[
 ///             Container(
 ///               color: Colors.red,
 ///               child: Center(
@@ -79,7 +80,7 @@ import 'viewport.dart';
 ///                       );
 ///                     }
 ///                   },
-///                   child: Text('Next'),
+///                   child: const Text('Next'),
 ///                 ),
 ///               ),
 ///             ),
@@ -96,7 +97,7 @@ import 'viewport.dart';
 ///                       );
 ///                     }
 ///                   },
-///                   child: Text('Previous'),
+///                   child: const Text('Previous'),
 ///                 ),
 ///               ),
 ///             ),
@@ -572,21 +573,21 @@ const PageScrollPhysics _kPagePhysics = PageScrollPhysics();
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {
-///    final controller = PageController(initialPage: 0);
+///    final PageController controller = PageController(initialPage: 0);
 ///    return PageView(
 ///      /// [PageView.scrollDirection] defaults to [Axis.horizontal].
 ///      /// Use [Axis.vertical] to scroll vertically.
 ///      scrollDirection: Axis.horizontal,
 ///      controller: controller,
-///      children: [
+///      children: const <Widget>[
 ///        Center(
-///          child: Text("First Page"),
+///          child: Text('First Page'),
 ///        ),
 ///        Center(
-///          child: Text("Second Page"),
+///          child: Text('Second Page'),
 ///        ),
 ///        Center(
-///          child: Text("Third Page"),
+///          child: Text('Third Page'),
 ///        )
 ///      ],
 ///    );
@@ -688,6 +689,8 @@ class PageView extends StatefulWidget {
   ///
   /// ```dart
   /// class MyPageView extends StatefulWidget {
+  ///   const MyPageView({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   _MyPageViewState createState() => _MyPageViewState();
   /// }
@@ -728,7 +731,7 @@ class PageView extends StatefulWidget {
   ///           children: <Widget>[
   ///             TextButton(
   ///               onPressed: () => _reverse(),
-  ///               child: Text('Reverse items'),
+  ///               child: const Text('Reverse items'),
   ///             ),
   ///           ],
   ///         ),

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -54,22 +54,24 @@ abstract class PreferredSizeWidget implements Widget {
 ///
 /// ```dart preamble
 /// class AppBarContent extends StatelessWidget {
+///   const AppBarContent({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Column(
 ///       mainAxisAlignment: MainAxisAlignment.end,
-///       children: [
+///       children: <Widget>[
 ///         Padding(
 ///           padding: const EdgeInsets.symmetric(horizontal: 10),
 ///           child: Row(
-///             children: [
-///               Text(
-///                 "PreferredSize Sample",
+///             children: <Widget>[
+///               const Text(
+///                 'PreferredSize Sample',
 ///                 style: TextStyle(color: Colors.white),
 ///               ),
-///               Spacer(),
+///               const Spacer(),
 ///               IconButton(
-///                 icon: Icon(
+///                 icon: const Icon(
 ///                   Icons.search,
 ///                   size: 20,
 ///                 ),
@@ -77,7 +79,7 @@ abstract class PreferredSizeWidget implements Widget {
 ///                 onPressed: () {},
 ///               ),
 ///               IconButton(
-///                 icon: Icon(
+///                 icon: const Icon(
 ///                   Icons.more_vert,
 ///                   size: 20,
 ///                 ),
@@ -98,16 +100,16 @@ abstract class PreferredSizeWidget implements Widget {
 ///     appBar: PreferredSize(
 ///       preferredSize: const Size.fromHeight(80.0),
 ///       child: Container(
-///         decoration: BoxDecoration(
+///         decoration: const BoxDecoration(
 ///           gradient: LinearGradient(
-///             colors: [Colors.blue, Colors.pink],
+///             colors: <Color>[Colors.blue, Colors.pink],
 ///           ),
 ///         ),
-///         child: AppBarContent(),
+///         child: const AppBarContent(),
 ///       ),
 ///     ),
-///     body: Center(
-///       child: Text("Content"),
+///     body: const Center(
+///       child: Text('Content'),
 ///     ),
 ///   );
 /// }

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -607,14 +607,16 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 /// ```
 ///
 /// ```dart main
-/// void main() => runApp(RestorationExampleApp());
+/// void main() => runApp(const RestorationExampleApp());
 /// ```
 ///
 /// ```dart preamble
 /// class RestorationExampleApp extends StatelessWidget {
+///   const RestorationExampleApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return MaterialApp(
+///     return const MaterialApp(
 ///       restorationScopeId: 'app',
 ///       title: 'Restorable Counter',
 ///       home: RestorableCounter(restorationId: 'counter'),
@@ -625,7 +627,7 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///
 /// ```dart
 /// class RestorableCounter extends StatefulWidget {
-///   RestorableCounter({Key? key, this.restorationId}) : super(key: key);
+///   const RestorableCounter({Key? key, this.restorationId}) : super(key: key);
 ///
 ///   final String? restorationId;
 ///
@@ -640,7 +642,7 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///   // During state restoration it is automatically restored to its old value.
 ///   // If no restoration data is available to restore the counter from, it is
 ///   // initialized to the specified default value of zero.
-///   RestorableInt _counter = RestorableInt(0);
+///   final RestorableInt _counter = RestorableInt(0);
 ///
 ///   // In this example, the restoration ID for the mixin is passed in through
 ///   // the [StatefulWidget]'s constructor.
@@ -673,13 +675,13 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       appBar: AppBar(
-///         title: Text('Restorable Counter'),
+///         title: const Text('Restorable Counter'),
 ///       ),
 ///       body: Center(
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.center,
 ///           children: <Widget>[
-///             Text(
+///             const Text(
 ///               'You have pushed the button this many times:',
 ///             ),
 ///             Text(
@@ -692,7 +694,7 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///       floatingActionButton: FloatingActionButton(
 ///         onPressed: _incrementCounter,
 ///         tooltip: 'Increment',
-///         child: Icon(Icons.add),
+///         child: const Icon(Icons.add),
 ///       ),
 ///     );
 ///   }

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -27,7 +27,7 @@ import 'restoration.dart';
 ///   // During state restoration it is automatically restored to its old value.
 ///   // If no restoration data is available to restore the answer from, it is
 ///   // initialized to the specified default value, in this case 42.
-///   RestorableInt _answer = RestorableInt(42);
+///   final RestorableInt _answer = RestorableInt(42);
 ///
 ///   @override
 ///   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -484,20 +484,22 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///
   /// ```dart
   /// class App extends StatelessWidget {
+  ///   const App({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   Widget build(BuildContext context) {
   ///     return MaterialApp(
   ///       initialRoute: '/',
-  ///       routes: {
-  ///         '/': (BuildContext context) => HomePage(),
-  ///         '/second_page': (BuildContext context) => SecondPage(),
+  ///       routes: <String, WidgetBuilder>{
+  ///         '/': (BuildContext context) => const HomePage(),
+  ///         '/second_page': (BuildContext context) => const SecondPage(),
   ///       },
   ///     );
   ///   }
   /// }
   ///
   /// class HomePage extends StatefulWidget {
-  ///   HomePage();
+  ///   const HomePage({Key? key}) : super(key: key);
   ///
   ///   @override
   ///   _HomePageState createState() => _HomePageState();
@@ -511,10 +513,10 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///         child: Column(
   ///           mainAxisSize: MainAxisSize.min,
   ///           children: <Widget>[
-  ///             Text('HomePage'),
+  ///             const Text('HomePage'),
   ///             // Press this button to open the SecondPage.
   ///             ElevatedButton(
-  ///               child: Text('Second Page >'),
+  ///               child: const Text('Second Page >'),
   ///               onPressed: () {
   ///                 Navigator.pushNamed(context, '/second_page');
   ///               },
@@ -527,6 +529,8 @@ mixin LocalHistoryRoute<T> on Route<T> {
   /// }
   ///
   /// class SecondPage extends StatefulWidget {
+  ///   const SecondPage({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   _SecondPageState createState() => _SecondPageState();
   /// }
@@ -535,7 +539,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///
   ///   bool _showRectangle = false;
   ///
-  ///   void _navigateLocallyToShowRectangle() async {
+  ///   Future<void> _navigateLocallyToShowRectangle() async {
   ///     // This local history entry essentially represents the display of the red
   ///     // rectangle. When this local history entry is removed, we hide the red
   ///     // rectangle.
@@ -552,14 +556,14 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///
   ///   @override
   ///   Widget build(BuildContext context) {
-  ///     final localNavContent = _showRectangle
+  ///     final Widget localNavContent = _showRectangle
   ///       ? Container(
   ///           width: 100.0,
   ///           height: 100.0,
   ///           color: Colors.red,
   ///         )
   ///       : ElevatedButton(
-  ///           child: Text('Show Rectangle'),
+  ///           child: const Text('Show Rectangle'),
   ///           onPressed: _navigateLocallyToShowRectangle,
   ///         );
   ///
@@ -570,7 +574,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///           children: <Widget>[
   ///             localNavContent,
   ///             ElevatedButton(
-  ///               child: Text('< Back'),
+  ///               child: const Text('< Back'),
   ///               onPressed: () {
   ///                 // Pop a route. If this is pressed while the red rectangle is
   ///                 // visible then it will will pop our local history entry, which
@@ -1620,15 +1624,18 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
 ///
 /// ```dart
 /// // Register the RouteObserver as a navigation observer.
-/// final RouteObserver<ModalRoute> routeObserver = RouteObserver<ModalRoute>();
+/// final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
 /// void main() {
 ///   runApp(MaterialApp(
 ///     home: Container(),
-///     navigatorObservers: [routeObserver],
+///     navigatorObservers: <RouteObserver<ModalRoute<void>>>[ routeObserver ],
 ///   ));
 /// }
 ///
 /// class RouteAwareWidget extends StatefulWidget {
+///   const RouteAwareWidget({Key? key}) : super(key: key);
+///
+///   @override
 ///   State<RouteAwareWidget> createState() => RouteAwareWidgetState();
 /// }
 ///
@@ -1909,13 +1916,15 @@ class RawDialogRoute<T> extends PopupRoute<T> {
 ///
 /// ```dart
 /// void main() {
-///   runApp(MyApp());
+///   runApp(const MyApp());
 /// }
 ///
 /// class MyApp extends StatelessWidget {
+///   const MyApp({Key? key}) : super(key: key);
+///
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return MaterialApp(
+///     return const MaterialApp(
 ///       restorationScopeId: 'app',
 ///       home: MyHomePage(),
 ///     );
@@ -1923,6 +1932,8 @@ class RawDialogRoute<T> extends PopupRoute<T> {
 /// }
 ///
 /// class MyHomePage extends StatelessWidget {
+///   const MyHomePage({Key? key}) : super(key: key);
+///
 ///   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
 ///     return RawDialogRoute<void>(
 ///       pageBuilder: (

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -113,7 +113,7 @@ class ScrollPhysics {
   /// `x` has the same behavior as `y`.
   ///
   /// ```dart
-  /// final FooScrollPhysics x = FooScrollPhysics().applyTo(BarScrollPhysics());
+  /// final FooScrollPhysics x = const FooScrollPhysics().applyTo(const BarScrollPhysics());
   /// const FooScrollPhysics y = FooScrollPhysics(parent: BarScrollPhysics());
   /// ```
   /// {@end-tool}
@@ -563,7 +563,7 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
 ///
 /// {@tool snippet}
 /// ```dart
-/// BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
+/// const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -449,7 +449,7 @@ abstract class ScrollView extends StatelessWidget {
 ///       ),
 ///     ),
 ///     SliverGrid(
-///       gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+///       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
 ///         maxCrossAxisExtent: 200.0,
 ///         mainAxisSpacing: 10.0,
 ///         crossAxisSpacing: 10.0,
@@ -495,12 +495,12 @@ abstract class ScrollView extends StatelessWidget {
 /// bottom SliverList will grow downwards.
 ///
 /// ```dart
-/// List<int> top = [];
-/// List<int> bottom = [0];
+/// List<int> top = <int>[];
+/// List<int> bottom = <int>[0];
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   const Key centerKey = ValueKey('bottom-sliver-list');
+///   const Key centerKey = ValueKey<String>('bottom-sliver-list');
 ///   return Scaffold(
 ///     appBar: AppBar(
 ///       title: const Text('Press on the plus to add items above and below'),
@@ -967,11 +967,11 @@ abstract class BoxScrollView extends ScrollView {
 /// ListView(
 ///   shrinkWrap: true,
 ///   padding: const EdgeInsets.all(20.0),
-///   children: <Widget>[
-///     const Text("I'm dedicating every day to you"),
-///     const Text('Domestic life was never quite my style'),
-///     const Text('When you smile, you knock me out, I fall apart'),
-///     const Text('And I thought I was so smart'),
+///   children: const <Widget>[
+///     Text("I'm dedicating every day to you"),
+///     Text('Domestic life was never quite my style'),
+///     Text('When you smile, you knock me out, I fall apart'),
+///     Text('And I thought I was so smart'),
 ///   ],
 /// )
 /// ```
@@ -1024,7 +1024,7 @@ abstract class BoxScrollView extends ScrollView {
 ///             );
 ///           },
 ///         )
-///       : Center(child: const Text('No items')),
+///       : const Center(child: Text('No items')),
 ///   );
 /// }
 /// ```
@@ -1228,7 +1228,7 @@ class ListView extends BoxScrollView {
   /// ```dart
   /// ListView.separated(
   ///   itemCount: 25,
-  ///   separatorBuilder: (BuildContext context, int index) => Divider(),
+  ///   separatorBuilder: (BuildContext context, int index) => const Divider(),
   ///   itemBuilder: (BuildContext context, int index) {
   ///     return ListTile(
   ///       title: Text('item $index'),
@@ -1323,6 +1323,8 @@ class ListView extends BoxScrollView {
   ///
   /// ```dart
   /// class MyListView extends StatefulWidget {
+  ///   const MyListView({Key? key}) : super(key: key);
+  ///
   ///   @override
   ///   _MyListViewState createState() => _MyListViewState();
   /// }
@@ -1350,7 +1352,7 @@ class ListView extends BoxScrollView {
   ///             },
   ///             childCount: items.length,
   ///             findChildIndexCallback: (Key key) {
-  ///               final ValueKey valueKey = key as ValueKey;
+  ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
   ///               return items.indexOf(data);
   ///             }
@@ -1363,7 +1365,7 @@ class ListView extends BoxScrollView {
   ///           children: <Widget>[
   ///             TextButton(
   ///               onPressed: () => _reverse(),
-  ///               child: Text('Reverse items'),
+  ///               child: const Text('Reverse items'),
   ///             ),
   ///           ],
   ///         ),

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -665,10 +665,10 @@ class RawScrollbar extends StatefulWidget {
   /// final ScrollController _controllerOne = ScrollController();
   /// final ScrollController _controllerTwo = ScrollController();
   ///
-  /// build(BuildContext context) {
+  /// Widget build(BuildContext context) {
   ///   return Column(
   ///     children: <Widget>[
-  ///       Container(
+  ///       SizedBox(
   ///        height: 200,
   ///        child: CupertinoScrollbar(
   ///          controller: _controllerOne,
@@ -679,7 +679,7 @@ class RawScrollbar extends StatefulWidget {
   ///          ),
   ///        ),
   ///      ),
-  ///      Container(
+  ///      SizedBox(
   ///        height: 200,
   ///        child: CupertinoScrollbar(
   ///          controller: _controllerTwo,
@@ -717,7 +717,7 @@ class RawScrollbar extends StatefulWidget {
   /// final ScrollController _controllerOne = ScrollController();
   /// final ScrollController _controllerTwo = ScrollController();
   ///
-  /// build(BuildContext context) {
+  /// Widget build(BuildContext context) {
   /// return Column(
   ///   children: <Widget>[
   ///     SizedBox(
@@ -741,7 +741,7 @@ class RawScrollbar extends StatefulWidget {
   ///          controller: _controllerTwo,
   ///          child: SingleChildScrollView(
   ///            controller: _controllerTwo,
-  ///            child: SizedBox(
+  ///            child: const SizedBox(
   ///              height: 2000,
   ///              width: 500,
   ///              child: Placeholder(),

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -259,7 +259,7 @@ typedef ChildIndexGetter = int? Function(Key key);
 ///       gridDelegate: _gridDelegate,
 ///       delegate: SliverChildBuilderDelegate(
 ///         (BuildContext context, int index) {
-///            return Text('...');
+///            return const Text('...');
 ///          },
 ///          childCount: 2,
 ///        ),
@@ -268,7 +268,7 @@ typedef ChildIndexGetter = int? Function(Key key);
 ///       gridDelegate: _gridDelegate,
 ///       delegate: SliverChildBuilderDelegate(
 ///         (BuildContext context, int index) {
-///            return Text('...');
+///            return const Text('...');
 ///          },
 ///          childCount: 2,
 ///          semanticIndexOffset: 2,
@@ -301,9 +301,9 @@ typedef ChildIndexGetter = int? Function(Key key);
 ///       delegate: SliverChildBuilderDelegate(
 ///         (BuildContext context, int index) {
 ///            if (index.isEven) {
-///              return Text('...');
+///              return const Text('...');
 ///            }
-///            return Spacer();
+///            return const Spacer();
 ///          },
 ///          semanticIndexCallback: (Widget widget, int localIndex) {
 ///            if (localIndex.isEven) {
@@ -966,7 +966,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
 ///
 /// ```dart
 /// SliverGrid(
-///   gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+///   gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
 ///     maxCrossAxisExtent: 200.0,
 ///     mainAxisSpacing: 10.0,
 ///     crossAxisSpacing: 10.0,
@@ -1479,7 +1479,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 ///
 /// ```dart
 /// bool _visible = true;
-/// List<Widget> listItems = <Widget>[
+/// List<Widget> listItems = const <Widget>[
 ///   Text('Now you see me,'),
 ///   Text("Now you don't!"),
 /// ];

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -253,7 +253,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///         delegate: SliverChildBuilderDelegate(
 ///           (BuildContext context, int index) {
 ///             return Container(
-///               color: index % 2 == 0
+///               color: index.isEven
 ///                 ? Colors.amber[200]
 ///                 : Colors.blue[200],
 ///             );
@@ -265,8 +265,8 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///         hasScrollBody: false,
 ///         child: Container(
 ///           color: Colors.orange[300],
-///           child: Padding(
-///             padding: const EdgeInsets.all(50.0),
+///           child: const Padding(
+///             padding: EdgeInsets.all(50.0),
 ///             child: FlutterLogo(size: 100),
 ///           ),
 ///         ),
@@ -295,7 +295,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///         delegate: SliverChildBuilderDelegate(
 ///           (BuildContext context, int index) {
 ///             return Container(
-///               color: index % 2 == 0
+///               color: index.isEven
 ///                 ? Colors.indigo[200]
 ///                 : Colors.orange[200],
 ///             );
@@ -303,16 +303,14 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///           childCount: 5,
 ///         ),
 ///       ),
-///       SliverFillRemaining(
+///       const SliverFillRemaining(
 ///         hasScrollBody: false,
-///         child: Container(
-///           child: Padding(
-///             padding: const EdgeInsets.all(50.0),
-///             child: Icon(
-///               Icons.pan_tool,
-///               size: 60,
-///               color: Colors.blueGrey,
-///             ),
+///         child: Padding(
+///           padding: EdgeInsets.all(50.0),
+///           child: Icon(
+///             Icons.pan_tool,
+///             size: 60,
+///             color: Colors.blueGrey,
 ///           ),
 ///         ),
 ///       ),
@@ -350,7 +348,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///     // BouncingScrollPhysics is combined with AlwaysScrollableScrollPhysics
 ///     // to allow for the overscroll, regardless of the depth of the
 ///     // scrollable.
-///     physics: BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+///     physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
 ///     slivers: <Widget>[
 ///       SliverToBoxAdapter(
 ///         child: Container(
@@ -374,7 +372,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///                 onPressed: () {
 ///                   /* Place your onPressed code here! */
 ///                 },
-///                 child: Text('Bottom Pinned Button!'),
+///                 child: const Text('Bottom Pinned Button!'),
 ///               ),
 ///             ),
 ///           ),

--- a/packages/flutter/lib/src/widgets/spacer.dart
+++ b/packages/flutter/lib/src/widgets/spacer.dart
@@ -19,7 +19,7 @@ import 'framework.dart';
 ///
 /// ```dart
 /// Row(
-///   children: <Widget>[
+///   children: const <Widget>[
 ///     Text('Begin'),
 ///     Spacer(), // Defaults to a flex of one.
 ///     Text('Middle'),

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -89,15 +89,15 @@ class _TableElementRow {
 /// Widget build(BuildContext context) {
 ///   return Table(
 ///     border: TableBorder.all(),
-///     columnWidths: {
+///     columnWidths: const <int, TableColumnWidth>{
 ///       0: IntrinsicColumnWidth(),
 ///       1: FlexColumnWidth(),
 ///       2: FixedColumnWidth(64),
 ///     },
 ///     defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-///     children: [
+///     children: <TableRow>[
 ///       TableRow(
-///         children: [
+///         children: <Widget>[
 ///           Container(
 ///             height: 32,
 ///             color: Colors.green,
@@ -117,10 +117,10 @@ class _TableElementRow {
 ///         ],
 ///       ),
 ///       TableRow(
-///         decoration: BoxDecoration(
+///         decoration: const BoxDecoration(
 ///           color: Colors.grey,
 ///         ),
-///         children: [
+///         children: <Widget>[
 ///           Container(
 ///             height: 64,
 ///             width: 128,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -304,7 +304,7 @@ class DefaultTextHeightBehavior extends InheritedTheme {
 ///   'Hello, $_name! How are you?',
 ///   textAlign: TextAlign.center,
 ///   overflow: TextOverflow.ellipsis,
-///   style: TextStyle(fontWeight: FontWeight.bold),
+///   style: const TextStyle(fontWeight: FontWeight.bold),
 /// )
 /// ```
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -29,7 +29,7 @@ export 'package:flutter/rendering.dart' show RelativeRect;
 /// This code defines a widget called `Spinner` that spins a green square
 /// continually. It is built with an [AnimatedWidget].
 ///
-/// ```dart imports
+/// ```dart dartImports
 /// import 'dart:math' as math;
 /// ```
 ///
@@ -53,7 +53,7 @@ export 'package:flutter/rendering.dart' show RelativeRect;
 /// ```
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 10),
 ///   vsync: this,
 /// )..repeat();
@@ -196,11 +196,11 @@ class _AnimatedState extends State<AnimatedWidget> {
 ///
 /// ```dart
 /// class _MyStatefulWidgetState extends State<MyStatefulWidget> with SingleTickerProviderStateMixin {
-///   late AnimationController _controller = AnimationController(
+///   late final AnimationController _controller = AnimationController(
 ///     duration: const Duration(seconds: 2),
 ///     vsync: this,
 ///   )..repeat(reverse: true);
-///   late Animation<Offset> _offsetAnimation = Tween<Offset>(
+///   late final Animation<Offset> _offsetAnimation = Tween<Offset>(
 ///     begin: Offset.zero,
 ///     end: const Offset(1.5, 0.0),
 ///   ).animate(CurvedAnimation(
@@ -403,11 +403,11 @@ class ScaleTransition extends AnimatedWidget {
 /// above:
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 2),
 ///   vsync: this,
 /// )..repeat(reverse: true);
-/// late Animation<double> _animation = CurvedAnimation(
+/// late final Animation<double> _animation = CurvedAnimation(
 ///   parent: _controller,
 ///   curve: Curves.elasticOut,
 /// );
@@ -506,11 +506,11 @@ class RotationTransition extends AnimatedWidget {
 /// where the internal widget has space to change its size.
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 3),
 ///   vsync: this,
 /// )..repeat();
-/// late Animation<double> _animation = CurvedAnimation(
+/// late final Animation<double> _animation = CurvedAnimation(
 ///   parent: _controller,
 ///   curve: Curves.fastOutSlowIn,
 /// );
@@ -528,8 +528,8 @@ class RotationTransition extends AnimatedWidget {
 ///       sizeFactor: _animation,
 ///       axis: Axis.horizontal,
 ///       axisAlignment: -1,
-///       child: Center(
-///           child: FlutterLogo(size: 200.0),
+///       child: const Center(
+///         child: FlutterLogo(size: 200.0),
 ///       ),
 ///     ),
 ///   );
@@ -631,11 +631,11 @@ class SizeTransition extends AnimatedWidget {
 /// the Flutter logo:
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 2),
 ///   vsync: this,
 /// )..repeat(reverse: true);
-/// late Animation<double> _animation = CurvedAnimation(
+/// late final Animation<double> _animation = CurvedAnimation(
 ///   parent: _controller,
 ///   curve: Curves.easeIn,
 /// );
@@ -728,18 +728,19 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 ///
 /// ```dart
 /// class _MyStatefulWidgetState extends State<MyStatefulWidget> with SingleTickerProviderStateMixin {
-///   late AnimationController controller = AnimationController(
+///   late final AnimationController controller = AnimationController(
 ///     duration: const Duration(milliseconds: 1000),
 ///     vsync: this,
 ///   );
-///   late Animation<double> animation = CurvedAnimation(
+///   late final Animation<double> animation = CurvedAnimation(
 ///     parent: controller,
 ///     curve: Curves.easeIn,
 ///   );
 ///
-///   initState() {
+///   @override
+///   void initState() {
 ///     super.initState();
-///     animation.addStatusListener((status) {
+///     animation.addStatusListener((AnimationStatus status) {
 ///       if (status == AnimationStatus.completed) {
 ///         controller.reverse();
 ///       } else if (status == AnimationStatus.dismissed) {
@@ -749,6 +750,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 ///     controller.forward();
 ///   }
 ///
+///   @override
 ///   Widget build(BuildContext context) {
 ///     return CustomScrollView(
 ///       slivers: <Widget>[
@@ -759,7 +761,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
 ///             delegate: SliverChildBuilderDelegate(
 ///               (BuildContext context, int index) {
 ///                 return Container(
-///                   color: index % 2 == 0
+///                   color: index.isEven
 ///                     ? Colors.indigo[200]
 ///                     : Colors.orange[200],
 ///                 );
@@ -872,7 +874,7 @@ class RelativeRectTween extends Tween<RelativeRect> {
 /// above:
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 2),
 ///   vsync: this,
 /// )..repeat(reverse: true);
@@ -885,24 +887,24 @@ class RelativeRectTween extends Tween<RelativeRect> {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   final double smallLogo = 100;
-///   final double bigLogo = 200;
+///   const double smallLogo = 100;
+///   const double bigLogo = 200;
 ///
 ///   return LayoutBuilder(
-///     builder: (context, constraints) {
+///     builder: (BuildContext context, BoxConstraints constraints) {
 ///       final Size biggest = constraints.biggest;
 ///       return Stack(
-///         children: [
+///         children: <Widget>[
 ///           PositionedTransition(
 ///             rect: RelativeRectTween(
-///               begin: RelativeRect.fromSize(Rect.fromLTWH(0, 0, smallLogo, smallLogo), biggest),
+///               begin: RelativeRect.fromSize(const Rect.fromLTWH(0, 0, smallLogo, smallLogo), biggest),
 ///               end: RelativeRect.fromSize(Rect.fromLTWH(biggest.width - bigLogo, biggest.height - bigLogo, bigLogo, bigLogo), biggest),
 ///             ).animate(CurvedAnimation(
 ///               parent: _controller,
 ///               curve: Curves.elasticInOut,
 ///             )),
-///             child: Padding(
-///               padding: const EdgeInsets.all(8),
+///             child: const Padding(
+///               padding: EdgeInsets.all(8),
 ///               child: FlutterLogo()
 ///             ),
 ///           ),
@@ -972,7 +974,7 @@ class PositionedTransition extends AnimatedWidget {
 /// above:
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 2),
 ///   vsync: this,
 /// )..repeat(reverse: true);
@@ -985,25 +987,25 @@ class PositionedTransition extends AnimatedWidget {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   final double smallLogo = 100;
-///   final double bigLogo = 200;
+///   const double smallLogo = 100;
+///   const double bigLogo = 200;
 ///
 ///   return LayoutBuilder(
-///     builder: (context, constraints) {
+///     builder: (BuildContext context, BoxConstraints constraints) {
 ///       final Size biggest = constraints.biggest;
 ///       return Stack(
-///         children: [
+///         children: <Widget>[
 ///           RelativePositionedTransition(
 ///             size: biggest,
 ///             rect: RectTween(
-///               begin: Rect.fromLTWH(0, 0, bigLogo, bigLogo),
+///               begin: const Rect.fromLTWH(0, 0, bigLogo, bigLogo),
 ///               end: Rect.fromLTWH(biggest.width - smallLogo, biggest.height - smallLogo, smallLogo, smallLogo),
 ///             ).animate(CurvedAnimation(
 ///               parent: _controller,
 ///               curve: Curves.elasticInOut,
 ///             )) as Animation<Rect>,
-///             child: Padding(
-///               padding: const EdgeInsets.all(8),
+///             child: const Padding(
+///               padding: EdgeInsets.all(8),
 ///               child: FlutterLogo()
 ///             ),
 ///           ),
@@ -1110,7 +1112,7 @@ class RelativePositionedTransition extends AnimatedWidget {
 ///   ),
 /// );
 ///
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   vsync: this,
 ///   duration: const Duration(seconds: 3),
 /// )..repeat(reverse: true);
@@ -1272,8 +1274,8 @@ class AlignTransition extends AnimatedWidget {
 ///     vsync: this,
 ///   )..repeat(reverse: true);
 ///   _styleTween = TextStyleTween(
-///     begin: TextStyle(fontSize: 50, color: Colors.blue, fontWeight: FontWeight.w900),
-///     end: TextStyle(fontSize: 50, color: Colors.red, fontWeight: FontWeight.w100),
+///     begin: const TextStyle(fontSize: 50, color: Colors.blue, fontWeight: FontWeight.w900),
+///     end: const TextStyle(fontSize: 50, color: Colors.red, fontWeight: FontWeight.w100),
 ///   );
 ///   _curvedAnimation = CurvedAnimation(
 ///     parent: _controller,
@@ -1292,7 +1294,7 @@ class AlignTransition extends AnimatedWidget {
 ///   return Center(
 ///     child: DefaultTextStyleTransition(
 ///       style: _styleTween.animate(_curvedAnimation),
-///       child: Text('Flutter'),
+///       child: const Text('Flutter'),
 ///     ),
 ///   );
 /// }
@@ -1388,12 +1390,12 @@ class DefaultTextStyleTransition extends AnimatedWidget {
 /// built with an [AnimatedBuilder] and makes use of the [child] feature to
 /// avoid having to rebuild the [Container] each time.
 ///
-/// ```dart imports
+/// ```dart dartImports
 /// import 'dart:math' as math;
 /// ```
 ///
 /// ```dart
-/// late AnimationController _controller = AnimationController(
+/// late final AnimationController _controller = AnimationController(
 ///   duration: const Duration(seconds: 10),
 ///   vsync: this,
 /// )..repeat();

--- a/packages/flutter/lib/src/widgets/tween_animation_builder.dart
+++ b/packages/flutter/lib/src/widgets/tween_animation_builder.dart
@@ -72,9 +72,9 @@ import 'value_listenable_builder.dart';
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return TweenAnimationBuilder(
+///   return TweenAnimationBuilder<double>(
 ///     tween: Tween<double>(begin: 0, end: targetValue),
-///     duration: Duration(seconds: 1),
+///     duration: const Duration(seconds: 1),
 ///     builder: (BuildContext context, double size, Widget? child) {
 ///       return IconButton(
 ///         iconSize: size,
@@ -87,7 +87,7 @@ import 'value_listenable_builder.dart';
 ///         },
 ///       );
 ///     },
-///     child: Icon(Icons.aspect_ratio),
+///     child: const Icon(Icons.aspect_ratio),
 ///   );
 /// }
 /// ```

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -47,7 +47,7 @@ typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, W
 ///
 /// ```dart
 /// class MyHomePage extends StatefulWidget {
-///   MyHomePage({Key? key, required this.title}) : super(key: key);
+///   const MyHomePage({Key? key, required this.title}) : super(key: key);
 ///   final String title;
 ///
 ///   @override
@@ -67,8 +67,8 @@ typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, W
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.center,
 ///           children: <Widget>[
-///             Text('You have pushed the button this many times:'),
-///             ValueListenableBuilder(
+///             const Text('You have pushed the button this many times:'),
+///             ValueListenableBuilder<int>(
 ///               builder: (BuildContext context, int value, Widget? child) {
 ///                 // This builder will only get called when the _counter
 ///                 // is updated.
@@ -90,7 +90,7 @@ typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, W
 ///         ),
 ///       ),
 ///       floatingActionButton: FloatingActionButton(
-///         child: Icon(Icons.plus_one),
+///         child: const Icon(Icons.plus_one),
 ///         onPressed: () => _counter.value += 1,
 ///       ),
 ///     );

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -27,7 +27,7 @@ import 'framework.dart';
 /// A card with `Hello World!` embedded inline within a TextSpan tree.
 ///
 /// ```dart
-/// Text.rich(
+/// const Text.rich(
 ///   TextSpan(
 ///     children: <InlineSpan>[
 ///       TextSpan(text: 'Flutter is'),

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -23,7 +23,7 @@ import 'routes.dart';
 ///     onWillPop: () async {
 ///       return shouldPop;
 ///     },
-///     child: Text('WillPopScope sample'),
+///     child: const Text('WillPopScope sample'),
 ///   );
 /// }
 /// ```
@@ -40,19 +40,19 @@ import 'routes.dart';
 ///     },
 ///     child: Scaffold(
 ///       appBar: AppBar(
-///         title: Text("Flutter WillPopScope demo"),
+///         title: const Text('Flutter WillPopScope demo'),
 ///       ),
 ///       body: Center(
 ///         child: Column(
 ///           mainAxisAlignment: MainAxisAlignment.center,
-///           children: [
+///           children: <Widget>[
 ///             OutlinedButton(
-///               child: Text('Push'),
+///               child: const Text('Push'),
 ///               onPressed: () {
-///                 Navigator.of(context).push(
-///                   MaterialPageRoute(
-///                     builder: (context) {
-///                       return MyStatefulWidget();
+///                 Navigator.of(context).push<void>(
+///                   MaterialPageRoute<void>(
+///                     builder: (BuildContext context) {
+///                       return const MyStatefulWidget();
 ///                     },
 ///                   ),
 ///                 );
@@ -68,10 +68,10 @@ import 'routes.dart';
 ///                 );
 ///               },
 ///             ),
-///             Text("Push to a new screen, then tap on shouldPop "
-///                 "button to toggle its value. Press the back "
-///                 "button in the appBar to check its behaviour "
-///                 "for different values of shouldPop"),
+///             const Text('Push to a new screen, then tap on shouldPop '
+///                 'button to toggle its value. Press the back '
+///                 'button in the appBar to check its behaviour '
+///                 'for different values of shouldPop'),
 ///           ],
 ///         ),
 ///       ),


### PR DESCRIPTION
## Description

This updates the samples to conform to the Flutter repo's `analysis_options.yaml` file, so that we can catch coding and style issues in the samples before they end up on DartPad.

In https://github.com/dart-lang/dart-services/pull/669, I fixed the DartPad analysis options to be those that are in the `packages/flutter/analysis_options_user.yaml`, so that it will use a predictable set of analysis options, but while that provides some protection, it doesn't help with consistent style and readability much. The Flutter repo options are designed for readability, even if they are a bit onerous at times. However, they happen to be a superset of what is now required on DartPad, so the DartPad analyzer warnings that are currently occurring for samples will go away.

In this PR, I also updated the sample templates to be more canonical (and to conform to the analysis options).

This process uncovered several major errors, incorrect code, and some cases where we were doing some very non-standard things.
