### PR TITLE
Removed RefreshIndicator accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -147,7 +147,7 @@ class RefreshIndicator extends StatefulWidget {
   final RefreshCallback onRefresh;
 
   /// The progress indicator's foreground color. The current theme's
-  /// [ThemeData.accentColor] by default.
+  /// [ColorScheme.primary] by default.
   final Color? color;
 
   /// The progress indicator's background color. The current theme's
@@ -229,8 +229,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     final ThemeData theme = Theme.of(context);
     _valueColor = _positionController.drive(
       ColorTween(
-        begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
-        end: (widget.color ?? theme.accentColor).withOpacity(1.0),
+        begin: (widget.color ?? theme.colorScheme.primary).withOpacity(0.0),
+        end: (widget.color ?? theme.colorScheme.primary).withOpacity(1.0),
       ).chain(CurveTween(
         curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
       )),
@@ -245,8 +245,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       final ThemeData theme = Theme.of(context);
       _valueColor = _positionController.drive(
         ColorTween(
-          begin: (widget.color ?? theme.accentColor).withOpacity(0.0),
-          end: (widget.color ?? theme.accentColor).withOpacity(1.0),
+          begin: (widget.color ?? theme.colorScheme.primary).withOpacity(0.0),
+          end: (widget.color ?? theme.colorScheme.primary).withOpacity(1.0),
         ).chain(CurveTween(
             curve: const Interval(0.0, 1.0 / _kDragSizeFactorLimit)
         )),

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -709,6 +709,42 @@ void main() {
     expect(refreshCalled, false);
   });
 
+  testWidgets('RefreshIndicator color defaults to ColorScheme.primary', (WidgetTester tester) async {
+    const Color primaryColor = Color(0xff4caf50);
+    final ThemeData theme = ThemeData.from(colorScheme: const ColorScheme.light().copyWith(primary: primaryColor));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter stateSetter) {
+            return RefreshIndicator(
+              triggerMode: RefreshIndicatorTriggerMode.anywhere,
+              onRefresh: holdRefresh,
+              child: ListView(
+                reverse: true,
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const <Widget>[
+                  SizedBox(
+                    height: 200.0,
+                    child: Text('X'),
+                  ),
+                  SizedBox(
+                    height: 800.0,
+                    child: Text('Y'),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.pump();
+    expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, primaryColor);
+  });
+
   testWidgets('RefreshIndicator.color can be updated at runtime', (WidgetTester tester) async {
     refreshCalled = false;
     Color refreshIndicatorColor = Colors.green;


### PR DESCRIPTION
This PR removes the RefreshIndicator widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

The `RefreshIndicator` widget's `color` property used the `ThemeData.accentColor` by default. This PR updates it to use the `ColorScheme.primary` instead.

## Breaking change

This is a breaking change. For apps that need a specific color for their RefreshIndicators they can just pass it into the constructor for the widget:

```dart
  RefreshIndicator(
    color: Colors.yellow,
     ...
  )
```

A new test was added to check verify the default `RefreshIndicator` color is now `ColorScheme.primary`.

This PR was tested against internal Google apps in cl/360775206.
