### PR TITLE
Removed accentColor dependency from ExpansionTile

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
+import 'color_scheme.dart';
 import 'colors.dart';
 import 'icons.dart';
 import 'list_tile.dart';
@@ -289,13 +290,14 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   @override
   void didChangeDependencies() {
     final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     _borderColorTween.end = theme.dividerColor;
     _headerColorTween
       ..begin = widget.collapsedTextColor ?? theme.textTheme.subtitle1!.color
-      ..end = widget.textColor ?? theme.accentColor;
+      ..end = widget.textColor ?? colorScheme.secondary;
     _iconColorTween
       ..begin = widget.collapsedIconColor ?? theme.unselectedWidgetColor
-      ..end = widget.iconColor ?? theme.accentColor;
+      ..end = widget.iconColor ?? colorScheme.secondary;
     _backgroundColorTween
       ..begin = widget.collapsedBackgroundColor
       ..end = widget.backgroundColor;

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -290,7 +290,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   @override
   void didChangeDependencies() {
     final ThemeData theme = Theme.of(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ColorScheme colorScheme = theme.colorScheme;
     _borderColorTween.end = theme.dividerColor;
     _headerColorTween
       ..begin = widget.collapsedTextColor ?? theme.textTheme.subtitle1!.color

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -163,7 +163,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSwatch().copyWith(primary: _foregroundColor),
+          colorScheme: ColorScheme.fromSwatch().copyWith(secondary: _foregroundColor),
           unselectedWidgetColor: _unselectedWidgetColor,
           textTheme: const TextTheme(subtitle1: TextStyle(color: _headerColor)),
         ),

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -43,7 +43,7 @@ class TestTextState extends State<TestText> {
 
 void main() {
   const Color _dividerColor = Color(0x1f333333);
-  const Color _accentColor = Colors.blueAccent;
+  const Color _secondaryColor = Colors.blueAccent;
   const Color _unselectedWidgetColor = Colors.black54;
   const Color _headerColor = Colors.black45;
 
@@ -163,7 +163,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          accentColor: _accentColor,
+          colorScheme: ColorScheme.fromSwatch().copyWith(secondary: _secondaryColor),
           unselectedWidgetColor: _unselectedWidgetColor,
           textTheme: const TextTheme(subtitle1: TextStyle(color: _headerColor)),
         ),
@@ -195,9 +195,9 @@ void main() {
     Color iconColor(Key key) => tester.state<TestIconState>(find.byKey(key)).iconTheme.color!;
     Color textColor(Key key) => tester.state<TestTextState>(find.byKey(key)).textStyle.color!;
 
-    expect(textColor(expandedTitleKey), _accentColor);
+    expect(textColor(expandedTitleKey), _secondaryColor);
     expect(textColor(collapsedTitleKey), _headerColor);
-    expect(iconColor(expandedIconKey), _accentColor);
+    expect(iconColor(expandedIconKey), _secondaryColor);
     expect(iconColor(collapsedIconKey), _unselectedWidgetColor);
 
     // Tap both tiles to change their state: collapse and extend respectively
@@ -208,9 +208,9 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(textColor(expandedTitleKey), _headerColor);
-    expect(textColor(collapsedTitleKey), _accentColor);
+    expect(textColor(collapsedTitleKey), _secondaryColor);
     expect(iconColor(expandedIconKey), _unselectedWidgetColor);
-    expect(iconColor(collapsedIconKey), _accentColor);
+    expect(iconColor(collapsedIconKey), _secondaryColor);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('ExpansionTile subtitle', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -43,7 +43,7 @@ class TestTextState extends State<TestText> {
 
 void main() {
   const Color _dividerColor = Color(0x1f333333);
-  const Color _secondaryColor = Colors.blueAccent;
+  const Color _foregroundColor = Colors.blueAccent;
   const Color _unselectedWidgetColor = Colors.black54;
   const Color _headerColor = Colors.black45;
 
@@ -163,7 +163,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSwatch().copyWith(secondary: _secondaryColor),
+          colorScheme: ColorScheme.fromSwatch().copyWith(primary: _foregroundColor),
           unselectedWidgetColor: _unselectedWidgetColor,
           textTheme: const TextTheme(subtitle1: TextStyle(color: _headerColor)),
         ),
@@ -195,9 +195,9 @@ void main() {
     Color iconColor(Key key) => tester.state<TestIconState>(find.byKey(key)).iconTheme.color!;
     Color textColor(Key key) => tester.state<TestTextState>(find.byKey(key)).textStyle.color!;
 
-    expect(textColor(expandedTitleKey), _secondaryColor);
+    expect(textColor(expandedTitleKey), _foregroundColor);
     expect(textColor(collapsedTitleKey), _headerColor);
-    expect(iconColor(expandedIconKey), _secondaryColor);
+    expect(iconColor(expandedIconKey), _foregroundColor);
     expect(iconColor(collapsedIconKey), _unselectedWidgetColor);
 
     // Tap both tiles to change their state: collapse and extend respectively
@@ -208,9 +208,9 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(textColor(expandedTitleKey), _headerColor);
-    expect(textColor(collapsedTitleKey), _secondaryColor);
+    expect(textColor(collapsedTitleKey), _foregroundColor);
     expect(iconColor(expandedIconKey), _unselectedWidgetColor);
-    expect(iconColor(collapsedIconKey), _secondaryColor);
+    expect(iconColor(collapsedIconKey), _foregroundColor);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('ExpansionTile subtitle', (WidgetTester tester) async {


### PR DESCRIPTION
The icon and title text color for expanded tiles is now the overall theme's ColorScheme.secondary color instead of the theme's accentColor. This PR removes the widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

This is technically not a breaking change, because it doesn't break any existing tests.  

Depends on internal Google changes: cl/365624789